### PR TITLE
feat(legal): complete phase2 graph stack and guardrails

### DIFF
--- a/fortress-guest-platform/backend/api/legal_cases.py
+++ b/fortress-guest-platform/backend/api/legal_cases.py
@@ -39,7 +39,6 @@ from backend.core.database import AsyncSessionLocal
 from backend.services.ediscovery_agent import LegacySession
 from backend.services.legal_extractor import extract_entities
 from backend.services.legal_case_graph import (
-    HiveMindFeedback,
     get_case_graph_snapshot,
     trigger_graph_refresh,
 )

--- a/fortress-guest-platform/backend/core/database.py
+++ b/fortress-guest-platform/backend/core/database.py
@@ -2,6 +2,7 @@
 Async database engine, session factory, and FastAPI dependency.
 """
 import structlog
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
 from sqlalchemy.orm import declarative_base
 
@@ -46,8 +47,14 @@ async def get_db():
 
 async def init_db():
     """Create tables if they don't exist (development convenience)."""
+    # Ensure legal model metadata is registered before create_all.
+    from backend.models.legal_base import LegalBase
+    from backend.models import legal_graph, legal_phase2  # noqa: F401
+
     async with async_engine.begin() as conn:
+        await conn.execute(text("CREATE SCHEMA IF NOT EXISTS legal"))
         await conn.run_sync(Base.metadata.create_all)
+        await conn.run_sync(LegalBase.metadata.create_all)
     logger.info("database_tables_ensured")
 
 

--- a/fortress-guest-platform/backend/models/__init__.py
+++ b/fortress-guest-platform/backend/models/__init__.py
@@ -36,7 +36,16 @@ from backend.models.hunter import HunterQueueEntry, HunterRun
 from backend.models.legal_graph import LegalCase, CaseGraphNode, CaseGraphEdge
 from backend.models.legal_discovery import DiscoveryDraftPack, DiscoveryDraftItem
 from backend.models.legal_deposition import DepositionTarget, CrossExamFunnel
-from backend.models.legal_phase2 import CaseStatement, SanctionsAlert, JurisdictionRule, HiveMindFeedbackEvent, PrivilegeLog, AiAuditLedger
+from backend.models.legal_phase2 import (
+    CaseStatement,
+    CaseGraphNode as CaseGraphNodePhase2,
+    CaseGraphEdge as CaseGraphEdgePhase2,
+    SanctionsAlert,
+    JurisdictionRule,
+    HiveMindFeedbackEvent,
+    PrivilegeLog,
+    AiAuditLedger,
+)
 from backend.models.treasury import YieldSimulation, YieldOverride, SeoRankSnapshot, OtaMicroUpdate
 from backend.models.intelligence_distillation import DistillationQueue, DistillationStatus
 from backend.models.legal import (
@@ -125,6 +134,8 @@ __all__ = [
     "CrossExamFunnel",
     # Legal Phase 2
     "CaseStatement",
+    "CaseGraphNodePhase2",
+    "CaseGraphEdgePhase2",
     "SanctionsAlert",
     "JurisdictionRule",
     "HiveMindFeedbackEvent",

--- a/fortress-guest-platform/backend/models/legal_phase2.py
+++ b/fortress-guest-platform/backend/models/legal_phase2.py
@@ -17,13 +17,60 @@ from backend.models.legal_base import LegalBase
 class CaseStatement(LegalBase):
     __tablename__ = "case_statements"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
     case_slug = Column(String(255), nullable=False, index=True)
     entity_name = Column(Text, nullable=False, index=True)
     quote_text = Column(Text, nullable=False)
     source_ref = Column(Text, nullable=True)
     doc_id = Column(Text, nullable=True)
     stated_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+
+class CaseGraphNode(LegalBase):
+    __tablename__ = "case_graph_nodes"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    case_slug = Column(String(255), nullable=False, index=True)
+    entity_name = Column(Text, nullable=False)
+    entity_type = Column(String(64), nullable=False, index=True)  # plaintiff|defendant|witness|counsel|company|court
+    pressure_score = Column(Integer, nullable=False, default=0)
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+
+class CaseGraphEdge(LegalBase):
+    __tablename__ = "case_graph_edges"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    case_slug = Column(String(255), nullable=False, index=True)
+    source_node_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("legal.case_graph_nodes.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    target_node_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("legal.case_graph_nodes.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    relationship_type = Column(String(128), nullable=False)
+    confidence_weight = Column(Integer, nullable=False, default=100)
+    source_statement_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("legal.case_statements.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
     created_at = Column(
         DateTime(timezone=True),
         nullable=False,

--- a/fortress-guest-platform/backend/services/legal_case_graph.py
+++ b/fortress-guest-platform/backend/services/legal_case_graph.py
@@ -1,794 +1,294 @@
 """
-Legal Case Graph Service — builds and refreshes entity/relationship
-graphs from case evidence using the Tier 0 Resilient Router.
-
-Level 10 Additions:
-  - RAG retrieval proof logged to backend/logs/rag_audit.log
-  - Retrieved source files written to legal.ai_audit_ledger.retrieved_vectors
-  - Strict Pydantic validation of LLM output (source_document must match)
+Legal Case Graph Service — phase-2 graph engine anchored to
+legal.case_statements, legal.case_graph_nodes, and legal.case_graph_edges.
 """
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
-import os
 from datetime import datetime, timezone
-from pathlib import Path as _Path
-from typing import Any, Optional
-from uuid import UUID, uuid4
+from typing import Any
 
-from fastapi import HTTPException
-from pydantic import BaseModel, Field, field_validator
-from sqlalchemy import Boolean, Column, DateTime, String, delete, select, text
+from pydantic import BaseModel, Field, ValidationError
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from backend.core.database import AsyncSessionLocal, Base
-from backend.models.legal_graph import LegalCase, CaseGraphNode, CaseGraphEdge
-from backend.services.ai_router import execute_resilient_inference
+from backend.core.config import settings
+from backend.core.database import AsyncSessionLocal
+from backend.models.legal_phase2 import CaseGraphEdge, CaseGraphNode, CaseStatement
 
-logger = logging.getLogger(__name__)
-
-LOG_DIR = _Path(__file__).resolve().parent.parent / "logs"
-LOG_DIR.mkdir(parents=True, exist_ok=True)
-_rag_handler = logging.FileHandler(LOG_DIR / "rag_audit.log")
-_rag_handler.setFormatter(logging.Formatter("%(asctime)s %(message)s"))
-rag_logger = logging.getLogger("rag_audit")
-rag_logger.addHandler(_rag_handler)
-rag_logger.setLevel(logging.INFO)
+logger = logging.getLogger("Crog.GraphEngine")
+MAX_GRAPH_NODES = max(1, int(settings.LEGAL_GRAPH_MAX_NODES))
 
 
-# ── Pydantic Schemas ──────────────────────────────────────────────
-
-class LegalEntity(BaseModel):
-    entity_type: str = Field(..., description="person|company|claim|document|email|exhibit|date")
-    label: str = Field(..., min_length=1)
-    source_document: str = Field(default="", description="File name the entity was extracted from")
-    metadata: dict[str, Any] = Field(default_factory=dict)
-
-class LegalEdge(BaseModel):
-    source_label: str = Field(..., min_length=1)
-    target_label: str = Field(..., min_length=1)
-    relationship_type: str = Field(default="related")
-    weight: float = Field(default=0.5, ge=0.0, le=1.0)
-    source_ref: str = Field(default="")
-
-class CaseGraphExtraction(BaseModel):
-    nodes: list[LegalEntity] = Field(default_factory=list)
-    edges: list[LegalEdge] = Field(default_factory=list)
+class GraphNodePayload(BaseModel):
+    entity_name: str = Field(min_length=1)
+    entity_type: str = Field(min_length=1)
+    pressure_score: int = Field(default=0, ge=0, le=100)
 
 
-class CaseStatement(Base):
-    """
-    Indexes verbatim quotes from entities for deposition cross-referencing.
-    """
-    __tablename__ = "legal_case_statements"
-
-    id = Column(String, primary_key=True, index=True)
-    case_slug = Column(String, index=True, nullable=False)
-    entity_name = Column(String, index=True, nullable=False)
-    quote_text = Column(String, nullable=False)
-    source_ref = Column(String, nullable=False)
-    stated_at = Column(DateTime, nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
+class GraphEdgePayload(BaseModel):
+    source_entity_name: str = Field(min_length=1)
+    target_entity_name: str = Field(min_length=1)
+    relationship_type: str = Field(min_length=1)
+    confidence_weight: int = Field(default=100, ge=0, le=100)
+    source_statement_id: str | None = None
 
 
-class HiveMindFeedback(Base):
-    """
-    Captures human counsel edits to Swarm-generated legal drafts.
-    Serves as the golden dataset for Nightly Forge alignment training.
-    """
-    __tablename__ = "legal_hive_mind_feedback_events"
-
-    id = Column(String, primary_key=True, index=True)
-    case_slug = Column(String, index=True, nullable=False)
-    module_type = Column(String, index=True, nullable=False)
-    original_swarm_text = Column(String, nullable=False)
-    human_edited_text = Column(String, nullable=False)
-    accepted = Column(Boolean, default=True)
-    user_id = Column(String, nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
+class GraphPayload(BaseModel):
+    nodes: list[GraphNodePayload] = Field(default_factory=list)
+    edges: list[GraphEdgePayload] = Field(default_factory=list)
 
 
-# ── Retrieval Proof ───────────────────────────────────────────────
-
-class RetrievalProof:
-    """Tracks which vault files were fed to the LLM."""
-    def __init__(self):
-        self.sources: list[dict[str, Any]] = []
-
-    def add(self, file_name: str, chars: int, source_type: str = "vault"):
-        self.sources.append({
-            "file_name": file_name,
-            "chars_contributed": chars,
-            "source_type": source_type,
-        })
-
-    def file_names(self) -> set[str]:
-        return {s["file_name"] for s in self.sources}
-
-    def to_json(self) -> list[dict]:
-        return self.sources
-
-    def log(self, case_slug: str):
-        top = self.sources[:5]
-        top_str = ", ".join(
-            f"[File: {s['file_name']}, Chars: {s['chars_contributed']}]"
-            for s in top
-        )
-        rag_logger.info(
-            "[CASE: %s] RETRIEVAL PROOF: Found %d sources. Top %d: %s",
-            case_slug, len(self.sources), min(5, len(self.sources)), top_str,
-        )
+GraphPayload.model_rebuild()
 
 
-EXTRACTOR_SYSTEM_PROMPT = (
-    "You are an expert legal AI graph extractor. Analyze the following case evidence. "
-    "Extract key entities (person, company, claim, document) and the relationships between them. "
-    "For every entity, include a 'source_document' field naming the exact file it came from. "
-    "You MUST respond ONLY with valid, minified JSON in this exact format: "
-    '{"nodes":[{"entity_type":"person","label":"John Doe",'
-    '"source_document":"Complaint_SUV2026000013.pdf",'
-    '"metadata":{"role":"Opposing Counsel"}}],'
-    '"edges":[{"source_label":"John Doe","target_label":"Contract A","relationship_type":"drafted",'
-    '"weight":0.9,"source_ref":"Email dated Oct 12"}]}'
-)
-
-EXPECTED_GRAPH_KEYS = {"nodes": True, "edges": True}
-
-
-def _extract_json_payload(content: str) -> dict:
-    raw = (content or "").strip()
-    if raw.startswith("```"):
-        first_nl = raw.find("\n")
-        if first_nl > 0:
-            raw = raw[first_nl + 1:]
-        else:
-            raw = raw[3:]
-    if raw.endswith("```"):
-        raw = raw[:-3]
-    raw = raw.strip()
+def _extract_json_object(raw_text: str) -> dict[str, Any]:
+    data = (raw_text or "").strip()
+    if data.startswith("```"):
+        first_newline = data.find("\n")
+        data = data[first_newline + 1 :] if first_newline > -1 else data[3:]
+    if data.endswith("```"):
+        data = data[:-3]
+    data = data.strip()
     try:
-        return json.loads(raw)
-    except Exception:
-        start = raw.find("{")
-        end = raw.rfind("}")
+        return json.loads(data)
+    except json.JSONDecodeError:
+        start = data.find("{")
+        end = data.rfind("}")
         if start >= 0 and end > start:
-            return json.loads(raw[start : end + 1])
+            return json.loads(data[start : end + 1])
         raise
 
 
-def _heuristic_graph_from_evidence(evidence_text: str) -> dict:
-    return {
-        "nodes": [
-            {"entity_type": "document", "label": "Case Evidence Corpus", "source_document": "", "metadata": {"type": "aggregate"}},
-            {"entity_type": "claim", "label": "Primary Claim", "source_document": "", "metadata": {"status": "pending_analysis"}},
-        ],
-        "edges": [
-            {
-                "source_label": "Case Evidence Corpus",
-                "target_label": "Primary Claim",
-                "relationship_type": "supports",
-                "weight": 0.5,
-                "source_ref": "aggregate_evidence",
-            },
-        ],
-    }
-
-
-def _validate_extraction(
-    parsed: dict,
-    known_files: set[str],
-) -> CaseGraphExtraction:
-    """Validate the LLM output via Pydantic. Warn (but don't reject) on
-    unknown source_document values so the graph still populates."""
-    extraction = CaseGraphExtraction.model_validate(parsed)
-
-    for entity in extraction.nodes:
-        src = entity.source_document.strip()
-        if src and known_files and src not in known_files:
-            src_lower = src.lower().replace("_", "").replace(" ", "").replace("-", "")
-            close = [
-                f for f in known_files
-                if src.lower() in f.lower()
-                or f.lower() in src.lower()
-                or src_lower in f.lower().replace("_", "").replace(" ", "").replace("-", "")
-                or f.lower().replace("_", "").replace(" ", "").replace("-", "") in src_lower
-            ]
-            if close:
-                rag_logger.warning(
-                    "SOURCE_FUZZY_MATCH: entity='%s' cited '%s', closest match='%s'",
-                    entity.label, src, close[0],
-                )
-                entity.source_document = close[0]
-            else:
-                rag_logger.warning(
-                    "SOURCE_UNVERIFIED: entity='%s' cited '%s' but file not in retrieval set (%d files)",
-                    entity.label, src, len(known_files),
-                )
-
-    return extraction
-
-
-async def _gather_evidence_text(
-    db: AsyncSession,
-    case_id: UUID,
-    proof: RetrievalProof,
-) -> str:
-    """Gather evidence text from vault documents and case statements.
-    Populates the RetrievalProof for audit logging."""
-    case_res = await db.execute(select(LegalCase).where(LegalCase.id == case_id))
-    case = case_res.scalar_one_or_none()
-    case_slug = case.slug if case else str(case_id)
-
-    chunks: list[str] = []
-
-    try:
-        vault_rows = await db.execute(
-            text("""
-                SELECT file_name, nfs_path, mime_type, chunk_count
-                FROM legal.vault_documents
-                WHERE case_slug = :slug AND processing_status = 'completed'
-                ORDER BY chunk_count DESC NULLS LAST, created_at DESC
-                LIMIT 15
-            """),
-            {"slug": case_slug},
-        )
-        for row in vault_rows.fetchall():
-            d = dict(row._mapping)
-            nfs = d.get("nfs_path", "")
-            fname = d.get("file_name", "")
-            if not nfs:
-                continue
-            try:
-                p = _Path(nfs)
-                if not p.exists():
-                    import subprocess
-                    r = subprocess.run(["sudo", "cat", nfs], capture_output=True, timeout=10)
-                    raw = r.stdout
-                else:
-                    raw = p.read_bytes()
-
-                mime = d.get("mime_type", "")
-                if "pdf" in (mime or "").lower():
-                    try:
-                        import fitz
-                        doc = fitz.open(stream=raw, filetype="pdf")
-                        file_text = "\n\n".join(page.get_text() for page in doc)
-                        doc.close()
-                    except Exception:
-                        file_text = raw.decode("utf-8", errors="ignore")
-                else:
-                    file_text = raw.decode("utf-8", errors="ignore")
-
-                if file_text.strip():
-                    contrib = file_text[:6000]
-                    chunks.append(f"[FILE: {fname}]\n{contrib}")
-                    proof.add(fname, len(contrib), "vault")
-            except Exception as exc:
-                logger.debug("vault_file_read_failed file=%s error=%s", fname, str(exc)[:120])
-    except Exception as exc:
-        await db.rollback()
-        logger.warning("vault_evidence_gather_failed error=%s", str(exc)[:200])
-
-    try:
-        stmt_rows = await db.execute(
-            text("""
-                SELECT entity_name, quote_text, source_ref, stated_at
-                FROM legal.case_statements
-                WHERE case_slug = :slug
-                ORDER BY stated_at DESC NULLS LAST
-                LIMIT 20
-            """),
-            {"slug": case_slug},
-        )
-        for row in stmt_rows.fetchall():
-            d = dict(row._mapping)
-            stmt_text = (
-                f"[STATEMENT by {d.get('entity_name','?')}] "
-                f"\"{d.get('quote_text','')}\" "
-                f"(ref: {d.get('source_ref','n/a')}, date: {d.get('stated_at','?')})"
+def _fallback_payload(statements: list[CaseStatement]) -> GraphPayload:
+    nodes_by_name: dict[str, GraphNodePayload] = {}
+    for statement in statements:
+        name = (statement.entity_name or "").strip()
+        if not name:
+            continue
+        if name not in nodes_by_name:
+            nodes_by_name[name] = GraphNodePayload(
+                entity_name=name,
+                entity_type="witness",
+                pressure_score=35,
             )
-            chunks.append(stmt_text)
-            proof.add(f"statement:{d.get('entity_name','?')}", len(stmt_text), "case_statement")
-    except Exception as exc:
-        logger.debug("case_statements_gather_failed error=%s", str(exc)[:200])
 
-    if chunks:
-        combined = "\n\n".join(chunks)
-        logger.info("evidence_gathered case_slug=%s sources=%d chars=%d", case_slug, len(chunks), len(combined))
-        return combined[:30000]
-
-    try:
-        evidence_rows = await db.execute(
-            text("""
-                SELECT row_to_json(e)::text AS evidence_row
-                FROM legal.case_evidence e
-                WHERE e.case_id = :case_id
-                ORDER BY e.id DESC LIMIT 20
-            """),
-            {"case_id": str(case_id)},
+    # Conservative baseline: chain neighboring entities from statement chronology.
+    edges: list[GraphEdgePayload] = []
+    ordered_names: list[str] = []
+    for statement in statements:
+        name = (statement.entity_name or "").strip()
+        if name:
+            ordered_names.append(name)
+    for idx in range(len(ordered_names) - 1):
+        source_name = ordered_names[idx]
+        target_name = ordered_names[idx + 1]
+        if source_name == target_name:
+            continue
+        edges.append(
+            GraphEdgePayload(
+                source_entity_name=source_name,
+                target_entity_name=target_name,
+                relationship_type="related",
+                confidence_weight=40,
+                source_statement_id=str(statements[idx].id),
+            )
         )
-        rows = [row.evidence_row for row in evidence_rows.fetchall() if row.evidence_row]
-        if rows:
-            for r in rows:
-                proof.add("legacy_case_evidence", len(r), "legacy")
-            return "\n".join(rows)
-    except Exception as exc:
-        await db.rollback()
-        logger.debug("legacy_evidence_table_unavailable error=%s", str(exc)[:200])
-    return ""
+
+    return GraphPayload(nodes=list(nodes_by_name.values()), edges=edges)
 
 
-async def _write_retrieval_to_audit_ledger(
-    db: AsyncSession,
-    case_slug: str,
-    proof: RetrievalProof,
-    prompt_hash: str,
-) -> None:
-    """Patch the audit ledger row with the retrieval proof."""
-    try:
-        await db.execute(
-            text("""
-                UPDATE legal.ai_audit_ledger
-                SET retrieved_vectors = :vecs, case_slug = :slug
-                WHERE id = (
-                    SELECT id FROM legal.ai_audit_ledger
-                    WHERE prompt_hash = :phash
-                      AND (retrieved_vectors IS NULL OR retrieved_vectors = '[]'::jsonb)
-                    ORDER BY created_at DESC
-                    LIMIT 1
-                )
-            """),
+def _truncate_payload_for_limit(payload: GraphPayload, limit: int) -> GraphPayload:
+    if len(payload.nodes) <= limit:
+        return payload
+
+    # Keep highest-pressure entities when payload exceeds legal graph ceiling.
+    selected_nodes = sorted(payload.nodes, key=lambda node: node.pressure_score, reverse=True)[:limit]
+    allowed = {node.entity_name.strip().lower() for node in selected_nodes}
+    selected_edges = [
+        edge
+        for edge in payload.edges
+        if edge.source_entity_name.strip().lower() in allowed
+        and edge.target_entity_name.strip().lower() in allowed
+    ]
+    return GraphPayload(nodes=selected_nodes, edges=selected_edges)
+
+
+class GraphEngine:
+    def __init__(self, llm_client: Any):
+        self.llm = llm_client
+
+    async def refresh_case_graph(self, session: AsyncSession, case_slug: str) -> dict[str, str]:
+        """Rebuild the graph from extracted statements for one case slug."""
+        logger.info("[GRAPH] Rebuilding neural map for %s...", case_slug)
+
+        statement_result = await session.execute(
+            select(CaseStatement)
+            .where(CaseStatement.case_slug == case_slug)
+            .order_by(CaseStatement.created_at.asc())
+        )
+        statements = statement_result.scalars().all()
+        if not statements:
+            return {"status": "insufficient_data"}
+
+        evidence_context = "\n".join(
+            f"- {s.entity_name}: {s.quote_text}" for s in statements if s.entity_name and s.quote_text
+        )
+
+        payload = _fallback_payload(statements)
+        if self.llm is not None and evidence_context:
+            prompt = (
+                "Analyze these case statements and return JSON with keys "
+                "`nodes` and `edges`. Nodes: entity_name, entity_type, pressure_score(0-100). "
+                "Edges: source_entity_name, target_entity_name, relationship_type, confidence_weight(0-100), "
+                "source_statement_id(optional UUID).\n\n"
+                f"Context:\n{evidence_context}"
+            )
+            try:
+                response = await self.llm.generate(prompt=prompt, response_format="json")
+                parsed = response if isinstance(response, dict) else _extract_json_object(getattr(response, "text", ""))
+                payload = GraphPayload.model_validate(parsed)
+            except (ValidationError, ValueError, TypeError, json.JSONDecodeError) as exc:
+                logger.warning("[GRAPH] Invalid LLM graph payload for %s, using fallback: %s", case_slug, str(exc)[:240])
+
+        if len(payload.nodes) > MAX_GRAPH_NODES:
+            logger.warning(
+                "[GRAPH] Node ceiling hit for %s (requested=%d limit=%d); truncating payload.",
+                case_slug,
+                len(payload.nodes),
+                MAX_GRAPH_NODES,
+            )
+            payload = _truncate_payload_for_limit(payload, MAX_GRAPH_NODES)
+
+        await session.execute(delete(CaseGraphEdge).where(CaseGraphEdge.case_slug == case_slug))
+        await session.execute(delete(CaseGraphNode).where(CaseGraphNode.case_slug == case_slug))
+        await session.flush()
+
+        statement_lookup = {str(s.id): s.id for s in statements}
+        node_id_by_name: dict[str, Any] = {}
+        now = datetime.now(timezone.utc)
+
+        for node in payload.nodes:
+            key = node.entity_name.strip().lower()
+            if not key:
+                continue
+            if key in node_id_by_name:
+                continue
+            model_node = CaseGraphNode(
+                case_slug=case_slug,
+                entity_name=node.entity_name.strip(),
+                entity_type=node.entity_type.strip().lower(),
+                pressure_score=node.pressure_score,
+                created_at=now,
+            )
+            session.add(model_node)
+            await session.flush()
+            node_id_by_name[key] = model_node.id
+
+        for edge in payload.edges:
+            source_key = edge.source_entity_name.strip().lower()
+            target_key = edge.target_entity_name.strip().lower()
+            source_node_id = node_id_by_name.get(source_key)
+            target_node_id = node_id_by_name.get(target_key)
+            if not source_node_id or not target_node_id:
+                continue
+            source_statement_id = statement_lookup.get(edge.source_statement_id or "")
+            model_edge = CaseGraphEdge(
+                case_slug=case_slug,
+                source_node_id=source_node_id,
+                target_node_id=target_node_id,
+                relationship_type=edge.relationship_type.strip(),
+                confidence_weight=edge.confidence_weight,
+                source_statement_id=source_statement_id,
+                created_at=now,
+            )
+            session.add(model_edge)
+
+        await session.commit()
+        logger.info("[GRAPH] Neural map refreshed for %s.", case_slug)
+        return {"status": "success"}
+
+    async def get_graph_snapshot(self, session: AsyncSession, case_slug: str) -> dict[str, Any]:
+        """Return strict JSON payload for frontend graph rendering."""
+        nodes_result = await session.execute(
+            select(CaseGraphNode)
+            .where(CaseGraphNode.case_slug == case_slug)
+            .order_by(CaseGraphNode.created_at.asc())
+        )
+        edges_result = await session.execute(
+            select(CaseGraphEdge)
+            .where(CaseGraphEdge.case_slug == case_slug)
+            .order_by(CaseGraphEdge.created_at.asc())
+        )
+
+        nodes = [
             {
-                "vecs": json.dumps(proof.to_json()),
-                "slug": case_slug,
-                "phash": prompt_hash,
-            },
-        )
-        await db.commit()
-    except Exception as exc:
-        try:
-            await db.rollback()
-        except Exception:
-            pass
-        logger.debug("audit_ledger_vector_patch_failed error=%s", str(exc)[:200])
-
-
-async def get_case_graph_snapshot(db: AsyncSession, case_slug: str) -> dict:
-    case_res = await db.execute(select(LegalCase).where(LegalCase.slug == case_slug))
-    case = case_res.scalar_one_or_none()
-    if not case:
-        raise HTTPException(status_code=404, detail=f"Legal case '{case_slug}' not found")
-
-    nodes_res = await db.execute(
-        select(CaseGraphNode).where(CaseGraphNode.case_id == case.id).order_by(CaseGraphNode.created_at.asc())
-    )
-    edges_res = await db.execute(
-        select(CaseGraphEdge).where(CaseGraphEdge.case_id == case.id).order_by(CaseGraphEdge.created_at.asc())
-    )
-    return {
-        "nodes": list(nodes_res.scalars().all()),
-        "edges": list(edges_res.scalars().all()),
-    }
+                "id": str(node.id),
+                "case_slug": node.case_slug,
+                "entity_name": node.entity_name,
+                "entity_type": node.entity_type,
+                "label": node.entity_name,
+                "content": node.entity_name,
+                "pressure_score": int(node.pressure_score or 0),
+            }
+            for node in nodes_result.scalars().all()
+        ]
+        edges = [
+            {
+                "id": str(edge.id),
+                "case_slug": edge.case_slug,
+                "source_node_id": str(edge.source_node_id),
+                "target_node_id": str(edge.target_node_id),
+                "relationship_type": edge.relationship_type,
+                "weight": float((edge.confidence_weight or 0) / 100.0),
+                "confidence_weight": int(edge.confidence_weight or 0),
+                "source_statement_id": str(edge.source_statement_id) if edge.source_statement_id else None,
+                "source_ref": edge.relationship_type,
+            }
+            for edge in edges_result.scalars().all()
+        ]
+        return {"case_slug": case_slug, "nodes": nodes, "edges": edges}
 
 
 async def trigger_graph_refresh(db: AsyncSession, case_slug: str) -> None:
-    case_res = await db.execute(select(LegalCase).where(LegalCase.slug == case_slug))
-    case = case_res.scalar_one_or_none()
-    if not case:
-        raise HTTPException(status_code=404, detail=f"Legal case '{case_slug}' not found")
-    case_id = case.id
+    engine = GraphEngine(llm_client=None)
+    await engine.refresh_case_graph(db, case_slug=case_slug)
 
-    proof = RetrievalProof()
-    evidence_text = await _gather_evidence_text(db, case_id, proof)
 
-    if not evidence_text:
-        logger.warning("legal_graph_no_evidence case_slug=%s preserving_existing", case_slug)
-        return
-
-    proof.log(case_slug)
-
-    prompt_hash = hashlib.sha256(evidence_text.encode("utf-8", errors="ignore")).hexdigest()
-
-    result = await execute_resilient_inference(
-        prompt=evidence_text,
-        task_type="legal",
-        system_message=EXTRACTOR_SYSTEM_PROMPT,
-        max_tokens=4096,
-        temperature=0.1,
-        db=db,
-        source_module="legal_case_graph",
-    )
-
-    await _write_retrieval_to_audit_ledger(db, case_slug, proof, prompt_hash)
-
-    try:
-        raw_parsed = _extract_json_payload(result.text)
-        extraction = _validate_extraction(raw_parsed, proof.file_names())
-        parsed = extraction.model_dump()
-
-        rag_logger.info(
-            "[CASE: %s] EXTRACTION VALIDATED: %d entities, %d edges (Pydantic OK)",
-            case_slug, len(extraction.nodes), len(extraction.edges),
-        )
-    except Exception as exc:
-        rag_logger.warning(
-            "[CASE: %s] EXTRACTION VALIDATION FAILED: %s — using heuristic fallback",
-            case_slug, str(exc)[:300],
-        )
-        logger.warning("legal_graph_json_parse_failed case_slug=%s using_heuristic error=%s", case_slug, str(exc)[:200])
-        parsed = _heuristic_graph_from_evidence(evidence_text)
-
-    raw_nodes = parsed.get("nodes") or parsed.get("entities", [])
-    raw_edges = parsed.get("edges", [])
-
-    try:
-        try:
-            await db.rollback()
-        except Exception:
-            pass
-        await db.execute(delete(CaseGraphEdge).where(CaseGraphEdge.case_id == case_id))
-        await db.execute(delete(CaseGraphNode).where(CaseGraphNode.case_id == case_id))
-
-        now = datetime.now(timezone.utc)
-        label_to_node_id: dict[str, UUID] = {}
-
-        for node in raw_nodes:
-            if isinstance(node, BaseModel):
-                node = node.model_dump()
-            label = str(node.get("label", "")).strip()
-            if not label:
-                continue
-            entity_type = str(node.get("entity_type", "unknown")).strip()
-            node_metadata = node.get("metadata") or {}
-            if node.get("source_document"):
-                node_metadata["source_document"] = node["source_document"]
-            model_node = CaseGraphNode(
-                id=uuid4(),
-                case_id=case_id,
-                entity_type=entity_type,
-                label=label,
-                node_metadata=node_metadata,
-                created_at=now,
-            )
-            db.add(model_node)
-            await db.flush()
-            label_to_node_id[label] = model_node.id
-
-        for edge in raw_edges:
-            if isinstance(edge, BaseModel):
-                edge = edge.model_dump()
-            source_label = str(edge.get("source_label", "")).strip()
-            target_label = str(edge.get("target_label", "")).strip()
-            if source_label not in label_to_node_id or target_label not in label_to_node_id:
-                continue
-            model_edge = CaseGraphEdge(
-                id=uuid4(),
-                case_id=case_id,
-                source_node_id=label_to_node_id[source_label],
-                target_node_id=label_to_node_id[target_label],
-                relationship_type=str(edge.get("relationship_type", "related")).strip(),
-                weight=float(edge.get("weight", 0.5)),
-                source_ref=str(edge.get("source_ref") or "").strip() or None,
-                created_at=now,
-            )
-            db.add(model_edge)
-
-        await db.commit()
-
-        rag_logger.info(
-            "[CASE: %s] GRAPH COMMITTED: %d nodes, %d edges persisted to Postgres",
-            case_slug, len(label_to_node_id), len(raw_edges),
-        )
-    except Exception as exc:
-        await db.rollback()
-        logger.error("legal_graph_refresh_db_failed case_slug=%s error=%s", case_slug, str(exc)[:500])
+async def get_case_graph_snapshot(db: AsyncSession, case_slug: str) -> dict[str, Any]:
+    engine = GraphEngine(llm_client=None)
+    return await engine.get_graph_snapshot(db, case_slug=case_slug)
 
 
 class LegalCaseGraphService:
     @staticmethod
-    async def get_graph_snapshot(case_slug: str, db: AsyncSession) -> dict:
+    async def get_graph_snapshot(case_slug: str, db: AsyncSession) -> dict[str, Any]:
         return await get_case_graph_snapshot(db, case_slug=case_slug)
 
     @staticmethod
-    async def refresh_case_graph(case_slug: str, db: AsyncSession) -> dict:
+    async def refresh_case_graph(case_slug: str, db: AsyncSession) -> dict[str, str]:
         await trigger_graph_refresh(db, case_slug=case_slug)
         return {"status": "graph_refreshed", "case_slug": case_slug}
 
 
 class LegalCaseGraphBuilder:
-    """Phase 2 Hybrid MVP graph builder backed by v2 graph tables."""
+    """Compatibility facade retained for existing callers."""
 
     @staticmethod
-    async def build_baseline_graph(case_slug: str, db: AsyncSession) -> dict:
-        evidence_rows = (
-            await db.execute(
-                text(
-                    """
-                    SELECT id, file_name, nas_path, qdrant_point_id, sha256_hash
-                    FROM legal.case_evidence
-                    WHERE case_slug = :case_slug
-                    ORDER BY uploaded_at DESC
-                    """
-                ),
-                {"case_slug": case_slug},
-            )
-        ).mappings().all()
-
-        entity_rows = (
-            await db.execute(
-                text(
-                    """
-                    SELECT id, name, type, role
-                    FROM legal.entities
-                    ORDER BY name ASC
-                    """
-                )
-            )
-        ).mappings().all()
-        seeded_entities = False
-        if not entity_rows and case_slug == "fish-trap-suv2026000013":
-            seeded_entities = True
-            entity_rows = [
-                {"id": uuid4(), "name": "Generali Global Assistance", "type": "company", "role": "plaintiff"},
-                {"id": uuid4(), "name": "J. David Stuart", "type": "person", "role": "affiant"},
-                {"id": uuid4(), "name": "Colleen Blackman", "type": "person", "role": "witness"},
-                {"id": uuid4(), "name": "2023 Schedule", "type": "claim", "role": "timeline_artifact"},
-            ]
-
-        timeline_rows = (
-            await db.execute(
-                text(
-                    """
-                    SELECT id, event_date, description, source_evidence_id
-                    FROM legal.timeline_events
-                    WHERE case_slug = :case_slug
-                    ORDER BY event_date ASC
-                    """
-                ),
-                {"case_slug": case_slug},
-            )
-        ).mappings().all()
-
-        await db.execute(text("DELETE FROM legal.case_graph_edges_v2 WHERE case_slug = :case_slug"), {"case_slug": case_slug})
-        await db.execute(text("DELETE FROM legal.case_graph_nodes_v2 WHERE case_slug = :case_slug"), {"case_slug": case_slug})
-        await db.commit()
-
-        node_ids: dict[str, str] = {}
-
-        def _node_key(prefix: str, ref: str) -> str:
-            return f"{prefix}:{ref}"
-
-        for e in evidence_rows:
-            node_id = str(uuid4())
-            await db.execute(
-                text(
-                    """
-                    INSERT INTO legal.case_graph_nodes_v2
-                        (id, case_slug, entity_type, entity_reference_id, label, properties_json)
-                    VALUES
-                        (:id, :case_slug, 'document', :entity_reference_id, :label, CAST(:props AS jsonb))
-                    """
-                ),
-                {
-                    "id": node_id,
-                    "case_slug": case_slug,
-                    "entity_reference_id": str(e["id"]),
-                    "label": e["file_name"],
-                    "props": json.dumps(
-                        {
-                            "nas_path": e["nas_path"],
-                            "qdrant_point_id": e["qdrant_point_id"],
-                            "sha256_hash": e["sha256_hash"],
-                        }
-                    ),
-                },
-            )
-            node_ids[_node_key("document", str(e["id"]))] = node_id
-
-        for ent in entity_rows:
-            node_id = str(uuid4())
-            await db.execute(
-                text(
-                    """
-                    INSERT INTO legal.case_graph_nodes_v2
-                        (id, case_slug, entity_type, entity_reference_id, label, properties_json)
-                    VALUES
-                        (:id, :case_slug, :entity_type, :entity_reference_id, :label, CAST(:props AS jsonb))
-                    """
-                ),
-                {
-                    "id": node_id,
-                    "case_slug": case_slug,
-                    "entity_type": (ent["type"] or "person").lower(),
-                    "entity_reference_id": str(ent["id"]),
-                    "label": ent["name"],
-                    "props": json.dumps({"role": ent["role"]}),
-                },
-            )
-            node_ids[_node_key("entity", str(ent["id"]))] = node_id
-
-        for t in timeline_rows:
-            node_id = str(uuid4())
-            await db.execute(
-                text(
-                    """
-                    INSERT INTO legal.case_graph_nodes_v2
-                        (id, case_slug, entity_type, entity_reference_id, label, properties_json)
-                    VALUES
-                        (:id, :case_slug, 'claim', :entity_reference_id, :label, CAST(:props AS jsonb))
-                    """
-                ),
-                {
-                    "id": node_id,
-                    "case_slug": case_slug,
-                    "entity_reference_id": str(t["id"]),
-                    "label": f"Timeline: {t['event_date']} — {str(t['description'])[:120]}",
-                    "props": json.dumps(
-                        {
-                            "event_date": str(t["event_date"]),
-                            "source_evidence_id": str(t["source_evidence_id"]) if t["source_evidence_id"] else None,
-                            "description": t["description"],
-                        }
-                    ),
-                },
-            )
-            node_ids[_node_key("timeline", str(t["id"]))] = node_id
-
-        edge_count = 0
-        edge_seen: set[tuple[str, str, str]] = set()
-
-        async def _insert_edge(src: str, tgt: str, rel: str, weight: float, source_evidence_id: str | None = None) -> None:
-            nonlocal edge_count
-            sig = (src, tgt, rel)
-            if sig in edge_seen:
-                return
-            edge_seen.add(sig)
-            edge_count += 1
-
-            # nosemgrep: dynamic SQL avoided via params
-            await db.execute(
-                text(
-                    """
-                    INSERT INTO legal.case_graph_edges_v2
-                        (id, case_slug, source_node_id, target_node_id, relationship_type, weight, source_evidence_id)
-                    VALUES
-                        (:id, :case_slug, :src, :tgt, :rel, :weight, :source_evidence_id)
-                    """
-                ),
-                {
-                    "id": str(uuid4()),
-                    "case_slug": case_slug,
-                    "src": src,
-                    "tgt": tgt,
-                    "rel": rel,
-                    "weight": weight,
-                    "source_evidence_id": source_evidence_id,
-                },
-            )
-
-        for ent in entity_rows:
-            ent_key = _node_key("entity", str(ent["id"]))
-            ent_node = node_ids.get(ent_key)
-            if not ent_node:
-                continue
-            ent_name = (ent["name"] or "").lower()
-            for ev in evidence_rows:
-                doc_node = node_ids.get(_node_key("document", str(ev["id"])))
-                if not doc_node:
-                    continue
-                file_name = (ev["file_name"] or "").lower()
-                if ent_name and ent_name in file_name:
-                    await _insert_edge(ent_node, doc_node, "MENTIONED_IN", 0.9, str(ev["id"]))
-                if "affidavit" in file_name and "generali" in ent_name:
-                    await _insert_edge(ent_node, doc_node, "FILED", 0.95, str(ev["id"]))
-                if "stuart" in ent_name and "affidavit" in file_name:
-                    await _insert_edge(ent_node, doc_node, "SIGNED", 0.85, str(ev["id"]))
-                if "blackman" in ent_name and ("schedule" in file_name or "affidavit" in file_name):
-                    await _insert_edge(ent_node, doc_node, "CONTRADICTS", 0.8, str(ev["id"]))
-
-        for t in timeline_rows:
-            t_node = node_ids.get(_node_key("timeline", str(t["id"])))
-            if not t_node:
-                continue
-            if t["source_evidence_id"]:
-                d_node = node_ids.get(_node_key("document", str(t["source_evidence_id"])))
-                if d_node:
-                    await _insert_edge(t_node, d_node, "SUPPORTED_BY", 0.7, str(t["source_evidence_id"]))
-                    continue
-            for ev in evidence_rows:
-                d_node = node_ids.get(_node_key("document", str(ev["id"])))
-                if d_node:
-                    await _insert_edge(t_node, d_node, "TIMELINE_CONTEXT", 0.35, str(ev["id"]))
-
-        if seeded_entities and evidence_rows:
-            primary_doc_key = _node_key("document", str(evidence_rows[0]["id"]))
-            primary_doc_node = node_ids.get(primary_doc_key)
-            if primary_doc_node:
-                for ent in entity_rows:
-                    ent_node = node_ids.get(_node_key("entity", str(ent["id"])))
-                    if ent_node:
-                        await _insert_edge(ent_node, primary_doc_node, "CASE_CONTEXT", 0.55, str(evidence_rows[0]["id"]))
-
-            blackman_node = None
-            schedule_node = None
-            for ent in entity_rows:
-                name = (ent.get("name") or "").lower()
-                ent_node = node_ids.get(_node_key("entity", str(ent["id"])))
-                if not ent_node:
-                    continue
-                if "colleen blackman" in name:
-                    blackman_node = ent_node
-                if "2023 schedule" in name:
-                    schedule_node = ent_node
-            if blackman_node and schedule_node:
-                await _insert_edge(blackman_node, schedule_node, "MENTIONED_IN", 0.8, str(evidence_rows[0]["id"]))
-
-        await db.commit()
-        node_count = len(node_ids)
-        logger.info("phase2_case_graph_built", case_slug=case_slug, nodes=node_count, edges=edge_count)
-        return {"status": "graph_built", "case_slug": case_slug, "nodes": node_count, "edges": edge_count}
-
-    @staticmethod
-    async def get_graph_snapshot(case_slug: str, db: AsyncSession) -> dict:
-        nodes = (
-            await db.execute(
-                text(
-                    """
-                    SELECT id, case_slug, entity_type, entity_reference_id, label, properties_json
-                    FROM legal.case_graph_nodes_v2
-                    WHERE case_slug = :case_slug
-                    ORDER BY label ASC
-                    """
-                ),
-                {"case_slug": case_slug},
-            )
-        ).mappings().all()
-        edges = (
-            await db.execute(
-                text(
-                    """
-                    SELECT id, case_slug, source_node_id, target_node_id, relationship_type, weight, source_evidence_id
-                    FROM legal.case_graph_edges_v2
-                    WHERE case_slug = :case_slug
-                    ORDER BY relationship_type ASC
-                    """
-                ),
-                {"case_slug": case_slug},
-            )
-        ).mappings().all()
+    async def build_baseline_graph(case_slug: str, db: AsyncSession) -> dict[str, Any]:
+        result = await GraphEngine(llm_client=None).refresh_case_graph(db, case_slug=case_slug)
         return {
+            "status": "graph_built",
             "case_slug": case_slug,
-            "nodes": [dict(n) for n in nodes],
-            "edges": [dict(e) for e in edges],
+            "refresh_status": result.get("status", "unknown"),
         }
 
+    @staticmethod
+    async def get_graph_snapshot(case_slug: str, db: AsyncSession) -> dict[str, Any]:
+        return await GraphEngine(llm_client=None).get_graph_snapshot(db, case_slug=case_slug)
 
-async def get_case_snapshot(case_slug: str) -> dict:
-    """Compatibility wrapper for deposition engine context fetch."""
+
+async def get_case_snapshot(case_slug: str) -> dict[str, Any]:
     async with AsyncSessionLocal() as db:
-        snapshot = await get_case_graph_snapshot(db, case_slug=case_slug)
-    return {
-        "nodes": [
-            {
-                "id": str(node.id),
-                "entity_type": node.entity_type,
-                "label": node.label,
-                "content": node.label,
-                "node_metadata": node.node_metadata or {},
-            }
-            for node in (snapshot.get("nodes") or [])
-        ],
-        "edges": [
-            {
-                "id": str(edge.id),
-                "source_node_id": str(edge.source_node_id),
-                "target_node_id": str(edge.target_node_id),
-                "relationship_type": edge.relationship_type,
-                "weight": float(edge.weight or 0.0),
-                "source_ref": edge.source_ref,
-            }
-            for edge in (snapshot.get("edges") or [])
-        ],
-    }
+        return await get_case_graph_snapshot(db, case_slug=case_slug)

--- a/fortress-guest-platform/backend/services/legal_discovery_engine.py
+++ b/fortress-guest-platform/backend/services/legal_discovery_engine.py
@@ -21,6 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from sqlalchemy import and_
 
+from backend.core.config import settings
 from backend.models.legal_discovery import DiscoveryDraftItem, DiscoveryDraftPack
 from backend.models.legal import DiscoveryDraftPack as DiscoveryDraftPackV2
 from backend.models.legal import DiscoveryDraftItem as DiscoveryDraftItemV2
@@ -33,7 +34,7 @@ from backend.services.legal_hive_mind import get_approved_exemplars, inject_exem
 
 logger = logging.getLogger(__name__)
 
-RULE_26_MAX_ITEMS = 25
+RULE_26_MAX_ITEMS = max(1, int(settings.LEGAL_DISCOVERY_MAX_ITEMS))
 DISCOVERY_CHAT_URL = os.getenv("LEGAL_DISCOVERY_CHAT_URL", "http://192.168.0.100/v1/chat/completions")
 DISCOVERY_CHAT_MODEL = os.getenv("LEGAL_DISCOVERY_CHAT_MODEL", "qwen2.5:7b")
 
@@ -43,6 +44,21 @@ PACK_TYPE_TO_RULE_TYPE = {
     "rfp": "rfp_cap",
     "admission": "admission_cap",
 }
+
+
+def _proportionality_mode() -> str:
+    mode = str(settings.LEGAL_PROPORTIONALITY_MODE or "strict").strip().lower()
+    return "advisory" if mode == "advisory" else "strict"
+
+
+def _resolve_item_limit(requested: int, jurisdiction_cap: int | None) -> int:
+    if _proportionality_mode() == "advisory":
+        return max(int(requested), 1)
+    return max(min(
+        int(requested),
+        jurisdiction_cap if jurisdiction_cap is not None else RULE_26_MAX_ITEMS,
+        RULE_26_MAX_ITEMS,
+    ), 1)
 
 
 async def _get_jurisdiction_cap(
@@ -71,17 +87,32 @@ def _graph_summary_text(snapshot: dict) -> str:
     if not nodes and not edges:
         return "No graph entities or edges are present."
 
-    node_label_by_id = {str(node.id): node.label for node in nodes}
+    def _get(node: object, key: str, default=None):
+        if isinstance(node, dict):
+            return node.get(key, default)
+        return getattr(node, key, default)
+
+    node_label_by_id = {str(_get(node, "id")): str(_get(node, "label") or _get(node, "entity_name") or "") for node in nodes}
     node_lines = [
-        f"- {node.label} [{node.entity_type}] metadata={json.dumps(node.node_metadata or {}, ensure_ascii=True)}"
+        f"- {str(_get(node, 'label') or _get(node, 'entity_name') or '')} "
+        f"[{str(_get(node, 'entity_type') or 'unknown')}] "
+        f"metadata={json.dumps(_get(node, 'node_metadata') or _get(node, 'metadata') or {}, ensure_ascii=True)}"
         for node in nodes
     ]
     edge_lines = []
     for edge in edges:
-        source_label = node_label_by_id.get(str(edge.source_node_id), str(edge.source_node_id))
-        target_label = node_label_by_id.get(str(edge.target_node_id), str(edge.target_node_id))
+        source_node_id = str(_get(edge, "source_node_id") or "")
+        target_node_id = str(_get(edge, "target_node_id") or "")
+        source_label = node_label_by_id.get(source_node_id, source_node_id)
+        target_label = node_label_by_id.get(target_node_id, target_node_id)
+        edge_weight = _get(edge, "weight")
+        if edge_weight is None:
+            confidence_weight = _get(edge, "confidence_weight")
+            edge_weight = (float(confidence_weight) / 100.0) if confidence_weight is not None else 0.0
         edge_lines.append(
-            f"- {source_label} -> ({edge.relationship_type}, weight={float(edge.weight or 0.0):.2f}) -> {target_label}; source_ref={edge.source_ref or 'n/a'}"
+            f"- {source_label} -> ({str(_get(edge, 'relationship_type') or 'related')}, "
+            f"weight={float(edge_weight or 0.0):.2f}) -> {target_label}; "
+            f"source_ref={str(_get(edge, 'source_ref') or 'n/a')}"
         )
 
     return (
@@ -97,9 +128,13 @@ def _extract_opposing_pii(snapshot: dict) -> dict:
     pii: dict = {}
     nodes = list(snapshot.get("nodes") or [])
     for node in nodes:
-        meta = node.node_metadata if hasattr(node, "node_metadata") else (node.get("metadata") or {})
+        if isinstance(node, dict):
+            meta = (node.get("node_metadata") or node.get("metadata") or {})
+            label = str(node.get("label") or node.get("entity_name") or "").strip()
+        else:
+            meta = getattr(node, "node_metadata", {}) or getattr(node, "metadata", {}) or {}
+            label = str(getattr(node, "label", "") or getattr(node, "entity_name", "")).strip()
         role = str(meta.get("role", "")).lower()
-        label = str(node.label if hasattr(node, "label") else node.get("label", "")).strip()
         if not label:
             continue
         if "opposing" in role or "counsel" in role or "claimant" in role or "plaintiff" in role:
@@ -172,6 +207,8 @@ async def generate_discovery_pack(
 ) -> dict:
     allowed_pack_types = {"interrogatory", "rfp", "admission"}
     normalized_pack_type = (pack_type or "").strip().lower()
+    if "foia" in normalized_pack_type and not settings.LEGAL_DISCOVERY_FOIA_ENABLED:
+        raise HTTPException(status_code=403, detail="FOIA discovery is disabled by policy")
     if normalized_pack_type not in allowed_pack_types:
         raise HTTPException(status_code=422, detail=f"Invalid pack_type '{pack_type}'")
     if item_limit < 1:
@@ -183,12 +220,7 @@ async def generate_discovery_pack(
         raise HTTPException(status_code=404, detail=f"Legal case '{case_slug}' not found")
 
     jurisdiction_cap = await _get_jurisdiction_cap(db, legal_case.court, normalized_pack_type)
-    effective_cap = min(
-        int(item_limit),
-        jurisdiction_cap if jurisdiction_cap is not None else RULE_26_MAX_ITEMS,
-        RULE_26_MAX_ITEMS,
-    )
-    limited_count = max(effective_cap, 1)
+    limited_count = _resolve_item_limit(item_limit, jurisdiction_cap)
 
     graph_snapshot = await get_case_graph_snapshot(db, case_slug=case_slug)
     graph_summary = _graph_summary_text(graph_snapshot)
@@ -267,6 +299,7 @@ async def generate_discovery_pack(
         "status": "draft",
         "items_generated": len(draft_items),
         "item_limit": limited_count,
+        "proportionality_mode": _proportionality_mode(),
         "items": draft_items,
         "inference_source": result.source,
         "breaker_state": result.breaker_state,
@@ -285,15 +318,19 @@ async def validate_discovery_pack(db: AsyncSession, pack_id: UUID) -> dict:
         select(DiscoveryDraftItem).where(DiscoveryDraftItem.pack_id == pack.id).order_by(DiscoveryDraftItem.item_number.asc())
     )
     items = list(items_res.scalars().all())
-    is_proportional = len(items) <= RULE_26_MAX_ITEMS
+    mode = _proportionality_mode()
+    within_rule_limit = len(items) <= RULE_26_MAX_ITEMS
+    is_proportional = within_rule_limit if mode == "strict" else True
     for item in items:
-        item.proportionality_flag = is_proportional
+        item.proportionality_flag = within_rule_limit
 
     await db.commit()
     return {
         "pack_id": str(pack.id),
         "items_count": len(items),
         "rule_26_limit": RULE_26_MAX_ITEMS,
+        "proportionality_mode": mode,
+        "rule_26_within_limit": within_rule_limit,
         "proportionality_passed": is_proportional,
     }
 
@@ -327,6 +364,11 @@ class LegalDiscoveryEngine:
             raise HTTPException(status_code=422, detail="target_entity is required")
         if max_items < 1 or max_items > 100:
             raise HTTPException(status_code=422, detail="max_items must be between 1 and 100")
+        if not settings.LEGAL_DISCOVERY_FOIA_ENABLED and "foia" in target_entity.lower():
+            raise HTTPException(status_code=403, detail="FOIA discovery is disabled by policy")
+
+        mode = _proportionality_mode()
+        effective_max_items = min(max_items, RULE_26_MAX_ITEMS) if mode == "strict" else max_items
 
         graph_snapshot = await LegalCaseGraphBuilder.get_graph_snapshot(case_slug=case_slug, db=db)
         nodes = graph_snapshot.get("nodes", [])
@@ -362,14 +404,14 @@ class LegalDiscoveryEngine:
                 "and taxonomy of these perfect examples.\n\n"
                 f"### PERFECT EXEMPLARS ###\n{exemplars_text}\n\n"
                 "### YOUR TASK ###\n"
-                f"Based on the case graph rationale: {rationale_hint}, generate exactly {max_items} "
+                f"Based on the case graph rationale: {rationale_hint}, generate exactly {effective_max_items} "
                 f"new INTERROGATORY/RFP items targeting {target_entity}. "
                 'Output strict JSON: {"items": [{"category": "...", "content": "...", "rationale": "..."}]}.'
             )
         else:
             system_prompt = (
                 f"You are a Tier 1 corporate defense litigator in Georgia. Analyze the provided Case Graph. "
-                f"Generate exactly {max_items} highly specific Interrogatories and Requests for Production "
+                f"Generate exactly {effective_max_items} highly specific Interrogatories and Requests for Production "
                 f"targeting {target_entity}. Do not use boilerplate. Base every question on the edges and "
                 f"contradictions in the graph. Output strict JSON: "
                 f'{{"items": [{{"category": "...", "content": "...", "rationale": "..."}}]}}.'
@@ -379,7 +421,7 @@ class LegalDiscoveryEngine:
             "Case graph JSON:\n"
             f"{json.dumps(graph_context, ensure_ascii=True, default=str)}\n\n"
             f"Target entity: {target_entity}\n"
-            f"Required item count: {max_items}\n"
+            f"Required item count: {effective_max_items}\n"
             "Only return strict JSON."
         )
 
@@ -409,14 +451,14 @@ class LegalDiscoveryEngine:
         except Exception as exc:
             raise HTTPException(status_code=502, detail=f"Invalid discovery model response: {str(exc)[:180]}") from exc
 
-        parsed_items = LegalDiscoveryEngine._parse_items_payload(content=content, max_items=max_items)
-        if len(parsed_items) < max_items:
+        parsed_items = LegalDiscoveryEngine._parse_items_payload(content=content, max_items=effective_max_items)
+        if len(parsed_items) < effective_max_items:
             parsed_items.extend(
                 LegalDiscoveryEngine._fallback_items_from_edges(
                     edges=edges,
                     target_entity=target_entity,
                     start_sequence=len(parsed_items) + 1,
-                    needed=max_items - len(parsed_items),
+                    needed=effective_max_items - len(parsed_items),
                 )
             )
 
@@ -432,7 +474,7 @@ class LegalDiscoveryEngine:
         await db.flush()
 
         created_items: list[dict] = []
-        for idx, item in enumerate(parsed_items[:max_items], start=1):
+        for idx, item in enumerate(parsed_items[:effective_max_items], start=1):
             category = str(item.get("category", "INTERROGATORY")).upper()
             if category not in {"INTERROGATORY", "RFP", "ADMISSION"}:
                 category = "INTERROGATORY"
@@ -465,6 +507,8 @@ class LegalDiscoveryEngine:
             "target_entity": target_entity,
             "status": "DRAFT",
             "items_generated": len(created_items),
+            "proportionality_mode": mode,
+            "item_limit": effective_max_items,
             "items": created_items,
             "model": DISCOVERY_CHAT_MODEL,
         }

--- a/fortress-guest-platform/backend/services/legal_evidence_ingestion.py
+++ b/fortress-guest-platform/backend/services/legal_evidence_ingestion.py
@@ -19,10 +19,12 @@ from uuid import UUID, uuid4
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from backend.core.config import settings
 from backend.models.legal_graph import CaseGraphEdge, CaseGraphNode, LegalCase
 from backend.services.ai_router import execute_resilient_inference
 
 logger = structlog.get_logger()
+MAX_GRAPH_NODES = max(1, int(settings.LEGAL_GRAPH_MAX_NODES))
 
 EXTRACTOR_SYSTEM_PROMPT = (
     "You are a Tier 0 Legal Evidence Extractor. Read the provided document chunk. "
@@ -230,7 +232,18 @@ async def ingest_document_to_graph(
         label_to_id[n.label] = n.id
 
     nodes_created = 0
+    existing_count = len(label_to_id)
+    remaining_node_budget = max(MAX_GRAPH_NODES - existing_count, 0)
+    if remaining_node_budget == 0:
+        logger.warning(
+            "evidence_ingestion_node_limit_reached",
+            case_slug=case_slug,
+            existing_nodes=existing_count,
+            limit=MAX_GRAPH_NODES,
+        )
     for node in all_nodes:
+        if remaining_node_budget <= 0:
+            break
         label = str(node.get("label", "")).strip()
         if not label or label in label_to_id:
             continue
@@ -246,6 +259,7 @@ async def ingest_document_to_graph(
         await db.flush()
         label_to_id[label] = new_node.id
         nodes_created += 1
+        remaining_node_budget -= 1
 
     edges_created = 0
     for edge in all_edges:

--- a/fortress-guest-platform/frontend-next/src/app/(dashboard)/legal/cases/[slug]/_components/case-detail-shell.tsx
+++ b/fortress-guest-platform/frontend-next/src/app/(dashboard)/legal/cases/[slug]/_components/case-detail-shell.tsx
@@ -153,8 +153,6 @@ export function CaseDetailShell({ slug }: { slug: string }) {
   const generateDiscoveryPack = useGenerateDiscoveryDraftPack(slug);
   const qc = useQueryClient();
   const [graphSnapshot, setGraphSnapshot] = useState<GraphSnapshot>({ nodes: [], edges: [] });
-  const [graphError, setGraphError] = useState<string | null>(null);
-  const [isGraphLoading, setIsGraphLoading] = useState<boolean>(true);
   const [isRefreshing, setIsRefreshing] = useState<boolean>(false);
   const [refreshBaseline, setRefreshBaseline] = useState<string>("");
   const [activeTargetNode, setActiveTargetNode] = useState<GraphNode | null>(null);
@@ -181,8 +179,6 @@ export function CaseDetailShell({ slug }: { slug: string }) {
   useEffect(() => {
     let cancelled = false;
     const loadSnapshot = async () => {
-      setIsGraphLoading(true);
-      setGraphError(null);
       try {
         const snapshot = await api.get<GraphSnapshot>(`/api/legal/cases/${slug}/graph/snapshot`);
         if (cancelled) return;
@@ -190,12 +186,7 @@ export function CaseDetailShell({ slug }: { slug: string }) {
           nodes: Array.isArray(snapshot?.nodes) ? snapshot.nodes : [],
           edges: Array.isArray(snapshot?.edges) ? snapshot.edges : [],
         });
-      } catch (err) {
-        if (cancelled) return;
-        setGraphError(err instanceof Error ? err.message : "Unable to load graph snapshot");
-      } finally {
-        if (!cancelled) setIsGraphLoading(false);
-      }
+      } catch { /* non-blocking for shell */ }
     };
     loadSnapshot();
     return () => { cancelled = true; };
@@ -271,7 +262,6 @@ export function CaseDetailShell({ slug }: { slug: string }) {
   const latestKillSheet = killSheetsQuery.data?.kill_sheets?.[0] ?? null;
 
   const handleGraphRefresh = async () => {
-    setGraphError(null);
     try {
       const response = await api.post<{ status: string; case_slug: string }>(
         `/api/legal/cases/${slug}/graph/refresh`,
@@ -284,11 +274,6 @@ export function CaseDetailShell({ slug }: { slug: string }) {
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to queue graph refresh");
     }
-  };
-
-  const handleNodeTarget = (node: GraphNode) => {
-    setActiveTargetNode(node);
-    setIsWarRoomOpen(true);
   };
 
   return (
@@ -376,22 +361,14 @@ export function CaseDetailShell({ slug }: { slug: string }) {
           <div className="grid gap-4 lg:grid-cols-2">
             <MasterTimeline slug={slug} />
             <div className="space-y-4">
-              <GraphSnapshotCard
-                nodes={graphSnapshot.nodes}
-                edges={graphSnapshot.edges}
-                isLoading={isGraphLoading}
-                error={graphError}
-                onNodeClick={handleNodeTarget}
-              />
+              <GraphSnapshotCard caseSlug={slug} />
             </div>
           </div>
 
           <EvidenceUpload slug={slug} onIngested={() => {
-            setIsGraphLoading(true);
             api.get<GraphSnapshot>(`/api/legal/cases/${slug}/graph/snapshot`)
               .then((s) => setGraphSnapshot({ nodes: Array.isArray(s?.nodes) ? s.nodes : [], edges: Array.isArray(s?.edges) ? s.edges : [] }))
-              .catch(() => {})
-              .finally(() => setIsGraphLoading(false));
+              .catch(() => {});
           }} />
 
           <DocumentViewer legalCase={c} slug={slug} />

--- a/fortress-guest-platform/frontend-next/src/app/(dashboard)/legal/cases/[slug]/_components/graph-snapshot-card.tsx
+++ b/fortress-guest-platform/frontend-next/src/app/(dashboard)/legal/cases/[slug]/_components/graph-snapshot-card.tsx
@@ -1,108 +1,122 @@
 "use client";
 
-import { Badge } from "@/components/ui/badge";
+import { useEffect, useState } from "react";
 
-type GraphNode = {
+interface GraphNode {
   id: string;
+  entity_name: string;
   entity_type: string;
-  label: string;
-  node_metadata: Record<string, unknown>;
-};
+  pressure_score: number;
+}
 
-type GraphEdge = {
+interface GraphEdge {
   id: string;
   source_node_id: string;
   target_node_id: string;
   relationship_type: string;
-  weight: number;
-  source_ref?: string | null;
-};
+  confidence_weight: number;
+}
 
-type GraphSnapshotCardProps = {
-  nodes: GraphNode[];
-  edges: GraphEdge[];
-  isLoading: boolean;
-  error: string | null;
-  onNodeClick?: (node: GraphNode) => void;
-};
+export function GraphSnapshotCard({ caseSlug }: { caseSlug: string }) {
+  const [nodes, setNodes] = useState<GraphNode[]>([]);
+  const [edges, setEdges] = useState<GraphEdge[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
 
-const ENTITY_COLORS: Record<string, string> = {
-  person: "text-blue-400 border-blue-500/30",
-  company: "text-purple-400 border-purple-500/30",
-  document: "text-emerald-400 border-emerald-500/30",
-  claim: "text-red-400 border-red-500/30",
-};
+  const fetchSnapshot = async () => {
+    try {
+      const res = await fetch(`/api/legal/cases/${caseSlug}/graph/snapshot`);
+      if (!res.ok) throw new Error("Failed to fetch graph snapshot");
+      const data = await res.json();
+      setNodes(Array.isArray(data?.nodes) ? data.nodes : []);
+      setEdges(Array.isArray(data?.edges) ? data.edges : []);
+    } catch (error) {
+      console.error("[GRAPH] Snapshot sync failed:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
-export function GraphSnapshotCard({ nodes, edges, isLoading, error, onNodeClick }: GraphSnapshotCardProps) {
-  const nodeLabelById = new Map(nodes.map((n) => [n.id, n.label]));
+  useEffect(() => {
+    void fetchSnapshot();
+  }, [caseSlug]);
+
+  const triggerRefresh = async () => {
+    setIsRefreshing(true);
+    try {
+      await fetch(`/api/legal/cases/${caseSlug}/graph/refresh`, { method: "POST" });
+      // For MVP: simple delayed pull after refresh request.
+      setTimeout(() => {
+        void fetchSnapshot();
+      }, 2000);
+    } catch (error) {
+      console.error("[GRAPH] Refresh trigger failed:", error);
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
+
+  if (isLoading) {
+    return <div className="text-gray-400 font-mono text-sm animate-pulse">Rendering Tactical Map...</div>;
+  }
+
+  const topTargets = [...nodes].sort((a, b) => b.pressure_score - a.pressure_score);
 
   return (
-    <div className="rounded-lg border border-zinc-800 bg-zinc-950/80 p-4 space-y-3">
-      <div className="flex items-center justify-between gap-2">
-        <p className="text-sm font-semibold text-zinc-100">Entity Graph Pressure Map</p>
-        <Badge variant="outline" className="bg-blue-500/10 text-blue-400 border-blue-500/30">
-          {nodes.length} {nodes.length === 1 ? "Entity" : "Entities"} &middot; {edges.length} {edges.length === 1 ? "Edge" : "Edges"}
-        </Badge>
+    <div className="bg-gray-900 border border-blue-900/50 rounded-lg p-6 mt-6">
+      <div className="flex justify-between items-center mb-6 border-b border-gray-800 pb-2">
+        <h3 className="text-blue-500 font-bold uppercase tracking-widest flex items-center gap-2">
+          Entity Graph Snapshot
+        </h3>
+        <button
+          onClick={triggerRefresh}
+          disabled={isRefreshing}
+          className="bg-blue-900/50 hover:bg-blue-800 text-blue-200 text-xs font-mono py-1 px-3 rounded transition-colors disabled:opacity-50"
+        >
+          {isRefreshing ? "Swarm Rebuilding..." : "Force Map Refresh"}
+        </button>
       </div>
 
-      {isLoading && <p className="text-xs text-zinc-400">Loading graph snapshot...</p>}
-
-      {error ? (
-        <p className="text-xs text-red-400">{error}</p>
-      ) : (
-        <>
-          <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-2">
-            {nodes.map((node) => (
-              <button
-                key={node.id}
-                type="button"
-                onClick={() => onNodeClick?.(node)}
-                className="rounded-md border border-zinc-800 bg-zinc-900/70 px-3 py-2 flex items-center justify-between gap-2 text-left transition hover:ring-2 hover:ring-red-500 hover:cursor-crosshair"
-              >
-                <span className="text-xs text-zinc-100 truncate">{node.label}</span>
-                <Badge
-                  variant="outline"
-                  className={`text-[10px] uppercase tracking-wide ${ENTITY_COLORS[node.entity_type] ?? "text-zinc-400 border-zinc-600"}`}
-                >
-                  {node.entity_type}
-                </Badge>
-              </button>
-            ))}
-            {nodes.length === 0 && !isLoading && (
-              <p className="text-xs text-zinc-400 col-span-full">No graph entities yet. Run &quot;Recalculate Graph Topology&quot; to extract.</p>
-            )}
-          </div>
-
-          {edges.length > 0 && (
-            <div className="space-y-2">
-              <p className="text-xs font-medium text-zinc-300">Contradiction / Edge Ledger</p>
-              {edges.map((edge) => {
-                const strengthClass =
-                  edge.weight >= 0.85
-                    ? "border-red-500/30"
-                    : edge.weight >= 0.7
-                      ? "border-amber-500/30"
-                      : "border-zinc-800";
-                return (
-                  <div key={edge.id} className={`rounded-md border ${strengthClass} bg-zinc-900/60 p-2`}>
-                    <p className="text-xs text-zinc-100">
-                      [{nodeLabelById.get(edge.source_node_id) ?? edge.source_node_id}]
-                      {" → "}
-                      <span className="text-amber-300">({edge.relationship_type})</span>
-                      {" → "}
-                      [{nodeLabelById.get(edge.target_node_id) ?? edge.target_node_id}]
-                    </p>
-                    <div className="flex items-center gap-3 mt-1">
-                      <span className="text-[10px] text-zinc-500">weight: {edge.weight.toFixed(2)}</span>
-                      <span className="text-[10px] text-zinc-400">ref: {edge.source_ref ?? "n/a"}</span>
-                    </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div>
+          <h4 className="text-gray-400 font-bold text-xs uppercase mb-3">Identified Targets</h4>
+          <div className="space-y-2">
+            {topTargets.map((node) => (
+              <div key={node.id} className="bg-gray-800 p-3 rounded border border-gray-700 flex justify-between items-center">
+                <div>
+                  <div className="text-gray-200 text-sm font-bold">{node.entity_name}</div>
+                  <div className="text-gray-500 text-xs font-mono uppercase">{node.entity_type}</div>
+                </div>
+                <div className="text-right">
+                  <div className={`text-xl font-bold ${node.pressure_score > 70 ? "text-red-500" : "text-blue-400"}`}>
+                    {node.pressure_score}
                   </div>
-                );
-              })}
-            </div>
-          )}
-        </>
-      )}
+                  <div className="text-gray-600 text-[10px] uppercase font-mono">Pressure</div>
+                </div>
+              </div>
+            ))}
+            {nodes.length === 0 && <div className="text-gray-600 text-sm font-mono">No entities mapped.</div>}
+          </div>
+        </div>
+
+        <div>
+          <h4 className="text-gray-400 font-bold text-xs uppercase mb-3">Tactical Relationships</h4>
+          <div className="space-y-2">
+            {edges.map((edge) => {
+              const source = nodes.find((n) => n.id === edge.source_node_id)?.entity_name || "Unknown";
+              const target = nodes.find((n) => n.id === edge.target_node_id)?.entity_name || "Unknown";
+              return (
+                <div key={edge.id} className="bg-gray-800/50 p-2 rounded border border-gray-700/50 text-sm">
+                  <span className="text-blue-300">{source}</span>
+                  <span className="text-gray-500 mx-2 text-xs font-mono">[{edge.relationship_type}]</span>
+                  <span className="text-amber-500">{target}</span>
+                </div>
+              );
+            })}
+            {edges.length === 0 && <div className="text-gray-600 text-sm font-mono">No relationships established.</div>}
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/fortress-guest-platform/frontend-next/src/app/(dashboard)/legal/cases/[slug]/_components/hive-mind-editor.tsx
+++ b/fortress-guest-platform/frontend-next/src/app/(dashboard)/legal/cases/[slug]/_components/hive-mind-editor.tsx
@@ -95,7 +95,7 @@ export function HiveMindEditor({
           disabled={isSubmitting}
           className="px-4 py-2 text-xs font-bold uppercase tracking-wider bg-emerald-700 hover:bg-emerald-600 text-white rounded transition-colors disabled:opacity-50"
         >
-          {isSubmitting ? "Syncing..." : "Approve & File"}
+          {isSubmitting ? "Syncing..." : "Approve & Sync"}
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- unify legal Phase 2 graph persistence by adding graph node/edge schema to `legal_phase2` and migrating statement anchoring to UUID-backed evidence links
- replace legacy graph service internals with a consolidated `GraphEngine`, preserve existing `/cases/{slug}/graph/refresh` and `/cases/{slug}/graph/snapshot` API surface, and mount the new Graph Snapshot card in the legal case dashboard
- enforce legal guardrails at runtime (graph node ceiling, FOIA policy gate, strict/advisory proportionality mode) and clarify UI wording from 'Approve & File' to 'Approve & Sync'

## Test plan
- [x] `python3 -m py_compile fortress-guest-platform/backend/models/legal_phase2.py fortress-guest-platform/backend/services/legal_case_graph.py fortress-guest-platform/backend/api/legal_cases.py fortress-guest-platform/backend/core/database.py fortress-guest-platform/backend/models/__init__.py`
- [x] `python3 -m py_compile fortress-guest-platform/backend/services/legal_deposition_engine.py fortress-guest-platform/backend/services/legal_discovery_engine.py fortress-guest-platform/backend/api/legal_graph.py fortress-guest-platform/backend/services/legal_sanctions_tripwire.py`
- [x] DB smoke: insert/select on `legal.case_statements` confirms UUID `id`
- [x] Graph smoke (HTTP wrapper): `POST /api/legal/cases/{slug}/graph/refresh` returns success and `GET /api/legal/cases/{slug}/graph/snapshot` returns bounded JSON
- [x] Discovery guardrail smoke: strict vs advisory proportionality behavior verified; FOIA disabled path returns `403`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to major refactor of legal graph persistence/snapshot shape and new runtime caps/policy gates that can change behavior or break callers if response formats/settings aren’t aligned.
> 
> **Overview**
> **Completes Phase 2 legal graph persistence and refresh flow.** Adds `legal_phase2` models for `case_graph_nodes`/`case_graph_edges` and migrates `case_statements.id` to UUIDs, with `init_db` now ensuring the `legal` schema exists and Phase 2 metadata is created.
> 
> **Replaces the legacy graph service internals with a simplified `GraphEngine`.** Graph rebuilds are now derived from `legal.case_statements`, enforce a configurable node ceiling (`LEGAL_GRAPH_MAX_NODES`), and return a strict JSON snapshot (including `pressure_score`/`confidence_weight`) while keeping the existing `trigger_graph_refresh`/`get_case_graph_snapshot` entrypoints.
> 
> **Adds legal guardrails in discovery + ingestion.** Discovery item caps are now configurable (`LEGAL_DISCOVERY_MAX_ITEMS`) with strict vs advisory proportionality behavior, FOIA generation is policy-gated, and evidence ingestion stops creating new nodes once the graph node budget is exhausted.
> 
> **Updates the legal dashboard UI.** The case detail page mounts a new self-contained `GraphSnapshotCard` that fetches/refreshes the snapshot client-side, and the Hive Mind approval CTA is renamed from “Approve & File” to “Approve & Sync”.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab5c42ff306e06860875bec58f964463704bfcb6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->