### PR TITLE
docs: add agent telemetry ledger

### DIFF
--- a/.cursor/rules/002-sovereign-constitution.mdc
+++ b/.cursor/rules/002-sovereign-constitution.mdc
@@ -69,6 +69,12 @@ All data crossing module boundaries MUST use Pydantic models with:
 All new multi-step agent workflows MUST use LangGraph `StateGraph`:
 - Define a `TypedDict` state class.
 - Include an `audit_trail` field in state.
+- Define **Node 5: The Chronicler** as the commit-gate historian for the workflow.
+- Before **Node 4 (Gateway)** is permitted to commit any code, Node 5 MUST append an entry to `docs/intelligence/agent_telemetry.md`.
+- Every Node 5 ledger entry MUST include these fields: `Objective`, `Execution`, `Friction`, `Resolution`.
+- `Execution` MUST list every modified file.
+- `Friction` MUST capture any errors surfaced by Node 3 (The Crucible) during local validation.
+- `Resolution` MUST record how the friction was solved or what the system learned if no code fix was required.
 - Terminal node MUST write to the Audit Ledger (Constitution Article III).
 
 ### Self-Healing Reflection Loop

--- a/docs/intelligence/agent_telemetry.md
+++ b/docs/intelligence/agent_telemetry.md
@@ -1,0 +1,22 @@
+# Agent Telemetry Ledger
+
+This ledger is the permanent Teacher-Student learning record for agent-executed repository work.
+Node 5, The Chronicler, MUST append an entry before Node 4 is allowed to commit code.
+
+## Entry Template
+
+### Entry XXX - YYYY-MM-DD - Short Title
+- **Objective:** What was requested.
+- **Execution:** Files modified.
+- **Friction:** Any errors caught by Node 3 (The Crucible) during local builds.
+- **Resolution:** How the friction was solved, or what was learned if no fix was required.
+
+---
+
+## Entries
+
+### Entry 001 - 2026-03-19 - AI Telemetry Ledger Bootstrap
+- **Objective:** Establish a permanent AI telemetry ledger, add Node 5 (The Chronicler) to the Sovereign Constitution, and seed the first Teacher-Student learning record.
+- **Execution:** Created `docs/intelligence/agent_telemetry.md`; updated `.cursor/rules/002-sovereign-constitution.mdc`.
+- **Friction:** `git checkout main` was blocked because `main` is already checked out in another worktree. The first Crucible attempt also failed because `eslint` was unavailable before installing frontend dependencies. After `npm ci`, `npm run lint` surfaced existing repo-wide frontend issues outside this change set, including `@typescript-eslint/no-explicit-any`, `react-hooks/set-state-in-effect`, `react/no-unescaped-entities`, `@next/next/no-html-link-for-pages`, and `react-hooks/refs`. `npm run build` completed successfully.
+- **Resolution:** Branched directly from `main` into `infra/agent-telemetry` inside this worktree, bootstrapped the frontend with `npm ci`, and treated the lint errors as pre-existing Crucible findings rather than telemetry-regression defects because this change only touched documentation and rules. The learning outcome is that Node 5 should record both environment bootstrap issues and unrelated validation debt before Node 4 commits.


### PR DESCRIPTION
## Summary
- add `docs/intelligence/agent_telemetry.md` as the permanent Teacher-Student telemetry ledger
- update `.cursor/rules/002-sovereign-constitution.mdc` to require Node 5 chronicler entries before Node 4 can commit
- seed Entry 001 with the bootstrap objective, execution, Crucible friction, and learning outcome

## Test plan
- [x] `npm ci` in `fortress-guest-platform/frontend-next`
- [x] `npm run build`
- [ ] `npm run lint` currently fails on pre-existing frontend lint violations outside this change set

Made with [Cursor](https://cursor.com)