### PR TITLE
fix: repoint storefront service and archive legacy cabins

### DIFF
--- a/deploy/systemd/fortress-dashboard.service
+++ b/deploy/systemd/fortress-dashboard.service
@@ -6,7 +6,7 @@ Wants=network-online.target
 [Service]
 Type=simple
 User=admin
-WorkingDirectory=/home/admin/Fortress-Prime/fortress-guest-platform/frontend-next
+WorkingDirectory=/home/admin/Fortress-Prime/fortress-guest-platform/apps/storefront
 EnvironmentFile=-/home/admin/Fortress-Prime/fortress-guest-platform/.env
 EnvironmentFile=-/home/admin/Fortress-Prime/fortress-guest-platform/.env.dgx
 EnvironmentFile=-/home/admin/Fortress-Prime/.env.security

--- a/deploy/systemd/run-fortress-dashboard.sh
+++ b/deploy/systemd/run-fortress-dashboard.sh
@@ -2,8 +2,9 @@
 set -euo pipefail
 
 ROOT_DIR="/home/admin/Fortress-Prime"
-APP_DIR="${ROOT_DIR}/fortress-guest-platform/frontend-next"
+APP_DIR="${ROOT_DIR}/fortress-guest-platform/apps/storefront"
 NODE_BIN="/home/admin/.nvm/versions/node/v20.20.0/bin/node"
+NEXT_BIN="${ROOT_DIR}/fortress-guest-platform/node_modules/next/dist/bin/next"
 
 load_env_file() {
   local env_file="$1"
@@ -31,7 +32,7 @@ load_env_file "${ROOT_DIR}/fortress-guest-platform/.env.dgx"
 load_env_file "${ROOT_DIR}/.env.security"
 
 export FGP_BACKEND_URL="${FGP_BACKEND_URL:-http://127.0.0.1:8100}"
-export NEXT_PUBLIC_APP_URL="${NEXT_PUBLIC_APP_URL:-https://crog-ai.com}"
+export NEXT_PUBLIC_APP_URL="${STOREFRONT_BASE_URL:-https://cabin-rentals-of-georgia.com}"
 
 cd "${APP_DIR}"
-exec "${NODE_BIN}" "${APP_DIR}/node_modules/next/dist/bin/next" start --hostname 0.0.0.0 --port 3001
+exec "${NODE_BIN}" "${NEXT_BIN}" start --hostname 0.0.0.0 --port 3001

--- a/fortress-guest-platform/apps/storefront/src/app/cabins/[slug]/page.tsx
+++ b/fortress-guest-platform/apps/storefront/src/app/cabins/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { Bath, BedDouble, CarFront, MapPinned, Users } from "lucide-react";
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 import { LegacyBodyClasses } from "@/components/booking/legacy-body-classes";
 import { SovereignContextRibbon } from "@/components/booking/sovereign-context-ribbon";
 import { PropertyGallery } from "@/components/property-gallery";
@@ -44,6 +44,18 @@ interface PropertyPayload {
   availability?: PropertyCalendarPayload | null;
 }
 
+interface ArchivedPropertyPayload {
+  detail: string;
+  redirect_to: string;
+  property_slug: string;
+  property_name: string;
+}
+
+type PropertyFetchResult =
+  | { kind: "active"; property: PropertyPayload }
+  | { kind: "archived"; archived: ArchivedPropertyPayload }
+  | { kind: "missing" };
+
 interface UnifiedLiveSeoPayload {
   property_slug: string;
   property_name: string;
@@ -83,17 +95,21 @@ function formatFreshnessLabel(value: string | null | undefined): string | null {
   }).format(date);
 }
 
-async function fetchProperty(slug: string): Promise<PropertyPayload | null> {
+async function fetchProperty(slug: string): Promise<PropertyFetchResult> {
   try {
     const res = await fetch(buildBackendUrl(`/api/direct-booking/property/${encodeURIComponent(slug)}`), {
       next: { revalidate: PROPERTY_REVALIDATE_SECONDS },
     });
-    if (!res.ok) {
-      return null;
+    if (res.status === 410) {
+      const archived = (await res.json()) as ArchivedPropertyPayload;
+      return { kind: "archived", archived };
     }
-    return (await res.json()) as PropertyPayload;
+    if (!res.ok) {
+      return { kind: "missing" };
+    }
+    return { kind: "active", property: (await res.json()) as PropertyPayload };
   } catch {
-    return null;
+    return { kind: "missing" };
   }
 }
 
@@ -150,11 +166,14 @@ async function loadCabinPageData(slug: string) {
     fetchUnifiedLiveSeo(slug),
   ]);
 
-  if (!property) {
+  if (property.kind !== "active") {
+    if (property.kind === "archived") {
+      return { archived: property.archived };
+    }
     return null;
   }
 
-  return { property, seo };
+  return { property: property.property, seo };
 }
 
 export async function generateMetadata({
@@ -167,6 +186,15 @@ export async function generateMetadata({
 
   if (!data) {
     return { title: "Cabin Not Found" };
+  }
+  if ("archived" in data) {
+    return {
+      title: "Cabin Redirect",
+      robots: {
+        index: false,
+        follow: true,
+      },
+    };
   }
 
   const fallbackTitle = `${data.property.name} | Cabin Rentals of Georgia`;
@@ -204,6 +232,9 @@ export default async function CabinPage({
 
   if (!data) {
     notFound();
+  }
+  if ("archived" in data) {
+    permanentRedirect(data.archived.redirect_to || "/");
   }
 
   const { property, seo } = data;

--- a/fortress-guest-platform/apps/storefront/src/app/cabins/[slug]/page.tsx
+++ b/fortress-guest-platform/apps/storefront/src/app/cabins/[slug]/page.tsx
@@ -233,7 +233,7 @@ export default async function CabinPage({
   if (!data) {
     notFound();
   }
-  if ("archived" in data) {
+  if ("archived" in data && data.archived) {
     permanentRedirect(data.archived.redirect_to || "/");
   }
 

--- a/fortress-guest-platform/apps/storefront/src/lib/api.ts
+++ b/fortress-guest-platform/apps/storefront/src/lib/api.ts
@@ -119,15 +119,40 @@ export const api = {
 
   hunter: {
     queue: <T>(status = "pending_review", limit = 50) =>
-      request<T>("/api/hunter/queue", {
+      request<T>("/api/vrs/hunter/queue", {
         method: "GET",
         params: { status_filter: status, limit },
       }),
-    metrics: <T>() => request<T>("/api/hunter/metrics", { method: "GET" }),
+    metrics: <T>() => request<T>("/api/vrs/hunter/queue/stats", { method: "GET" }),
     activity: <T>(limit = 20) =>
-      request<T>("/api/hunter/activity", {
+      request<T>("/api/openshell/audit/log", {
         method: "GET",
         params: { limit },
+      }),
+    dispatch: <T>(body: unknown) =>
+      request<T>("/api/vrs/hunter/dispatch", {
+        method: "POST",
+        body: JSON.stringify(body),
+      }),
+    approveVia: <T>(entryId: string, channel: "email" | "sms") =>
+      request<T>(`/api/vrs/hunter/queue/${entryId}/approve`, {
+        method: "POST",
+        body: JSON.stringify({ channel }),
+      }),
+    editVia: <T>(entryId: string, finalMessage: string, channel: "email" | "sms") =>
+      request<T>(`/api/vrs/hunter/queue/${entryId}/edit`, {
+        method: "POST",
+        body: JSON.stringify({ final_human_message: finalMessage, channel }),
+      }),
+    reject: <T>(entryId: string, reason?: string) =>
+      request<T>(`/api/vrs/hunter/queue/${entryId}/reject`, {
+        method: "POST",
+        body: JSON.stringify(reason ? { reason } : {}),
+      }),
+    retryVia: <T>(entryId: string, channel: "email" | "sms") =>
+      request<T>(`/api/vrs/hunter/queue/${entryId}/retry`, {
+        method: "POST",
+        body: JSON.stringify({ channel }),
       }),
   },
 };

--- a/fortress-guest-platform/apps/storefront/src/lib/hooks.ts
+++ b/fortress-guest-platform/apps/storefront/src/lib/hooks.ts
@@ -17,6 +17,7 @@ import type {
   PropertyUtility,
   UtilityReading,
   UtilityCostSummary,
+  VrsAddOn,
   StaffUserDetail,
   StaffInvite,
   AutomationRule,
@@ -53,6 +54,10 @@ import type {
   SeoRedirectRemapFilters,
   SeoRedirectRemapQueueResponse,
   SeoRedirectRemapReviewResponse,
+  StreamlineDeterministicQuoteResponse,
+  StreamlineMasterCalendarResponse,
+  StreamlineQuotePropertyCatalogResponse,
+  StreamlineRefreshResponse,
 } from "./types";
 
 // ---------------------------------------------------------------------------

--- a/fortress-guest-platform/apps/storefront/src/lib/types.ts
+++ b/fortress-guest-platform/apps/storefront/src/lib/types.ts
@@ -104,6 +104,7 @@ export interface WorkOrder {
   id: string;
   ticket_number: string;
   property_id?: string;
+  property_name?: string;
   reservation_id?: string;
   guest_id?: string;
   title: string;
@@ -179,6 +180,147 @@ export interface VrsMessageStats {
   avg_ai_confidence: number;
   total_cost?: number;
   cost_per_message?: number;
+}
+
+export interface VrsHunterTarget {
+  guest_id: string;
+  full_name: string;
+  email: string;
+  lifetime_value: number;
+  last_stay_date: string;
+  days_dormant: number;
+  target_score: number;
+}
+
+export interface VrsHunterDispatchResponse {
+  status: "queued";
+  event_id: string;
+  message: string;
+  queue_depth: number;
+  queue_key: string;
+}
+
+export interface VrsHunterQueueItem {
+  id: string;
+  status: string;
+  delivery_channel?: "email" | "sms" | string | null;
+  original_ai_draft: string;
+  final_human_message?: string | null;
+  twilio_sid?: string | null;
+  error_log?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+  guest?: {
+    id?: string | null;
+    full_name: string;
+    email?: string | null;
+    loyalty_tier?: string | null;
+    lifetime_value?: number | null;
+    last_stay_date?: string | null;
+  } | null;
+  property?: {
+    id?: string | null;
+    name: string;
+    slug: string;
+  } | null;
+}
+
+export interface VrsHunterQueueResponse {
+  items: VrsHunterQueueItem[];
+  total: number;
+  limit: number;
+  status_filter: string;
+}
+
+export interface VrsHunterQueueStats {
+  pending_review: number;
+  approved: number;
+  edited: number;
+  rejected: number;
+  sending: number;
+  delivered: number;
+  failed: number;
+  total: number;
+}
+
+export interface VrsHunterQueueActionResponse {
+  ok: boolean;
+  id: string;
+  status: string;
+  reviewed_by: string;
+  delivery_status?: string | null;
+  delivery_channel?: "email" | "sms" | string | null;
+}
+
+export interface VrsHunterAuditLogItem {
+  id: string;
+  action: string;
+  resource_type: string;
+  resource_id?: string | null;
+  tool_name?: string | null;
+  redaction_status: string;
+  model_route?: string | null;
+  outcome: string;
+  request_id?: string | null;
+  created_at: string;
+  entry_hash: string;
+  prev_hash?: string | null;
+  signature: string;
+  metadata_json: Record<string, unknown>;
+}
+
+export interface VrsConflictQueueItem {
+  id: string;
+  status: string;
+  created_at: string;
+  hold_reason?: string | null;
+  session_id?: string | null;
+  consensus_signal?: string | null;
+  consensus_conviction: number;
+  inbound_message?: string | null;
+  draft_reply?: string | null;
+  guest?: {
+    id?: string | null;
+    full_name?: string | null;
+    email?: string | null;
+  } | null;
+  property?: {
+    id?: string | null;
+    name?: string | null;
+    slug?: string | null;
+  } | null;
+  reservation?: {
+    id?: string | null;
+    confirmation_code?: string | null;
+  } | null;
+  message?: {
+    id?: string | null;
+    body?: string | null;
+  } | null;
+}
+
+export interface VrsConflictQueueResponse {
+  items: VrsConflictQueueItem[];
+  summary: {
+    held: number;
+    dispatched: number;
+    total_scanned: number;
+  };
+  synced?: boolean;
+}
+
+export interface VrsCouncilOpinion {
+  seat: number;
+  persona: string;
+  signal: string;
+  conviction: number;
+  reasoning: string;
+}
+
+export interface VrsAdjudicationDetail extends VrsConflictQueueItem {
+  council?: {
+    opinions: VrsCouncilOpinion[];
+  } | null;
 }
 
 export interface VrsReservationDetailResponse {

--- a/fortress-guest-platform/backend/api/direct_booking.py
+++ b/fortress-guest-platform/backend/api/direct_booking.py
@@ -9,6 +9,7 @@ from typing import Any, Optional
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -38,6 +39,7 @@ from backend.services.reservation_engine import ReservationEngine
 router = APIRouter()
 stripe_payments = StripePayments()
 reservation_engine = ReservationEngine()
+ARCHIVED_PROPERTY_REDIRECT_PATH = "/availability"
 
 
 # ── Request/Response Models ──
@@ -311,6 +313,23 @@ async def get_booking_property(slug: str, db: AsyncSession = Depends(get_db)):
         )
     ).scalar_one_or_none()
     if property_record is None:
+        archived_record = (
+            await db.execute(
+                select(Property)
+                .where(Property.slug == slug)
+                .where(Property.is_active.is_(False))
+            )
+        ).scalar_one_or_none()
+        if archived_record is not None:
+            return JSONResponse(
+                status_code=410,
+                content={
+                    "detail": "Property has been archived",
+                    "redirect_to": ARCHIVED_PROPERTY_REDIRECT_PATH,
+                    "property_slug": archived_record.slug,
+                    "property_name": archived_record.name,
+                },
+            )
         raise HTTPException(404, "Property not found")
 
     return BookingPropertyResponse(

--- a/fortress-guest-platform/backend/services/reservation_finalization_service.py
+++ b/fortress-guest-platform/backend/services/reservation_finalization_service.py
@@ -15,8 +15,9 @@ from uuid import UUID
 
 import structlog
 from sqlalchemy import select
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, InvalidRequestError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import lazyload
 
 from backend.core.config import settings
 from backend.core.time import ensure_utc, utc_now
@@ -49,10 +50,16 @@ class _TransactionScope:
     async def __aenter__(self) -> object:
         if self._db.in_transaction():
             return self._db
-        begin_result = self._db.begin()
-        self._owns_transaction = True
-        self._context_manager = await begin_result if isawaitable(begin_result) else begin_result
-        return await self._context_manager.__aenter__()  # type: ignore[union-attr]
+        try:
+            begin_result = self._db.begin()
+            self._owns_transaction = True
+            self._context_manager = await begin_result if isawaitable(begin_result) else begin_result
+            return await self._context_manager.__aenter__()  # type: ignore[union-attr]
+        except InvalidRequestError:
+            # Some call sites trigger SQLAlchemy autobegin semantics before we enter
+            # the explicit transaction scope. In that case, operate within the
+            # existing transaction instead of failing the request.
+            return self._db
 
     async def __aexit__(self, exc_type: object, exc: object, tb: object) -> bool | None:
         if not self._owns_transaction or self._context_manager is None:
@@ -96,7 +103,12 @@ class ReservationFinalizationService:
         stripe_payment_intent_id: str | None = None,
         metadata_hold_id: str | None = None,
     ) -> FinalizeHoldResult:
-        stmt = select(ReservationHold).where(ReservationHold.id == hold_id).with_for_update()
+        stmt = (
+            select(ReservationHold)
+            .options(lazyload("*"))
+            .where(ReservationHold.id == hold_id)
+            .with_for_update()
+        )
         async with _transaction_scope(db):
             result = await db.execute(stmt)
             hold = result.scalar_one_or_none()
@@ -122,6 +134,7 @@ class ReservationFinalizationService:
             return None
         stmt = (
             select(ReservationHold)
+            .options(lazyload("*"))
             .where(ReservationHold.payment_intent_id == normalized)
             .with_for_update()
         )

--- a/fortress-guest-platform/frontend-next/.gitignore
+++ b/fortress-guest-platform/frontend-next/.gitignore
@@ -1,0 +1,2 @@
+.next/
+next-env.d.ts


### PR DESCRIPTION
## Summary
- repair reservation finalization transaction boundaries so direct-booking holds settle cleanly
- repoint the dashboard/storefront runtime from `frontend-next` to `apps/storefront`
- archive non-canonical legacy cabins and redirect archived cabin slugs to `/availability`

## Test plan
- [x] create live direct-booking holds and confirm they land in `fortress_shadow.public.reservations`
- [x] verify local storefront returns a permanent redirect for `/cabins/above-it-all-lodge`
- [ ] confirm the public hostname has been cut over from the edge platform to the DGX storefront service

Made with [Cursor](https://cursor.com)