### PR TITLE
feat(trust-ledger): Phase I deposits, damage charges, Stripe convergence

### DIFF
--- a/fortress-guest-platform/apps/command-center/src/app/(dashboard)/damage-claims/page.tsx
+++ b/fortress-guest-platform/apps/command-center/src/app/(dashboard)/damage-claims/page.tsx
@@ -7,6 +7,7 @@ import {
   useCreateDamageClaim,
   useGenerateLegalDraft,
   useApproveDamageClaim,
+  useChargeDamageClaim,
   useSendDamageClaim,
   useUpdateDamageClaim,
   useReservationOptions,
@@ -48,6 +49,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import {
   AlertTriangle,
   Camera,
+  CreditCard,
   FileText,
   Plus,
   Shield,
@@ -90,6 +92,9 @@ interface DamageClaim {
   inspection_date: string | null;
   resolution: string | null;
   resolution_amount: number | null;
+  stripe_charge_id?: string | null;
+  amount_charged?: number | null;
+  charge_executed_at?: string | null;
   created_at: string;
   confirmation_code?: string | null;
   check_in_date?: string | null;
@@ -158,6 +163,7 @@ export default function DamageClaimsPage() {
   const generateDraft = useGenerateLegalDraft();
   const approveClaim = useApproveDamageClaim();
   const sendClaim = useSendDamageClaim();
+  const chargeClaim = useChargeDamageClaim();
   const updateClaim = useUpdateDamageClaim();
   const { data: inspections } = useInspectionHistory({ limit: 25 });
   const { data: inspSummary } = useInspectionSummary();
@@ -171,6 +177,8 @@ export default function DamageClaimsPage() {
   const [activeTab, setActiveTab] = useState("claims");
   const [editingDescription, setEditingDescription] = useState(false);
   const [editedDescription, setEditedDescription] = useState("");
+  const [showChargeModal, setShowChargeModal] = useState(false);
+  const [chargeAmount, setChargeAmount] = useState("");
 
   const claimsList = Array.isArray(claims) ? (claims as DamageClaim[]) : [];
   const claimStats = stats as ClaimStats | undefined;
@@ -963,6 +971,25 @@ export default function DamageClaimsPage() {
                         Mark Resolved
                       </Button>
                     )}
+                    {["approved", "sent", "resolved"].includes(selectedClaim.status) && !selectedClaim.stripe_charge_id && (
+                      <Button
+                        size="sm"
+                        variant="destructive"
+                        onClick={() => {
+                          setChargeAmount(String(selectedClaim.resolution_amount ?? selectedClaim.estimated_cost ?? ""));
+                          setShowChargeModal(true);
+                        }}
+                      >
+                        <CreditCard className="mr-1.5 h-4 w-4" />
+                        Charge Guest
+                      </Button>
+                    )}
+                    {selectedClaim.stripe_charge_id && (
+                      <Badge className="bg-emerald-500/10 text-emerald-600 border border-emerald-500/30 px-2 py-1 text-xs font-mono">
+                        <CreditCard className="mr-1 h-3 w-3" />
+                        Charged ${selectedClaim.amount_charged?.toFixed(2)} · {selectedClaim.stripe_charge_id}
+                      </Badge>
+                    )}
                   </div>
                 </div>
               </div>
@@ -970,6 +997,79 @@ export default function DamageClaimsPage() {
           )}
         </SheetContent>
       </Sheet>
+
+      {/* Charge Guest Modal */}
+      <Dialog open={showChargeModal} onOpenChange={setShowChargeModal}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <CreditCard className="h-5 w-5 text-destructive" />
+              Charge Guest
+            </DialogTitle>
+          </DialogHeader>
+          {selectedClaim && (
+            <div className="space-y-4 pt-2">
+              <div className="rounded-md bg-destructive/10 border border-destructive/30 p-3 text-sm text-destructive">
+                This will immediately charge the guest&apos;s saved payment method off-session via Stripe. This action cannot be undone.
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="charge-amount">Charge Amount ($)</Label>
+                <Input
+                  id="charge-amount"
+                  type="number"
+                  step="0.01"
+                  min="0.01"
+                  value={chargeAmount}
+                  onChange={(e) => setChargeAmount(e.target.value)}
+                  placeholder="0.00"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Estimated cost: ${selectedClaim.estimated_cost?.toFixed(2) ?? "—"}
+                  {selectedClaim.resolution_amount ? ` · Resolution amount: $${selectedClaim.resolution_amount.toFixed(2)}` : ""}
+                </p>
+              </div>
+              <div className="flex justify-end gap-2 pt-2">
+                <Button variant="outline" size="sm" onClick={() => setShowChargeModal(false)}>
+                  Cancel
+                </Button>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  disabled={!chargeAmount || Number(chargeAmount) <= 0 || chargeClaim.isPending}
+                  onClick={() => {
+                    chargeClaim.mutate(
+                      { id: selectedClaim.id, amount: Number(chargeAmount), note: undefined },
+                      {
+                        onSuccess: (data) => {
+                          setShowChargeModal(false);
+                          if (data?.charged) {
+                            setSelectedClaim((prev) =>
+                              prev
+                                ? {
+                                    ...prev,
+                                    stripe_charge_id: data.stripe_charge_id,
+                                    amount_charged: data.amount_charged,
+                                    charge_executed_at: new Date().toISOString(),
+                                  }
+                                : null
+                            );
+                          }
+                        },
+                      }
+                    );
+                  }}
+                >
+                  {chargeClaim.isPending ? (
+                    <><Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> Charging…</>
+                  ) : (
+                    <><CreditCard className="mr-1.5 h-4 w-4" /> Confirm Charge</>
+                  )}
+                </Button>
+              </div>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/fortress-guest-platform/apps/command-center/src/components/reservations/FolioSheet.tsx
+++ b/fortress-guest-platform/apps/command-center/src/components/reservations/FolioSheet.tsx
@@ -708,11 +708,32 @@ function SecurityDepositCard({
   onToggled: (resp: DepositToggleResponse) => void;
 }) {
   const [toggling, setToggling] = useState(false);
+  const [depositAction, setDepositAction] = useState<"initiate" | "capture" | "release" | null>(null);
 
   const isRequired = deposit?.is_required ?? false;
   const amount = deposit?.amount ?? 500;
   const status = deposit?.status ?? "none";
   const showPendingFlag = isRequired && status === "none";
+
+  const handleDepositAction = async (action: "initiate" | "capture" | "release") => {
+    if (!reservationId || depositAction) return;
+    setDepositAction(action);
+    try {
+      const resp = await api.post<{ security_deposit_status: string; stripe_pi?: string; amount?: number }>(
+        `/api/reservations/${reservationId}/deposit/${action}`
+      );
+      onToggled({
+        reservation_id: reservationId,
+        security_deposit_required: isRequired,
+        security_deposit_amount: resp.amount ?? amount,
+        security_deposit_status: resp.security_deposit_status,
+      } as DepositToggleResponse);
+    } catch {
+      // Error handled by api wrapper
+    } finally {
+      setDepositAction(null);
+    }
+  };
 
   const handleToggle = async () => {
     if (!reservationId || toggling) return;
@@ -783,17 +804,36 @@ function SecurityDepositCard({
               Card vaulted. {usd(amount)} hold will execute 24 hours prior to arrival.
             </p>
           )}
+          {(status === "none" || status === "pending" || status === "scheduled") && isRequired && (
+            <div className="pt-1">
+              <button
+                disabled={!!depositAction}
+                onClick={() => handleDepositAction("initiate")}
+                className="px-3 py-1.5 rounded-lg bg-blue-500/15 text-blue-400 border border-blue-500/30 text-xs font-medium hover:bg-blue-500/25 transition-colors disabled:opacity-50"
+              >
+                {depositAction === "initiate" ? "Initiating…" : "Initiate Hold"}
+              </button>
+            </div>
+          )}
           {status === "authorized" && (
             <div className="space-y-2">
               <p className="text-xs text-amber-400">
                 {usd(amount)} hold active on guest&apos;s card. Expires in 7 days from authorization.
               </p>
               <div className="flex gap-2">
-                <button className="px-3 py-1.5 rounded-lg bg-red-500/15 text-red-400 border border-red-500/30 text-xs font-medium hover:bg-red-500/25 transition-colors">
-                  Capture for Damage
+                <button
+                  disabled={!!depositAction}
+                  onClick={() => handleDepositAction("capture")}
+                  className="px-3 py-1.5 rounded-lg bg-red-500/15 text-red-400 border border-red-500/30 text-xs font-medium hover:bg-red-500/25 transition-colors disabled:opacity-50"
+                >
+                  {depositAction === "capture" ? "Capturing…" : "Capture for Damage"}
                 </button>
-                <button className="px-3 py-1.5 rounded-lg bg-zinc-700/50 text-zinc-400 border border-zinc-600/30 text-xs font-medium hover:bg-zinc-700 transition-colors">
-                  Release Hold
+                <button
+                  disabled={!!depositAction}
+                  onClick={() => handleDepositAction("release")}
+                  className="px-3 py-1.5 rounded-lg bg-zinc-700/50 text-zinc-400 border border-zinc-600/30 text-xs font-medium hover:bg-zinc-700 transition-colors disabled:opacity-50"
+                >
+                  {depositAction === "release" ? "Releasing…" : "Release Hold"}
                 </button>
               </div>
             </div>

--- a/fortress-guest-platform/backend/api/damage_claims.py
+++ b/fortress-guest-platform/backend/api/damage_claims.py
@@ -472,3 +472,98 @@ async def send_claim_response(
     claim.status = "sent"
     await db.commit()
     return {"ok": True, "sent_via": via, "claim_number": claim.claim_number}
+
+
+class DamageChargeRequest(BaseModel):
+    amount: float = Field(..., gt=0, description="Amount to charge in dollars")
+    note: Optional[str] = None
+
+
+@router.post("/{claim_id}/charge")
+async def charge_damage_claim(
+    claim_id: UUID,
+    body: DamageChargeRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: dict = Depends(require_manager_or_admin),
+):
+    """
+    Execute an off-session Stripe charge against the guest for a damage claim.
+    Requires the guest to have a stripe_customer_id with a saved default payment method.
+    If no saved method exists, returns moto_fallback=true so staff can use the MOTO terminal.
+    """
+    import stripe as stripe_lib
+    from backend.integrations.stripe_payments import StripePayments
+
+    claim = await db.get(DamageClaim, claim_id)
+    if not claim:
+        raise HTTPException(404, "Claim not found")
+    if claim.status not in ("approved", "sent", "resolved"):
+        raise HTTPException(400, f"Claim must be approved/sent/resolved before charging (current: {claim.status})")
+    if claim.stripe_charge_id:
+        raise HTTPException(400, f"Claim already charged: {claim.stripe_charge_id}")
+
+    guest = await db.get(Guest, claim.guest_id)
+    if not guest or not guest.stripe_customer_id:
+        return {
+            "charged": False,
+            "moto_fallback": True,
+            "reason": "no_saved_payment_method",
+            "message": "Guest has no saved payment method — use the MOTO terminal to collect card details.",
+        }
+
+    amount_cents = int(round(body.amount * 100))
+    reservation = await db.get(Reservation, claim.reservation_id) if claim.reservation_id else None
+    conf_code = reservation.confirmation_code if reservation else str(claim_id)[:8]
+
+    try:
+        stripe = StripePayments()
+        result = await stripe.charge_off_session(
+            customer_id=guest.stripe_customer_id,
+            amount_cents=amount_cents,
+            description=f"Damage claim {claim.claim_number} — {conf_code}",
+            metadata={
+                "claim_id": str(claim.id),
+                "claim_number": claim.claim_number or "",
+                "reservation_id": str(claim.reservation_id or ""),
+                "source": "fortress_damage_charge",
+            },
+        )
+    except stripe_lib.error.CardError as e:
+        raise HTTPException(402, f"Card declined: {e.user_message or str(e)}")
+    except stripe_lib.error.InvalidRequestError as e:
+        if "no attached payment source" in str(e).lower() or "no default payment method" in str(e).lower():
+            return {
+                "charged": False,
+                "moto_fallback": True,
+                "reason": "no_default_payment_method",
+                "message": "Guest has no default payment method on file — use the MOTO terminal.",
+            }
+        raise HTTPException(400, f"Stripe error: {str(e)}")
+
+    staff_email = (current_user or {}).get("email") or (current_user or {}).get("sub") or "staff"
+    claim.stripe_charge_id = result["payment_intent_id"]
+    claim.amount_charged = body.amount
+    claim.charge_payment_method_id = result.get("payment_method_id") or ""
+    claim.charge_executed_at = datetime.utcnow()
+    claim.charge_executed_by = staff_email
+    claim.status = "resolved"
+    claim.resolution_amount = body.amount
+    if body.note:
+        claim.resolution = body.note
+    claim.resolved_at = datetime.utcnow()
+    await db.commit()
+
+    logger.info(
+        "damage_claim_charged",
+        claim_id=str(claim.id),
+        claim_number=claim.claim_number,
+        stripe_charge_id=result["payment_intent_id"],
+        amount=body.amount,
+        staff=staff_email,
+    )
+    return {
+        "charged": True,
+        "stripe_charge_id": result["payment_intent_id"],
+        "amount_charged": body.amount,
+        "claim_number": claim.claim_number,
+    }

--- a/fortress-guest-platform/backend/api/financial_approvals.py
+++ b/fortress-guest-platform/backend/api/financial_approvals.py
@@ -1,0 +1,177 @@
+"""
+Financial Approvals API — NeMo Triage endpoints for the Commander Dashboard.
+
+GET  /pending   → List pending approvals with joined reservation context
+POST /{id}/execute → Execute a pending approval with absorb | invoice strategy
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
+
+from backend.core.database import get_db
+from backend.models.financial_approval import FinancialApproval
+from backend.models.reservation import Reservation
+from backend.services.financial_approval_service import execute_financial_approval
+
+logger = structlog.get_logger()
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Response schemas
+# ---------------------------------------------------------------------------
+
+
+class ReservationContext(BaseModel):
+    confirmation_code: str | None = None
+    guest_name: str | None = None
+    guest_email: str | None = None
+    check_in: str | None = None
+    check_out: str | None = None
+    total_amount_cents: int | None = None
+    booking_source: str | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class PendingApprovalResponse(BaseModel):
+    id: str
+    reservation_id: str
+    status: str
+    discrepancy_type: str
+    local_total_cents: int
+    streamline_total_cents: int
+    delta_cents: int
+    context_payload: dict
+    resolution_strategy: str | None = None
+    stripe_invoice_id: str | None = None
+    created_at: str
+    resolved_at: str | None = None
+    reservation: ReservationContext | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class ExecuteRequest(BaseModel):
+    strategy: Literal["absorb", "invoice"]
+
+
+class ExecuteResponse(BaseModel):
+    id: str
+    status: str
+    resolution_strategy: str | None
+    resolved_by: str | None
+    resolved_at: str | None
+    delta_cents: int
+    stripe_invoice_id: str | None = None
+
+    model_config = {"from_attributes": True}
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@router.get("/pending", response_model=list[PendingApprovalResponse])
+async def list_pending_approvals(
+    db: AsyncSession = Depends(get_db),
+):
+    """Return all pending FinancialApproval records with reservation context."""
+    result = await db.execute(
+        select(FinancialApproval)
+        .where(FinancialApproval.status == "pending")
+        .order_by(FinancialApproval.created_at.desc())
+    )
+    approvals = result.scalars().all()
+
+    reservation_ids = {a.reservation_id for a in approvals}
+    reservations_by_key: dict[str, Reservation] = {}
+
+    if reservation_ids:
+        res_result = await db.execute(
+            select(Reservation).where(
+                Reservation.confirmation_code.in_(reservation_ids)
+                | Reservation.streamline_reservation_id.in_(reservation_ids)
+            )
+        )
+        for r in res_result.scalars().all():
+            if r.confirmation_code:
+                reservations_by_key[r.confirmation_code] = r
+            if r.streamline_reservation_id:
+                reservations_by_key[r.streamline_reservation_id] = r
+
+    items: list[PendingApprovalResponse] = []
+    for a in approvals:
+        reservation = reservations_by_key.get(a.reservation_id)
+        res_ctx = None
+        if reservation is not None:
+            total_cents = None
+            if reservation.total_amount is not None:
+                total_cents = int(reservation.total_amount * 100)
+            res_ctx = ReservationContext(
+                confirmation_code=reservation.confirmation_code,
+                guest_name=reservation.guest_name or "",
+                guest_email=reservation.guest_email or "",
+                check_in=str(reservation.check_in_date) if reservation.check_in_date else None,
+                check_out=str(reservation.check_out_date) if reservation.check_out_date else None,
+                total_amount_cents=total_cents,
+                booking_source=reservation.booking_source,
+            )
+
+        items.append(
+            PendingApprovalResponse(
+                id=str(a.id),
+                reservation_id=a.reservation_id,
+                status=a.status,
+                discrepancy_type=a.discrepancy_type,
+                local_total_cents=a.local_total_cents,
+                streamline_total_cents=a.streamline_total_cents,
+                delta_cents=a.delta_cents,
+                context_payload=a.context_payload or {},
+                resolution_strategy=a.resolution_strategy,
+                stripe_invoice_id=a.stripe_invoice_id,
+                created_at=a.created_at.isoformat() if a.created_at else "",
+                resolved_at=a.resolved_at.isoformat() if a.resolved_at else None,
+                reservation=res_ctx,
+            )
+        )
+
+    return items
+
+
+@router.post("/{approval_id}/execute", response_model=ExecuteResponse)
+async def execute_approval(
+    approval_id: str,
+    body: ExecuteRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    """Execute a pending financial approval with the chosen strategy."""
+    try:
+        approval = await execute_financial_approval(
+            db,
+            approval_id=approval_id,
+            commander_username="commander",
+            strategy=body.strategy,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    await db.commit()
+
+    return ExecuteResponse(
+        id=str(approval.id),
+        status=approval.status,
+        resolution_strategy=approval.resolution_strategy,
+        resolved_by=approval.resolved_by,
+        resolved_at=approval.resolved_at.isoformat() if approval.resolved_at else None,
+        delta_cents=approval.delta_cents,
+        stripe_invoice_id=approval.stripe_invoice_id,
+    )

--- a/fortress-guest-platform/backend/api/reservation_webhooks.py
+++ b/fortress-guest-platform/backend/api/reservation_webhooks.py
@@ -10,6 +10,13 @@ The Revenue Consumer Daemon picks up the event within milliseconds and
 executes the CROG Alpha 65/35 split — all before the guest receives their
 confirmation email.
 
+Also exposes POST /api/webhooks/streamline for optional inbound Streamline
+push payloads: stores the raw JSON in ``StreamlinePayloadVault`` for audit /
+reconciliation. Primary guest-payment trust ledger posting remains on Stripe
+webhooks (``post_checkout_trust_entry`` / ``post_invoice_clearing_entry``).
+Optional structured variance posting is supported via ``fortress_trust_variance``
+(see docs/streamline-trust-webhook.md).
+
 Security: HMAC-SHA256 signature via X-Fortress-Signature header.
 Auth: Public endpoint (no JWT); protected by shared secret.
 """
@@ -20,7 +27,7 @@ import uuid
 from datetime import date, datetime, timezone
 from decimal import Decimal
 from enum import Enum
-from typing import Optional
+from typing import Any, Optional
 
 import structlog
 from fastapi import APIRouter, Depends, Header, HTTPException, Request
@@ -31,6 +38,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from backend.core.config import settings
 from backend.core.database import get_db
 from backend.core.event_publisher import EventPublisher
+from backend.models.streamline_payload_vault import StreamlinePayloadVault
+from backend.services.trust_ledger import post_variance_trust_entry
 
 logger = structlog.get_logger(service="reservation_webhooks")
 router = APIRouter()
@@ -90,6 +99,96 @@ def _verify_hmac(payload_bytes: bytes, signature: str, secret: str) -> bool:
         secret.encode("utf-8"), payload_bytes, hashlib.sha256
     ).hexdigest()
     return hmac.compare_digest(expected, signature)
+
+
+def _effective_streamline_webhook_secret() -> str:
+    """Dedicated Streamline webhook secret, or the reservation webhook secret."""
+    return (
+        (settings.streamline_webhook_secret or settings.reservation_webhook_secret or "")
+        .strip()
+    )
+
+
+def _normalize_json_object(raw: Any) -> dict[str, Any]:
+    """Coerce parsed JSON into a dict for JSONB storage."""
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, list):
+        return {"_list_payload": raw}
+    return {"_scalar": raw}
+
+
+def _extract_event_type_from_streamline_body(body: dict[str, Any]) -> str:
+    et = body.get("event_type") or body.get("eventType") or body.get("type")
+    if isinstance(et, str) and et.strip():
+        return et.strip()[:100]
+    return "streamline_webhook"
+
+
+def _extract_reservation_id_from_streamline_body(body: dict[str, Any]) -> Optional[str]:
+    """Best-effort reservation / confirmation id for vault indexing."""
+    for key in (
+        "reservation_id",
+        "reservationId",
+        "streamline_reservation_id",
+        "confirmation_code",
+        "confirmationCode",
+    ):
+        v = body.get(key)
+        if isinstance(v, str) and v.strip():
+            return v.strip()[:100]
+    res = body.get("reservation")
+    if isinstance(res, dict):
+        for key in ("id", "reservation_id", "confirmation_code"):
+            v = res.get(key)
+            if isinstance(v, str) and v.strip():
+                return v.strip()[:100]
+            if isinstance(v, (int, float)):
+                return str(int(v))[:100]
+    return None
+
+
+async def _maybe_post_variance_from_streamline_payload(
+    db: AsyncSession,
+    body: dict[str, Any],
+    reservation_id: Optional[str],
+) -> str:
+    """
+    Optional trust-ledger variance when Streamline pushes a structured block.
+
+    Expects ``fortress_trust_variance`` with:
+    ``amount_cents``, ``debit_account_name``, ``credit_account_name``, ``event_id``,
+    and optionally ``reservation_id`` (else uses extracted reservation id).
+    """
+    block = body.get("fortress_trust_variance")
+    if not isinstance(block, dict):
+        return "skipped"
+    rid = block.get("reservation_id") or reservation_id
+    if rid is None or (isinstance(rid, str) and not rid.strip()):
+        logger.warning("streamline_webhook_variance_missing_reservation_id")
+        return "skipped"
+    rid_str = str(rid).strip()[:255]
+    amount = block.get("amount_cents")
+    debit = block.get("debit_account_name")
+    credit = block.get("credit_account_name")
+    event_id = block.get("event_id")
+    if not isinstance(amount, int) or amount <= 0:
+        return "skipped"
+    if not isinstance(debit, str) or not debit.strip():
+        return "skipped"
+    if not isinstance(credit, str) or not credit.strip():
+        return "skipped"
+    if not isinstance(event_id, str) or not event_id.strip():
+        return "skipped"
+    await post_variance_trust_entry(
+        db,
+        reservation_id=rid_str,
+        amount_cents=amount,
+        debit_account_name=debit.strip(),
+        credit_account_name=credit.strip(),
+        event_id=event_id.strip()[:255],
+    )
+    return "posted"
 
 
 async def _already_journaled(db: AsyncSession, confirmation_code: str) -> bool:
@@ -325,4 +424,79 @@ async def reservation_webhook(
         "action": action,
         "confirmation_code": payload.confirmation_code,
         "revenue_emitted": revenue_emitted,
+    }
+
+
+@router.post("/streamline")
+async def streamline_inbound_webhook(
+    request: Request,
+    x_fortress_signature: Optional[str] = Header(None, alias="x-fortress-signature"),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Inbound Streamline push: persist raw JSON to ``StreamlinePayloadVault``.
+
+    HMAC verification uses ``STREAMLINE_WEBHOOK_SECRET`` when set; otherwise
+    ``RESERVATION_WEBHOOK_SECRET`` (same behavior as ``/reservations``).
+    When no secret is configured, signatures are not required (dev only).
+
+    Guest payment trust entries remain on Stripe webhooks. Optional variance
+    posting: include ``fortress_trust_variance`` (see docs/streamline-trust-webhook.md).
+    """
+    raw_body = await request.body()
+    secret = _effective_streamline_webhook_secret()
+    if secret:
+        if not x_fortress_signature:
+            raise HTTPException(status_code=401, detail="Missing X-Fortress-Signature header")
+        if not _verify_hmac(raw_body, x_fortress_signature, secret):
+            logger.error("streamline_webhook_hmac_invalid")
+            raise HTTPException(status_code=401, detail="Invalid signature")
+
+    import json as json_mod
+
+    try:
+        parsed = json_mod.loads(raw_body)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid JSON payload")
+
+    body = _normalize_json_object(parsed)
+    event_type = _extract_event_type_from_streamline_body(body)
+    reservation_id = _extract_reservation_id_from_streamline_body(body)
+
+    vault_row = StreamlinePayloadVault(
+        event_type=event_type,
+        raw_payload=body,
+        reservation_id=reservation_id,
+    )
+    db.add(vault_row)
+    await db.flush()
+
+    trust_ledger = "skipped"
+    try:
+        trust_ledger = await _maybe_post_variance_from_streamline_payload(
+            db, body, reservation_id
+        )
+    except ValueError as exc:
+        logger.warning("streamline_webhook_variance_value_error", error=str(exc)[:300])
+        trust_ledger = "error"
+    except Exception:
+        logger.exception("streamline_webhook_variance_failed")
+        trust_ledger = "error"
+
+    await db.commit()
+
+    logger.info(
+        "streamline_webhook_accepted",
+        vault_id=str(vault_row.id),
+        event_type=event_type,
+        reservation_id=reservation_id,
+        trust_ledger=trust_ledger,
+    )
+
+    return {
+        "status": "accepted",
+        "vault_id": str(vault_row.id),
+        "event_type": event_type,
+        "reservation_id": reservation_id,
+        "trust_ledger": trust_ledger,
     }

--- a/fortress-guest-platform/backend/api/reservations.py
+++ b/fortress-guest-platform/backend/api/reservations.py
@@ -75,8 +75,15 @@ def _et_today():
     return datetime.now(pytz.timezone("America/New_York")).date()
 
 
+def _normalize_reservation_status(raw: object) -> str:
+    """Lowercase + underscores so UI/TapeChart match Streamline casing (e.g. Confirmed → confirmed)."""
+    s = str(raw or "").strip().lower().replace(" ", "_")
+    return s if s else "confirmed"
+
+
 def _enrich_reservation(r: Reservation, guest: Guest = None, prop: Property = None) -> dict:
     data = {c.name: getattr(r, c.name) for c in r.__table__.columns}
+    data["status"] = _normalize_reservation_status(data.get("status"))
     today = _et_today()
     data["is_current"] = bool(r.check_in_date and r.check_out_date and r.check_in_date <= today <= r.check_out_date)
     data["is_arriving_today"] = r.check_in_date == today
@@ -490,6 +497,158 @@ async def toggle_security_deposit(
     )
 
 
+# ── Security Deposit Hold / Capture / Release ────────────────────
+
+class DepositActionResponse(BaseModel):
+    reservation_id: str
+    security_deposit_status: str
+    stripe_pi: Optional[str] = None
+    amount: Optional[float] = None
+
+
+@router.post("/{reservation_id}/deposit/initiate")
+async def initiate_security_deposit(
+    reservation_id: UUID,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Place a manual-capture PaymentIntent authorization hold for the security deposit.
+    Transitions status: none/pending/scheduled → authorized.
+    Requires the guest to have a stripe_customer_id (created at booking).
+    """
+    from backend.integrations.stripe_payments import StripePayments
+    from backend.models import Guest
+
+    reservation = await db.get(Reservation, reservation_id)
+    if not reservation:
+        raise HTTPException(404, "Reservation not found")
+    if not reservation.security_deposit_required:
+        raise HTTPException(400, "Security deposit is not required for this reservation")
+    if reservation.security_deposit_status == "authorized":
+        raise HTTPException(400, "Deposit hold already active")
+    if reservation.security_deposit_status in ("captured", "released"):
+        raise HTTPException(400, f"Deposit already finalized: {reservation.security_deposit_status}")
+
+    guest = await db.get(Guest, reservation.guest_id)
+    if not guest:
+        raise HTTPException(404, "Guest not found")
+
+    stripe = StripePayments()
+    customer_id = await stripe.get_or_create_customer(
+        email=reservation.guest_email or guest.email,
+        name=reservation.guest_name or f"{guest.first_name} {guest.last_name}",
+        stripe_customer_id=guest.stripe_customer_id or None,
+    )
+
+    # Save back if newly created
+    if not guest.stripe_customer_id:
+        guest.stripe_customer_id = customer_id
+
+    amount_cents = int(float(reservation.security_deposit_amount or 500.00) * 100)
+    result = await stripe.create_deposit_intent(
+        customer_id=customer_id,
+        amount_cents=amount_cents,
+        reservation_id=str(reservation_id),
+        description=f"Security deposit — {reservation.confirmation_code}",
+    )
+
+    reservation.security_deposit_stripe_pi = result["payment_intent_id"]
+    reservation.security_deposit_status = "authorized"
+    reservation.security_deposit_updated_at = datetime.utcnow()
+    await db.commit()
+
+    _log.info(
+        "security_deposit_initiated",
+        reservation_id=str(reservation_id),
+        intent_id=result["payment_intent_id"],
+        amount_cents=amount_cents,
+    )
+    return DepositActionResponse(
+        reservation_id=str(reservation_id),
+        security_deposit_status="authorized",
+        stripe_pi=result["payment_intent_id"],
+        amount=float(reservation.security_deposit_amount or 500.00),
+    )
+
+
+@router.post("/{reservation_id}/deposit/capture")
+async def capture_security_deposit(
+    reservation_id: UUID,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Capture the authorized deposit hold — charges the guest's card.
+    Transitions status: authorized → captured.
+    """
+    from backend.integrations.stripe_payments import StripePayments
+
+    reservation = await db.get(Reservation, reservation_id)
+    if not reservation:
+        raise HTTPException(404, "Reservation not found")
+    if reservation.security_deposit_status != "authorized":
+        raise HTTPException(400, f"Cannot capture deposit in status: {reservation.security_deposit_status}")
+    if not reservation.security_deposit_stripe_pi:
+        raise HTTPException(400, "No active deposit PaymentIntent found")
+
+    stripe = StripePayments()
+    result = await stripe.capture_deposit_intent(reservation.security_deposit_stripe_pi)
+
+    reservation.security_deposit_status = "captured"
+    reservation.security_deposit_updated_at = datetime.utcnow()
+    await db.commit()
+
+    _log.info(
+        "security_deposit_captured",
+        reservation_id=str(reservation_id),
+        intent_id=reservation.security_deposit_stripe_pi,
+        amount_captured=result.get("amount_captured"),
+    )
+    return DepositActionResponse(
+        reservation_id=str(reservation_id),
+        security_deposit_status="captured",
+        stripe_pi=reservation.security_deposit_stripe_pi,
+        amount=result.get("amount_captured", 0) / 100,
+    )
+
+
+@router.post("/{reservation_id}/deposit/release")
+async def release_security_deposit(
+    reservation_id: UUID,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Cancel the authorized deposit hold — releases the hold with no charge.
+    Transitions status: authorized → released.
+    """
+    from backend.integrations.stripe_payments import StripePayments
+
+    reservation = await db.get(Reservation, reservation_id)
+    if not reservation:
+        raise HTTPException(404, "Reservation not found")
+    if reservation.security_deposit_status != "authorized":
+        raise HTTPException(400, f"Cannot release deposit in status: {reservation.security_deposit_status}")
+    if not reservation.security_deposit_stripe_pi:
+        raise HTTPException(400, "No active deposit PaymentIntent found")
+
+    stripe = StripePayments()
+    await stripe.cancel_deposit_intent(reservation.security_deposit_stripe_pi)
+
+    reservation.security_deposit_status = "released"
+    reservation.security_deposit_updated_at = datetime.utcnow()
+    await db.commit()
+
+    _log.info(
+        "security_deposit_released",
+        reservation_id=str(reservation_id),
+        intent_id=reservation.security_deposit_stripe_pi,
+    )
+    return DepositActionResponse(
+        reservation_id=str(reservation_id),
+        security_deposit_status="released",
+        stripe_pi=reservation.security_deposit_stripe_pi,
+    )
+
+
 # ── Unified Folio Aggregator ─────────────────────────────────────
 
 
@@ -577,22 +736,22 @@ async def _aggregate_folio(
 
     folio_deposit = FolioSecurityDeposit(
         is_required=bool(getattr(res, "security_deposit_required", False)),
-        amount=_f(getattr(res, "security_deposit_amount", 500.00)) or 500.00,
+        amount_cents=getattr(res, "security_deposit_amount", 500.00),
         status=_s(getattr(res, "security_deposit_status", "none")) or "none",
         stripe_payment_intent=getattr(res, "security_deposit_stripe_pi", None),
         updated_at=_sd(getattr(res, "security_deposit_updated_at", None)),
     )
 
     folio_financials = FolioFinancials(
-        total_amount=_f(res.total_amount),
-        paid_amount=_f(res.paid_amount),
-        balance_due=_f(res.balance_due),
-        nightly_rate=_f(res.nightly_rate),
-        cleaning_fee=_f(res.cleaning_fee),
-        pet_fee=_f(res.pet_fee),
-        damage_waiver_fee=_f(res.damage_waiver_fee),
-        service_fee=_f(res.service_fee),
-        tax_amount=_f(res.tax_amount),
+        total_amount_cents=res.total_amount,
+        paid_amount_cents=res.paid_amount,
+        balance_due_cents=res.balance_due,
+        nightly_rate_cents=res.nightly_rate,
+        cleaning_fee_cents=res.cleaning_fee,
+        pet_fee_cents=res.pet_fee,
+        damage_waiver_fee_cents=res.damage_waiver_fee,
+        service_fee_cents=res.service_fee,
+        tax_amount_cents=res.tax_amount,
         currency=_s(res.currency) or "USD",
         price_breakdown=res.price_breakdown if isinstance(res.price_breakdown, dict) else None,
         streamline_financial_detail=res.streamline_financial_detail if isinstance(res.streamline_financial_detail, dict) else None,

--- a/fortress-guest-platform/backend/api/storefront_checkout.py
+++ b/fortress-guest-platform/backend/api/storefront_checkout.py
@@ -1,0 +1,1026 @@
+"""
+Public storefront checkout — Sovereign Universal Ledger + Stripe PaymentIntent.
+
+SOVEREIGNTY ASSERTION: This module has ZERO runtime dependency on Streamline
+or any external PMS for pricing, tax calculation, or checkout finality.
+Every dollar is computed from the local Postgres ledger (properties.rate_card,
+fees, taxes, pricing_overrides, learned_rules).  Streamline is notified
+*after* financial finality as a dumb calendar sync — never consulted during
+the checkout critical path.
+
+The /quote endpoint returns the canonical Universal Ledger format consumed by:
+  1. The Next.js checkout sidebar (cabin-rentals-of-georgia)
+  2. The Fortress storefront SovereignQuoteWidget
+  3. The Godhead Swarm's agent_hermes for legacy pricing parity verification
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from decimal import ROUND_HALF_UP, Decimal
+from typing import Any
+from uuid import UUID
+
+import redis.asyncio as aioredis
+import structlog
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, EmailStr, Field
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.core.config import settings
+from backend.core.database import get_db
+from backend.integrations.stripe_payments import StripePayments
+from backend.models.financial_primitives import Fee, PropertyFee, PropertyTax, Tax
+from backend.models.learned_rule import LearnedRule
+from backend.models.property import Property
+from backend.models.vrs_add_on import VRSAddOn, VRSAddOnScope
+from backend.services.ledger import (
+    BucketedItem,
+    LedgerTaxBreakdown,
+    TaxBucket,
+    classify_item,
+    classify_item_full,
+    resolve_taxes,
+)
+from backend.services.pricing_service import (
+    PricingError,
+    PROCESSING_FEE_RATE,
+    calculate_processing_fee,
+    _apply_learned_rules,
+    _build_fee_line_items,
+    _build_override_line_items,
+    _build_tax_line_items,
+    _load_active_learned_rules,
+    _load_applicable_fees,
+    _load_applicable_taxes,
+    _load_overlapping_pricing_overrides,
+    _to_money,
+)
+from backend.services.quote_builder import QuoteBuilderError, build_local_rent_quote
+
+logger = structlog.get_logger()
+router = APIRouter()
+stripe_payments = StripePayments()
+
+TWO_PLACES = Decimal("0.01")
+ONE_HUNDRED = Decimal("100.00")
+EXTRA_GUEST_THRESHOLD = 4
+EXTRA_GUEST_PER_NIGHT = Decimal("25.00")
+PET_DEPOSIT_AMOUNT = Decimal("250.00")
+
+
+def _to_cents(value: Decimal) -> int:
+    """Convert a dollar Decimal to integer cents with half-up rounding."""
+    return int((value * 100).to_integral_value(rounding=ROUND_HALF_UP))
+
+
+_TAX_SNAPSHOT_TTL = 1800  # 30 minutes
+
+
+async def _cache_tax_snapshot(payment_intent_id: str, tax_breakdown: "TaxBreakdown") -> None:
+    """Cache the tax breakdown in Redis so the settlement webhook can persist it."""
+    try:
+        r = aioredis.from_url(settings.redis_url, encoding="utf-8", decode_responses=True)
+        await r.set(
+            f"tax_snapshot:{payment_intent_id}",
+            tax_breakdown.model_dump_json(),
+            ex=_TAX_SNAPSHOT_TTL,
+        )
+        await r.aclose()
+    except Exception:
+        logger.warning("tax_snapshot_cache_failed", pi=payment_intent_id)
+
+
+async def _cache_ledger_line_items(payment_intent_id: str, line_items: list[dict]) -> None:
+    """Cache the Universal Ledger line items so the settlement webhook can persist them."""
+    try:
+        r = aioredis.from_url(settings.redis_url, encoding="utf-8", decode_responses=True)
+        await r.set(
+            f"ledger_items:{payment_intent_id}",
+            json.dumps(line_items),
+            ex=_TAX_SNAPSHOT_TTL,
+        )
+        await r.aclose()
+    except Exception:
+        logger.warning("ledger_items_cache_failed", pi=payment_intent_id)
+
+
+async def retrieve_ledger_line_items(payment_intent_id: str) -> list[dict] | None:
+    """Retrieve cached Universal Ledger line items for a payment intent."""
+    try:
+        r = aioredis.from_url(settings.redis_url, encoding="utf-8", decode_responses=True)
+        raw = await r.get(f"ledger_items:{payment_intent_id}")
+        await r.aclose()
+        if raw:
+            return json.loads(raw)
+    except Exception:
+        logger.warning("ledger_items_retrieve_failed", pi=payment_intent_id)
+    return None
+
+
+async def retrieve_tax_snapshot(payment_intent_id: str) -> dict | None:
+    """Retrieve a cached tax breakdown for a payment intent.
+
+    Called by the Stripe webhook settlement handler to persist the exact
+    tax state from checkout time onto the Reservation row.
+    """
+    try:
+        r = aioredis.from_url(settings.redis_url, encoding="utf-8", decode_responses=True)
+        raw = await r.get(f"tax_snapshot:{payment_intent_id}")
+        await r.aclose()
+        if raw:
+            return json.loads(raw)
+    except Exception:
+        logger.warning("tax_snapshot_retrieve_failed", pi=payment_intent_id)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Pydantic schemas — Universal Ledger
+# ---------------------------------------------------------------------------
+
+
+class StorefrontQuoteRequest(BaseModel):
+    """Incoming quote request from the checkout frontend."""
+    property_id: str
+    arrival_date: date
+    departure_date: date
+    adults: int = Field(ge=1, le=24, default=2)
+    children: int = Field(ge=0, le=24, default=0)
+    pets: int = Field(ge=0, le=10, default=0)
+    selected_add_on_ids: list[str] = Field(default_factory=list)
+    promo_code: str = Field(default="", max_length=50)
+    # Optional booking channel — used to apply channel-specific fee rules
+    # (e.g. VRBO/HA-OLB bookings cap the Processing Fee at $59.95).
+    booking_source: str = Field(default="", max_length=50)
+
+
+class LedgerLineItem(BaseModel):
+    """
+    A single row in the Universal Ledger.
+
+    This is the atomic unit of pricing transparency. Every dollar charged to a
+    guest MUST appear as a LedgerLineItem. The Godhead Swarm's agent_hermes
+    reads these items to verify Legacy-vs-DGX parity — if a fee is missing
+    from this list, Hermes will flag it as a discrepancy.
+
+    Types:
+      - rent: Base nightly accommodation
+      - fee: Mandatory fees (cleaning, extra guest, pet cleaning)
+      - addon: Optional guest-selected add-ons (firewood, early check-in)
+      - tax: Government-mandated lodging taxes
+      - deposit: Refundable security deposits (pet deposit)
+      - discount: AI-learned or promotional adjustments (negative amount)
+
+    Bucket indicates the tax classification (lodging, admin, goods, service, exempt).
+    amount_cents is the dollar amount expressed as integer cents (e.g. $19.99 = 1999).
+    """
+    id: str
+    name: str
+    amount_cents: int
+    is_taxable: bool
+    is_refundable: bool = True
+    refund_policy: str = "full"
+    type: str
+    bucket: str = "lodging"
+
+
+class TaxBreakdownDetail(BaseModel):
+    """Single tax line for the itemized breakdown."""
+    tax_name: str
+    tax_rate: float
+    taxable_base_cents: int
+    amount_cents: int
+    bucket: str
+
+
+class TaxBreakdown(BaseModel):
+    """Itemized tax breakdown by tax authority for FinTech-grade reporting."""
+    state_sales_tax_cents: int
+    county_sales_tax_cents: int
+    lodging_tax_cents: int
+    hospitality_tax_cents: int
+    dot_fee_cents: int
+    total_tax_cents: int
+    county: str
+    details: list[TaxBreakdownDetail]
+
+
+class LedgerSummary(BaseModel):
+    """
+    Aggregated totals for the Universal Ledger.
+
+    All amounts are integer cents. The frontend MUST use grand_total_cents
+    as the authoritative total — never sum line items client-side and never
+    multiply floats by 100. This eliminates IEEE 754 rounding drift.
+    """
+    taxable_subtotal_cents: int
+    tax_amount_cents: int
+    non_taxable_subtotal_cents: int
+    grand_total_cents: int
+    tax_breakdown: TaxBreakdown | None = None
+
+
+class OptionalFeeOption(BaseModel):
+    """An optional fee the guest can opt into (e.g. Early Check-In)."""
+    id: str
+    name: str
+    amount_cents: int
+
+
+class SkippedFeeAudit(BaseModel):
+    """Audit record for an optional fee that was excluded from the quote."""
+    fee_id: str
+    fee_name: str
+    reason: str
+
+
+class DebugAudit(BaseModel):
+    """Diagnostic audit trail attached to every quote for observability."""
+    skipped_optional_fees: list[SkippedFeeAudit] = Field(default_factory=list)
+    selected_optional_fee_ids: list[str] = Field(default_factory=list)
+    processing_fee_base: float = 0.0
+    processing_fee_rate: float = 0.0
+    processing_fee_amount: float = 0.0
+
+
+class StorefrontQuoteResponse(BaseModel):
+    """
+    Universal Ledger quote response.
+
+    This schema is the single source of truth for checkout pricing across:
+      - The cabin-rentals-of-georgia Next.js checkout sidebar
+      - The Fortress storefront SovereignQuoteWidget
+      - The Godhead Swarm agent_hermes LLM forensics engine
+      - The Shadow Router legacy parity auditing pipeline
+
+    Every dollar is represented as a LedgerLineItem with semantic metadata
+    (type, is_taxable) so both human reviewers and AI agents can understand
+    the pricing logic without reverse-engineering math.
+    """
+    property_id: str
+    property_name: str
+    nights: int
+    line_items: list[LedgerLineItem]
+    summary: LedgerSummary
+    is_bookable: bool
+    currency: str = "USD"
+    available_enhancements: list[OptionalFeeOption] = Field(default_factory=list)
+    debug_audit: DebugAudit | None = None
+
+
+# ---------------------------------------------------------------------------
+# Add-on resolution
+# ---------------------------------------------------------------------------
+
+
+async def _resolve_add_ons(
+    db: AsyncSession,
+    property_id: UUID,
+    selected_ids: list[str],
+    nights: int,
+    guests: int,
+) -> list[LedgerLineItem]:
+    if not selected_ids:
+        return []
+
+    uuids: list[UUID] = []
+    for sid in selected_ids:
+        try:
+            uuids.append(UUID(sid))
+        except ValueError:
+            continue
+
+    if not uuids:
+        return []
+
+    stmt = (
+        select(VRSAddOn)
+        .where(VRSAddOn.id.in_(uuids))
+        .where(VRSAddOn.is_active.is_(True))
+        .where(
+            (VRSAddOn.property_id == property_id)
+            | (VRSAddOn.scope == VRSAddOnScope.GLOBAL)
+        )
+    )
+    rows = (await db.execute(stmt)).scalars().all()
+
+    items: list[LedgerLineItem] = []
+    for addon in rows:
+        base = Decimal(str(addon.price))
+        if addon.pricing_model.value == "per_night":
+            amount = _to_money(base * Decimal(nights))
+        elif addon.pricing_model.value == "per_guest":
+            amount = _to_money(base * Decimal(guests))
+        else:
+            amount = _to_money(base)
+
+        cls = classify_item_full("addon", addon.name)
+        items.append(LedgerLineItem(
+            id=str(addon.id),
+            name=addon.name,
+            amount_cents=_to_cents(amount),
+            is_taxable=True,
+            is_refundable=cls.is_refundable,
+            refund_policy=cls.refund_policy,
+            type="addon",
+            bucket=cls.bucket.value,
+        ))
+
+    return items
+
+
+# ---------------------------------------------------------------------------
+# Percentage fee fallback — guarantees fee_type is always read
+# ---------------------------------------------------------------------------
+
+
+async def _load_percentage_fees(db: AsyncSession) -> dict[str, dict]:
+    """Raw SQL lookup for percentage-based fees, bypassing ORM column mapping.
+
+    Returns {fee_id_str: {"fee_type": ..., "percentage_rate": ...}} for any
+    fee whose fee_type = 'percentage'. This ensures the Processing Fee is
+    never silently dropped if the ORM metadata cache is stale.
+    """
+    try:
+        from sqlalchemy import text as sql_text
+        rows = (await db.execute(sql_text(
+            "SELECT id::text, fee_type, percentage_rate "
+            "FROM fees WHERE fee_type = 'percentage' AND percentage_rate IS NOT NULL"
+        ))).fetchall()
+        return {
+            r[0]: {"fee_type": r[1], "percentage_rate": r[2]}
+            for r in rows
+        }
+    except Exception:
+        return {}
+
+
+async def _load_optional_fee_ids(db: AsyncSession) -> set[str]:
+    """Raw SQL lookup for optional fee IDs, bypassing ORM metadata cache.
+
+    This is the authoritative gatekeeper — if a fee's is_optional column is
+    TRUE in the database, it MUST be excluded from the base quote regardless
+    of what the ORM's cached model reports.
+    """
+    try:
+        from sqlalchemy import text as sql_text
+        rows = (await db.execute(sql_text(
+            "SELECT id::text FROM fees WHERE is_optional = true"
+        ))).fetchall()
+        return {r[0] for r in rows}
+    except Exception:
+        return set()
+
+
+# ---------------------------------------------------------------------------
+# Quote endpoint — Universal Ledger
+# ---------------------------------------------------------------------------
+
+
+@router.post("/quote", response_model=StorefrontQuoteResponse)
+async def storefront_quote(
+    payload: StorefrontQuoteRequest,
+    db: AsyncSession = Depends(get_db),
+) -> StorefrontQuoteResponse:
+    prop_filters = []
+    try:
+        prop_filters.append(Property.id == UUID(payload.property_id))
+    except ValueError:
+        pass
+    prop_filters.append(Property.slug == payload.property_id)
+
+    result = await db.execute(select(Property).where(or_(*prop_filters)).limit(1))
+    prop = result.scalars().first()
+    if prop is None:
+        raise HTTPException(status_code=404, detail="Property not found")
+    if not prop.is_active:
+        raise HTTPException(status_code=404, detail="Property is not active")
+
+    property_id: UUID = prop.id
+    nights = (payload.departure_date - payload.arrival_date).days
+    if nights < 1:
+        raise HTTPException(status_code=400, detail="Departure must be after arrival")
+
+    # ── Live Fire Promo Override ──
+    if payload.promo_code == "COMMANDER-LIVE-FIRE":
+        promo_row = (await db.execute(
+            select(LearnedRule)
+            .where(LearnedRule.rule_name == "LIVE_FIRE_PROMO")
+            .where(LearnedRule.status == "active")
+            .limit(1)
+        )).scalars().first()
+        if promo_row is not None:
+            logger.info("live_fire_promo_activated", property=prop.name, nights=nights)
+            return StorefrontQuoteResponse(
+                property_id=str(property_id),
+                property_name=prop.name,
+                nights=nights,
+                line_items=[LedgerLineItem(
+                    id="promo_live_fire",
+                    name=f"Live Fire Test ({nights} nights)",
+                    amount_cents=100,
+                    is_taxable=False,
+                    is_refundable=False,
+                    refund_policy="none",
+                    type="rent",
+                    bucket="exempt",
+                )],
+                summary=LedgerSummary(
+                    taxable_subtotal_cents=0,
+                    tax_amount_cents=0,
+                    non_taxable_subtotal_cents=100,
+                    grand_total_cents=100,
+                ),
+                is_bookable=True,
+            )
+
+    total_guests = payload.adults + payload.children
+    is_bookable = total_guests <= int(prop.max_guests or 0)
+
+    try:
+        rent_quote = await build_local_rent_quote(
+            property_id,
+            payload.arrival_date,
+            payload.departure_date,
+            db,
+        )
+    except QuoteBuilderError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    overrides = await _load_overlapping_pricing_overrides(
+        db, property_id, payload.arrival_date, payload.departure_date,
+    )
+    override_items, override_total = _build_override_line_items(
+        rent_quote.nightly_breakdown, overrides,
+    )
+
+    fees = await _load_applicable_fees(db, property_id)
+    taxes = await _load_applicable_taxes(db, property_id)
+
+    # ── Build the Universal Ledger ──
+    ledger: list[LedgerLineItem] = []
+    taxable_subtotal = Decimal("0.00")
+    non_taxable_subtotal = Decimal("0.00")
+
+    # 1. Base Rent
+    adjusted_rent = _to_money(rent_quote.rent)
+    nightly_avg = (_to_money(rent_quote.rent / Decimal(nights))) if nights else Decimal("0.00")
+    ledger.append(LedgerLineItem(
+        id="base_rent",
+        name=f"Base Rent ({nights} nights @ ${nightly_avg}/night)",
+        amount_cents=_to_cents(adjusted_rent),
+        is_taxable=True,
+        type="rent",
+    ))
+    taxable_subtotal += adjusted_rent
+
+    # 2. Yield overrides
+    for oi in override_items:
+        ledger.append(LedgerLineItem(
+            id=f"override_{oi.description[:20].replace(' ', '_').lower()}",
+            name=oi.description,
+            amount_cents=_to_cents(oi.amount),
+            is_taxable=True,
+            type="discount" if oi.amount < 0 else "fee",
+        ))
+        taxable_subtotal += oi.amount
+
+    # 3. Strict Whitelist fee loop — two-pass architecture.
+    #
+    #    GATEKEEPER RULE: A fee with is_optional=True in the database is
+    #    NEVER included in the base quote.  It only enters the ledger when
+    #    its UUID appears in request.selected_add_on_ids.
+    #
+    #    We read is_optional via raw SQL (_load_optional_fee_ids) to guarantee
+    #    correctness even if the SQLAlchemy metadata cache is stale.
+    #
+    #    Pass 1: flat fees (Cleaning, ADW, Pet, plus any SELECTED optional fees)
+    #    Pass 2: percentage fees (Processing Fee) on expanded base:
+    #            adjusted_rent + included_flat_fees
+    pct_fee_cache = await _load_percentage_fees(db)
+    optional_fee_ids = await _load_optional_fee_ids(db)
+    selected_set = set(payload.selected_add_on_ids)
+
+    flat_fee_total = Decimal("0.00")
+    deferred_pct_fees: list[tuple] = []
+    available_enhancements: list[OptionalFeeOption] = []
+    audit = DebugAudit(selected_optional_fee_ids=list(selected_set & optional_fee_ids))
+
+    for fee in fees:
+        if bool(fee.is_pet_fee) and payload.pets < 1:
+            continue
+
+        # ── HARD INTERCEPT ──────────────────────────────────────────────
+        # Streamline injects "Early Check-In" / "Late Check-Out" as
+        # mandatory line items.  We override that here unconditionally:
+        # these fees are NEVER part of the base quote regardless of what
+        # any database flag says.  They only enter the ledger when the
+        # guest explicitly selects them via selected_add_on_ids.
+        fee_name_lower = (fee.name or "").lower()
+        is_check_in_out = (
+            "check-in" in fee_name_lower
+            or "check-out" in fee_name_lower
+            or "early" in fee_name_lower
+            or "late" in fee_name_lower
+        )
+        if is_check_in_out:
+            try:
+                opt_amount = _to_money(Decimal(str(fee.flat_amount)))
+            except Exception:
+                opt_amount = Decimal("0.00")
+            available_enhancements.append(OptionalFeeOption(
+                id=str(fee.id),
+                name=fee.name,
+                amount_cents=_to_cents(opt_amount),
+            ))
+            if str(fee.id) not in selected_set:
+                audit.skipped_optional_fees.append(SkippedFeeAudit(
+                    fee_id=str(fee.id),
+                    fee_name=fee.name,
+                    reason="hard_intercept: check-in/check-out stripped from base",
+                ))
+                logger.info(
+                    "hard_intercept_stripped_fee",
+                    fee_name=fee.name,
+                    fee_id=str(fee.id),
+                )
+                continue
+            ledger.append(LedgerLineItem(
+                id=f"addon_{fee.id}",
+                name=fee.name,
+                amount_cents=_to_cents(opt_amount),
+                is_taxable=False,
+                is_refundable=False,
+                refund_policy="none",
+                type="addon",
+                bucket="exempt",
+            ))
+            non_taxable_subtotal += opt_amount
+            logger.info(
+                "hard_intercept_guest_selected",
+                fee_name=fee.name,
+                fee_id=str(fee.id),
+                amount=float(opt_amount),
+            )
+            continue
+        # ── END HARD INTERCEPT ──────────────────────────────────────────
+
+        fee_id_str = str(fee.id)
+        is_optional = fee_id_str in optional_fee_ids or getattr(fee, "is_optional", False)
+
+        if is_optional:
+            opt_amount = _to_money(Decimal(str(fee.flat_amount)))
+            available_enhancements.append(OptionalFeeOption(
+                id=fee_id_str,
+                name=fee.name,
+                amount_cents=_to_cents(opt_amount),
+            ))
+            if fee_id_str not in selected_set:
+                audit.skipped_optional_fees.append(SkippedFeeAudit(
+                    fee_id=fee_id_str,
+                    fee_name=fee.name,
+                    reason="not in selected_add_on_ids",
+                ))
+                continue
+
+        fee_type = getattr(fee, "fee_type", None)
+        pct_rate = getattr(fee, "percentage_rate", None)
+
+        if fee_type is None and fee_id_str in pct_fee_cache:
+            fee_type = pct_fee_cache[fee_id_str]["fee_type"]
+            pct_rate = pct_fee_cache[fee_id_str]["percentage_rate"]
+
+        fee_type = fee_type or "flat"
+
+        if fee_type == "percentage" and pct_rate is not None:
+            deferred_pct_fees.append((fee, Decimal(str(pct_rate))))
+            continue
+
+        amount = _to_money(Decimal(str(fee.flat_amount)))
+        if amount == Decimal("0.00"):
+            continue
+        ledger.append(LedgerLineItem(
+            id=f"fee_{fee.id}",
+            name=fee.name,
+            amount_cents=_to_cents(amount),
+            is_taxable=True,
+            type="fee",
+        ))
+        taxable_subtotal += amount
+        flat_fee_total += amount
+
+    # Pass 2 — percentage fees on the expanded base (rent + included flat fees)
+    pct_base = adjusted_rent + flat_fee_total
+    for fee, rate in deferred_pct_fees:
+        amount = _to_money(pct_base * rate / ONE_HUNDRED)
+        if amount == Decimal("0.00"):
+            continue
+        ledger.append(LedgerLineItem(
+            id=f"fee_{fee.id}",
+            name=fee.name,
+            amount_cents=_to_cents(amount),
+            is_taxable=True,
+            type="fee",
+        ))
+        taxable_subtotal += amount
+        audit.processing_fee_base = float(pct_base)
+        audit.processing_fee_rate = float(rate)
+        audit.processing_fee_amount = float(amount)
+
+    # ── HARD FALLBACK: Guarantee Processing Fee exists ──────────────
+    # If the database percentage-fee path above didn't emit one, calculate it
+    # using the two-rule logic:
+    #   Non-VRBO: 6% of (Rent + included flat fees), no cap
+    #   VRBO/HA:  min(6%, $59.95 cap)
+    if audit.processing_fee_amount == 0.0:
+        proc_base = adjusted_rent + flat_fee_total
+        proc_amount = calculate_processing_fee(proc_base, payload.booking_source)
+        if proc_amount > Decimal("0.00"):
+            ledger.append(LedgerLineItem(
+                id="processing_fee_hard",
+                name="Processing Fee",
+                amount_cents=_to_cents(proc_amount),
+                is_taxable=True,
+                type="fee",
+            ))
+            taxable_subtotal += proc_amount
+            audit.processing_fee_base = float(proc_base)
+            audit.processing_fee_rate = float(PROCESSING_FEE_RATE)
+            audit.processing_fee_amount = float(proc_amount)
+            logger.info(
+                "processing_fee_hard_fallback",
+                base=float(proc_base),
+                rate=float(PROCESSING_FEE_RATE),
+                booking_source=payload.booking_source or "direct",
+                amount=float(proc_amount),
+            )
+
+    # 4. Extra Guest Fee (if adults > threshold)
+    if payload.adults > EXTRA_GUEST_THRESHOLD:
+        extra = payload.adults - EXTRA_GUEST_THRESHOLD
+        extra_amount = _to_money(EXTRA_GUEST_PER_NIGHT * Decimal(extra) * Decimal(nights))
+        ledger.append(LedgerLineItem(
+            id="extra_guest_fee",
+            name=f"Extra Guest Fee ({extra} guests × {nights} nights)",
+            amount_cents=_to_cents(extra_amount),
+            is_taxable=True,
+            type="fee",
+        ))
+        taxable_subtotal += extra_amount
+
+    # 5. Optional Add-Ons
+    addon_items = await _resolve_add_ons(
+        db, property_id, payload.selected_add_on_ids, nights, total_guests,
+    )
+    for addon in addon_items:
+        ledger.append(addon)
+        addon_dollars = Decimal(addon.amount_cents) / Decimal(100)
+        if addon.is_taxable:
+            taxable_subtotal += addon_dollars
+        else:
+            non_taxable_subtotal += addon_dollars
+
+    # 6. Godhead Phase 3 — AI Learned Rules
+    learned_rules = await _load_active_learned_rules(db, property_id)
+    days_to_arrival = (payload.arrival_date - date.today()).days
+    rule_context = {
+        "days_to_arrival": days_to_arrival,
+        "nights": nights,
+        "guests": total_guests,
+        "adults": payload.adults,
+        "children": payload.children,
+        "pets": payload.pets,
+    }
+    from backend.models.pricing import QuoteLineItem
+    learned_ql, learned_adj = _apply_learned_rules(learned_rules, taxable_subtotal, rule_context)
+    for lqi in learned_ql:
+        ledger.append(LedgerLineItem(
+            id=f"learned_{lqi.description[:30].replace(' ', '_').lower()}",
+            name=lqi.description,
+            amount_cents=_to_cents(lqi.amount),
+            is_taxable=True,
+            type=lqi.type,
+        ))
+        taxable_subtotal += lqi.amount
+
+    # 7. Taxes — Multi-Bucket Ledger Resolver
+    taxable_subtotal = _to_money(taxable_subtotal)
+
+    bucketed_items: list[BucketedItem] = []
+    for li in ledger:
+        cls = classify_item_full(li.type, li.name)
+        li.bucket = cls.bucket.value
+        li.is_refundable = cls.is_refundable
+        li.refund_policy = cls.refund_policy
+        bucketed_items.append(BucketedItem(
+            name=li.name,
+            amount=Decimal(li.amount_cents) / Decimal(100),
+            item_type=li.type,
+            bucket=cls.bucket,
+        ))
+
+    county_name: str | None = getattr(prop, "county", None)
+    tax_result: LedgerTaxBreakdown = resolve_taxes(bucketed_items, county_name, nights)
+    total_tax = tax_result.total_tax
+
+    for detail in tax_result.details:
+        if detail.amount == Decimal("0.00"):
+            continue
+        ledger.append(LedgerLineItem(
+            id=f"tax_{detail.tax_name[:30].replace(' ', '_').lower()}",
+            name=detail.tax_name,
+            amount_cents=_to_cents(detail.amount),
+            is_taxable=False,
+            is_refundable=False,
+            refund_policy="follows_base",
+            type="tax",
+            bucket="tax",
+        ))
+
+    resolved_county = (county_name or "Fannin").strip().title()
+    tax_breakdown = TaxBreakdown(
+        state_sales_tax_cents=_to_cents(tax_result.state_sales_tax),
+        county_sales_tax_cents=_to_cents(tax_result.county_sales_tax),
+        lodging_tax_cents=_to_cents(tax_result.lodging_tax),
+        hospitality_tax_cents=_to_cents(tax_result.hospitality_tax),
+        dot_fee_cents=_to_cents(tax_result.dot_fee),
+        total_tax_cents=_to_cents(tax_result.total_tax),
+        county=resolved_county,
+        details=[
+            TaxBreakdownDetail(
+                tax_name=d.tax_name,
+                tax_rate=float(d.tax_rate),
+                taxable_base_cents=_to_cents(d.taxable_base),
+                amount_cents=_to_cents(d.amount),
+                bucket=d.bucket.value,
+            )
+            for d in tax_result.details
+            if d.amount > Decimal("0.00")
+        ],
+    )
+
+    # 8. Pet Deposit (non-taxable, refundable)
+    if payload.pets > 0:
+        ledger.append(LedgerLineItem(
+            id="pet_deposit",
+            name="Refundable Pet Deposit",
+            amount_cents=_to_cents(PET_DEPOSIT_AMOUNT),
+            is_taxable=False,
+            is_refundable=True,
+            refund_policy="full",
+            type="deposit",
+            bucket="exempt",
+        ))
+        non_taxable_subtotal += PET_DEPOSIT_AMOUNT
+
+    non_taxable_subtotal = _to_money(non_taxable_subtotal)
+    grand_total = _to_money(taxable_subtotal + total_tax + non_taxable_subtotal)
+
+    logger.info(
+        "storefront_quote_generated",
+        property=prop.name,
+        nights=nights,
+        line_item_count=len(ledger),
+        grand_total=float(grand_total),
+    )
+
+    return StorefrontQuoteResponse(
+        property_id=str(property_id),
+        property_name=prop.name,
+        nights=nights,
+        line_items=ledger,
+        summary=LedgerSummary(
+            taxable_subtotal_cents=_to_cents(taxable_subtotal),
+            tax_amount_cents=_to_cents(total_tax),
+            non_taxable_subtotal_cents=_to_cents(non_taxable_subtotal),
+            grand_total_cents=_to_cents(grand_total),
+            tax_breakdown=tax_breakdown,
+        ),
+        available_enhancements=available_enhancements,
+        debug_audit=audit,
+        is_bookable=is_bookable,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Checkout (Stripe PaymentIntent) — now uses Universal Ledger internally
+# ---------------------------------------------------------------------------
+
+
+class CheckoutPayload(BaseModel):
+    property_id: str
+    arrival_date: date
+    departure_date: date
+    adults: int = Field(ge=1, le=24, default=2)
+    children: int = Field(ge=0, le=24, default=0)
+    pets: int = Field(ge=0, le=10, default=0)
+    selected_add_on_ids: list[str] = Field(default_factory=list)
+    promo_code: str = Field(default="", max_length=50)
+    total_cents: int | None = None
+    first_name: str = Field(min_length=1, max_length=100)
+    last_name: str = Field(min_length=1, max_length=100)
+    email: EmailStr
+    phone: str = Field(min_length=7, max_length=20)
+    address: str = Field(max_length=255, default="")
+    city: str = Field(max_length=100, default="")
+    state: str = Field(max_length=50, default="")
+    zip_code: str = Field(max_length=20, default="")
+
+
+class CheckoutResponse(BaseModel):
+    status: str
+    client_secret: str
+    payment_intent_id: str
+    amount_cents: int
+    property_name: str
+    nights: int
+
+
+@router.post("/process", response_model=CheckoutResponse)
+async def process_checkout(
+    payload: CheckoutPayload,
+    db: AsyncSession = Depends(get_db),
+) -> CheckoutResponse:
+    quote_req = StorefrontQuoteRequest(
+        property_id=payload.property_id,
+        arrival_date=payload.arrival_date,
+        departure_date=payload.departure_date,
+        adults=payload.adults,
+        children=payload.children,
+        pets=payload.pets,
+        selected_add_on_ids=payload.selected_add_on_ids,
+        promo_code=payload.promo_code,
+    )
+    ledger_quote = await storefront_quote(quote_req, db)
+    amount_cents = ledger_quote.summary.grand_total_cents
+
+    if amount_cents < 100:
+        raise HTTPException(status_code=422, detail="Quote total is below minimum")
+
+    guest_name = f"{payload.first_name} {payload.last_name}"
+
+    logger.info(
+        "storefront_checkout_initiated",
+        property=ledger_quote.property_name,
+        guest=guest_name,
+        email=payload.email,
+        nights=ledger_quote.nights,
+        amount_cents=amount_cents,
+    )
+
+    try:
+        intent = await stripe_payments.create_payment_intent(
+            amount_cents=amount_cents,
+            reservation_id=f"STOREFRONT-{payload.property_id}-{payload.arrival_date}",
+            guest_email=payload.email,
+            guest_name=guest_name,
+            property_name=ledger_quote.property_name,
+            extra_metadata={
+                "property_id": ledger_quote.property_id,
+                "arrival": str(payload.arrival_date),
+                "departure": str(payload.departure_date),
+                "adults": str(payload.adults),
+                "children": str(payload.children),
+                "pets": str(payload.pets),
+                "phone": payload.phone,
+                "source": "storefront_checkout",
+            },
+        )
+    except Exception as e:
+        logger.error("stripe_payment_intent_failed", error=str(e))
+        raise HTTPException(status_code=502, detail="Payment processing unavailable")
+
+    if ledger_quote.summary.tax_breakdown:
+        await _cache_tax_snapshot(
+            intent["payment_intent_id"],
+            ledger_quote.summary.tax_breakdown,
+        )
+
+    await _cache_ledger_line_items(
+        intent["payment_intent_id"],
+        [li.model_dump() for li in ledger_quote.line_items],
+    )
+
+    return CheckoutResponse(
+        status="payment_intent_created",
+        client_secret=intent["client_secret"],
+        payment_intent_id=intent["payment_intent_id"],
+        amount_cents=amount_cents,
+        property_name=ledger_quote.property_name,
+        nights=ledger_quote.nights,
+    )
+
+
+@router.get("/stripe-key")
+async def get_storefront_stripe_key() -> dict:
+    key = settings.stripe_publishable_key
+    if not key:
+        raise HTTPException(503, "Stripe is not configured")
+    return {"publishable_key": key}
+
+
+@router.get("/addons")
+async def get_property_addons(
+    property_id: str,
+    db: AsyncSession = Depends(get_db),
+) -> list[dict]:
+    prop_uuid: UUID | None = None
+    try:
+        prop_uuid = UUID(property_id)
+    except ValueError:
+        result = await db.execute(
+            select(Property).where(Property.slug == property_id).limit(1)
+        )
+        prop = result.scalars().first()
+        if prop:
+            prop_uuid = prop.id
+
+    if prop_uuid is None:
+        return []
+
+    stmt = (
+        select(VRSAddOn)
+        .where(VRSAddOn.is_active.is_(True))
+        .where(
+            (VRSAddOn.property_id == prop_uuid)
+            | (VRSAddOn.scope == VRSAddOnScope.GLOBAL)
+        )
+        .order_by(VRSAddOn.name)
+    )
+    rows = (await db.execute(stmt)).scalars().all()
+
+    return [
+        {
+            "id": str(addon.id),
+            "name": addon.name,
+            "description": addon.description or "",
+            "price": float(addon.price),
+            "pricing_model": addon.pricing_model.value if addon.pricing_model else "flat_fee",
+            "scope": addon.scope.value if addon.scope else "global",
+        }
+        for addon in rows
+    ]
+
+
+class ConfirmationResponse(BaseModel):
+    status: str
+    confirmation_code: str | None = None
+    property_name: str | None = None
+    check_in: str | None = None
+    check_out: str | None = None
+    nights: int | None = None
+    guest_name: str | None = None
+    total_amount: float | None = None
+    payment_intent_id: str
+
+
+@router.get("/confirmation/{payment_intent_id}", response_model=ConfirmationResponse)
+async def get_confirmation(
+    payment_intent_id: str,
+    db: AsyncSession = Depends(get_db),
+) -> ConfirmationResponse:
+    from sqlalchemy import text as sql_text
+    from backend.models.reservation import Reservation
+    from backend.models.property import Property as Prop
+
+    row = await db.execute(
+        sql_text(
+            "SELECT id, confirmation_code, property_id, check_in_date, check_out_date, "
+            "guest_name, total_amount, status "
+            "FROM reservations "
+            "WHERE price_breakdown->>'stripe_payment_intent_id' = :pi "
+            "LIMIT 1"
+        ),
+        {"pi": payment_intent_id},
+    )
+    res = row.fetchone()
+
+    if res is None:
+        stripe_client = StripePayments()
+        try:
+            pi_status = stripe_client.retrieve_payment_intent_status(payment_intent_id)
+        except Exception:
+            pi_status = "unknown"
+
+        return ConfirmationResponse(
+            status=f"processing ({pi_status})",
+            payment_intent_id=payment_intent_id,
+        )
+
+    prop = await db.get(Prop, res.property_id)
+    nights = (res.check_out_date - res.check_in_date).days if res.check_in_date and res.check_out_date else None
+
+    return ConfirmationResponse(
+        status=res.status,
+        confirmation_code=res.confirmation_code,
+        property_name=prop.name if prop else None,
+        check_in=res.check_in_date.isoformat() if res.check_in_date else None,
+        check_out=res.check_out_date.isoformat() if res.check_out_date else None,
+        nights=nights,
+        guest_name=res.guest_name,
+        total_amount=float(res.total_amount) if res.total_amount else None,
+        payment_intent_id=payment_intent_id,
+    )

--- a/fortress-guest-platform/backend/api/stripe_webhooks.py
+++ b/fortress-guest-platform/backend/api/stripe_webhooks.py
@@ -74,7 +74,9 @@ async def stripe_webhook(
     if event_type == "payment_intent.succeeded":
         obj = event["data"]["object"]
         metadata = obj.get("metadata") or {}
-        if metadata.get("source") == "direct_booking_hold":
+        source = metadata.get("source", "")
+
+        if source == "direct_booking_hold":
             payment_intent_id = str(obj.get("id") or "").strip()
             meta_hold = metadata.get("hold_id") or metadata.get("reservation_hold_id")
             meta_hold = str(meta_hold).strip() if meta_hold else None
@@ -150,6 +152,15 @@ async def stripe_webhook(
                 )
             return {"status": "ok", "event_type": event_type}
 
+        if source == "storefront_checkout":
+            await _process_storefront_settlement(obj, metadata, db)
+            return {"status": "ok", "event_type": event_type}
+
+    if event_type == "invoice.paid":
+        invoice_obj = event["data"]["object"]
+        await _process_invoice_paid(invoice_obj, db)
+        return {"status": "ok", "event_type": event_type}
+
     if event_type == "checkout.session.completed":
         session = event["data"]["object"]
 
@@ -205,6 +216,130 @@ async def _process_guest_quote_payment(
             "guest_quote_webhook_processing_failed",
             guest_quote_id=guest_quote_id,
             error=str(exc)[:300],
+        )
+
+
+async def _process_invoice_paid(
+    invoice_obj: dict,
+    db: AsyncSession,
+) -> None:
+    """
+    Handle ``invoice.paid`` — clear the Accounts Receivable trust entry
+    for a FinancialApproval invoice and stamp an immutable audit trail.
+
+    Idempotent: skips if the approval is not in ``approved`` status or
+    if the ``context_payload`` already contains a ``payment_cleared_at``
+    timestamp.
+    """
+    from datetime import datetime, timezone
+
+    from sqlalchemy import select
+
+    from backend.models.financial_approval import FinancialApproval
+    from backend.services.trust_ledger import post_invoice_clearing_entry
+
+    stripe_invoice_id = str(invoice_obj.get("id", "")).strip()
+    if not stripe_invoice_id:
+        return
+
+    metadata = invoice_obj.get("metadata") or {}
+    source = metadata.get("source", "")
+    if source != "financial_approval_invoice":
+        return
+
+    try:
+        result = await db.execute(
+            select(FinancialApproval).where(
+                FinancialApproval.stripe_invoice_id == stripe_invoice_id,
+            )
+        )
+        approval = result.scalars().first()
+
+        if approval is None:
+            approval_id_from_meta = metadata.get("approval_id", "")
+            if approval_id_from_meta:
+                from uuid import UUID
+
+                result = await db.execute(
+                    select(FinancialApproval).where(
+                        FinancialApproval.id == UUID(approval_id_from_meta),
+                    )
+                )
+                approval = result.scalars().first()
+
+        if approval is None:
+            logger.warning(
+                "invoice_paid_approval_not_found",
+                stripe_invoice_id=stripe_invoice_id,
+                metadata=metadata,
+            )
+            return
+
+        existing_ctx = approval.context_payload or {}
+        if existing_ctx.get("payment_cleared_at"):
+            logger.info(
+                "invoice_paid_already_cleared",
+                stripe_invoice_id=stripe_invoice_id,
+                approval_id=str(approval.id),
+            )
+            return
+
+        amount_paid_cents = int(invoice_obj.get("amount_paid", 0))
+        if amount_paid_cents <= 0:
+            logger.warning(
+                "invoice_paid_zero_amount",
+                stripe_invoice_id=stripe_invoice_id,
+                approval_id=str(approval.id),
+            )
+            return
+
+        await post_invoice_clearing_entry(
+            db,
+            amount_cents=amount_paid_cents,
+            stripe_invoice_id=stripe_invoice_id,
+        )
+
+        now = datetime.now(timezone.utc)
+        receipt_url = str(
+            invoice_obj.get("hosted_invoice_url")
+            or invoice_obj.get("invoice_pdf")
+            or ""
+        )
+        charge_id = ""
+        charge_obj = invoice_obj.get("charge")
+        if isinstance(charge_obj, str):
+            charge_id = charge_obj
+        elif isinstance(charge_obj, dict):
+            charge_id = charge_obj.get("id", "")
+
+        updated_ctx = {
+            **existing_ctx,
+            "payment_cleared_at": now.isoformat(),
+            "payment_amount_cents": amount_paid_cents,
+            "stripe_receipt_url": receipt_url,
+            "stripe_charge_id": charge_id,
+            "stripe_invoice_status": str(invoice_obj.get("status", "")),
+            "cleared_by": "stripe_invoice_paid_webhook",
+        }
+        approval.context_payload = updated_ctx
+
+        await db.commit()
+
+        logger.info(
+            "invoice_paid_ledger_cleared",
+            approval_id=str(approval.id),
+            stripe_invoice_id=stripe_invoice_id,
+            amount_paid_cents=amount_paid_cents,
+            reservation_id=approval.reservation_id,
+            receipt_url=receipt_url,
+        )
+
+    except Exception as exc:
+        await db.rollback()
+        logger.error(
+            "invoice_paid_processing_failed",
+            stripe_invoice_id=stripe_invoice_id,
+            error=str(exc)[:400],
         )
 
 
@@ -400,3 +535,250 @@ async def _process_capital_call_funding(
             staging_id=staging_id,
             error=str(exc),
         )
+
+
+# ---------------------------------------------------------------------------
+# Storefront Checkout → Reservation + Streamline Write-Back
+# ---------------------------------------------------------------------------
+
+
+async def _process_storefront_settlement(
+    payment_object: dict,
+    metadata: dict,
+    db: AsyncSession,
+) -> None:
+    """
+    Handle payment_intent.succeeded for storefront_checkout source.
+
+    1. Find-or-create the Guest record
+    2. Create a confirmed Reservation via ReservationEngine
+    3. Optionally bridge to Streamline if settlement bridge is enabled
+    """
+    from datetime import date as date_type
+    from decimal import Decimal
+    from uuid import UUID
+
+    from sqlalchemy import select
+
+    from backend.models.guest import Guest
+    from backend.services.reservation_engine import ReservationEngine
+
+    payment_intent_id = str(payment_object.get("id", "")).strip()
+    amount_cents = int(payment_object.get("amount_received") or payment_object.get("amount", 0))
+    guest_email = metadata.get("guest_email", "").strip()
+    guest_name = metadata.get("guest_name", "").strip()
+    phone = metadata.get("phone", "").strip()
+    property_id_str = metadata.get("property_id", "").strip()
+    arrival_str = metadata.get("arrival", "")
+    departure_str = metadata.get("departure", "")
+    adults = int(metadata.get("adults", 2))
+    children = int(metadata.get("children", 0))
+    pets = int(metadata.get("pets", 0))
+
+    if not property_id_str or not arrival_str or not departure_str:
+        logger.warning(
+            "storefront_settlement_missing_metadata",
+            payment_intent_id=payment_intent_id,
+            metadata=metadata,
+        )
+        return
+
+    property_id = UUID(property_id_str)
+    check_in = date_type.fromisoformat(arrival_str)
+    check_out = date_type.fromisoformat(departure_str)
+
+    existing = await db.execute(
+        text(
+            "SELECT id FROM reservations "
+            "WHERE price_breakdown->>'stripe_payment_intent_id' = :pi "
+            "LIMIT 1"
+        ),
+        {"pi": payment_intent_id},
+    )
+    if existing.scalar() is not None:
+        logger.info(
+            "storefront_settlement_already_processed",
+            payment_intent_id=payment_intent_id,
+        )
+        return
+
+    guest_result = await db.execute(
+        select(Guest).where(Guest.email == guest_email).limit(1)
+    )
+    guest = guest_result.scalars().first()
+
+    if guest is None:
+        name_parts = guest_name.split(" ", 1)
+        guest = Guest(
+            first_name=name_parts[0] if name_parts else "Guest",
+            last_name=name_parts[1] if len(name_parts) > 1 else "",
+            email=guest_email or f"storefront-{payment_intent_id[:8]}@placeholder.local",
+            phone_number=phone or "0000000000",
+        )
+        db.add(guest)
+        await db.flush()
+        logger.info(
+            "storefront_guest_created",
+            guest_id=str(guest.id),
+            email=guest_email,
+        )
+
+    total_amount = Decimal(str(amount_cents)) / Decimal("100")
+
+    engine = ReservationEngine()
+    try:
+        reservation = await engine.create_reservation(
+            db,
+            data={
+                "guest_id": guest.id,
+                "property_id": property_id,
+                "check_in_date": check_in,
+                "check_out_date": check_out,
+                "num_guests": adults + children,
+                "num_adults": adults,
+                "num_children": children,
+                "num_pets": pets,
+                "booking_source": "storefront_checkout",
+                "total_amount": total_amount,
+                "paid_amount": total_amount,
+                "balance_due": Decimal("0.00"),
+                "currency": "USD",
+                "internal_notes": f"Stripe PI: {payment_intent_id}",
+            },
+        )
+    except ValueError as exc:
+        logger.error(
+            "storefront_reservation_creation_failed",
+            payment_intent_id=payment_intent_id,
+            error=str(exc),
+        )
+        return
+
+    reservation.guest_email = guest_email
+    reservation.guest_name = guest_name
+    reservation.guest_phone = phone
+    reservation.price_breakdown = {
+        "stripe_payment_intent_id": payment_intent_id,
+        "amount_cents": amount_cents,
+        "source": "storefront_checkout",
+    }
+
+    from backend.api.storefront_checkout import retrieve_ledger_line_items, retrieve_tax_snapshot
+
+    tax_snap = await retrieve_tax_snapshot(payment_intent_id)
+    if tax_snap:
+        reservation.tax_breakdown = tax_snap
+        logger.info(
+            "tax_breakdown_persisted",
+            reservation_id=str(reservation.id),
+            payment_intent_id=payment_intent_id,
+        )
+
+    cached_items = await retrieve_ledger_line_items(payment_intent_id)
+    if cached_items:
+        reservation.price_breakdown = {
+            "stripe_payment_intent_id": payment_intent_id,
+            "amount_cents": amount_cents,
+            "source": "storefront_checkout",
+            "line_items": cached_items,
+        }
+        logger.info(
+            "ledger_line_items_persisted",
+            reservation_id=str(reservation.id),
+            item_count=len(cached_items),
+        )
+
+    reservation.security_deposit_required = pets > 0
+    if pets > 0:
+        reservation.security_deposit_amount = Decimal("250.00")
+        reservation.security_deposit_status = "pending"
+
+    from backend.services.trust_ledger import post_checkout_trust_entry
+
+    try:
+        await post_checkout_trust_entry(
+            db,
+            reservation_id=str(reservation.id),
+            amount_cents=amount_cents,
+            stripe_pi_id=payment_intent_id,
+        )
+        logger.info(
+            "trust_ledger_entry_posted",
+            reservation_id=str(reservation.id),
+            amount_cents=amount_cents,
+        )
+    except Exception as exc:
+        logger.warning(
+            "trust_ledger_entry_failed",
+            reservation_id=str(reservation.id),
+            error=str(exc)[:300],
+        )
+
+    await db.commit()
+
+    logger.info(
+        "storefront_reservation_confirmed",
+        payment_intent_id=payment_intent_id,
+        reservation_id=str(reservation.id),
+        confirmation_code=reservation.confirmation_code,
+        property_id=str(property_id),
+        total_amount=float(total_amount),
+    )
+
+    if settings.streamline_sovereign_bridge_settlement_enabled:
+        from backend.services.sovereign_inventory_manager import (
+            sovereign_inventory_manager,
+        )
+
+        try:
+            bridge = await sovereign_inventory_manager.finalize_legacy_reservation(
+                db,
+                reservation_id=reservation.id,
+                stripe_payment_intent_id=payment_intent_id,
+            )
+            logger.info(
+                "storefront_legacy_sync_attempt",
+                reservation_id=str(reservation.id),
+                legacy_notified=bridge.legacy_notified,
+                detail=bridge.detail,
+            )
+        except Exception as exc:
+            logger.warning(
+                "storefront_legacy_sync_deferred",
+                reservation_id=str(reservation.id),
+                error=str(exc)[:300],
+            )
+            qid = await sovereign_inventory_manager.queue_strike20_settlement_for_reconciliation(
+                db,
+                reservation_id=reservation.id,
+                stripe_payment_intent_id=payment_intent_id,
+                failure_reason=str(exc)[:500],
+            )
+            if qid > 0:
+                logger.info(
+                    "storefront_settlement_replay_queued",
+                    deferred_api_write_id=qid,
+                    reservation_id=str(reservation.id),
+                )
+
+            from backend.models.pending_sync import PendingSync
+            pending = PendingSync(
+                reservation_id=reservation.id,
+                property_id=property_id,
+                sync_type="create_reservation",
+                status="pending",
+                payload={
+                    "confirmation_code": reservation.confirmation_code,
+                    "stripe_payment_intent_id": payment_intent_id,
+                    "guest_email": guest_email,
+                    "check_in": str(check_in),
+                    "check_out": str(check_out),
+                    "amount_cents": amount_cents,
+                },
+            )
+            db.add(pending)
+            await db.commit()
+            logger.info(
+                "hermes_pending_sync_buffered",
+                reservation_id=str(reservation.id),
+            )

--- a/fortress-guest-platform/backend/api/telemetry.py
+++ b/fortress-guest-platform/backend/api/telemetry.py
@@ -1181,6 +1181,146 @@ async def trigger_semrush_parity_observation(
 
 
 # ---------------------------------------------------------------------------
+# Checkout Parity Console — live parity_audits feed for Step 1 Telemetry Launch
+# ---------------------------------------------------------------------------
+
+class CheckoutParityAuditRow(BaseModel):
+    id: str
+    reservation_id: str
+    confirmation_id: str
+    local_total: float
+    streamline_total: float
+    delta: float
+    status: str
+    local_breakdown: dict = Field(default_factory=dict)
+    streamline_breakdown: dict = Field(default_factory=dict)
+    created_at: datetime | None = None
+
+
+class RevenueSplitSummary(BaseModel):
+    total_rent: float = 0.0
+    total_fees: float = 0.0
+    total_taxes: float = 0.0
+    total_deposits: float = 0.0
+    commissionable_total: float = 0.0
+    pass_through_total: float = 0.0
+
+
+class CheckoutParityPayload(BaseModel):
+    consecutive_confirmed: int
+    total_confirmed: int
+    total_discrepancy: int
+    target_gate: int = 100
+    gate_progress_pct: float
+    hermes_mode: str
+    recent_audits: list[CheckoutParityAuditRow]
+    revenue_split: RevenueSplitSummary
+    last_audit_at: datetime | None = None
+    system_status: str
+
+
+@router.get("/checkout-parity")
+async def checkout_parity_console(
+    _: StaffUser = Depends(RoleChecker([StaffRole.SUPER_ADMIN, StaffRole.MANAGER, StaffRole.REVIEWER])),
+    db: AsyncSession = Depends(get_db),
+    limit: int = 50,
+) -> CheckoutParityPayload:
+    from backend.models.parity_audit import ParityAudit
+
+    recent_q = (
+        select(ParityAudit)
+        .order_by(desc(ParityAudit.created_at))
+        .limit(limit)
+    )
+    result = await db.execute(recent_q)
+    rows = result.scalars().all()
+
+    total_q = select(
+        func.count().filter(ParityAudit.status == "confirmed").label("confirmed"),
+        func.count().filter(ParityAudit.status == "discrepancy").label("discrepancy"),
+    )
+    counts = (await db.execute(total_q)).one()
+    total_confirmed = counts.confirmed or 0
+    total_discrepancy = counts.discrepancy or 0
+
+    consecutive = 0
+    if rows:
+        for row in rows:
+            if row.status == "confirmed":
+                consecutive += 1
+            else:
+                break
+
+    rent_total = 0.0
+    fee_total = 0.0
+    tax_total = 0.0
+    deposit_total = 0.0
+    for row in rows:
+        breakdown = row.local_breakdown or {}
+        for item in breakdown.get("items", []):
+            item_type = (item.get("fee_type") or item.get("type") or "").lower()
+            amount = float(item.get("amount", 0))
+            if item_type == "rent":
+                rent_total += amount
+            elif item_type == "tax":
+                tax_total += amount
+            elif item_type == "deposit":
+                deposit_total += amount
+            else:
+                fee_total += amount
+
+    commissionable = rent_total
+    pass_through = fee_total + tax_total + deposit_total
+
+    gate_pct = min(100.0, (consecutive / 100) * 100) if consecutive >= 0 else 0.0
+    hermes_mode = "READ_ONLY" if not getattr(settings, "HERMES_EXECUTOR_ENABLED", False) else "EXECUTOR"
+
+    if total_discrepancy == 0 and total_confirmed > 0:
+        system_status = "NOMINAL"
+    elif total_discrepancy > 0 and consecutive >= 10:
+        system_status = "RECOVERING"
+    elif total_discrepancy > 0:
+        system_status = "ALERT"
+    else:
+        system_status = "AWAITING_DATA"
+
+    recent_audits = [
+        CheckoutParityAuditRow(
+            id=str(r.id),
+            reservation_id=str(r.reservation_id),
+            confirmation_id=r.confirmation_id,
+            local_total=float(r.local_total),
+            streamline_total=float(r.streamline_total),
+            delta=float(r.delta),
+            status=r.status,
+            local_breakdown=r.local_breakdown or {},
+            streamline_breakdown=r.streamline_breakdown or {},
+            created_at=r.created_at,
+        )
+        for r in rows
+    ]
+
+    return CheckoutParityPayload(
+        consecutive_confirmed=consecutive,
+        total_confirmed=total_confirmed,
+        total_discrepancy=total_discrepancy,
+        gate_progress_pct=gate_pct,
+        hermes_mode=hermes_mode,
+        recent_audits=recent_audits,
+        revenue_split=RevenueSplitSummary(
+            total_rent=round(rent_total, 2),
+            total_fees=round(fee_total, 2),
+            total_taxes=round(tax_total, 2),
+            total_deposits=round(deposit_total, 2),
+            commissionable_total=round(commissionable, 2),
+            pass_through_total=round(pass_through, 2),
+        ),
+        last_audit_at=rows[0].created_at if rows else None,
+        system_status=system_status,
+    )
+
+
+# ---------------------------------------------------------------------------
 # WebSocket: 1 Hz system health stream for Command Center (same payload as REST)
 # ---------------------------------------------------------------------------
 _SYSTEM_HEALTH_WS_INTERVAL_SEC = 1.0

--- a/fortress-guest-platform/backend/api/trust_ledger_command_center.py
+++ b/fortress-guest-platform/backend/api/trust_ledger_command_center.py
@@ -1,0 +1,72 @@
+"""Read-only NeMo Command Center aggregates for sovereign trust ledger monitoring."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload, selectinload
+
+from backend.api.command_c2 import PULSE_ACCESS
+from backend.core.database import get_db
+from backend.models.staff import StaffUser
+from backend.models.trust_ledger import TrustLedgerEntry, TrustTransaction
+from backend.workers.hermes_daily_auditor import verify_hash_chain
+
+router = APIRouter()
+
+
+@router.get("/")
+async def trust_ledger_command_center(
+    _: StaffUser = Depends(PULSE_ACCESS),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """
+    Hash-chain health (Hermes verifier) plus the 50 most recent trust transactions
+    with ledger entry summaries for the Command Center dashboard.
+    """
+    hash_chain = await verify_hash_chain(db)
+
+    count_stmt = select(func.count()).select_from(TrustTransaction)
+    total_result = await db.execute(count_stmt)
+    total_transaction_count = int(total_result.scalar_one() or 0)
+
+    stmt = (
+        select(TrustTransaction)
+        .options(
+            selectinload(TrustTransaction.entries).joinedload(TrustLedgerEntry.account),
+        )
+        .order_by(TrustTransaction.timestamp.desc())
+        .limit(50)
+    )
+    result = await db.execute(stmt)
+    rows = result.scalars().unique().all()
+
+    transactions: list[dict] = []
+    for txn in rows:
+        entry_payloads: list[dict] = []
+        for ent in txn.entries:
+            acct = ent.account
+            entry_payloads.append(
+                {
+                    "account_name": acct.name if acct is not None else "?",
+                    "amount_cents": ent.amount_cents,
+                    "entry_type": ent.entry_type.value,
+                }
+            )
+        transactions.append(
+            {
+                "id": str(txn.id),
+                "streamline_event_id": txn.streamline_event_id,
+                "timestamp": txn.timestamp.isoformat(),
+                "signature": txn.signature,
+                "previous_signature": txn.previous_signature,
+                "entries": entry_payloads,
+            }
+        )
+
+    return {
+        "hash_chain": hash_chain,
+        "transactions": transactions,
+        "total_transaction_count": total_transaction_count,
+    }

--- a/fortress-guest-platform/backend/integrations/stripe_payments.py
+++ b/fortress-guest-platform/backend/integrations/stripe_payments.py
@@ -85,6 +85,115 @@ class StripePayments:
         intent = stripe.PaymentIntent.retrieve(payment_intent_id)
         return str(getattr(intent, "status", "") or "")
 
+    async def create_deposit_intent(
+        self,
+        customer_id: str,
+        amount_cents: int,
+        reservation_id: str,
+        description: str,
+    ) -> dict:
+        """
+        Create a manual-capture PaymentIntent for a security deposit hold.
+        The card is authorized (hold placed) but NOT charged until capture_deposit_intent().
+        setup_future_usage saves the payment method for subsequent off-session charges.
+        """
+        self._require_configured()
+        intent = stripe.PaymentIntent.create(
+            amount=amount_cents,
+            currency="usd",
+            customer=customer_id,
+            capture_method="manual",
+            setup_future_usage="off_session",
+            payment_method_types=["card"],
+            description=description,
+            metadata={
+                "reservation_id": reservation_id,
+                "purpose": "security_deposit",
+                "source": "fortress_deposit_flow",
+            },
+        )
+        logger.info(
+            "stripe_deposit_intent_created",
+            intent_id=intent.id,
+            amount_cents=amount_cents,
+            reservation_id=reservation_id,
+        )
+        return {
+            "payment_intent_id": intent.id,
+            "client_secret": intent.client_secret,
+            "status": intent.status,
+            "amount_cents": amount_cents,
+        }
+
+    async def capture_deposit_intent(self, payment_intent_id: str) -> dict:
+        """Capture an authorized deposit hold — charges the guest's card."""
+        self._require_configured()
+        intent = stripe.PaymentIntent.capture(payment_intent_id)
+        logger.info(
+            "stripe_deposit_captured",
+            intent_id=intent.id,
+            status=intent.status,
+            amount_received=intent.amount_received,
+        )
+        return {
+            "payment_intent_id": intent.id,
+            "status": intent.status,
+            "amount_captured": intent.amount_received,
+        }
+
+    async def cancel_deposit_intent(self, payment_intent_id: str) -> dict:
+        """Cancel an authorized deposit hold — releases the hold with no charge."""
+        self._require_configured()
+        intent = stripe.PaymentIntent.cancel(payment_intent_id)
+        logger.info(
+            "stripe_deposit_released",
+            intent_id=intent.id,
+            status=intent.status,
+        )
+        return {
+            "payment_intent_id": intent.id,
+            "status": intent.status,
+        }
+
+    async def charge_off_session(
+        self,
+        customer_id: str,
+        amount_cents: int,
+        description: str,
+        metadata: dict | None = None,
+    ) -> dict:
+        """
+        Create and immediately confirm a PaymentIntent off-session using the
+        customer's default saved payment method. Used for damage claim charges.
+        Returns payment_intent_id, status, and payment_method_id on success.
+        Raises stripe.error.CardError if the card declines.
+        """
+        self._require_configured()
+        intent = stripe.PaymentIntent.create(
+            amount=amount_cents,
+            currency="usd",
+            customer=customer_id,
+            confirm=True,
+            off_session=True,
+            payment_method_types=["card"],
+            description=description,
+            metadata=metadata or {},
+        )
+        pm_id = str(getattr(intent, "payment_method", "") or "")
+        logger.info(
+            "stripe_off_session_charge",
+            intent_id=intent.id,
+            amount_cents=amount_cents,
+            customer_id=customer_id,
+            status=intent.status,
+        )
+        return {
+            "payment_intent_id": intent.id,
+            "status": intent.status,
+            "payment_method_id": pm_id,
+            "amount_cents": amount_cents,
+        }
+
     async def create_moto_intent(
         self,
         amount_cents: int,
@@ -212,6 +321,89 @@ class StripePayments:
             "product_id": product.id,
             "price_id": price.id,
             "amount_cents": amount_cents,
+        }
+
+    async def get_or_create_customer(
+        self,
+        email: str,
+        name: str = "",
+        stripe_customer_id: str | None = None,
+    ) -> str:
+        """Return an existing Stripe Customer ID or create a new one."""
+        self._require_configured()
+
+        if stripe_customer_id:
+            try:
+                cust = stripe.Customer.retrieve(stripe_customer_id)
+                if not getattr(cust, "deleted", False):
+                    return cust.id
+            except stripe.error.InvalidRequestError:
+                pass
+
+        existing = stripe.Customer.list(email=email, limit=1)
+        if existing.data:
+            return existing.data[0].id
+
+        cust = stripe.Customer.create(email=email, name=name or email)
+        logger.info(
+            "stripe_customer_created",
+            customer_id=cust.id,
+            email=email,
+        )
+        return cust.id
+
+    async def create_invoice(
+        self,
+        customer_id: str,
+        amount_cents: int,
+        description: str,
+        reservation_id: str,
+        approval_id: str,
+    ) -> dict:
+        """
+        Create and send a Stripe Invoice for a parity discrepancy.
+
+        Returns ``{"invoice_id", "hosted_url", "amount_cents", "status"}``.
+        """
+        self._require_configured()
+
+        invoice = stripe.Invoice.create(
+            customer=customer_id,
+            collection_method="send_invoice",
+            days_until_due=7,
+            description=description,
+            metadata={
+                "reservation_id": reservation_id,
+                "approval_id": approval_id,
+                "source": "financial_approval_invoice",
+            },
+            auto_advance=True,
+        )
+
+        stripe.InvoiceItem.create(
+            customer=customer_id,
+            invoice=invoice.id,
+            amount=amount_cents,
+            currency="usd",
+            description=description,
+        )
+
+        finalized = stripe.Invoice.finalize_invoice(invoice.id)
+        stripe.Invoice.send_invoice(finalized.id)
+
+        logger.info(
+            "stripe_invoice_created_and_sent",
+            invoice_id=finalized.id,
+            amount_cents=amount_cents,
+            customer_id=customer_id,
+            reservation_id=reservation_id,
+            approval_id=approval_id,
+        )
+        return {
+            "invoice_id": finalized.id,
+            "hosted_url": finalized.hosted_invoice_url,
+            "amount_cents": amount_cents,
+            "status": finalized.status,
         }
 
     async def handle_webhook(self, payload: bytes, sig_header: str) -> dict:

--- a/fortress-guest-platform/backend/main.py
+++ b/fortress-guest-platform/backend/main.py
@@ -122,6 +122,9 @@ from backend.api import openshell_audit as openshell_audit_api
 from backend.api import legacy_pages as legacy_pages_api
 from backend.api import activities as activities_api
 from backend.api import blogs as blogs_api
+from backend.api import financial_approvals as financial_approvals_api
+from backend.api import storefront_checkout as storefront_checkout_api
+from backend.api import trust_ledger_command_center as trust_ledger_command_center_api
 from backend.core.tenant import TenantMiddleware
 
 # Configure structured logging
@@ -416,6 +419,9 @@ async def lifespan(app: FastAPI):
 
     kb_sync_task = asyncio.create_task(_deferred_kb_sync_enqueue())
 
+    from backend.workers.hermes_daily_auditor import hermes_daily_auditor_loop
+    auditor_task = asyncio.create_task(hermes_daily_auditor_loop())
+
     # Streamline full sync (sync_all) runs in a dedicated process:
     # systemd fortress-sync-worker → python -m backend.sync
     logger.info("streamline_full_sync_delegated_to_sync_worker")
@@ -423,6 +429,7 @@ async def lifespan(app: FastAPI):
     yield
 
     kb_sync_task.cancel()
+    auditor_task.cancel()
     if app.state.arq_pool is not None:
         await app.state.arq_pool.aclose()
     from backend.core.http_client import close_shared_client
@@ -609,6 +616,13 @@ app.include_router(openshell_audit_api.router, prefix="/api/openshell/audit", ta
 app.include_router(legacy_pages_api.router, prefix="/api/v1/pages", tags=["Legacy Pages"])
 app.include_router(activities_api.router, prefix="/api/v1/activities", tags=["Activities"])
 app.include_router(blogs_api.router, prefix="/api/v1/blogs", tags=["Blogs"])
+app.include_router(financial_approvals_api.router, prefix="/api/v1/financial-approvals", tags=["Financial Approvals"])
+app.include_router(storefront_checkout_api.router, prefix="/api/v1/checkout", tags=["Storefront Checkout"])
+app.include_router(
+    trust_ledger_command_center_api.router,
+    prefix="/api/trust-ledger/command-center",
+    tags=["Trust Ledger Command Center"],
+)
 
 
 # ---------------------------------------------------------------------------

--- a/fortress-guest-platform/backend/models/damage_claim.py
+++ b/fortress-guest-platform/backend/models/damage_claim.py
@@ -45,6 +45,13 @@ class DamageClaim(Base):
     resolution_amount = Column(DECIMAL(10, 2))
     resolved_at = Column(TIMESTAMP)
 
+    # Stripe charge execution
+    stripe_charge_id = Column(String(255))
+    amount_charged = Column(DECIMAL(10, 2))
+    charge_payment_method_id = Column(String(255))
+    charge_executed_at = Column(TIMESTAMP(timezone=True))
+    charge_executed_by = Column(String(255))
+
     # Vector embedding (stored in Qdrant fgp_golden_claims)
     qdrant_point_id = Column(UUID(as_uuid=True))
 

--- a/fortress-guest-platform/backend/models/financial_primitives.py
+++ b/fortress-guest-platform/backend/models/financial_primitives.py
@@ -35,8 +35,17 @@ class Fee(Base):
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
     name = Column(String(255), nullable=False, unique=True, index=True)
-    flat_amount = Column(Numeric(12, 2), nullable=False)
+    flat_amount = Column(Numeric(12, 2), nullable=False, server_default="0")
+    fee_type = Column(
+        String(20), nullable=False, server_default="flat",
+        doc="'flat' = flat_amount is the charge; 'percentage' = percentage_rate applied to pre-processing subtotal (rent + all flat fees)",
+    )
+    percentage_rate = Column(
+        Numeric(6, 3), nullable=True,
+        doc="Used when fee_type='percentage'. Rate in whole-number percent (e.g. 3.000 = 3%).",
+    )
     is_pet_fee = Column(Boolean, nullable=False, default=False, server_default="false")
+    is_optional = Column(Boolean, nullable=False, default=False, server_default="false")
     is_active = Column(Boolean, nullable=False, default=True, server_default="true")
     created_at = Column(DateTime(timezone=True), default=utc_now, nullable=False)
     updated_at = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False)

--- a/fortress-guest-platform/backend/models/trust_ledger.py
+++ b/fortress-guest-platform/backend/models/trust_ledger.py
@@ -24,6 +24,10 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from backend.core.database import Base
 from backend.core.time import utc_now
 
+# Import swarm_governance before TrustTransaction so TrustDecision exists in the
+# registry when SQLAlchemy resolves the string relationship (avoids mapper init failure).
+from backend.models import swarm_governance as _swarm_governance  # noqa: F401
+
 
 def _enum_column(enum_cls: type[enum.Enum], name: str) -> SqlEnum:
     return SqlEnum(
@@ -79,8 +83,13 @@ class TrustTransaction(Base):
 
     __tablename__ = "trust_transactions"
     __table_args__ = (
-        Index("ix_trust_transactions_streamline_event_id", "streamline_event_id"),
+        UniqueConstraint(
+            "streamline_event_id",
+            name="uq_trust_transactions_streamline_event_id",
+        ),
+        UniqueConstraint("signature", name="uq_trust_transactions_signature"),
         Index("ix_trust_transactions_decision_timestamp", "decision_id", "timestamp"),
+        Index("ix_trust_transactions_previous_signature", "previous_signature"),
     )
 
     id: Mapped[UUID] = mapped_column(
@@ -89,11 +98,11 @@ class TrustTransaction(Base):
         default=uuid4,
         server_default=text("gen_random_uuid()"),
     )
-    streamline_event_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
-    decision_id: Mapped[UUID] = mapped_column(
+    streamline_event_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    decision_id: Mapped[UUID | None] = mapped_column(
         PostgresUUID(as_uuid=True),
         ForeignKey("trust_decisions.id", ondelete="RESTRICT"),
-        nullable=False,
+        nullable=True,
     )
     timestamp: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
@@ -102,6 +111,8 @@ class TrustTransaction(Base):
         server_default=text("now()"),
         index=True,
     )
+    signature: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    previous_signature: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
     decision: Mapped["TrustDecision"] = relationship(
         "TrustDecision",

--- a/fortress-guest-platform/backend/services/financial_approval_service.py
+++ b/fortress-guest-platform/backend/services/financial_approval_service.py
@@ -1,0 +1,241 @@
+"""
+Financial Approval Execution Service — 1-click commander approval.
+
+When the commander approves a pending ``FinancialApproval`` from the
+sovereign queue, this service executes one of two resolution strategies:
+
+  **absorb** — Post a variance trust entry to balance the internal
+  ledger.  The guest is not billed for the discrepancy.
+
+  **invoice** — Create a Stripe Invoice for ``delta_cents`` and email
+  it to the guest.  Post an Accounts Receivable trust entry.  When the
+  guest pays, the ``invoice.paid`` webhook can auto-clear the receivable.
+
+Both strategies update ``Reservation.total_amount`` to match the
+Streamline total so the shadow folio is officially balanced.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Literal
+from uuid import UUID
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.models.financial_approval import FinancialApproval
+from backend.models.guest import Guest
+from backend.models.reservation import Reservation
+from backend.services.trust_ledger import post_variance_trust_entry
+
+logger = structlog.get_logger()
+
+TWO_PLACES = Decimal("0.01")
+
+
+async def execute_financial_approval(
+    db: AsyncSession,
+    approval_id: str,
+    commander_username: str,
+    strategy: Literal["absorb", "invoice"] = "absorb",
+) -> FinancialApproval:
+    """
+    Execute a pending financial approval with the chosen resolution
+    strategy.
+
+    Raises ``ValueError`` when the approval is not found or not pending.
+    """
+    approval_uuid = UUID(approval_id)
+
+    result = await db.execute(
+        select(FinancialApproval).where(
+            FinancialApproval.id == approval_uuid,
+            FinancialApproval.status == "pending",
+        )
+    )
+    approval = result.scalars().first()
+    if approval is None:
+        raise ValueError(
+            f"FinancialApproval {approval_id} not found or not in 'pending' status"
+        )
+
+    reservation = await _resolve_reservation(db, approval.reservation_id)
+
+    if strategy == "invoice":
+        await _execute_invoice_strategy(db, approval, reservation, commander_username)
+    else:
+        await _execute_absorb_strategy(db, approval, commander_username)
+
+    if reservation is not None:
+        new_total = Decimal(approval.streamline_total_cents) / Decimal(100)
+        new_total = new_total.quantize(TWO_PLACES, rounding=ROUND_HALF_UP)
+        reservation.total_amount = new_total
+        logger.info(
+            "reservation_total_rebalanced",
+            reservation_id=str(reservation.id),
+            old_total_cents=approval.local_total_cents,
+            new_total_cents=approval.streamline_total_cents,
+        )
+
+    now = datetime.now(timezone.utc)
+    approval.status = "approved"
+    approval.resolution_strategy = strategy
+    approval.resolved_by = commander_username
+    approval.resolved_at = now
+
+    await db.flush()
+
+    logger.info(
+        "financial_approval_executed",
+        approval_id=approval_id,
+        commander=commander_username,
+        strategy=strategy,
+        delta_cents=approval.delta_cents,
+    )
+    return approval
+
+
+async def _resolve_reservation(
+    db: AsyncSession,
+    reservation_id_str: str,
+) -> Reservation | None:
+    """Look up a Reservation by confirmation_code or streamline_reservation_id."""
+    result = await db.execute(
+        select(Reservation).where(
+            Reservation.confirmation_code == reservation_id_str,
+        )
+    )
+    reservation = result.scalars().first()
+    if reservation is not None:
+        return reservation
+
+    result = await db.execute(
+        select(Reservation).where(
+            Reservation.streamline_reservation_id == reservation_id_str,
+        )
+    )
+    return result.scalars().first()
+
+
+async def _execute_absorb_strategy(
+    db: AsyncSession,
+    approval: FinancialApproval,
+    commander_username: str,
+) -> None:
+    """Post the variance trust entry to balance the internal ledger."""
+    context = approval.context_payload or {}
+    auto_resolution = context.get("auto_resolution", {})
+    proposed_entry = auto_resolution.get("proposed_entry")
+
+    if proposed_entry is None:
+        raise ValueError(
+            f"FinancialApproval {approval.id} has no proposed_entry in context_payload"
+        )
+
+    debit_account = proposed_entry["debit_account"]
+    credit_account = proposed_entry["credit_account"]
+    entry_amount_cents = int(proposed_entry["amount_cents"])
+
+    if entry_amount_cents <= 0:
+        raise ValueError(
+            f"proposed_entry.amount_cents must be positive, got {entry_amount_cents}"
+        )
+
+    await post_variance_trust_entry(
+        db,
+        reservation_id=approval.reservation_id,
+        amount_cents=entry_amount_cents,
+        debit_account_name=debit_account,
+        credit_account_name=credit_account,
+        event_id=f"approval:{approval.id}",
+    )
+
+    logger.info(
+        "absorb_strategy_executed",
+        approval_id=str(approval.id),
+        debit_account=debit_account,
+        credit_account=credit_account,
+        amount_cents=entry_amount_cents,
+    )
+
+
+async def _execute_invoice_strategy(
+    db: AsyncSession,
+    approval: FinancialApproval,
+    reservation: Reservation | None,
+    commander_username: str,
+) -> None:
+    """
+    Create a Stripe Invoice for the delta and post an Accounts Receivable
+    trust entry.
+    """
+    from backend.integrations.stripe_payments import StripePayments
+
+    delta_cents = abs(approval.delta_cents)
+    if delta_cents <= 0:
+        raise ValueError("Cannot invoice a zero-cent delta")
+
+    guest = None
+    if reservation is not None:
+        guest = await db.get(Guest, reservation.guest_id)
+
+    if guest is None:
+        raise ValueError(
+            f"Cannot invoice — no guest found for reservation "
+            f"{approval.reservation_id}"
+        )
+
+    guest_email = guest.email or ""
+    guest_name = getattr(guest, "full_name", "") or f"{guest.first_name} {guest.last_name}"
+    if not guest_email:
+        raise ValueError(
+            f"Cannot invoice — guest {guest.id} has no email address"
+        )
+
+    stripe_client = StripePayments()
+    customer_id = await stripe_client.get_or_create_customer(
+        email=guest_email,
+        name=guest_name,
+        stripe_customer_id=guest.stripe_customer_id,
+    )
+
+    if not guest.stripe_customer_id:
+        guest.stripe_customer_id = customer_id
+        await db.flush()
+
+    delta_dollars = Decimal(delta_cents) / Decimal(100)
+    description = (
+        f"Pricing adjustment for reservation {approval.reservation_id} "
+        f"— ${delta_dollars:.2f}"
+    )
+
+    invoice_result = await stripe_client.create_invoice(
+        customer_id=customer_id,
+        amount_cents=delta_cents,
+        description=description,
+        reservation_id=approval.reservation_id,
+        approval_id=str(approval.id),
+    )
+
+    approval.stripe_invoice_id = invoice_result["invoice_id"]
+
+    await post_variance_trust_entry(
+        db,
+        reservation_id=approval.reservation_id,
+        amount_cents=delta_cents,
+        debit_account_name="Accounts Receivable",
+        credit_account_name="Guest Advance Deposits",
+        event_id=f"invoice:{invoice_result['invoice_id']}",
+    )
+
+    logger.info(
+        "invoice_strategy_executed",
+        approval_id=str(approval.id),
+        invoice_id=invoice_result["invoice_id"],
+        hosted_url=invoice_result["hosted_url"],
+        amount_cents=delta_cents,
+        customer_id=customer_id,
+        guest_email=guest_email,
+    )

--- a/fortress-guest-platform/backend/services/ledger.py
+++ b/fortress-guest-platform/backend/services/ledger.py
@@ -1,0 +1,664 @@
+"""
+Multi-Bucket Tax Resolver — FinTech-grade tax engine for North Georgia.
+
+Every line item on a guest invoice falls into exactly one tax bucket.
+Each bucket defines which taxes apply and at what rates, based on
+the property's county/city. This eliminates the guesswork from monthly
+tax filings: the system knows exactly how much is owed to the State
+of Georgia, to each county, and to the GA DOT.
+
+Tax Buckets:
+  LODGING  — Rent, Cleaning, Extra Guest Fees
+             → Sales Tax (7%) + County/City Lodging Tax + GA DOT Fee ($5/night)
+  EXEMPT   — ADW, Processing Fee, Early Check-In, Late Check-Out
+             → NO TAX (legacy-verified: these are non-taxable pass-throughs)
+  GOODS    — Firewood, physical supplies sold to guests
+             → Sales Tax (7%) ONLY
+  SERVICE  — Guided Fishing, concierge services
+             → NO TAX (services exempt under GA code)
+  EXEMPT   — Refundable deposits, discounts
+             → NO TAX
+
+Tax Rates (Georgia, calibrated 2026):
+  All jurisdictions:  State 4% + Local 3% = 7% combined Sales Tax
+  Fannin (Unincorp):  6% Lodging | $5/night DOT
+  Blue Ridge (City):  8% Lodging | $5/night DOT
+  Gilmer:             8% Lodging | $5/night DOT
+  Union:              5% Lodging | $5/night DOT
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from decimal import Decimal, ROUND_HALF_UP
+from enum import Enum
+from typing import Any, Sequence
+
+import structlog
+from sqlalchemy import and_, select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+predict_logger = structlog.get_logger(service="predictive_ledger")
+
+TWO_PLACES = Decimal("0.01")
+ONE_HUNDRED = Decimal("100")
+
+
+def _money(value: Decimal) -> Decimal:
+    return value.quantize(TWO_PLACES, rounding=ROUND_HALF_UP)
+
+
+class TaxBucket(str, Enum):
+    LODGING = "lodging"
+    ADMIN = "admin"
+    GOODS = "goods"
+    SERVICE = "service"
+    EXEMPT = "exempt"
+
+
+@dataclass(frozen=True)
+class CountyTaxRates:
+    county: str
+    state_sales_rate: Decimal
+    county_sales_rate: Decimal
+    lodging_tax_rate: Decimal
+    dot_nightly_fee: Decimal
+    hospitality_tax_rate: Decimal = Decimal("0.00")
+
+    @property
+    def combined_sales_rate(self) -> Decimal:
+        return self.state_sales_rate + self.county_sales_rate
+
+
+COUNTY_RATES: dict[str, CountyTaxRates] = {
+    "fannin": CountyTaxRates(
+        county="Fannin",
+        state_sales_rate=Decimal("4.00"),
+        county_sales_rate=Decimal("3.00"),
+        lodging_tax_rate=Decimal("6.00"),
+        dot_nightly_fee=Decimal("5.00"),
+        hospitality_tax_rate=Decimal("0.206"),
+    ),
+    "blue ridge": CountyTaxRates(
+        county="Blue Ridge",
+        state_sales_rate=Decimal("4.00"),
+        county_sales_rate=Decimal("3.00"),
+        lodging_tax_rate=Decimal("8.00"),
+        dot_nightly_fee=Decimal("5.00"),
+    ),
+    "gilmer": CountyTaxRates(
+        county="Gilmer",
+        state_sales_rate=Decimal("4.00"),
+        county_sales_rate=Decimal("3.00"),
+        lodging_tax_rate=Decimal("8.00"),
+        dot_nightly_fee=Decimal("5.00"),
+    ),
+    "union": CountyTaxRates(
+        county="Union",
+        state_sales_rate=Decimal("4.00"),
+        county_sales_rate=Decimal("3.00"),
+        lodging_tax_rate=Decimal("5.00"),
+        dot_nightly_fee=Decimal("5.00"),
+    ),
+}
+
+DEFAULT_COUNTY = "fannin"
+
+
+def get_county_rates(county: str | None) -> CountyTaxRates:
+    if not county:
+        return COUNTY_RATES[DEFAULT_COUNTY]
+    key = county.strip().lower()
+    return COUNTY_RATES.get(key, COUNTY_RATES[DEFAULT_COUNTY])
+
+
+ITEM_TYPE_TO_BUCKET: dict[str, TaxBucket] = {
+    "rent": TaxBucket.LODGING,
+    "fee": TaxBucket.LODGING,
+    "addon": TaxBucket.LODGING,
+    "deposit": TaxBucket.EXEMPT,
+    "discount": TaxBucket.LODGING,
+}
+
+@dataclass(frozen=True)
+class ClassificationRule:
+    pattern: re.Pattern[str]
+    bucket: TaxBucket
+    priority: int
+
+
+CLASSIFICATION_RULES: list[ClassificationRule] = [
+    ClassificationRule(re.compile(r"deposit|\brefund\b", re.I),                      TaxBucket.EXEMPT,  100),
+    ClassificationRule(re.compile(r"waiver|damage|adw|processing|admin", re.I),      TaxBucket.EXEMPT,  90),
+    ClassificationRule(re.compile(r"check.?in|check.?out|early.?arr|late.?dep", re.I), TaxBucket.EXEMPT, 85),
+    ClassificationRule(re.compile(r"firewood|fire\s*wood", re.I),                    TaxBucket.GOODS,   80),
+    ClassificationRule(re.compile(r"fish|guide|concierge", re.I),                    TaxBucket.SERVICE, 70),
+    ClassificationRule(re.compile(r"clean|pet|extra.guest", re.I),                   TaxBucket.LODGING, 60),
+]
+
+
+def classify_item(item_type: str, item_name: str) -> TaxBucket:
+    """Classify a line item into a tax bucket using regex pattern matching.
+
+    Rules are evaluated in priority order (highest first). The first match wins.
+    If no regex matches, falls back to ITEM_TYPE_TO_BUCKET or LODGING default.
+    """
+    name = item_name.strip()
+    for rule in CLASSIFICATION_RULES:
+        if rule.pattern.search(name):
+            return rule.bucket
+    return ITEM_TYPE_TO_BUCKET.get(item_type, TaxBucket.LODGING)
+
+
+@dataclass
+class TaxLineDetail:
+    tax_name: str
+    tax_rate: Decimal
+    taxable_base: Decimal
+    amount: Decimal
+    bucket: TaxBucket
+
+
+@dataclass
+class LedgerTaxBreakdown:
+    state_sales_tax: Decimal = Decimal("0.00")
+    county_sales_tax: Decimal = Decimal("0.00")
+    lodging_tax: Decimal = Decimal("0.00")
+    hospitality_tax: Decimal = Decimal("0.00")
+    dot_fee: Decimal = Decimal("0.00")
+    total_tax: Decimal = Decimal("0.00")
+    details: list[TaxLineDetail] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "state_sales_tax": float(self.state_sales_tax),
+            "county_sales_tax": float(self.county_sales_tax),
+            "lodging_tax": float(self.lodging_tax),
+            "hospitality_tax": float(self.hospitality_tax),
+            "dot_fee": float(self.dot_fee),
+            "total_tax": float(self.total_tax),
+            "details": [
+                {
+                    "tax_name": d.tax_name,
+                    "tax_rate": float(d.tax_rate),
+                    "taxable_base": float(d.taxable_base),
+                    "amount": float(d.amount),
+                    "bucket": d.bucket.value,
+                }
+                for d in self.details
+            ],
+        }
+
+
+@dataclass
+class BucketedItem:
+    name: str
+    amount: Decimal
+    item_type: str
+    bucket: TaxBucket
+
+
+@dataclass(frozen=True)
+class ClassificationResult:
+    bucket: TaxBucket
+    is_refundable: bool
+    refund_policy: str
+
+
+def _refund_policy_for(bucket: TaxBucket, item_type: str) -> tuple[bool, str]:
+    """Derive refundability from tax bucket and item type.
+
+    Deposits are always refundable regardless of bucket.
+    Taxes follow the refund status of their base item.
+    EXEMPT and ADMIN items (ADW, Processing Fee, etc.) are non-refundable.
+    Everything else (LODGING, GOODS, SERVICE) is refundable by default.
+    """
+    if item_type == "deposit":
+        return True, "full"
+    if item_type == "tax":
+        return False, "follows_base"
+    if bucket in (TaxBucket.EXEMPT, TaxBucket.ADMIN):
+        return False, "none"
+    return True, "full"
+
+
+def classify_item_full(item_type: str, item_name: str) -> ClassificationResult:
+    """Classify a line item into a tax bucket with refundability metadata."""
+    bucket = classify_item(item_type, item_name)
+    is_refundable, refund_policy = _refund_policy_for(bucket, item_type)
+    return ClassificationResult(
+        bucket=bucket,
+        is_refundable=is_refundable,
+        refund_policy=refund_policy,
+    )
+
+
+def resolve_taxes(
+    items: Sequence[BucketedItem],
+    county: str | None,
+    nights: int,
+) -> LedgerTaxBreakdown:
+    """
+    Compute the exact tax breakdown for a set of line items.
+
+    Returns a LedgerTaxBreakdown with per-tax-authority amounts and
+    per-line detail records for full audit transparency.
+    """
+    rates = get_county_rates(county)
+    breakdown = LedgerTaxBreakdown()
+
+    lodging_base = Decimal("0.00")
+    admin_base = Decimal("0.00")
+    goods_base = Decimal("0.00")
+
+    for item in items:
+        if item.bucket == TaxBucket.LODGING:
+            lodging_base += item.amount
+        elif item.bucket == TaxBucket.ADMIN:
+            admin_base += item.amount
+        elif item.bucket == TaxBucket.GOODS:
+            goods_base += item.amount
+
+    # --- LODGING bucket taxes ---
+    if lodging_base > Decimal("0.00"):
+        state_on_lodging = _money(lodging_base * rates.state_sales_rate / ONE_HUNDRED)
+        breakdown.state_sales_tax += state_on_lodging
+        breakdown.details.append(TaxLineDetail(
+            tax_name=f"GA State Sales Tax ({rates.state_sales_rate}%)",
+            tax_rate=rates.state_sales_rate,
+            taxable_base=lodging_base,
+            amount=state_on_lodging,
+            bucket=TaxBucket.LODGING,
+        ))
+
+        county_on_lodging = _money(lodging_base * rates.county_sales_rate / ONE_HUNDRED)
+        breakdown.county_sales_tax += county_on_lodging
+        breakdown.details.append(TaxLineDetail(
+            tax_name=f"{rates.county} County Sales Tax ({rates.county_sales_rate}%)",
+            tax_rate=rates.county_sales_rate,
+            taxable_base=lodging_base,
+            amount=county_on_lodging,
+            bucket=TaxBucket.LODGING,
+        ))
+
+        lodging_tax = _money(lodging_base * rates.lodging_tax_rate / ONE_HUNDRED)
+        breakdown.lodging_tax = lodging_tax
+        breakdown.details.append(TaxLineDetail(
+            tax_name=f"{rates.county} County Lodging Tax ({rates.lodging_tax_rate}%)",
+            tax_rate=rates.lodging_tax_rate,
+            taxable_base=lodging_base,
+            amount=lodging_tax,
+            bucket=TaxBucket.LODGING,
+        ))
+
+        dot_total = _money(rates.dot_nightly_fee * Decimal(str(nights)))
+        breakdown.dot_fee = dot_total
+        breakdown.details.append(TaxLineDetail(
+            tax_name=f"GA DOT Fee (${rates.dot_nightly_fee}/night × {nights})",
+            tax_rate=Decimal("0.00"),
+            taxable_base=Decimal(str(nights)),
+            amount=dot_total,
+            bucket=TaxBucket.LODGING,
+        ))
+
+        if rates.hospitality_tax_rate > Decimal("0.00"):
+            hosp_tax = _money(lodging_base * rates.hospitality_tax_rate / ONE_HUNDRED)
+            breakdown.hospitality_tax = hosp_tax
+            breakdown.details.append(TaxLineDetail(
+                tax_name=f"{rates.county} Hospitality Tax ({rates.hospitality_tax_rate}%)",
+                tax_rate=rates.hospitality_tax_rate,
+                taxable_base=lodging_base,
+                amount=hosp_tax,
+                bucket=TaxBucket.LODGING,
+            ))
+
+    # --- ADMIN bucket taxes (sales tax only — NO lodging tax, NO DOT) ---
+    if admin_base > Decimal("0.00"):
+        state_on_admin = _money(admin_base * rates.state_sales_rate / ONE_HUNDRED)
+        breakdown.state_sales_tax += state_on_admin
+        breakdown.details.append(TaxLineDetail(
+            tax_name=f"GA State Sales Tax on Admin Fees ({rates.state_sales_rate}%)",
+            tax_rate=rates.state_sales_rate,
+            taxable_base=admin_base,
+            amount=state_on_admin,
+            bucket=TaxBucket.ADMIN,
+        ))
+
+        county_on_admin = _money(admin_base * rates.county_sales_rate / ONE_HUNDRED)
+        breakdown.county_sales_tax += county_on_admin
+        breakdown.details.append(TaxLineDetail(
+            tax_name=f"{rates.county} County Sales Tax on Admin Fees ({rates.county_sales_rate}%)",
+            tax_rate=rates.county_sales_rate,
+            taxable_base=admin_base,
+            amount=county_on_admin,
+            bucket=TaxBucket.ADMIN,
+        ))
+
+    # --- GOODS bucket taxes (sales tax only) ---
+    if goods_base > Decimal("0.00"):
+        state_on_goods = _money(goods_base * rates.state_sales_rate / ONE_HUNDRED)
+        breakdown.state_sales_tax += state_on_goods
+        breakdown.details.append(TaxLineDetail(
+            tax_name=f"GA State Sales Tax on Goods ({rates.state_sales_rate}%)",
+            tax_rate=rates.state_sales_rate,
+            taxable_base=goods_base,
+            amount=state_on_goods,
+            bucket=TaxBucket.GOODS,
+        ))
+
+        county_on_goods = _money(goods_base * rates.county_sales_rate / ONE_HUNDRED)
+        breakdown.county_sales_tax += county_on_goods
+        breakdown.details.append(TaxLineDetail(
+            tax_name=f"{rates.county} County Sales Tax on Goods ({rates.county_sales_rate}%)",
+            tax_rate=rates.county_sales_rate,
+            taxable_base=goods_base,
+            amount=county_on_goods,
+            bucket=TaxBucket.GOODS,
+        ))
+
+    # SERVICE and EXEMPT buckets: $0 tax — nothing to add
+
+    breakdown.state_sales_tax = _money(breakdown.state_sales_tax)
+    breakdown.county_sales_tax = _money(breakdown.county_sales_tax)
+    breakdown.lodging_tax = _money(breakdown.lodging_tax)
+    breakdown.hospitality_tax = _money(breakdown.hospitality_tax)
+    breakdown.dot_fee = _money(breakdown.dot_fee)
+    breakdown.total_tax = _money(
+        breakdown.state_sales_tax
+        + breakdown.county_sales_tax
+        + breakdown.lodging_tax
+        + breakdown.hospitality_tax
+        + breakdown.dot_fee
+    )
+
+    return breakdown
+
+
+# ---------------------------------------------------------------------------
+# Owner Payout — Fiduciary-grade split logic
+# ---------------------------------------------------------------------------
+
+# Items in these buckets are pass-through: they do NOT enter the commission
+# base.  They are collected from the guest, held in trust, and disbursed to
+# their respective authorities (tax collectors, cleaning vendors, insurance).
+PASS_THROUGH_BUCKETS: frozenset[TaxBucket] = frozenset({
+    TaxBucket.ADMIN,    # ADW, Processing Fee
+    TaxBucket.EXEMPT,   # Deposits, refunds
+})
+
+PASS_THROUGH_TYPES: frozenset[str] = frozenset({
+    "tax",
+    "deposit",
+})
+
+# DEFAULT_COMMISSION_RATE was removed — rates are per-owner, stored in
+# owner_payout_accounts.commission_rate. Pass the rate explicitly to
+# calculate_owner_payout(). Do not add a default here.
+#
+# DEFAULT_CC_PROCESSING_RATE / DEFAULT_CC_PROCESSING_FLAT were removed in
+# Phase B (2026-04-14). Model A: CC processing fees are absorbed by the
+# company and are NOT deducted from the owner's net payout.
+# Owner net = gross_revenue - commission. Period.
+
+
+@dataclass
+class OwnerPayoutLineItem:
+    name: str
+    amount: Decimal
+    category: str  # "commissionable", "pass_through", "deduction"
+
+
+@dataclass
+class OwnerPayoutBreakdown:
+    gross_revenue: Decimal = Decimal("0.00")
+    pass_through_total: Decimal = Decimal("0.00")
+    commission_rate: Decimal = Decimal("0.00")
+    commission_amount: Decimal = Decimal("0.00")
+    cc_processing_fee: Decimal = Decimal("0.00")
+    net_owner_payout: Decimal = Decimal("0.00")
+    total_collected: Decimal = Decimal("0.00")
+    details: list[OwnerPayoutLineItem] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "gross_revenue": float(self.gross_revenue),
+            "pass_through_total": float(self.pass_through_total),
+            "commission_rate": float(self.commission_rate),
+            "commission_amount": float(self.commission_amount),
+            "cc_processing_fee": float(self.cc_processing_fee),
+            "net_owner_payout": float(self.net_owner_payout),
+            "total_collected": float(self.total_collected),
+            "details": [
+                {"name": d.name, "amount": float(d.amount), "category": d.category}
+                for d in self.details
+            ],
+        }
+
+
+def _is_pass_through(item: BucketedItem) -> bool:
+    """Determine whether a line item is pass-through (excluded from commission base)."""
+    if item.item_type in PASS_THROUGH_TYPES:
+        return True
+    if item.bucket in PASS_THROUGH_BUCKETS:
+        return True
+    bucket = classify_item(item.item_type, item.name)
+    if bucket in PASS_THROUGH_BUCKETS:
+        return True
+    name_lower = item.name.strip().lower()
+    if "clean" in name_lower:
+        return True
+    return False
+
+
+def calculate_owner_payout(
+    items: Sequence[BucketedItem],
+    commission_rate: Decimal,
+) -> OwnerPayoutBreakdown:
+    """Compute the owner's net payout from a set of invoice line items.
+
+    Model A (confirmed 2026-04-14): CC processing fees are absorbed by the
+    company and are NOT deducted from the owner's share.
+
+    Commissionable items:   Rent, Pet Fees, Extra Guest Fees, Add-Ons
+    Pass-through items:     Cleaning Fees, ADW, Processing Fee, Taxes, Deposits
+
+    Formula:
+        gross_revenue    = sum of commissionable items
+        commission       = gross_revenue × commission_rate / 100
+        net_owner_payout = gross_revenue - commission
+    """
+    breakdown = OwnerPayoutBreakdown(commission_rate=commission_rate)
+    total_collected = Decimal("0.00")
+
+    for item in items:
+        total_collected += item.amount
+        if _is_pass_through(item):
+            breakdown.pass_through_total += item.amount
+            breakdown.details.append(OwnerPayoutLineItem(
+                name=item.name, amount=item.amount, category="pass_through",
+            ))
+        else:
+            breakdown.gross_revenue += item.amount
+            breakdown.details.append(OwnerPayoutLineItem(
+                name=item.name, amount=item.amount, category="commissionable",
+            ))
+
+    breakdown.total_collected = _money(total_collected)
+    breakdown.gross_revenue = _money(breakdown.gross_revenue)
+    breakdown.pass_through_total = _money(breakdown.pass_through_total)
+
+    breakdown.commission_amount = _money(
+        breakdown.gross_revenue * commission_rate / ONE_HUNDRED
+    )
+
+    # CC processing fee is zero — absorbed by the company (Model A).
+    breakdown.cc_processing_fee = Decimal("0.00")
+
+    breakdown.net_owner_payout = _money(
+        breakdown.gross_revenue
+        - breakdown.commission_amount
+    )
+
+    breakdown.details.append(OwnerPayoutLineItem(
+        name=f"Management Commission ({commission_rate}%)",
+        amount=-breakdown.commission_amount,
+        category="deduction",
+    ))
+
+    return breakdown
+
+
+# ---------------------------------------------------------------------------
+# Predictive Analytics — 30/60/90-day revenue & tax projections
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ProjectionWindow:
+    label: str
+    days: int
+    start: date
+    end: date
+    confirmed_revenue: Decimal = Decimal("0.00")
+    projected_revenue: Decimal = Decimal("0.00")
+    cancellation_adjusted: Decimal = Decimal("0.00")
+    estimated_owner_payout: Decimal = Decimal("0.00")
+    estimated_tax_obligation: Decimal = Decimal("0.00")
+    reservation_count: int = 0
+    cancelled_count: int = 0
+
+    def to_dict(self) -> dict:
+        return {
+            "label": self.label,
+            "days": self.days,
+            "start": self.start.isoformat(),
+            "end": self.end.isoformat(),
+            "confirmed_revenue": float(self.confirmed_revenue),
+            "projected_revenue": float(self.projected_revenue),
+            "cancellation_adjusted": float(self.cancellation_adjusted),
+            "estimated_owner_payout": float(self.estimated_owner_payout),
+            "estimated_tax_obligation": float(self.estimated_tax_obligation),
+            "reservation_count": self.reservation_count,
+            "cancellation_rate_applied": float(self._cancel_rate),
+        }
+
+    @property
+    def _cancel_rate(self) -> Decimal:
+        total = self.reservation_count + self.cancelled_count
+        if total == 0:
+            return Decimal("0.00")
+        return _money(Decimal(str(self.cancelled_count)) / Decimal(str(total)) * ONE_HUNDRED)
+
+
+OWNER_PAYOUT_RATIO = Decimal("0.75")
+WINDOWS = [("30-day", 30), ("60-day", 60), ("90-day", 90)]
+
+
+class PredictiveAnalytics:
+    """Project owner payouts and tax obligations for upcoming windows."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def project(self, reference_date: date | None = None) -> list[dict]:
+        from backend.models.reservation import Reservation
+        from backend.models.property import Property
+
+        today = reference_date or date.today()
+        historical_cancel_rate = await self._historical_cancellation_rate(Reservation, today)
+        results = []
+
+        for label, days in WINDOWS:
+            window_start = today
+            window_end = today + timedelta(days=days)
+
+            window = ProjectionWindow(
+                label=label, days=days, start=window_start, end=window_end,
+            )
+
+            confirmed_stmt = (
+                select(
+                    func.count(Reservation.id),
+                    func.coalesce(func.sum(Reservation.total_amount), 0),
+                )
+                .where(and_(
+                    Reservation.check_in_date >= window_start,
+                    Reservation.check_in_date < window_end,
+                    Reservation.status.in_(["confirmed", "checked_in"]),
+                ))
+            )
+            row = (await self.db.execute(confirmed_stmt)).one()
+            window.reservation_count = int(row[0])
+            window.confirmed_revenue = _money(Decimal(str(row[1])))
+
+            cancelled_stmt = (
+                select(func.count(Reservation.id))
+                .where(and_(
+                    Reservation.check_in_date >= today - timedelta(days=180),
+                    Reservation.check_in_date < today,
+                    Reservation.status == "cancelled",
+                ))
+            )
+            window.cancelled_count = (await self.db.execute(cancelled_stmt)).scalar() or 0
+
+            keep_rate = (ONE_HUNDRED - historical_cancel_rate) / ONE_HUNDRED
+            window.cancellation_adjusted = _money(window.confirmed_revenue * keep_rate)
+            window.projected_revenue = window.cancellation_adjusted
+
+            window.estimated_owner_payout = _money(
+                window.cancellation_adjusted * OWNER_PAYOUT_RATIO
+            )
+
+            avg_tax_rate = await self._avg_effective_tax_rate(Reservation, today)
+            window.estimated_tax_obligation = _money(
+                window.cancellation_adjusted * avg_tax_rate / ONE_HUNDRED
+            )
+
+            results.append(window.to_dict())
+
+        predict_logger.info(
+            "predictive_projection_complete",
+            windows=len(results),
+            cancel_rate=float(historical_cancel_rate),
+        )
+        return results
+
+    async def _historical_cancellation_rate(self, Reservation: Any, today: date) -> Decimal:
+        lookback = today - timedelta(days=365)
+        stmt = select(
+            func.count(Reservation.id).filter(Reservation.status == "cancelled"),
+            func.count(Reservation.id),
+        ).where(and_(
+            Reservation.check_in_date >= lookback,
+            Reservation.check_in_date < today,
+        ))
+        row = (await self.db.execute(stmt)).one()
+        total = int(row[1])
+        if total == 0:
+            return Decimal("8.00")  # industry default 8%
+        cancelled = int(row[0])
+        return _money(Decimal(str(cancelled)) / Decimal(str(total)) * ONE_HUNDRED)
+
+    async def _avg_effective_tax_rate(self, Reservation: Any, today: date) -> Decimal:
+        """Compute the average effective tax rate from recent completed reservations."""
+        lookback = today - timedelta(days=180)
+        stmt = (
+            select(Reservation.total_amount, Reservation.tax_amount)
+            .where(and_(
+                Reservation.check_out_date >= lookback,
+                Reservation.check_out_date < today,
+                Reservation.status.in_(["confirmed", "checked_out", "completed"]),
+                Reservation.total_amount > 0,
+                Reservation.tax_amount > 0,
+            ))
+            .limit(200)
+        )
+        rows = (await self.db.execute(stmt)).all()
+        if not rows:
+            return Decimal("18.00")  # safe fallback
+        total_rev = sum(Decimal(str(r[0] or 0)) for r in rows)
+        total_tax = sum(Decimal(str(r[1] or 0)) for r in rows)
+        if total_rev == Decimal("0"):
+            return Decimal("18.00")
+        return _money(total_tax / total_rev * ONE_HUNDRED)

--- a/fortress-guest-platform/backend/services/trust_ledger.py
+++ b/fortress-guest-platform/backend/services/trust_ledger.py
@@ -1,0 +1,286 @@
+"""
+Sovereign Trust Ledger — Double-entry posting service.
+
+Posts debit/credit entries to ``trust_ledger_entries`` linked by a
+``TrustTransaction``.  Supports both swarm-gated transactions (with a
+``TrustDecision``) and system-initiated transactions (Stripe checkout,
+approval execution) where ``decision_id`` is NULL.
+"""
+from __future__ import annotations
+
+import hashlib
+from uuid import uuid4
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.core.time import utc_now
+from backend.models.trust_ledger import (
+    TrustAccount,
+    TrustAccountType,
+    TrustLedgerEntry,
+    TrustLedgerEntryType,
+    TrustTransaction,
+)
+
+logger = structlog.get_logger()
+
+
+async def _sign_transaction(db: AsyncSession, txn: TrustTransaction) -> None:
+    """Compute SHA-256 hash chain fields on ``txn`` (INSERT only — DB forbids UPDATE)."""
+    result = await db.execute(
+        select(TrustTransaction.signature)
+        .where(TrustTransaction.signature.isnot(None))
+        .order_by(TrustTransaction.timestamp.desc())
+        .limit(1)
+    )
+    prev_sig = result.scalar_one_or_none() or "GENESIS"
+    payload = f"{prev_sig}|{txn.streamline_event_id}|{txn.id}|{txn.timestamp.isoformat()}"
+    txn.previous_signature = prev_sig if prev_sig != "GENESIS" else None
+    txn.signature = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+async def _add_trust_transaction_idempotent(
+    db: AsyncSession,
+    txn: TrustTransaction,
+) -> TrustTransaction:
+    """Insert ``txn`` or return the existing row when ``streamline_event_id`` collides."""
+    await _sign_transaction(db, txn)
+    try:
+        async with db.begin_nested():
+            db.add(txn)
+            await db.flush()
+    except IntegrityError:
+        result = await db.execute(
+            select(TrustTransaction).where(
+                TrustTransaction.streamline_event_id == txn.streamline_event_id
+            )
+        )
+        existing = result.scalars().first()
+        if existing is not None:
+            logger.info(
+                "trust_transaction_idempotent_hit",
+                streamline_event_id=txn.streamline_event_id,
+                existing_transaction_id=str(existing.id),
+            )
+            db.expunge(txn)
+            return existing
+        raise
+    return txn
+
+
+async def _get_or_create_account(
+    db: AsyncSession,
+    name: str,
+    account_type: TrustAccountType,
+) -> TrustAccount:
+    """Return the TrustAccount with the given name, creating it if absent."""
+    result = await db.execute(
+        select(TrustAccount).where(TrustAccount.name == name).limit(1)
+    )
+    account = result.scalars().first()
+    if account is not None:
+        return account
+
+    account = TrustAccount(id=uuid4(), name=name, type=account_type)
+    db.add(account)
+    await db.flush()
+    logger.info("trust_account_created", name=name, type=account_type.value)
+    return account
+
+
+async def post_checkout_trust_entry(
+    db: AsyncSession,
+    reservation_id: str,
+    amount_cents: int,
+    stripe_pi_id: str,
+) -> TrustTransaction:
+    """
+    Post the guest-payment double-entry to the sovereign trust ledger.
+
+    Debit:  amount_cents → "Operating Cash" (Asset)
+    Credit: amount_cents → "Guest Advance Deposits" (Liability)
+
+    Called immediately after a successful Stripe PaymentIntent confirmation
+    inside ``_process_storefront_settlement()``.
+    """
+    if amount_cents <= 0:
+        raise ValueError(f"amount_cents must be positive, got {amount_cents}")
+
+    cash_account = await _get_or_create_account(
+        db, "Operating Cash", TrustAccountType.ASSET,
+    )
+    deposit_account = await _get_or_create_account(
+        db, "Guest Advance Deposits", TrustAccountType.LIABILITY,
+    )
+
+    txn = TrustTransaction(
+        id=uuid4(),
+        streamline_event_id=f"stripe:{stripe_pi_id}",
+        decision_id=None,
+        timestamp=utc_now(),
+    )
+    expected_txn_id = txn.id
+    txn = await _add_trust_transaction_idempotent(db, txn)
+    if txn.id != expected_txn_id:
+        return txn
+
+    debit_entry = TrustLedgerEntry(
+        id=uuid4(),
+        transaction_id=txn.id,
+        account_id=cash_account.id,
+        amount_cents=amount_cents,
+        entry_type=TrustLedgerEntryType.DEBIT,
+    )
+    credit_entry = TrustLedgerEntry(
+        id=uuid4(),
+        transaction_id=txn.id,
+        account_id=deposit_account.id,
+        amount_cents=amount_cents,
+        entry_type=TrustLedgerEntryType.CREDIT,
+    )
+    db.add(debit_entry)
+    db.add(credit_entry)
+    await db.flush()
+
+    logger.info(
+        "trust_entry_posted",
+        transaction_id=str(txn.id),
+        reservation_id=reservation_id,
+        stripe_pi_id=stripe_pi_id,
+        amount_cents=amount_cents,
+        debit_account="Operating Cash",
+        credit_account="Guest Advance Deposits",
+    )
+    return txn
+
+
+async def post_invoice_clearing_entry(
+    db: AsyncSession,
+    amount_cents: int,
+    stripe_invoice_id: str,
+) -> TrustTransaction:
+    """
+    Clear the Accounts Receivable created by the invoice strategy when
+    the guest pays the Stripe Invoice.
+
+    Debit:  amount_cents → "Operating Cash" (Asset — cash received)
+    Credit: amount_cents → "Accounts Receivable" (Asset — receivable zeroed)
+
+    Called from the ``invoice.paid`` webhook handler.
+    """
+    if amount_cents <= 0:
+        raise ValueError(f"amount_cents must be positive, got {amount_cents}")
+
+    cash_account = await _get_or_create_account(
+        db, "Operating Cash", TrustAccountType.ASSET,
+    )
+    ar_account = await _get_or_create_account(
+        db, "Accounts Receivable", TrustAccountType.ASSET,
+    )
+
+    txn = TrustTransaction(
+        id=uuid4(),
+        streamline_event_id=f"invoice_paid:{stripe_invoice_id}",
+        decision_id=None,
+        timestamp=utc_now(),
+    )
+    expected_txn_id = txn.id
+    txn = await _add_trust_transaction_idempotent(db, txn)
+    if txn.id != expected_txn_id:
+        return txn
+
+    debit_entry = TrustLedgerEntry(
+        id=uuid4(),
+        transaction_id=txn.id,
+        account_id=cash_account.id,
+        amount_cents=amount_cents,
+        entry_type=TrustLedgerEntryType.DEBIT,
+    )
+    credit_entry = TrustLedgerEntry(
+        id=uuid4(),
+        transaction_id=txn.id,
+        account_id=ar_account.id,
+        amount_cents=amount_cents,
+        entry_type=TrustLedgerEntryType.CREDIT,
+    )
+    db.add(debit_entry)
+    db.add(credit_entry)
+    await db.flush()
+
+    logger.info(
+        "invoice_clearing_entry_posted",
+        transaction_id=str(txn.id),
+        stripe_invoice_id=stripe_invoice_id,
+        amount_cents=amount_cents,
+        debit_account="Operating Cash",
+        credit_account="Accounts Receivable",
+    )
+    return txn
+
+
+async def post_variance_trust_entry(
+    db: AsyncSession,
+    reservation_id: str,
+    amount_cents: int,
+    debit_account_name: str,
+    credit_account_name: str,
+    event_id: str,
+) -> TrustTransaction:
+    """
+    Post an arbitrary debit/credit pair to the trust ledger.
+
+    Used by the 1-click approval service to execute proposed variance
+    adjustments from the FinancialApproval queue.
+    """
+    if amount_cents <= 0:
+        raise ValueError(f"amount_cents must be positive, got {amount_cents}")
+
+    debit_account = await _get_or_create_account(
+        db, debit_account_name, TrustAccountType.ASSET,
+    )
+    credit_account = await _get_or_create_account(
+        db, credit_account_name, TrustAccountType.ASSET,
+    )
+
+    txn = TrustTransaction(
+        id=uuid4(),
+        streamline_event_id=event_id,
+        decision_id=None,
+        timestamp=utc_now(),
+    )
+    expected_txn_id = txn.id
+    txn = await _add_trust_transaction_idempotent(db, txn)
+    if txn.id != expected_txn_id:
+        return txn
+
+    debit_entry = TrustLedgerEntry(
+        id=uuid4(),
+        transaction_id=txn.id,
+        account_id=debit_account.id,
+        amount_cents=amount_cents,
+        entry_type=TrustLedgerEntryType.DEBIT,
+    )
+    credit_entry = TrustLedgerEntry(
+        id=uuid4(),
+        transaction_id=txn.id,
+        account_id=credit_account.id,
+        amount_cents=amount_cents,
+        entry_type=TrustLedgerEntryType.CREDIT,
+    )
+    db.add(debit_entry)
+    db.add(credit_entry)
+    await db.flush()
+
+    logger.info(
+        "variance_trust_entry_posted",
+        transaction_id=str(txn.id),
+        reservation_id=reservation_id,
+        amount_cents=amount_cents,
+        debit_account=debit_account_name,
+        credit_account=credit_account_name,
+        event_id=event_id,
+    )
+    return txn

--- a/fortress-guest-platform/backend/workers/hermes_daily_auditor.py
+++ b/fortress-guest-platform/backend/workers/hermes_daily_auditor.py
@@ -1,0 +1,381 @@
+"""
+Hermes Daily Auditor — Continuous parity verification for active reservations.
+
+Runs once per day (or on-demand).  Queries every confirmed reservation where
+check_out_date >= today, fetches the current Streamline price for each, and
+routes any drift through the same 3-tier FinancialApproval pipeline used by
+the real-time Hermes sync worker.
+
+Rate-limiting:
+  - 1-second sleep between API calls to respect Streamline's throttle
+  - Configurable batch size (default 50)
+  - Graceful backoff on consecutive failures
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal, ROUND_HALF_UP
+from uuid import uuid4
+
+import structlog
+from sqlalchemy import select, and_
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.core.database import AsyncSessionLocal
+from backend.models.financial_approval import FinancialApproval
+from backend.models.parity_audit import ParityAudit
+from backend.models.reservation import Reservation
+from backend.models.trust_ledger import TrustTransaction
+
+logger = structlog.get_logger(service="hermes_daily_auditor")
+
+BATCH_SIZE = 50
+INTER_CALL_DELAY = 1.0        # seconds between Streamline API calls
+BACKOFF_BASE = 5.0             # seconds after a failure
+BACKOFF_MAX = 60.0             # cap on exponential backoff
+AUTO_RESOLVE_THRESHOLD_CENTS = 1000  # ≤ $10.00
+
+
+async def verify_hash_chain(db: AsyncSession) -> dict:
+    """
+    Walk signed trust transactions in timestamp order and recompute SHA-256 hashes.
+
+    Returns ``{verified_count, broken_at, status}`` where ``status`` is ``ok`` or ``broken``.
+    """
+    result = await db.execute(
+        select(TrustTransaction)
+        .where(TrustTransaction.signature.isnot(None))
+        .order_by(TrustTransaction.timestamp.asc(), TrustTransaction.id.asc())
+    )
+    rows = result.scalars().all()
+    prev_sig = "GENESIS"
+    for i, txn in enumerate(rows):
+        payload = f"{prev_sig}|{txn.streamline_event_id}|{txn.id}|{txn.timestamp.isoformat()}"
+        expected = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+        if expected != txn.signature:
+            logger.critical(
+                "trust_hash_chain_broken",
+                transaction_id=str(txn.id),
+                streamline_event_id=txn.streamline_event_id,
+            )
+            try:
+                from backend.agents.nemo_observer import NemoObserver
+
+                observer = NemoObserver()
+                await observer.analyze_discrepancy(
+                    reservation_id="sovereign_ledger",
+                    confirmation_id="hash_chain_verification",
+                    local_total=txn.signature or "",
+                    streamline_total=expected,
+                    delta="0",
+                    local_breakdown={
+                        "event": "trust_hash_chain_breach",
+                        "broken_transaction_id": str(txn.id),
+                        "streamline_event_id": txn.streamline_event_id,
+                    },
+                    streamline_breakdown={
+                        "expected_hash": expected,
+                        "stored_hash": txn.signature,
+                    },
+                )
+            except Exception as exc:
+                logger.warning(
+                    "trust_hash_chain_nemo_hook_error",
+                    transaction_id=str(txn.id),
+                    error=str(exc)[:300],
+                )
+            return {
+                "verified_count": i,
+                "broken_at": str(txn.id),
+                "status": "broken",
+            }
+        prev_sig = txn.signature
+    return {
+        "verified_count": len(rows),
+        "broken_at": None,
+        "status": "ok",
+    }
+
+
+def _decimal_to_cents(value: Decimal) -> int:
+    return int((value * 100).to_integral_value(rounding=ROUND_HALF_UP))
+
+
+def _deprioritize() -> None:
+    try:
+        os.nice(10)
+    except (OSError, AttributeError):
+        pass
+
+
+async def _audit_single_reservation(
+    db: AsyncSession,
+    res: Reservation,
+    client: "StreamlineClient",
+) -> str:
+    """Audit one reservation against Streamline.  Returns outcome label."""
+    confirmation_code = res.confirmation_code
+    if not confirmation_code:
+        return "skipped_no_confirmation"
+
+    result = await client.fetch_live_quote(res.streamline_reservation_id)
+    if result is None:
+        logger.warning(
+            "daily_audit_no_data",
+            reservation_id=str(res.id),
+            confirmation_code=confirmation_code,
+        )
+        return "skipped_no_data"
+
+    local_total = Decimal(str(res.total_amount or 0))
+    local_cents = _decimal_to_cents(local_total)
+    streamline_cents = _decimal_to_cents(result.streamline_total)
+    delta_cents = abs(streamline_cents - local_cents)
+
+    local_breakdown = {
+        "total_amount": str(res.total_amount),
+        "total_cents": local_cents,
+        "tax_amount": str(res.tax_amount),
+        "source": "reservation_table",
+    }
+    if isinstance(res.price_breakdown, dict):
+        local_breakdown["price_breakdown"] = res.price_breakdown
+    if isinstance(res.tax_breakdown, dict):
+        local_breakdown["tax_breakdown"] = res.tax_breakdown
+
+    streamline_breakdown = {
+        "total": str(result.streamline_total),
+        "total_cents": streamline_cents,
+        "taxes": str(result.streamline_taxes),
+        "rent": str(result.streamline_rent),
+        "fees": [
+            {"name": f.name, "amount": str(f.amount), "type": f.fee_type, "bucket": f.bucket}
+            for f in result.fees
+        ],
+    }
+
+    # ── Tier 1: Exact match ─────────────────────────────────────
+    if delta_cents == 0:
+        audit = ParityAudit(
+            id=uuid4(),
+            reservation_id=str(res.id),
+            confirmation_id=confirmation_code,
+            local_total=local_total,
+            streamline_total=result.streamline_total,
+            delta=Decimal("0.00"),
+            local_breakdown=local_breakdown,
+            streamline_breakdown=streamline_breakdown,
+            status="confirmed",
+        )
+        db.add(audit)
+        await db.flush()
+        return "confirmed"
+
+    delta_dec = Decimal(delta_cents) / Decimal(100)
+
+    # ── Tier 2: Minor variance (≤ $10) — auto-resolve ──────────
+    if delta_cents <= AUTO_RESOLVE_THRESHOLD_CENTS:
+        variance_direction = "under" if streamline_cents > local_cents else "over"
+
+        audit = ParityAudit(
+            id=uuid4(),
+            reservation_id=str(res.id),
+            confirmation_id=confirmation_code,
+            local_total=local_total,
+            streamline_total=result.streamline_total,
+            delta=delta_dec,
+            local_breakdown=local_breakdown,
+            streamline_breakdown=streamline_breakdown,
+            status="auto_resolved",
+        )
+        db.add(audit)
+
+        approval = FinancialApproval(
+            id=uuid4(),
+            reservation_id=str(res.id),
+            status="auto_resolved",
+            discrepancy_type="daily_audit_drift",
+            local_total_cents=local_cents,
+            streamline_total_cents=streamline_cents,
+            delta_cents=delta_cents,
+            context_payload={
+                "local_breakdown": local_breakdown,
+                "streamline_breakdown": streamline_breakdown,
+                "variance_direction": variance_direction,
+                "audit_source": "hermes_daily_auditor",
+                "auto_resolution": {
+                    "type": "system_variance_adjustment",
+                    "description": (
+                        f"Daily audit auto-resolved {variance_direction}-charge of "
+                        f"${delta_dec:.2f} (Δ{delta_cents}¢)"
+                    ),
+                    "proposed_entry": {
+                        "debit_account": "Streamline Variance" if variance_direction == "under" else "Guest Receivable",
+                        "credit_account": "Guest Receivable" if variance_direction == "under" else "Streamline Variance",
+                        "amount_cents": delta_cents,
+                    },
+                },
+            },
+            resolved_by="hermes_daily_auditor",
+            resolved_at=datetime.now(timezone.utc),
+        )
+        db.add(approval)
+        await db.flush()
+
+        logger.info(
+            "daily_audit_auto_resolved",
+            reservation_id=str(res.id),
+            delta_cents=delta_cents,
+            direction=variance_direction,
+        )
+        return "auto_resolved"
+
+    # ── Tier 3: Material discrepancy (> $10) — queue for review ─
+    audit = ParityAudit(
+        id=uuid4(),
+        reservation_id=str(res.id),
+        confirmation_id=confirmation_code,
+        local_total=local_total,
+        streamline_total=result.streamline_total,
+        delta=delta_dec,
+        local_breakdown=local_breakdown,
+        streamline_breakdown=streamline_breakdown,
+        status="discrepancy",
+    )
+    db.add(audit)
+
+    approval = FinancialApproval(
+        id=uuid4(),
+        reservation_id=str(res.id),
+        status="pending",
+        discrepancy_type="daily_audit_drift",
+        local_total_cents=local_cents,
+        streamline_total_cents=streamline_cents,
+        delta_cents=delta_cents,
+        context_payload={
+            "local_breakdown": local_breakdown,
+            "streamline_breakdown": streamline_breakdown,
+            "severity": "material",
+            "audit_source": "hermes_daily_auditor",
+            "requires_commander_review": True,
+        },
+    )
+    db.add(approval)
+    await db.flush()
+
+    logger.critical(
+        "daily_audit_discrepancy_queued",
+        reservation_id=str(res.id),
+        confirmation_code=confirmation_code,
+        local_cents=local_cents,
+        streamline_cents=streamline_cents,
+        delta_cents=delta_cents,
+    )
+    return "pending"
+
+
+async def run_daily_audit() -> dict:
+    """Audit all active reservations against Streamline.  Returns summary."""
+    from backend.services.streamline_client import StreamlineClient
+
+    today = date.today()
+    stats: dict = {
+        "total": 0,
+        "confirmed": 0,
+        "auto_resolved": 0,
+        "pending": 0,
+        "errors": 0,
+        "skipped": 0,
+        "trust_chain": None,
+    }
+
+    client = StreamlineClient()
+    try:
+        async with AsyncSessionLocal() as db:
+            stmt = (
+                select(Reservation)
+                .where(
+                    and_(
+                        Reservation.check_out_date >= today,
+                        Reservation.status == "confirmed",
+                        Reservation.confirmation_code.isnot(None),
+                    )
+                )
+                .order_by(Reservation.check_in_date.asc())
+                .limit(BATCH_SIZE)
+            )
+            rows = (await db.execute(stmt)).scalars().all()
+            stats["total"] = len(rows)
+
+            if not rows:
+                logger.info("daily_audit_no_active_reservations")
+                await db.commit()
+                stats["trust_chain"] = await verify_hash_chain(db)
+                return stats
+
+            consecutive_failures = 0
+
+            for res in rows:
+                try:
+                    outcome = await _audit_single_reservation(db, res, client)
+                    if outcome.startswith("skipped"):
+                        stats["skipped"] += 1
+                    else:
+                        stats[outcome] = stats.get(outcome, 0) + 1
+                    consecutive_failures = 0
+                except Exception as exc:
+                    stats["errors"] += 1
+                    consecutive_failures += 1
+                    logger.warning(
+                        "daily_audit_reservation_error",
+                        reservation_id=str(res.id),
+                        error=str(exc)[:300],
+                    )
+                    backoff = min(BACKOFF_BASE * (2 ** (consecutive_failures - 1)), BACKOFF_MAX)
+                    await asyncio.sleep(backoff)
+                    continue
+
+                await asyncio.sleep(INTER_CALL_DELAY)
+
+            await db.commit()
+            stats["trust_chain"] = await verify_hash_chain(db)
+
+    finally:
+        await client.close()
+
+    logger.info("daily_audit_complete", **stats)
+    return stats
+
+
+async def hermes_daily_auditor_loop() -> None:
+    """Run the daily auditor at 00:00 UTC every day (FastAPI lifespan / standalone)."""
+    _deprioritize()
+    logger.info(
+        "hermes_continuous_auditor_scheduled",
+        schedule="00:00 daily",
+        message="🛡️ Hermes Continuous Auditor scheduled for 00:00 daily.",
+    )
+
+    while True:
+        now = datetime.now(timezone.utc)
+        next_midnight = now.replace(
+            hour=0, minute=0, second=0, microsecond=0
+        ) + timedelta(days=1)
+        sleep_seconds = max(0.0, (next_midnight - now).total_seconds())
+        logger.info(
+            "hermes_auditor_sleeping_until_midnight",
+            seconds=int(sleep_seconds),
+            next_run_utc=next_midnight.isoformat(),
+        )
+        await asyncio.sleep(sleep_seconds)
+
+        try:
+            result = await run_daily_audit()
+            logger.info("hermes_daily_audit_finished", **result)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.error("hermes_daily_auditor_loop_error", error=str(exc)[:400])


### PR DESCRIPTION
Phase I trust ledger feature: deposits via Stripe, off-session damage charges, signed hash-chain ledger entries, checkout parity audit, reservation webhooks with payload vault, and storefront checkout Stripe event handling.

## What's in this PR

**Backend models**
- `financial_primitives`: fee_type, percentage_rate, is_optional on Fee
- `trust_ledger`: hash-chain signature columns, streamline_event_id uniqueness, nullable decision_id
- `damage_claim`: Stripe charge execution fields

**Backend integrations + API**
- `stripe_payments`: deposit intent create/capture helpers (+192)
- `stripe_webhooks`: storefront_checkout + invoice.paid handlers (+383)
- `reservation_webhooks`: Streamline webhook endpoint + payload vault (+175)
- `telemetry`: checkout parity audit models + endpoint (+140)
- `reservations`: deposit initiate/authorize/capture/release endpoints (+169)
- `damage_claims`: POST /{claim_id}/charge off-session endpoint (+95)

**New API routers (previously deferred from foundation)**
- `financial_approvals`
- `storefront_checkout`
- `trust_ledger_command_center`

**New services**
- `financial_approval_service`
- `ledger`
- `trust_ledger`

**New worker**
- `hermes_daily_auditor` (registered as a lifespan task)

**main.py updates**
- 3 new router registrations
- hermes_daily_auditor lifespan startup/shutdown

**Frontend**
- FolioSheet.tsx: deposit action buttons
- damage-claims/page.tsx: charge guest modal

## Verification

- Python AST parse passes on main.py (+14 lines inserted surgically)
- All imports resolve to files in this branch (no missing dependencies)
- Companion Alembic migrations already landed in foundation PR #11

## Merge strategy

Please use **Create a merge commit**.
