### PR TITLE
feat(legal-council): restore SSE streaming + async deliberate pattern

### DIFF
--- a/fortress-guest-platform/apps/command-center/src/app/(dashboard)/legal/_components/legal-cases-shell.tsx
+++ b/fortress-guest-platform/apps/command-center/src/app/(dashboard)/legal/_components/legal-cases-shell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { Scale, ChevronRight, Clock } from "lucide-react";
+import { Scale, ChevronRight, Clock, Mail } from "lucide-react";
 import { useLegalCases } from "@/lib/legal-hooks";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -48,13 +48,22 @@ export function LegalCasesShell() {
             Active litigation, deadlines, and AI extraction intelligence.
           </p>
         </div>
-        <Link
-          href="/legal/council"
-          className="inline-flex items-center gap-2 rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 transition-colors"
-        >
-          Council of 9
-          <ChevronRight className="h-4 w-4" />
-        </Link>
+        <div className="flex items-center gap-2">
+          <Link
+            href="/legal/email-intake"
+            className="inline-flex items-center gap-2 rounded-md border border-border px-3 py-2 text-sm font-medium text-foreground hover:bg-accent transition-colors"
+          >
+            <Mail className="h-4 w-4" />
+            Email Intake
+          </Link>
+          <Link
+            href="/legal/council"
+            className="inline-flex items-center gap-2 rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 transition-colors"
+          >
+            Council of 9
+            <ChevronRight className="h-4 w-4" />
+          </Link>
+        </div>
       </div>
 
       {isLoading && (

--- a/fortress-guest-platform/apps/command-center/src/app/(dashboard)/legal/cases/[slug]/_components/counsel-threat-matrix.tsx
+++ b/fortress-guest-platform/apps/command-center/src/app/(dashboard)/legal/cases/[slug]/_components/counsel-threat-matrix.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useState } from "react";
-import { api } from "@/lib/api";
+import { useMemo } from "react";
 import { RoleGatedAction } from "@/components/access/role-gated-action";
 import { useAppStore } from "@/lib/store";
 import { canManageLegalOps } from "@/lib/roles";
@@ -33,26 +32,26 @@ const SIGNAL_LABEL: Record<string, string> = {
 export function CounselThreatMatrix({ slug }: { slug: string }) {
   const user = useAppStore((state) => state.user);
   const canOperate = canManageLegalOps(user);
-  const [result, setResult] = useState<DeliberationResult | null>(null);
-  const [loading, setLoading] = useState(false);
+  const council = useCouncilStream(slug);
 
   const handleDeliberate = async () => {
     toast.info("Convening the Counsel of 9 — this may take several minutes...");
     try {
-      const data = await api.post<DeliberationResult>(
-        `/api/internal/legal/cases/${slug}/deliberate`,
-      );
-      setResult(data);
+      await council.start();
       toast.success("Counsel deliberation complete");
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Deliberation failed");
     }
   };
 
-  const isRunning = council.connectionState !== "idle" &&
+  const isRunning =
+    council.connectionState !== "idle" &&
     council.connectionState !== "done" &&
     council.connectionState !== "stopped" &&
     council.connectionState !== "error";
+  const consensus = council.consensus ?? council.finalResult;
+  const opinions = council.opinions;
+  const liveSummary = useMemo(() => council.streamLines.slice(-8), [council.streamLines]);
 
   return (
     <Card>
@@ -66,10 +65,10 @@ export function CounselThreatMatrix({ slug }: { slug: string }) {
             <Button
               size="sm"
               onClick={handleDeliberate}
-              disabled={!canOperate || loading}
+              disabled={!canOperate || isRunning}
               className="text-xs h-7"
             >
-              {loading ? (
+              {isRunning ? (
                 <>
                   <Loader2 className="h-3 w-3 mr-1 animate-spin" />
                   Deliberating...

--- a/fortress-guest-platform/apps/command-center/src/app/api/legal/council/[jobId]/stream/route.ts
+++ b/fortress-guest-platform/apps/command-center/src/app/api/legal/council/[jobId]/stream/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { buildBackendUrl } from "@/lib/server/backend-url";
+import { getFortressIngressHeaders } from "@/lib/server/fortress-ingress-headers";
 
 const SESSION_COOKIE = "fortress_session";
 
@@ -13,7 +14,7 @@ export async function GET(
 ) {
   const { jobId } = await params;
   const upstreamUrl = new URL(
-    buildBackendUrl(`/api/legal/council/${encodeURIComponent(jobId)}/stream`),
+    buildBackendUrl(`/api/internal/legal/council/${encodeURIComponent(jobId)}/stream`),
   );
   const cursor = request.nextUrl.searchParams.get("cursor");
   if (cursor) {
@@ -22,6 +23,7 @@ export async function GET(
 
   const headers: Record<string, string> = {
     Accept: "text/event-stream",
+    ...getFortressIngressHeaders(request),
   };
 
   let token: string | null = null;

--- a/fortress-guest-platform/apps/command-center/src/lib/use-council-stream.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/use-council-stream.ts
@@ -624,7 +624,7 @@ export function useCouncilStream(
 
     const requestConfig = buildStartRequest
       ? buildStartRequest(caseSlug)
-      : { url: `/api/legal/cases/${caseSlug}/deliberate` };
+      : { url: `/api/internal/legal/cases/${caseSlug}/deliberate` };
     const response = await api.post<CouncilStartResponse>(
       requestConfig.url,
       requestConfig.body,

--- a/fortress-guest-platform/backend/api/legal_cases.py
+++ b/fortress-guest-platform/backend/api/legal_cases.py
@@ -132,23 +132,28 @@ def _compute_deadline_fields(d: dict) -> dict:
 
 @router.get("/cases", summary="List all legal cases")
 async def list_cases():
-    async with LegacySession() as session:
-        result = await session.execute(text("""
-            SELECT c.*,
-                   d.consensus_signal  AS live_ai_status,
-                   d.trigger_type      AS latest_action,
-                   d.timestamp         AS last_ai_review
-            FROM legal.cases c
-            LEFT JOIN LATERAL (
-                SELECT consensus_signal, trigger_type, timestamp
-                FROM legal_cmd.deliberation_events
-                WHERE case_slug = c.case_slug
-                ORDER BY timestamp DESC
-                LIMIT 1
-            ) d ON true
-            ORDER BY c.critical_date ASC NULLS LAST, c.id
-        """))
-        rows = result.fetchall()
+    try:
+        async with LegacySession() as session:
+            result = await session.execute(text("""
+                SELECT c.*,
+                       d.consensus_signal  AS live_ai_status,
+                       d.trigger_type      AS latest_action,
+                       d.timestamp         AS last_ai_review
+                FROM legal.cases c
+                LEFT JOIN LATERAL (
+                    SELECT consensus_signal, trigger_type, timestamp
+                    FROM legal_cmd.deliberation_events
+                    WHERE case_slug = c.case_slug
+                    ORDER BY timestamp DESC
+                    LIMIT 1
+                ) d ON true
+                ORDER BY c.critical_date ASC NULLS LAST, c.id
+            """))
+            rows = result.fetchall()
+    except Exception as exc:
+        # Missing DB, schema, or GRANTs on fortress_db should not brick the Command Center shell.
+        logger.warning("legal_cases_list_failed", error=str(exc)[:500])
+        return {"cases": []}
 
     cases = []
     for row in rows:
@@ -1435,28 +1440,30 @@ async def build_case_chronology(slug: str, background_tasks: BackgroundTasks):
 
 @router.post("/cases/{slug}/deliberate", summary="Convene the Counsel of 9")
 async def deliberate_case(slug: str):
-    """Run the Counsel of 9 deliberation against the case graph + chronology."""
-    from backend.services.legal_council import run_council_deliberation
+    """
+    Enqueue a Council of 9 deliberation via ARQ and return the job_id so the
+    frontend can subscribe to the Redis-backed SSE stream at
+    GET /api/legal/council/{job_id}/stream.
+    """
     from backend.services.legal_case_graph import get_case_graph_snapshot
     from backend.services.legal_chronology import get_chronology
-    import json as _json
+    from backend.services.async_jobs import enqueue_async_job
 
-    async with AsyncSessionLocal() as db:
-        snapshot = await get_case_graph_snapshot(db, case_slug=slug)
-        timeline = await get_chronology(db, slug)
+    async with AsyncSessionLocal() as graph_db:
+        snapshot = await get_case_graph_snapshot(graph_db, case_slug=slug)
+        try:
+            timeline = await get_chronology(graph_db, slug)
+        except Exception:
+            timeline = []   # chronology_events table may not exist yet
 
     nodes = snapshot.get("nodes", [])
     edges = snapshot.get("edges", [])
-    node_lines = []
+    node_lines, edge_lines, label_by_id = [], [], {}
     for n in nodes:
         label = n.label if hasattr(n, "label") else n.get("label", "?")
         etype = n.entity_type if hasattr(n, "entity_type") else n.get("entity_type", "?")
         node_lines.append(f"[{etype}] {label}")
-    edge_lines = []
-    label_by_id = {}
-    for n in nodes:
         nid = str(n.id if hasattr(n, "id") else n.get("id", "?"))
-        label = n.label if hasattr(n, "label") else n.get("label", "?")
         label_by_id[nid] = label
     for e in edges:
         src = label_by_id.get(str(e.source_node_id if hasattr(e, "source_node_id") else e.get("source_node_id", "?")), "?")
@@ -1464,9 +1471,8 @@ async def deliberate_case(slug: str):
         rel = e.relationship_type if hasattr(e, "relationship_type") else e.get("relationship_type", "?")
         edge_lines.append(f"{src} --({rel})--> {tgt}")
 
-    chrono_lines = []
-    for ev in timeline:
-        chrono_lines.append(f"{ev.get('event_date','?')}: {ev.get('event_description','')}")
+    chrono_lines = [f"{ev.get('event_date','?')}: {ev.get('event_description','')}"
+                    for ev in timeline]
 
     case_brief = (
         f"Case: {slug}\n\n"
@@ -1475,16 +1481,26 @@ async def deliberate_case(slug: str):
         f"CHRONOLOGY:\n" + "\n".join(chrono_lines)
     )
 
-    import uuid as _uuid
-    result = await run_council_deliberation(
-        session_id=str(_uuid.uuid4()),
-        case_brief=case_brief,
-        context=f"Graph: {len(nodes)} entities, {len(edges)} edges. Timeline: {len(timeline)} events.",
-        case_slug=slug,
-        trigger_type="GLASS_DELIBERATE",
-    )
-
-    return result
+    async with AsyncSessionLocal() as job_db:
+        job = await enqueue_async_job(
+            job_db,
+            worker_name="run_legal_council_job",
+            job_name="legal_council",
+            payload={
+                "case_slug": slug,
+                "case_brief": case_brief,
+                "context": f"Graph: {len(nodes)} entities, {len(edges)} edges. Timeline: {len(timeline)} events.",
+                "trigger_type": "GLASS_DELIBERATE",
+            },
+        )
+    job_id = str(job.id)
+    return {
+        "job_id": job_id,
+        "status": "queued",
+        "case_slug": slug,
+        "stream_url": f"/api/internal/legal/council/{job_id}/stream",
+        "status_url": f"/api/async/jobs/{job_id}",
+    }
 
 
 @router.get("/cases/{slug}/chronology", summary="Get master chronology timeline")

--- a/fortress-guest-platform/backend/api/legal_council.py
+++ b/fortress-guest-platform/backend/api/legal_council.py
@@ -173,6 +173,82 @@ async def get_session_state(session_id: str):
     return session
 
 
+@router.get("/council/{job_id}/stream")
+async def stream_council_job(job_id: str, request: Request, cursor: str | None = None):
+    """
+    Redis-backed SSE stream for an ARQ council deliberation job.
+
+    Replays stored events (from cursor) then subscribes to live pub/sub.
+    The frontend EventSource connects here after POST /cases/{slug}/deliberate
+    returns {"job_id": "..."}.
+    """
+    from backend.core.council_stream import (
+        create_council_redis,
+        replay_council_events,
+        is_terminal_event,
+    )
+
+    async def generate():
+        redis = await create_council_redis()
+        try:
+            # 1. Replay buffered events (handles reconnect with ?cursor=)
+            history = await replay_council_events(redis, job_id, after_id=cursor)
+            for stream_id, event in history:
+                yield f"id: {stream_id}\ndata: {json.dumps(event, ensure_ascii=False)}\n\n"
+                if is_terminal_event(event):
+                    return
+
+            # 2. Subscribe to live channel for remaining events
+            pubsub = redis.pubsub()
+            channel = f"council_stream:{job_id}"
+            await pubsub.subscribe(channel)
+            try:
+                timeout = 0
+                while not await request.is_disconnected():
+                    msg = await pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0)
+                    if msg and msg.get("type") == "message":
+                        raw = msg.get("data", "{}")
+                        try:
+                            envelope = json.loads(raw)
+                            event = envelope.get("event", envelope)
+                            stream_id = envelope.get("stream_id", "")
+                        except Exception:
+                            event = {"type": "raw", "data": raw}
+                            stream_id = ""
+                        if stream_id:
+                            yield f"id: {stream_id}\ndata: {json.dumps(event, ensure_ascii=False)}\n\n"
+                        else:
+                            yield f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
+                        timeout = 0
+                        if is_terminal_event(event):
+                            return
+                    else:
+                        timeout += 1
+                        if timeout % 15 == 0:
+                            yield ": heartbeat\n\n"
+                        if timeout > 600:   # 10 minutes idle → close
+                            yield f"data: {json.dumps({'type':'timeout','job_id':job_id})}\n\n"
+                            return
+            finally:
+                await pubsub.unsubscribe(channel)
+                await pubsub.close()
+        except Exception as exc:
+            logger.exception("council_stream_error  job_id=%s  error=%s", job_id, str(exc)[:200])
+            yield f"data: {json.dumps({'type':'error','message':str(exc)[:200],'job_id':job_id})}\n\n"
+        finally:
+            await redis.close()
+
+    return StreamingResponse(
+        generate(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache, no-store",
+            "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
+        },
+    )
+
+
 @router.get("/council/personas")
 async def get_personas():
     """List all 9 Legal Council personas with their profiles."""


### PR DESCRIPTION
Restores the council SSE streaming endpoint and async ARQ-backed deliberate job queue that were accidentally removed during rebase regression repair commits (7d433dd47, bf1fbc91a, c877c87ab). The working-tree version is the intended forward state — the earlier removal was rebase loss, confirmed by operator review.

## Backend

- `api/legal_council`: `GET /council/{job_id}/stream` — Redis-backed SSE endpoint streaming deliberation progress events (+76 lines)
- `api/legal_cases`: `list_cases` wrapped in graceful try/except; `deliberate_case()` converted to ARQ async job enqueue pattern

## Command-center frontend

- BFF proxy: `/api/legal/council/[jobId]/stream/route.ts` with ingress headers + path correction to `/api/internal/legal/council/`
- `use-council-stream.ts`: hook default URL updated for isolated internal route
- `legal-cases-shell.tsx`: "Email Intake" button alongside "Council of 9"
- `counsel-threat-matrix.tsx`: re-adopts `useCouncilStream` with expanded consensus, opinions, and liveSummary support

## Merge strategy

Please use **Create a merge commit**.
