### PR TITLE
feat(seo): live pipeline KPI stats endpoint + UI

### DIFF
--- a/fortress-guest-platform/apps/command-center/src/app/(dashboard)/growth/seo-copilot/page.tsx
+++ b/fortress-guest-platform/apps/command-center/src/app/(dashboard)/growth/seo-copilot/page.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   Brain,
   Send,
   TrendingUp,
-  Globe,
-  FileSearch,
-  Gauge,
+  FileText,
+  CheckCircle,
+  AlertCircle,
 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -15,27 +15,85 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 
-const KPI_CARDS = [
-  { label: "Domain Authority", value: "--", icon: Globe, color: "text-blue-400" },
-  { label: "Indexed Pages", value: "--", icon: FileSearch, color: "text-emerald-400" },
-  { label: "Avg. Position", value: "--", icon: TrendingUp, color: "text-amber-400" },
-  { label: "Core Web Vitals", value: "--", icon: Gauge, color: "text-purple-400" },
-] as const;
+interface PipelineStats {
+  drafts_created: number;
+  pending_review: number;
+  deployed_count: number;
+  properties_without_draft: number;
+  total_active_properties: number;
+  avg_godhead_score: number | null;
+  active_rubrics: number;
+}
+
+function usePipelineStats() {
+  const [stats, setStats] = useState<PipelineStats | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/seo/pipeline-stats")
+      .then((r) => r.ok ? r.json() : null)
+      .then((data) => {
+        if (data) setStats(data as PipelineStats);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  return { stats, loading };
+}
 
 export default function SeoCopilotPage() {
   const [message, setMessage] = useState("");
+  const { stats, loading } = usePipelineStats();
+
+  const kpiCards = [
+    {
+      label: "Drafts Created",
+      value: loading ? null : (stats?.drafts_created ?? 0),
+      icon: FileText,
+      color: "text-blue-400",
+    },
+    {
+      label: "Pending Review",
+      value: loading ? null : (stats?.pending_review ?? 0),
+      icon: AlertCircle,
+      color: "text-amber-400",
+    },
+    {
+      label: "Deployed",
+      value: loading ? null : (stats?.deployed_count ?? 0),
+      icon: CheckCircle,
+      color: "text-emerald-400",
+    },
+    {
+      label: "Properties Uncovered",
+      value: loading
+        ? null
+        : stats
+        ? `${stats.properties_without_draft}/${stats.total_active_properties}`
+        : "--",
+      icon: TrendingUp,
+      color: "text-purple-400",
+    },
+  ] as const;
 
   return (
     <div className="space-y-4">
       <div className="grid gap-3 md:grid-cols-4">
-        {KPI_CARDS.map((kpi) => (
+        {kpiCards.map((kpi) => (
           <Card key={kpi.label}>
             <CardContent className="pt-4 pb-3">
               <div className="flex items-center justify-between">
                 <p className="text-xs text-muted-foreground">{kpi.label}</p>
                 <kpi.icon className={`h-3.5 w-3.5 ${kpi.color}`} />
               </div>
-              <p className="text-xl font-bold font-mono">{kpi.value}</p>
+              {loading ? (
+                <Skeleton className="h-7 w-16 mt-1" />
+              ) : (
+                <p className="text-xl font-bold font-mono">
+                  {kpi.value ?? "--"}
+                </p>
+              )}
             </CardContent>
           </Card>
         ))}
@@ -50,6 +108,11 @@ export default function SeoCopilotPage() {
               <Badge variant="outline" className="bg-emerald-500/10 text-emerald-500 border-emerald-500/20 ml-auto">
                 Teacher / Student
               </Badge>
+              {stats && (
+                <Badge variant="outline" className="text-xs font-mono">
+                  {stats.active_rubrics} rubric{stats.active_rubrics !== 1 ? "s" : ""} active
+                </Badge>
+              )}
             </CardTitle>
           </CardHeader>
           <CardContent>
@@ -95,23 +158,50 @@ export default function SeoCopilotPage() {
             <CardTitle className="text-base">Optimization Queue</CardTitle>
           </CardHeader>
           <CardContent className="space-y-2">
-            {Array.from({ length: 6 }).map((_, i) => (
-              <div key={i} className="flex items-center gap-2 rounded-md bg-muted/50 p-2.5">
-                <Skeleton className="h-4 w-4 rounded-full shrink-0" />
-                <div className="flex-1 space-y-1">
-                  <Skeleton className="h-3 w-full" />
-                  <Skeleton className="h-2.5 w-2/3" />
-                </div>
-                <Skeleton className="h-5 w-14 rounded-full" />
-              </div>
-            ))}
+            {loading
+              ? Array.from({ length: 6 }).map((_, i) => (
+                  <div key={i} className="flex items-center gap-2 rounded-md bg-muted/50 p-2.5">
+                    <Skeleton className="h-4 w-4 rounded-full shrink-0" />
+                    <div className="flex-1 space-y-1">
+                      <Skeleton className="h-3 w-full" />
+                      <Skeleton className="h-2.5 w-2/3" />
+                    </div>
+                    <Skeleton className="h-5 w-14 rounded-full" />
+                  </div>
+                ))
+              : stats && stats.pending_review > 0
+              ? (
+                  <div className="flex flex-col items-center justify-center h-24 gap-2">
+                    <p className="text-sm font-semibold text-amber-500">{stats.pending_review} patch{stats.pending_review !== 1 ? "es" : ""} pending review</p>
+                    <a
+                      href="/growth/seo-approval"
+                      className="text-xs text-blue-400 underline underline-offset-2"
+                    >
+                      Open approval queue →
+                    </a>
+                  </div>
+                )
+              : (
+                  <div className="flex flex-col items-center justify-center h-24 gap-1">
+                    <CheckCircle className="h-6 w-6 text-emerald-500" />
+                    <p className="text-sm text-muted-foreground">Queue is clear</p>
+                  </div>
+                )
+            }
           </CardContent>
         </Card>
       </div>
 
       <Card>
         <CardHeader className="pb-3">
-          <CardTitle className="text-base">Keyword Performance (Coming Soon)</CardTitle>
+          <CardTitle className="text-base">
+            Keyword Performance
+            {stats?.avg_godhead_score != null && (
+              <span className="ml-2 text-xs font-normal text-muted-foreground">
+                Avg God Head score: <span className="font-mono text-emerald-400">{stats.avg_godhead_score.toFixed(2)}</span>
+              </span>
+            )}
+          </CardTitle>
         </CardHeader>
         <CardContent>
           <div className="flex h-[200px] items-center justify-center rounded-lg border border-dashed bg-muted/20">

--- a/fortress-guest-platform/backend/api/seo_patches.py
+++ b/fortress-guest-platform/backend/api/seo_patches.py
@@ -1043,3 +1043,84 @@ async def get_live_payload(
     db: AsyncSession = Depends(get_db),
 ) -> LiveSEOPayloadResponse:
     return await _load_deployed_live_payload(db, property_slug)
+
+
+# ── Pipeline stats (internal dashboard KPIs) ─────────────────────────────────
+
+class SEOPipelineStatsResponse(BaseModel):
+    """Real-time SEO pipeline counters for the Command Center dashboard."""
+    # Patch queue counts
+    drafts_created: int
+    pending_review: int
+    deployed_count: int
+    needs_rewrite: int
+    # Rubric health
+    active_rubrics: int
+    # Property coverage
+    properties_with_draft: int
+    properties_without_draft: int
+    total_active_properties: int
+    # Aggregate quality
+    avg_godhead_score: float | None
+
+
+@router.get("/pipeline-stats", response_model=SEOPipelineStatsResponse)
+async def seo_pipeline_stats(db: AsyncSession = Depends(get_db)) -> SEOPipelineStatsResponse:
+    """
+    Returns internal SEO pipeline metrics for Command Center KPI cards.
+    No auth required — counts only, no PII.
+    """
+    # Patch status counts
+    status_rows = (
+        await db.execute(
+            select(SEOPatch.status, func.count(SEOPatch.id)).group_by(SEOPatch.status)
+        )
+    ).all()
+    counts: dict[str, int] = {row_status: row_count for row_status, row_count in status_rows}
+
+    # Active rubrics
+    active_rubrics = (
+        await db.execute(select(func.count(SEORubric.id)).where(SEORubric.status == "active"))
+    ).scalar_one() or 0
+
+    # Property coverage — active properties
+    total_active_props = (
+        await db.execute(
+            select(func.count(Property.id)).where(Property.is_active.is_(True))
+        )
+    ).scalar_one() or 0
+
+    ACTIVE_STATUSES = ("drafted", "grading", "needs_rewrite", "pending_human", "deployed")
+    props_with_draft = (
+        await db.execute(
+            select(func.count(SEOPatch.property_id.distinct())).where(
+                SEOPatch.status.in_(ACTIVE_STATUSES),
+                SEOPatch.property_id.isnot(None),
+            )
+        )
+    ).scalar_one() or 0
+
+    # Average godhead score for deployed patches
+    avg_score_row = (
+        await db.execute(
+            select(func.avg(SEOPatch.godhead_score)).where(
+                SEOPatch.status == "deployed",
+                SEOPatch.godhead_score.isnot(None),
+            )
+        )
+    ).scalar_one()
+    avg_score = round(float(avg_score_row), 3) if avg_score_row is not None else None
+
+    return SEOPipelineStatsResponse(
+        drafts_created=counts.get("drafted", 0) + counts.get("grading", 0)
+            + counts.get("needs_rewrite", 0) + counts.get("pending_human", 0)
+            + counts.get("deployed", 0) + counts.get("rejected", 0),
+        pending_review=counts.get("pending_human", 0),
+        deployed_count=counts.get("deployed", 0),
+        needs_rewrite=counts.get("needs_rewrite", 0),
+        active_rubrics=int(active_rubrics),
+        properties_with_draft=int(props_with_draft),
+        properties_without_draft=max(0, int(total_active_props) - int(props_with_draft)),
+        total_active_properties=int(total_active_props),
+        avg_godhead_score=avg_score,
+    )


### PR DESCRIPTION
Replaces static placeholder KPI cards in the SEO copilot dashboard with live data.

## Changes

- `backend/api/seo_patches`: new `GET /seo/pipeline-stats` endpoint returning drafts / pending / deployed / avg_godhead_score
- `seo-copilot/page.tsx`: consumes `usePipelineStats()` hook for live counters

## Merge strategy

Please use **Create a merge commit**.
