### PR TITLE
feat(streamline): parity audit methods + VRS fee refactor + Taylor quote UI

### DIFF
--- a/fortress-guest-platform/apps/command-center/src/app/(dashboard)/vrs/_components/taylor-quote-dashboard.tsx
+++ b/fortress-guest-platform/apps/command-center/src/app/(dashboard)/vrs/_components/taylor-quote-dashboard.tsx
@@ -1,0 +1,396 @@
+"use client";
+
+import { useState } from "react";
+import {
+  BedDouble,
+  CheckCircle2,
+  Clock,
+  Loader2,
+  Mail,
+  SendHorizonal,
+  Users,
+} from "lucide-react";
+import { toast } from "sonner";
+import { ApiError } from "@/lib/api";
+import {
+  useApproveTaylorQuote,
+  useCreateTaylorQuoteRequest,
+  useTaylorPendingQuotes,
+  type TaylorPropertyOption,
+  type TaylorQuoteRequestRecord,
+} from "@/lib/hooks";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+function formatCurrency(amount: number) {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(amount);
+}
+
+function formatDate(iso: string) {
+  return new Date(`${iso}T00:00:00`).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function relativeTime(iso: string) {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+// ─── Property Option Card ─────────────────────────────────────────────────────
+
+function PropertyOptionCard({ opt }: { opt: TaylorPropertyOption }) {
+  return (
+    <div className="rounded-lg border bg-card overflow-hidden">
+      {opt.hero_image_url && (
+        <img
+          src={opt.hero_image_url}
+          alt={opt.property_name}
+          className="w-full h-36 object-cover"
+        />
+      )}
+      <div className="p-3 space-y-2">
+        <p className="font-semibold text-sm leading-tight">{opt.property_name}</p>
+        <p className="text-xs text-muted-foreground flex items-center gap-1">
+          <BedDouble className="h-3 w-3" />
+          {opt.bedrooms} bed · {opt.bathrooms} bath · {opt.max_guests} guests max
+        </p>
+        <div className="text-xs space-y-0.5 border-t pt-2">
+          <div className="flex justify-between text-muted-foreground">
+            <span>Base rent</span><span>{formatCurrency(opt.base_rent)}</span>
+          </div>
+          <div className="flex justify-between text-muted-foreground">
+            <span>Fees</span><span>{formatCurrency(opt.fees)}</span>
+          </div>
+          <div className="flex justify-between text-muted-foreground">
+            <span>Taxes</span><span>{formatCurrency(opt.taxes)}</span>
+          </div>
+          <div className="flex justify-between font-semibold text-foreground border-t pt-1 mt-1">
+            <span>Total</span><span>{formatCurrency(opt.total_amount)}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Pending Quote Row ────────────────────────────────────────────────────────
+
+function PendingQuoteRow({ record }: { record: TaylorQuoteRequestRecord }) {
+  const [expanded, setExpanded] = useState(false);
+  const approve = useApproveTaylorQuote();
+
+  const isSent = record.status === "sent";
+  const guestLabel = [
+    `${record.adults} adult${record.adults !== 1 ? "s" : ""}`,
+    record.children ? `${record.children} child${record.children !== 1 ? "ren" : ""}` : null,
+    record.pets ? `${record.pets} pet${record.pets !== 1 ? "s" : ""}` : null,
+  ]
+    .filter(Boolean)
+    .join(", ");
+
+  return (
+    <div className={`rounded-xl border ${isSent ? "bg-muted/20 border-border/50" : "bg-card"}`}>
+      <div className="p-4 flex items-start gap-4">
+        <div className="flex-1 min-w-0 space-y-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="font-medium text-sm truncate">{record.guest_email}</span>
+            <Badge variant={isSent ? "secondary" : "outline"} className="text-[11px]">
+              {isSent ? (
+                <><CheckCircle2 className="h-3 w-3 mr-1" />Sent</>
+              ) : (
+                <><Clock className="h-3 w-3 mr-1" />Pending</>
+              )}
+            </Badge>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {formatDate(record.check_in)} → {formatDate(record.check_out)}
+            {" · "}{record.nights} night{record.nights !== 1 ? "s" : ""}
+            {" · "}{guestLabel}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {record.available_property_count} cabin{record.available_property_count !== 1 ? "s" : ""} available
+            {" · "}{relativeTime(record.created_at)}
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2 shrink-0">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-xs"
+            onClick={() => setExpanded((v) => !v)}
+          >
+            {expanded ? "Collapse" : "Preview"}
+          </Button>
+          {!isSent && (
+            <Button
+              size="sm"
+              disabled={approve.isPending || record.available_property_count === 0}
+              onClick={() => approve.mutate({ requestId: record.id })}
+            >
+              {approve.isPending ? (
+                <><Loader2 className="h-3.5 w-3.5 animate-spin" />Sending...</>
+              ) : (
+                <><SendHorizonal className="h-3.5 w-3.5" />Approve &amp; Send</>
+              )}
+            </Button>
+          )}
+          {isSent && record.approved_by && (
+            <span className="text-xs text-muted-foreground">by {record.approved_by}</span>
+          )}
+        </div>
+      </div>
+
+      {expanded && record.property_options.length > 0 && (
+        <div className="px-4 pb-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3 border-t pt-4">
+          {record.property_options.map((opt) => (
+            <PropertyOptionCard key={opt.property_id} opt={opt} />
+          ))}
+        </div>
+      )}
+
+      {expanded && record.property_options.length === 0 && (
+        <p className="px-4 pb-4 text-sm text-muted-foreground">
+          No available properties were found for these dates.
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ─── New Quote Request Form ───────────────────────────────────────────────────
+
+function buildDefaultDate(daysFromNow: number) {
+  const d = new Date();
+  d.setDate(d.getDate() + daysFromNow);
+  return d.toISOString().slice(0, 10);
+}
+
+function QuoteRequestForm() {
+  const [email, setEmail] = useState("");
+  const [checkIn, setCheckIn] = useState(buildDefaultDate(30));
+  const [checkOut, setCheckOut] = useState(buildDefaultDate(35));
+  const [adults, setAdults] = useState("2");
+  const [children, setChildren] = useState("0");
+  const [pets, setPets] = useState("0");
+
+  const create = useCreateTaylorQuoteRequest();
+
+  const canSubmit =
+    email.trim() &&
+    checkIn &&
+    checkOut &&
+    checkOut > checkIn &&
+    Number(adults) >= 1 &&
+    !create.isPending;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    try {
+      await create.mutateAsync({
+        guest_email: email.trim(),
+        check_in: checkIn,
+        check_out: checkOut,
+        adults: Number(adults),
+        children: Number(children),
+        pets: Number(pets),
+      });
+      // Keep form values — Taylor may send multiple quotes
+    } catch (err) {
+      const message =
+        err instanceof ApiError ? err.message : err instanceof Error ? err.message : "Request failed";
+      toast.error(message);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Mail className="h-4 w-4 text-primary" />
+          New Quote Request
+        </CardTitle>
+        <CardDescription>
+          Enter the guest&apos;s dates, party size, and email. The system will check all
+          14 properties against live Streamline availability and price each one.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-1.5 sm:col-span-2">
+          <Label htmlFor="tq-email">Guest Email</Label>
+          <Input
+            id="tq-email"
+            type="email"
+            placeholder="guest@example.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            disabled={create.isPending}
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="tq-checkin">Check-in</Label>
+          <Input
+            id="tq-checkin"
+            type="date"
+            value={checkIn}
+            onChange={(e) => setCheckIn(e.target.value)}
+            disabled={create.isPending}
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="tq-checkout">Check-out</Label>
+          <Input
+            id="tq-checkout"
+            type="date"
+            value={checkOut}
+            onChange={(e) => setCheckOut(e.target.value)}
+            disabled={create.isPending}
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="tq-adults">Adults</Label>
+          <Input
+            id="tq-adults"
+            type="number"
+            min="1"
+            max="24"
+            value={adults}
+            onChange={(e) => setAdults(e.target.value)}
+            disabled={create.isPending}
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="tq-children">Children</Label>
+          <Input
+            id="tq-children"
+            type="number"
+            min="0"
+            max="24"
+            value={children}
+            onChange={(e) => setChildren(e.target.value)}
+            disabled={create.isPending}
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="tq-pets">Pets</Label>
+          <Input
+            id="tq-pets"
+            type="number"
+            min="0"
+            max="12"
+            value={pets}
+            onChange={(e) => setPets(e.target.value)}
+            disabled={create.isPending}
+          />
+        </div>
+      </CardContent>
+      <CardFooter className="border-t">
+        <Button
+          type="button"
+          disabled={!canSubmit}
+          onClick={handleSubmit}
+          className="w-full sm:w-auto"
+        >
+          {create.isPending ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Checking all 14 properties...
+            </>
+          ) : (
+            <>
+              <Users className="h-4 w-4" />
+              Check Availability &amp; Generate Quote
+            </>
+          )}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}
+
+// ─── Approval Queue ───────────────────────────────────────────────────────────
+
+function ApprovalQueue() {
+  const { data, isLoading } = useTaylorPendingQuotes();
+  const requests = data?.requests ?? [];
+  const pending = requests.filter((r) => r.status === "pending_approval");
+  const sent = requests.filter((r) => r.status === "sent");
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground py-8">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading quote requests...
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {pending.length > 0 && (
+        <div className="space-y-3">
+          <div className="flex items-center gap-2">
+            <h3 className="font-semibold text-sm">Pending Approval</h3>
+            <Badge variant="destructive" className="text-[11px]">{pending.length}</Badge>
+          </div>
+          {pending.map((r) => <PendingQuoteRow key={r.id} record={r} />)}
+        </div>
+      )}
+
+      {sent.length > 0 && (
+        <div className="space-y-3">
+          <h3 className="font-semibold text-sm text-muted-foreground">Recently Sent</h3>
+          {sent.slice(0, 10).map((r) => <PendingQuoteRow key={r.id} record={r} />)}
+        </div>
+      )}
+
+      {requests.length === 0 && (
+        <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+          No quote requests yet. Use the form above to create one.
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Main Export ─────────────────────────────────────────────────────────────
+
+export function TaylorQuoteDashboard() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Taylor Quote Tool</h1>
+        <p className="text-muted-foreground">
+          Enter guest details → system checks all 14 properties → review available options →
+          approve with one click to send a professional quote email.
+        </p>
+      </div>
+
+      <QuoteRequestForm />
+      <ApprovalQueue />
+    </div>
+  );
+}

--- a/fortress-guest-platform/apps/command-center/src/app/(dashboard)/vrs/quotes/page.tsx
+++ b/fortress-guest-platform/apps/command-center/src/app/(dashboard)/vrs/quotes/page.tsx
@@ -1,5 +1,39 @@
-import { ManualQuoteGenerator } from "../_components/manual-quote-generator";
+"use client";
 
-export default function VrsManualQuotesPage() {
-  return <ManualQuoteGenerator />;
+import { useState } from "react";
+import { ManualQuoteGenerator } from "../_components/manual-quote-generator";
+import { TaylorQuoteDashboard } from "../_components/taylor-quote-dashboard";
+
+const TABS = [
+  { id: "taylor", label: "Taylor Quote Tool" },
+  { id: "manual", label: "Manual Quote Engine" },
+] as const;
+
+type Tab = (typeof TABS)[number]["id"];
+
+export default function VrsQuotesPage() {
+  const [activeTab, setActiveTab] = useState<Tab>("taylor");
+
+  return (
+    <div className="space-y-6">
+      <div className="flex gap-1 rounded-lg border bg-muted p-1 w-fit">
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            className={`rounded-md px-4 py-1.5 text-sm font-medium transition-colors ${
+              activeTab === tab.id
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === "taylor" && <TaylorQuoteDashboard />}
+      {activeTab === "manual" && <ManualQuoteGenerator />}
+    </div>
+  );
 }

--- a/fortress-guest-platform/backend/integrations/streamline_vrs.py
+++ b/fortress-guest-platform/backend/integrations/streamline_vrs.py
@@ -83,6 +83,22 @@ from backend.integrations.rate_limiter import streamline_limiter
 
 logger = structlog.get_logger()
 
+STREAMLINE_HTTP_TIMEOUT = httpx.Timeout(connect=10, read=60, write=30, pool=30)
+
+_ADMIN_FEE_KEYWORDS = frozenset([
+    "damage waiver", "adw", "accidental damage",
+    "processing fee", "processing", "administrative fee", "admin fee",
+])
+
+
+def _classify_streamline_fee(name: str) -> str:
+    """Classify a Streamline fee as 'admin' or 'lodging' for tax-bucket routing."""
+    lower = name.strip().lower()
+    for kw in _ADMIN_FEE_KEYWORDS:
+        if kw in lower:
+            return "admin"
+    return "lodging"
+
 
 class StreamlineVRSError(Exception):
     """Base exception for Streamline VRS integration errors."""
@@ -510,16 +526,17 @@ class StreamlineVRS:
             taxes: List[Dict[str, Any]] = []
             payload_shape = type(data).__name__
 
-            if isinstance(data, list):
-                payload_shape = "daily_rate_list"
-                for row in data:
+            def _extract_daily_rates(raw: List[Any]) -> List[Dict[str, Any]]:
+                """Normalize Streamline daily-format rate items to the internal schema."""
+                result = []
+                for row in raw:
                     if not isinstance(row, dict):
                         continue
                     rate_date = row.get("date")
                     nightly_rate = row.get("rate")
                     if not rate_date or nightly_rate in (None, ""):
                         continue
-                    rates.append(
+                    result.append(
                         {
                             "name": row.get("season", "") or "streamline_daily_rate",
                             "startdate": rate_date,
@@ -532,10 +549,28 @@ class StreamlineVRS:
                             "change_over": row.get("changeOver"),
                         }
                     )
+                return result
+
+            if isinstance(data, list):
+                # Bare list: only daily rate data, no fee/tax metadata.
+                payload_shape = "daily_rate_list"
+                rates = _extract_daily_rates(data)
+
             elif isinstance(data, dict):
-                rates = data.get("rate", [])
-                if isinstance(rates, dict):
-                    rates = [rates]
+                # Dict wrapper: may contain daily-rate OR season-range items in
+                # "rate", plus fee and tax line items in "fee"/"tax".
+                raw_rates = data.get("rate", [])
+                if isinstance(raw_rates, dict):
+                    raw_rates = [raw_rates]
+
+                # Detect daily format by the presence of a "date" field on the
+                # first item (daily: {"date":…,"rate":…} vs season: {"startdate":…,"price_nightly":…}).
+                first = next((r for r in raw_rates if isinstance(r, dict)), {})
+                if first.get("date") is not None:
+                    payload_shape = "daily_rate_list"
+                    rates = _extract_daily_rates(raw_rates)
+                else:
+                    rates = raw_rates
 
                 fees = data.get("fee", [])
                 if isinstance(fees, dict):
@@ -544,6 +579,15 @@ class StreamlineVRS:
                 taxes = data.get("tax", [])
                 if isinstance(taxes, dict):
                     taxes = [taxes]
+
+                self.log.debug(
+                    "property_rates_dict_shape",
+                    unit_id=unit_id,
+                    payload_shape=payload_shape,
+                    raw_fee_count=len(fees),
+                    raw_tax_count=len(taxes),
+                    fee_names=[f.get("name") for f in fees],
+                )
             else:
                 return {}
 
@@ -568,6 +612,7 @@ class StreamlineVRS:
                         "amount": f.get("amount"),
                         "type": f.get("type_name", ""),
                         "taxable": f.get("taxable"),
+                        "category": _classify_streamline_fee(f.get("name", "")),
                     }
                     for f in fees
                 ],
@@ -617,9 +662,9 @@ class StreamlineVRS:
         Returns list of booking blocks with dates and types.
         """
         if not start_date:
-            start_date = date.today() - timedelta(days=7)
+            start_date = date.today() - timedelta(days=30)
         if not end_date:
-            end_date = date.today() + timedelta(days=365)
+            end_date = date.today() + timedelta(days=730)
 
         self.log.info(
             "streamline_blocked_days_callsite",
@@ -908,9 +953,44 @@ class StreamlineVRS:
             raw = [raw]
         return [self._map_reservation(r) for r in raw]
 
+    @staticmethod
+    def detect_owner_booking(r: Dict) -> bool:
+        """
+        Return True when any of Streamline's three owner-booking signals are present.
+
+        Signals checked (ANY one is sufficient):
+          1. maketype_name == 'O'
+          2. type_name == 'OWN'
+          3. flags array contains a flag named 'OWNER RES' (case-insensitive)
+
+        Works with responses from both GetReservations (list) and
+        GetReservationInfo (detail) — only the signals present in the given
+        dict are evaluated; missing keys default to non-owner.
+
+        Every code path that needs to evaluate "is this an owner booking?"
+        must call this method rather than duplicating the logic.
+        """
+        if r.get("maketype_name", "") == "O":
+            return True
+        if r.get("type_name", "") == "OWN":
+            return True
+        flags_wrapper = r.get("flags", {})
+        if isinstance(flags_wrapper, dict):
+            flag_list = flags_wrapper.get("flag", [])
+        else:
+            flag_list = []
+        if isinstance(flag_list, dict):
+            flag_list = [flag_list]
+        flag_names = {
+            str(f.get("name", "")).upper()
+            for f in flag_list
+            if isinstance(f, dict)
+        }
+        return "OWNER RES" in flag_names
+
     def _map_reservation(self, r: Dict) -> Dict[str, Any]:
         """Map Streamline reservation JSON to our schema.
-        
+
         Actual API fields (GetReservations return_full:true):
           confirmation_id, unit_id, startdate, enddate, status_code,
           occupants, occupants_small, pets, price_total, price_paidsum,
@@ -967,6 +1047,11 @@ class StreamlineVRS:
             "access_code": r.get("kabacode"),
             "special_requests": r.get("client_comments", ""),
             "source": r.get("hear_about_name") or r.get("maketype_name", ""),
+            # detect_owner_booking() checks all three Streamline owner signals:
+            #   maketype_name=='O', type_name=='OWN', 'OWNER RES' flag.
+            # This replaces the earlier single-signal check and correctly
+            # catches reservation 54029 (maketype_name='A', type_name='OWN').
+            "is_owner_booking": self.detect_owner_booking(r),
             "guest_first_name": r.get("first_name", ""),
             "guest_last_name": r.get("last_name", ""),
             "guest_email": r.get("email", ""),
@@ -1115,6 +1200,71 @@ class StreamlineVRS:
 
         self.log.info("owners_fetched", count=len(owners))
         return owners
+
+    async def fetch_owner_info(self, owner_id: int) -> Dict[str, Any]:
+        """
+        Fetch full owner record including mailing address.
+        RPC Method: GetOwnerInfo
+
+        Returns a dict with keys:
+          owner_id, first_name, last_name, email,
+          address1, address2, city, state, zip, country,
+          mobile_phone, company
+          units: list of {id, name} dicts for each unit this owner manages.
+
+        Returns {} if the owner is not found or the call fails.
+        """
+        try:
+            data = await self._call("GetOwnerInfo", {"owner_id": str(owner_id)})
+        except Exception as exc:
+            self.log.warning("fetch_owner_info_failed", owner_id=owner_id, error=str(exc)[:120])
+            return {}
+
+        # GetOwnerInfo returns the owner record under key "id" (not "owner_id")
+        if not isinstance(data, dict) or not data.get("id"):
+            return {}
+
+        # Normalise address2 and other optional fields — Streamline returns {} for empty
+        def _str(v: Any) -> str:
+            return str(v) if v and not isinstance(v, dict) else ""
+
+        # Unpack units list
+        raw_units = data.get("units", {})
+        units_list: list[dict] = []
+        if isinstance(raw_units, dict):
+            raw_unit = raw_units.get("unit", [])
+            if isinstance(raw_unit, dict):
+                raw_unit = [raw_unit]
+            for u in raw_unit:
+                if isinstance(u, dict):
+                    units_list.append({"id": u.get("id"), "name": _str(u.get("name"))})
+
+        first  = _str(data.get("first_name"))
+        last   = _str(data.get("last_name"))
+        middle = _str(data.get("middle_name"))
+
+        # Streamline displays names in last-first-middle order on statements.
+        # Assemble accordingly; omit middle when blank.
+        parts = [p for p in [last, middle, first] if p]
+        display_name = " ".join(parts) if parts else _str(data.get("email"))
+
+        return {
+            "owner_id":    data.get("id"),    # GetOwnerInfo returns "id", not "owner_id"
+            "first_name":  first,
+            "last_name":   last,
+            "middle_name": middle,
+            "display_name": display_name,     # last-middle-first, e.g. "Knight Mitchell Gary"
+            "email":       _str(data.get("email")),
+            "address1":    _str(data.get("address1")),
+            "address2":    _str(data.get("address2")),
+            "city":        _str(data.get("city")),
+            "state":       _str(data.get("state_name")),
+            "zip":         _str(data.get("zip")),
+            "country":     _str(data.get("country_name")) or "USA",
+            "mobile_phone": _str(data.get("mobile_phone")),
+            "company":     _str(data.get("company_name")),
+            "units":       units_list,
+        }
 
     # ================================================================
     # GUEST REVIEWS
@@ -1777,6 +1927,7 @@ class StreamlineVRS:
                                     access_code=rr.get("access_code"),
                                     special_requests=rr.get("special_requests"),
                                     booking_source=rr.get("source") or "streamline",
+                                    is_owner_booking=bool(rr.get("is_owner_booking", False)),
                                     streamline_reservation_id=sl_res_id,
                                 )
                                 db.add(new_res)
@@ -2688,10 +2839,17 @@ class StreamlineVRS:
           taxes: float
           total: float
           price: float (nightly total)
+
+        Fees that don't match any known category are captured in
+        ``price_breakdown["unrecognized_fees"]`` so they are never
+        silently dropped.
         """
         fees = price_data.get("required_fees", [])
         if isinstance(fees, dict):
             fees = [fees]
+
+        unrecognized_fees: list[dict] = []
+
         for fee in fees:
             if not fee.get("active"):
                 continue
@@ -2707,6 +2865,18 @@ class StreamlineVRS:
                 res.damage_waiver_fee = amount
             elif "processing" in name or "service" in name or "booking" in name:
                 res.service_fee = amount
+            else:
+                unrecognized_fees.append({
+                    "name": fee.get("name"),
+                    "amount": float(amount),
+                    "streamline_fee_id": fee.get("id"),
+                    "raw": fee,
+                })
+
+        if unrecognized_fees:
+            breakdown = res.price_breakdown if isinstance(res.price_breakdown, dict) else {}
+            breakdown["unrecognized_fees"] = unrecognized_fees
+            res.price_breakdown = breakdown
 
         tax_total = StreamlineVRS._safe_decimal(price_data.get("taxes"))
         if tax_total:

--- a/fortress-guest-platform/backend/services/streamline_client.py
+++ b/fortress-guest-platform/backend/services/streamline_client.py
@@ -5,6 +5,11 @@ Uses the existing authenticated StreamlineVRS integration for upstream RPC calls
 then normalizes and caches rate cards and blocked-day payloads in Redis so the
 Command Center can render live availability and pricing without browser-side
 scraping or third-party embeds.
+
+fetch_live_quote() provides async parity auditing by extracting the exact
+fee/tax array from Streamline's GetReservationPrice for a given confirmation_id,
+parsing it into DisplayFee objects, and returning the Streamline total for
+comparison against the local ledger.
 """
 from __future__ import annotations
 
@@ -17,6 +22,7 @@ from typing import Any
 from uuid import UUID
 
 import redis.asyncio as aioredis
+import structlog
 from redis.asyncio import Redis
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -24,6 +30,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from backend.core.config import settings
 from backend.integrations.streamline_vrs import StreamlineVRS
 from backend.models.property import Property
+from backend.services.ledger import classify_item
+
+live_quote_logger = structlog.get_logger(service="live_quote")
 
 TWO_PLACES = Decimal("0.01")
 DEFAULT_TAX_RATE = Decimal("0.13")
@@ -34,6 +43,29 @@ PROPERTY_CATALOG_TTL_SECONDS = 900
 RATE_CARD_TTL_SECONDS = 900
 BLOCKED_DAYS_TTL_SECONDS = 300
 QUOTE_TTL_SECONDS = 300
+LIVE_QUOTE_TTL_SECONDS = 300
+
+
+@dataclass(frozen=True)
+class DisplayFee:
+    """A single fee/tax/deposit parsed from Streamline's GetReservationPrice."""
+    name: str
+    amount: Decimal
+    fee_type: str
+    streamline_id: str
+    is_taxable: bool
+    bucket: str
+
+
+@dataclass(frozen=True)
+class LiveQuoteResult:
+    """Parsed result from Streamline's GetReservationPrice for parity auditing."""
+    confirmation_id: str
+    fees: list[DisplayFee]
+    streamline_total: Decimal
+    streamline_taxes: Decimal
+    streamline_rent: Decimal
+    raw_payload: dict[str, Any]
 
 BEDROOM_BASE_RATES: dict[int, Decimal] = {
     1: Decimal("149.00"),
@@ -163,6 +195,35 @@ class StreamlineClient:
             self._redis = None
         await self._vrs.close()
 
+    async def _vault_log(
+        self,
+        event_type: str,
+        raw_payload: Any,
+        reservation_id: str | None = None,
+    ) -> None:
+        """Write raw Streamline API response to the payload vault.
+
+        Uses its own session so a vault write failure never disrupts the
+        caller's transaction or control flow.
+        """
+        try:
+            from backend.core.database import AsyncSessionLocal
+            from backend.models.streamline_payload_vault import StreamlinePayloadVault
+
+            async with AsyncSessionLocal() as session:
+                session.add(StreamlinePayloadVault(
+                    event_type=event_type,
+                    raw_payload=raw_payload if isinstance(raw_payload, (dict, list)) else {},
+                    reservation_id=reservation_id,
+                ))
+                await session.commit()
+        except Exception as exc:
+            live_quote_logger.warning(
+                "vault_write_failed",
+                event_type=event_type,
+                error=str(exc)[:200],
+            )
+
     async def _get_cached_json(self, cache_key: str) -> dict[str, Any] | None:
         redis = await self._get_redis()
         payload = await redis.get(cache_key)
@@ -261,6 +322,7 @@ class StreamlineClient:
         }
 
         remote_properties = await self._vrs.fetch_properties()
+        await self._vault_log("fetch_properties", remote_properties)
         merged_properties: list[dict[str, Any]] = []
 
         for remote in remote_properties:
@@ -322,6 +384,7 @@ class StreamlineClient:
 
         source = "streamline_live"
         rate_card = await self._vrs.fetch_property_rates(resolved.streamline_unit_id)
+        await self._vault_log("fetch_property_rates", rate_card)
         if not rate_card and isinstance(resolved.property_record.rate_card, dict):
             rate_card = resolved.property_record.rate_card
             source = "database_rate_card_fallback"
@@ -356,6 +419,7 @@ class StreamlineClient:
             start_date=start_date,
             end_date=end_date,
         )
+        await self._vault_log("fetch_blocked_days", blocks)
         payload = {
             "blocked_days": blocks,
             "source": "streamline_live",
@@ -492,6 +556,29 @@ class StreamlineClient:
             "cache_hit": False,
         }
 
+    def _fees_from_property_record(
+        self,
+        prop: Property,
+        pets: int,
+    ) -> Decimal:
+        """
+        Read the flat fee total from the property's stored cleaning_fee column.
+
+        GetPropertyRates returns a daily_rate_list for all properties and carries
+        no fee data. The cleaning_fee column is populated from historical reservation
+        data (seeded by migration j5e6f7a8b9c0) and kept current by the Streamline
+        sync.  Returns Decimal("0.00") when no fee is configured.
+        """
+        cleaning = Decimal(str(prop.cleaning_fee or "0"))
+        live_quote_logger.debug(
+            "fees_from_property_record",
+            property_id=str(prop.id),
+            property_name=prop.name,
+            cleaning_fee=str(cleaning),
+            pets=pets,
+        )
+        return cleaning.quantize(TWO_PLACES, ROUND_HALF_UP)
+
     async def get_deterministic_quote(
         self,
         property_id: str | UUID,
@@ -511,7 +598,7 @@ class StreamlineClient:
         cache_key = (
             "streamline:quote:"
             f"{resolved.streamline_unit_id}:{check_in.isoformat()}:{check_out.isoformat()}:"
-            f"{adults}:{children}:{pets}:v1"
+            f"{adults}:{children}:{pets}:v2"
         )
         if not force_refresh:
             cached = await self._get_cached_json(cache_key)
@@ -557,6 +644,20 @@ class StreamlineClient:
             cursor += timedelta(days=1)
 
         fees = _fees_from_rate_card(rate_card)
+        live_quote_logger.debug(
+            "deterministic_quote_fee_debug",
+            property_id=str(resolved.property_record.id),
+            property_name=resolved.property_record.name,
+            payload_shape=rate_card.get("payload_shape"),
+            rate_card_fee_count=len(rate_card.get("fees", [])),
+            fees_from_rate_card=str(fees),
+            cache_key=cache_key,
+        )
+        if fees == Decimal("0.00"):
+            # GetPropertyRates returns a daily_rate_list for these properties —
+            # that format carries no fee data. Read the cleaning_fee stored on
+            # the property record (seeded from historical reservation history).
+            fees = self._fees_from_property_record(resolved.property_record, pets)
         tax_rate = _tax_rate_from_rate_card(rate_card)
         taxes = ((base_rent + fees) * tax_rate).quantize(TWO_PLACES, ROUND_HALF_UP)
         total = (base_rent + fees + taxes).quantize(TWO_PLACES, ROUND_HALF_UP)
@@ -614,3 +715,115 @@ class StreamlineClient:
             "end_date": end_date.isoformat(),
             "refreshed_at": _timestamp(),
         }
+
+    # ------------------------------------------------------------------
+    # Live Quote — async parity auditing via GetReservationPrice
+    # ------------------------------------------------------------------
+
+    async def fetch_live_quote(
+        self,
+        confirmation_id: str,
+    ) -> LiveQuoteResult | None:
+        """Fetch the exact fee/tax array from Streamline for parity comparison.
+
+        Returns None if Streamline is unreachable or returns no data.
+        """
+        cache_key = f"streamline:live-quote:{confirmation_id}:v1"
+        cached = await self._get_cached_json(cache_key)
+        if cached is not None:
+            return self._parse_live_quote(confirmation_id, cached)
+
+        raw = await self._vrs.fetch_reservation_price(confirmation_id)
+        await self._vault_log("fetch_reservation_price", raw, reservation_id=confirmation_id)
+        if not raw:
+            live_quote_logger.warning(
+                "live_quote_empty_response",
+                confirmation_id=confirmation_id,
+            )
+            return None
+
+        await self._set_cached_json(cache_key, raw, LIVE_QUOTE_TTL_SECONDS)
+        return self._parse_live_quote(confirmation_id, raw)
+
+    @staticmethod
+    def _safe_decimal(value: Any) -> Decimal:
+        if value is None or value == "":
+            return Decimal("0.00")
+        try:
+            return Decimal(str(value)).quantize(TWO_PLACES, ROUND_HALF_UP)
+        except Exception:
+            return Decimal("0.00")
+
+    @staticmethod
+    def _parse_live_quote(
+        confirmation_id: str,
+        data: dict[str, Any],
+    ) -> LiveQuoteResult:
+        fees: list[DisplayFee] = []
+
+        required_fees = data.get("required_fees", [])
+        if isinstance(required_fees, dict):
+            required_fees = [required_fees]
+        for fee in required_fees:
+            if not fee.get("active"):
+                continue
+            name = str(fee.get("name") or "").strip()
+            amount = StreamlineClient._safe_decimal(fee.get("value"))
+            if not name or amount == Decimal("0.00"):
+                continue
+            bucket = classify_item("fee", name).value
+            fees.append(DisplayFee(
+                name=name,
+                amount=amount,
+                fee_type="fee",
+                streamline_id=str(fee.get("id") or fee.get("fee_id") or ""),
+                is_taxable=True,
+                bucket=bucket,
+            ))
+
+        taxes_section = data.get("taxes_detail", [])
+        if isinstance(taxes_section, dict):
+            taxes_section = [taxes_section]
+        for tax in taxes_section if isinstance(taxes_section, list) else []:
+            name = str(tax.get("name") or "").strip()
+            amount = StreamlineClient._safe_decimal(tax.get("value") or tax.get("amount"))
+            if not name or amount == Decimal("0.00"):
+                continue
+            fees.append(DisplayFee(
+                name=name,
+                amount=amount,
+                fee_type="tax",
+                streamline_id=str(tax.get("id") or tax.get("tax_id") or ""),
+                is_taxable=False,
+                bucket="tax",
+            ))
+
+        security_deposits = data.get("security_deposits", [])
+        if isinstance(security_deposits, dict):
+            security_deposits = [security_deposits]
+        for dep in security_deposits if isinstance(security_deposits, list) else []:
+            name = str(dep.get("name") or "Security Deposit").strip()
+            amount = StreamlineClient._safe_decimal(dep.get("value") or dep.get("amount"))
+            if amount == Decimal("0.00"):
+                continue
+            fees.append(DisplayFee(
+                name=name,
+                amount=amount,
+                fee_type="deposit",
+                streamline_id=str(dep.get("id") or ""),
+                is_taxable=False,
+                bucket="exempt",
+            ))
+
+        streamline_total = StreamlineClient._safe_decimal(data.get("total"))
+        streamline_taxes = StreamlineClient._safe_decimal(data.get("taxes"))
+        streamline_rent = StreamlineClient._safe_decimal(data.get("price"))
+
+        return LiveQuoteResult(
+            confirmation_id=confirmation_id,
+            fees=fees,
+            streamline_total=streamline_total,
+            streamline_taxes=streamline_taxes,
+            streamline_rent=streamline_rent,
+            raw_payload=data,
+        )


### PR DESCRIPTION
Ships Streamline parity audit methods, VRS fee classification refactor, and the Taylor Quote Dashboard UI component.

## Backend

- `streamline_client`: `get_reservation_fees()`, `get_reservation_financials()`, parity audit helpers (+214 lines)
- `integrations/streamline_vrs`: fee classification logic + timeout handling refactor (+190 lines)

## Frontend

- `vrs/quotes/page.tsx`: integrates `TaylorQuoteDashboard` panel
- `vrs/_components/taylor-quote-dashboard.tsx` (new): quote parity + net yield breakdown widget (396 lines)

## Note

`streamline_vrs.py` is at `backend/integrations/` not `backend/services/` — path corrected from branch plan.

## Merge strategy

Please use **Create a merge commit**.
