### PR TITLE
chore(dev-config): environment knobs, Google API deps, typed backend client

### DIFF
--- a/fortress-guest-platform/.cursorrules
+++ b/fortress-guest-platform/.cursorrules
@@ -48,4 +48,18 @@ Kills Mock Data: Rule #3 stops Cursor from generating components filled with con
 
 Protects the SEO Estate: Rule #4 forces the AI to recognize your legacy Drupal architecture. It will not accidentally overwrite your drupal_granular_blueprint.json logic or break the [...slug]/page.tsx catch-all route we just built.
 
-Shall I hold position while you drop this into the root of fortress-guest-platform, or are we pivoting straight back to executing the 70B Bulk SEO Generation run?
+## CRITICAL: SOVEREIGN LEDGER & IMMUTABILITY LAWS
+
+These rules are non-negotiable. Violation will corrupt the financial audit trail and may trigger Postgres kernel-level exceptions that crash the calling transaction.
+
+### NO MUTATION
+The `trust_transactions` and `trust_ledger_entries` tables are **strictly append-only**. Postgres `BEFORE UPDATE OR DELETE` triggers (`trg_immutable_trust_transactions`, `trg_immutable_trust_ledger_entries`) will `RAISE EXCEPTION` on any attempt to modify or remove rows. **Never** write ORM code, raw SQL, Alembic migration steps, or ad-hoc scripts that attempt to `UPDATE` or `DELETE` records in these tables. The database kernel will reject it. If you need to correct a ledger error, post a **reversal entry** (a new offsetting debit/credit pair) — never mutate the original.
+
+### HASH CHAIN INTEGRITY
+Every new `TrustTransaction` is cryptographically signed using the SHA-256 hash of the previous transaction's signature via `_sign_transaction()` in `backend/services/trust_ledger.py`. The payload format is: `f"{prev_sig}|{txn.streamline_event_id}|{txn.id}|{txn.timestamp.isoformat()}"`. **Always** route financial entries through the posting functions in `backend/services/trust_ledger.py` (`post_checkout_trust_entry`, `post_invoice_clearing_entry`, `post_variance_trust_entry`). **Never** insert into `trust_transactions` or `trust_ledger_entries` manually or via raw SQL. Doing so will break the hash chain and trigger a `CRITICAL BREACH` alert from the Hermes daily auditor (`backend/workers/hermes_daily_auditor.py`).
+
+### IDEMPOTENCY FIRST
+Webhook handlers (Stripe in `backend/api/stripe_webhooks.py`, Streamline in `backend/api/reservation_webhooks.py`) must handle `sqlalchemy.exc.IntegrityError` on the `uq_trust_transactions_streamline_event_id` unique constraint gracefully. The trust ledger's `_add_trust_transaction_idempotent()` already does this — it catches the collision and returns the existing `TrustTransaction`. Webhook endpoints **must** interpret a duplicate-hit return as success and respond with **HTTP 200 OK** to prevent Stripe/Streamline retry storms. Never re-raise `IntegrityError` from an idempotent trust posting path.
+
+### ZERO TRUST: STRIPE IS THE SOURCE OF TRUTH FOR FUNDS
+**Stripe** is the absolute, authoritative source of truth for all guest payment transactions. Trust ledger entries for guest payments (`post_checkout_trust_entry`, `post_invoice_clearing_entry`) are triggered **exclusively** by Stripe webhook events (`payment_intent.succeeded`, `invoice.paid`). **Streamline** (the legacy PMS) is used only for: (1) payload vaulting to `StreamlinePayloadVault` for audit/reconciliation, (2) reservation metadata upserts, and (3) variance matching via the Hermes daily auditor. **Never** create trust ledger payment entries based on Streamline data alone.

--- a/fortress-guest-platform/apps/command-center/next.config.ts
+++ b/fortress-guest-platform/apps/command-center/next.config.ts
@@ -12,6 +12,9 @@ const nextConfig: NextConfig = {
         "staging.cabin-rentals-of-georgia.com",
         "beta.cabin-rentals-of-georgia.com",
         "cabin-rentals-of-georgia.vercel.app",
+        "localhost:3001",
+        "192.168.0.100:3001",
+        "192.168.0.114:3001",
         ...staffHostsForServerActions(),
       ],
     },
@@ -39,6 +42,10 @@ const nextConfig: NextConfig = {
         source: "/cabin/:slug",
         destination: "/cabins/:slug",
       },
+      // Legacy API path (no hyphen): old client chunks still call /api/workorders/ — backend is /api/work-orders/
+      { source: "/api/workorders", destination: "/api/work-orders" },
+      { source: "/api/workorders/", destination: "/api/work-orders/" },
+      { source: "/api/workorders/:path*", destination: "/api/work-orders/:path*" },
     ];
   },
   async headers() {

--- a/fortress-guest-platform/apps/command-center/package.json
+++ b/fortress-guest-platform/apps/command-center/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 3000 -H 0.0.0.0",
     "build": "next build && node ../../scripts/sync-next-standalone-assets.mjs",
     "start": "next start",
     "lint": "eslint",

--- a/fortress-guest-platform/apps/command-center/src/lib/server/fortress-backend.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/server/fortress-backend.ts
@@ -1,0 +1,80 @@
+import "server-only";
+
+import { z } from "zod";
+
+const backendHealthSchema = z.object({
+  status: z.literal("ok"),
+  service: z.literal("fortress-prime-backend"),
+  environment: z.string().min(1),
+  version: z.string().min(1),
+  timestamp_utc: z.string().datetime({ offset: true }),
+  ingress: z.literal("command_center"),
+  request_host: z.string().min(1),
+});
+
+export type BackendHealth = z.infer<typeof backendHealthSchema>;
+
+export class BackendConnectionError extends Error {
+  readonly statusCode?: number;
+
+  constructor(message: string, statusCode?: number) {
+    super(message);
+    this.name = "BackendConnectionError";
+    this.statusCode = statusCode;
+  }
+}
+
+function requiredEnv(
+  name: "FORTRESS_BACKEND_BASE_URL" | "FORTRESS_INTERNAL_API_TOKEN",
+): string {
+  const value = process.env[name]?.trim();
+
+  if (!value) {
+    throw new BackendConnectionError(
+      `Missing required environment variable: ${name}`,
+    );
+  }
+
+  return value;
+}
+
+function getBackendBaseUrl(): URL {
+  const url = new URL(requiredEnv("FORTRESS_BACKEND_BASE_URL"));
+
+  if (url.protocol !== "https:") {
+    throw new BackendConnectionError(
+      "FORTRESS_BACKEND_BASE_URL must use https.",
+    );
+  }
+
+  return new URL(url.toString().replace(/\/$/, "") + "/");
+}
+
+export async function fetchBackendHealth(): Promise<BackendHealth> {
+  const sharedSecret = requiredEnv("FORTRESS_INTERNAL_API_TOKEN");
+  const target = new URL("internal/health", getBackendBaseUrl());
+
+  const response = await fetch(target, {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${sharedSecret}`,
+      "X-Fortress-Ingress": "command_center",
+      "X-Fortress-Tunnel-Signature": sharedSecret,
+    },
+    cache: "no-store",
+    next: { revalidate: 0 },
+    redirect: "error",
+    signal: AbortSignal.timeout(5_000),
+  });
+
+  if (!response.ok) {
+    throw new BackendConnectionError(
+      `Backend health probe failed: ${response.status} ${response.statusText}`,
+      response.status,
+    );
+  }
+
+  const payload: unknown = await response.json();
+  return backendHealthSchema.parse(payload);
+}

--- a/fortress-guest-platform/backend/requirements.txt
+++ b/fortress-guest-platform/backend/requirements.txt
@@ -25,6 +25,9 @@ twilio==9.0.4
 boto3==1.34.79
 openai==1.14.3
 openpyxl==3.1.5
+google-api-python-client==2.189.0
+google-auth==2.48.0
+google-auth-oauthlib==1.2.4
 
 # 5. Security & System Utilities
 cryptography==42.0.5


### PR DESCRIPTION
Narrowly scoped environment config additions plus the typed backend client helper that was deferred from PR #18.

## Changes

- `backend/requirements.txt`: pinned Google API deps (`google-api-python-client`, `google-auth`, `google-auth-oauthlib`)
- `apps/command-center/next.config.ts`: LAN dev origins + `/api/workorders` → `/api/work-orders` rewrite rule
- `apps/command-center/package.json`: dev server binds `0.0.0.0:3000`
- `apps/command-center/src/lib/server/fortress-backend.ts` (new): typed backend client with Zod-validated schema (deferred from PR #18)
- `.cursorrules`: Sovereign Ledger & Immutability Laws block (aligned with CLAUDE.md)

## Merge strategy

Please use **Create a merge commit**.
