### PR TITLE
feat(vrs): guest quote engine with Streamline + Taylor + Stripe paths

### DIFF
--- a/config.py
+++ b/config.py
@@ -36,8 +36,8 @@ SPARK_04_IP = os.getenv("SPARK_04_IP", "192.168.0.108")  # Sovereign — Swarm W
 
 # Fabric LAN (200G RoCEv2 NDR, MTU 9000) — compute-path only
 FABRIC_NODES = {
-    "captain":   {"mgmt": SPARK_01_IP, "fabric": os.getenv("FABRIC_CAPTAIN", "10.10.10.2")},
-    "muscle":    {"mgmt": SPARK_02_IP, "fabric": os.getenv("FABRIC_MUSCLE", "10.10.10.1")},
+    "captain":   {"mgmt": SPARK_01_IP, "fabric": os.getenv("FABRIC_CAPTAIN", "10.101.1.2")},
+    "muscle":    {"mgmt": SPARK_02_IP, "fabric": os.getenv("FABRIC_MUSCLE", "10.101.1.1")},
     "ocular":    {"mgmt": SPARK_03_IP, "fabric": os.getenv("FABRIC_OCULAR", "10.10.10.3")},
     "sovereign": {"mgmt": SPARK_04_IP, "fabric": os.getenv("FABRIC_SOVEREIGN", "10.10.10.4")},
 }
@@ -188,3 +188,20 @@ def get_inference_client(mode: str = None) -> tuple:
     else:
         # Default: SWARM (production)
         return OpenAI(base_url=SWARM_ENDPOINT, api_key="not-needed"), SWARM_MODEL
+
+
+# =============================================================================
+# OLLAMA ENDPOINTS — Sentinel & RAG Embedding Nodes
+# =============================================================================
+
+def get_ollama_endpoints() -> list:
+    """
+    Return list of Ollama endpoints for all active Spark nodes.
+    Used by fortress_sentinel.py for distributed embedding.
+    """
+    return [
+        f"http://{SPARK_01_IP}:11434",  # Captain
+        f"http://{SPARK_02_IP}:11434",  # Muscle
+        f"http://{SPARK_03_IP}:11434",  # Ocular
+        f"http://{SPARK_04_IP}:11434",  # Sovereign
+    ]

--- a/fortress-guest-platform/backend/api/vrs_quotes.py
+++ b/fortress-guest-platform/backend/api/vrs_quotes.py
@@ -3,10 +3,12 @@ Public quote endpoints for guest checkout flows.
 """
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from decimal import Decimal
 from typing import Any
 from uuid import UUID
+
+import structlog
 
 from arq.connections import ArqRedis
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
@@ -14,16 +16,21 @@ from pydantic import BaseModel, EmailStr, Field, model_validator
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from backend.core.config import settings
 from backend.core.database import get_db
 from backend.core.queue import get_arq_pool
+from backend.models.media import PropertyImage
 from backend.models.property import Property
+from backend.models.taylor_quote import TaylorQuoteRequest, TaylorQuoteStatus
 from backend.models.vrs_add_on import VRSAddOn, VRSAddOnPricingModel, VRSAddOnScope
 from backend.models.vrs_quotes import GuestQuote, GuestQuoteStatus
 from backend.services.email_service import is_email_configured, send_email
 from backend.services.async_jobs import enqueue_async_job, extract_request_actor
 from backend.services.quote_builder import calculate_property_quote
+from backend.services.fast_quote_service import FastQuoteError, calculate_locked_fast_quote_breakdown
 from backend.services.streamline_client import StreamlineClient
 
+log = structlog.get_logger(__name__)
 
 router = APIRouter()
 LEGACY_PROPERTY_MAP = {
@@ -84,6 +91,15 @@ class StreamlineRefreshRequest(BaseModel):
     property_id: str | UUID
     start_date: date
     end_date: date
+
+
+class TaylorQuoteCreateRequest(BaseModel):
+    guest_email: EmailStr
+    check_in: date
+    check_out: date
+    adults: int = Field(default=2, ge=1, le=24)
+    children: int = Field(default=0, ge=0, le=24)
+    pets: int = Field(default=0, ge=0, le=12)
 
 
 async def resolve_quote_property(
@@ -472,6 +488,677 @@ async def refresh_streamline_quote_cache(
         raise HTTPException(status_code=502, detail=str(exc)) from exc
     finally:
         await client.close()
+
+
+@router.get("/{quote_id}")
+async def get_guest_quote_public(
+    quote_id: UUID,
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """
+    Public guest quote lookup — no auth required.
+    The UUID itself is the unforgeable capability token.
+    PII (guest email, phone) is never returned.
+    """
+    result = await db.execute(select(GuestQuote).where(GuestQuote.id == quote_id))
+    quote = result.scalar_one_or_none()
+    if quote is None:
+        raise HTTPException(status_code=404, detail="Quote not found")
+
+    # Derive effective status without mutating the row — expiry is caller-visible
+    now = datetime.utcnow()
+    effective_status = quote.status
+    if quote.status == GuestQuoteStatus.PENDING and quote.expires_at < now:
+        effective_status = GuestQuoteStatus.EXPIRED
+
+    # Resolve property record and hero image in two targeted queries
+    property_record: Property | None = None
+    hero_image_url: str | None = None
+    if quote.property_id:
+        prop_res = await db.execute(
+            select(Property).where(Property.id == quote.property_id)
+        )
+        property_record = prop_res.scalar_one_or_none()
+
+        if property_record is not None:
+            img_res = await db.execute(
+                select(PropertyImage)
+                .where(PropertyImage.property_id == property_record.id)
+                .order_by(PropertyImage.is_hero.desc(), PropertyImage.display_order)
+                .limit(1)
+            )
+            img = img_res.scalar_one_or_none()
+            if img is not None:
+                hero_image_url = img.sovereign_url or img.legacy_url
+
+    source_snapshot: dict = quote.source_snapshot or {}
+    return {
+        "id": str(quote.id),
+        "status": effective_status,
+        "target_property_id": quote.target_property_id,
+        "property_name": (
+            property_record.name
+            if property_record
+            else source_snapshot.get("resolved_property_name", "Mountain Cabin")
+        ),
+        "property_slug": property_record.slug if property_record else None,
+        "property_type": getattr(property_record, "property_type", None) if property_record else None,
+        "property_bedrooms": property_record.bedrooms if property_record else None,
+        "property_bathrooms": float(property_record.bathrooms) if property_record else None,
+        "property_max_guests": property_record.max_guests if property_record else None,
+        "property_hero_image": hero_image_url,
+        "check_in": quote.check_in.isoformat() if quote.check_in else None,
+        "check_out": quote.check_out.isoformat() if quote.check_out else None,
+        "nights": quote.nights,
+        "adults": quote.adults,
+        "children": quote.children,
+        "pets": quote.pets,
+        "currency": quote.currency,
+        "base_rent": float(quote.base_rent),
+        "taxes": float(quote.taxes),
+        "fees": float(quote.fees),
+        "total_amount": float(quote.total_amount),
+        "sovereign_narrative": quote.sovereign_narrative,
+        "quote_breakdown": quote.quote_breakdown,
+        "stripe_payment_link_url": quote.stripe_payment_link_url,
+        "expires_at": quote.expires_at.isoformat(),
+        "accepted_at": quote.accepted_at.isoformat() if quote.accepted_at else None,
+        "created_at": quote.created_at.isoformat(),
+    }
+
+
+def _fmt(amount: float) -> str:
+    return f"${amount:,.2f}"
+
+
+def _fmt_date(d: date) -> str:
+    return d.strftime("%B %-d, %Y")
+
+
+def _build_taylor_email_html(
+    req: TaylorQuoteRequest,
+    quote_url_map: dict[str, str] | None = None,
+) -> str:
+    """Render the multi-property quote email for a TaylorQuoteRequest."""
+    options: list[dict] = req.property_options or []
+    nights = req.nights
+    check_in_str = _fmt_date(req.check_in)
+    check_out_str = _fmt_date(req.check_out)
+    guest_summary = f"{req.adults} adult{'s' if req.adults != 1 else ''}"
+    if req.children:
+        guest_summary += f", {req.children} child{'ren' if req.children != 1 else ''}"
+    if req.pets:
+        guest_summary += f", {req.pets} pet{'s' if req.pets != 1 else ''}"
+
+    property_cards_html = ""
+    for opt in options:
+        hero_url: str | None = opt.get("hero_image_url")
+        hero_block = ""
+        if hero_url:
+            alt = opt.get("property_name", "Cabin")
+            hero_block = (
+                f'<tr><td style="padding:0;line-height:0;">'
+                f'<img src="{hero_url}" alt="{alt}" width="576" '
+                f'style="display:block;width:100%;max-height:240px;object-fit:cover;border-radius:10px 10px 0 0;">'
+                f"</td></tr>"
+            )
+
+        beds = opt.get("bedrooms", 0)
+        baths = opt.get("bathrooms", 0)
+        max_g = opt.get("max_guests", 0)
+        specs = f"{beds} bed &middot; {baths} bath &middot; up to {max_g} guests"
+
+        base_rent = float(opt.get("base_rent", 0))
+        fees = float(opt.get("fees", 0))
+        taxes = float(opt.get("taxes", 0))
+        total = float(opt.get("total_amount", 0))
+        booking_url = (quote_url_map or {}).get(
+            opt.get("property_id", ""), opt.get("booking_url", "#")
+        )
+        property_name = opt.get("property_name", "Cabin")
+
+        property_cards_html += f"""
+    <tr>
+      <td style="padding:0 32px 28px;">
+        <table width="100%" cellpadding="0" cellspacing="0"
+               style="border:1px solid #e4e4e7;border-radius:10px;overflow:hidden;background:#fafafa;">
+          {hero_block}
+          <tr>
+            <td style="padding:20px 20px 0;">
+              <h3 style="margin:0 0 4px;color:#18181b;font-size:17px;font-weight:700;line-height:1.3;">
+                {property_name}
+              </h3>
+              <p style="margin:0 0 16px;color:#71717a;font-size:13px;">{specs}</p>
+              <table width="100%" cellpadding="0" cellspacing="0"
+                     style="font-size:14px;color:#52525b;border-top:1px solid #f4f4f5;">
+                <tr>
+                  <td style="padding:8px 0 6px;border-bottom:1px solid #f4f4f5;">Base rent</td>
+                  <td align="right" style="padding:8px 0 6px;border-bottom:1px solid #f4f4f5;">{_fmt(base_rent)}</td>
+                </tr>
+                <tr>
+                  <td style="padding:6px 0;border-bottom:1px solid #f4f4f5;">Fees</td>
+                  <td align="right" style="padding:6px 0;border-bottom:1px solid #f4f4f5;">{_fmt(fees)}</td>
+                </tr>
+                <tr>
+                  <td style="padding:6px 0 10px;border-bottom:1px solid #f4f4f5;">Taxes</td>
+                  <td align="right" style="padding:6px 0 10px;border-bottom:1px solid #f4f4f5;">{_fmt(taxes)}</td>
+                </tr>
+                <tr>
+                  <td style="padding:10px 0 0;font-weight:700;color:#18181b;font-size:16px;">Total</td>
+                  <td align="right" style="padding:10px 0 0;font-weight:700;color:#18181b;font-size:16px;">
+                    {_fmt(total)}
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:18px 20px 20px;" align="center">
+              <a href="{booking_url}"
+                 style="display:inline-block;background:#18181b;color:#ffffff;text-decoration:none;
+                        padding:12px 32px;border-radius:8px;font-size:14px;font-weight:600;">
+                Book This Cabin &rarr;
+              </a>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+"""
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#f4f4f5;">
+  <table width="100%" cellpadding="0" cellspacing="0"
+         style="max-width:640px;margin:40px auto;background:#ffffff;border-radius:12px;
+                overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,.1);">
+    <tr>
+      <td style="background:#18181b;padding:28px 32px;text-align:center;">
+        <h1 style="margin:0;color:#ffffff;font-size:20px;font-weight:700;letter-spacing:-0.025em;">
+          Cabin Rentals of Georgia
+        </h1>
+      </td>
+    </tr>
+    <tr>
+      <td style="padding:32px 32px 24px;">
+        <h2 style="margin:0 0 8px;color:#18181b;font-size:22px;font-weight:700;line-height:1.3;">
+          Your cabin quote is ready
+        </h2>
+        <p style="margin:0 0 6px;color:#52525b;font-size:15px;line-height:1.6;">
+          We found <strong>{len(options)} available cabin{'s' if len(options) != 1 else ''}</strong>
+          for your stay:
+        </p>
+        <p style="margin:0 0 0;color:#18181b;font-size:15px;font-weight:600;line-height:1.6;">
+          {check_in_str} &rarr; {check_out_str}
+          &nbsp;&middot;&nbsp; {nights} night{'s' if nights != 1 else ''}
+          &nbsp;&middot;&nbsp; {guest_summary}
+        </p>
+      </td>
+    </tr>
+    {property_cards_html}
+    <tr>
+      <td style="padding:24px 32px;border-top:1px solid #f4f4f5;text-align:center;">
+        <p style="margin:0;color:#a1a1aa;font-size:12px;line-height:1.8;">
+          Questions? Reply to this email or call us at (706) 832-3231.<br>
+          Cabin Rentals of Georgia &middot; Blue Ridge, GA
+        </p>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>"""
+
+
+def _build_taylor_email_text(
+    req: TaylorQuoteRequest,
+    quote_url_map: dict[str, str] | None = None,
+) -> str:
+    lines = [
+        "Your cabin quote is ready — Cabin Rentals of Georgia",
+        "",
+        f"Dates: {req.check_in} to {req.check_out} ({req.nights} nights)",
+        f"Guests: {req.adults} adults, {req.children} children, {req.pets} pets",
+        "",
+    ]
+    for opt in (req.property_options or []):
+        book_link = (quote_url_map or {}).get(
+            opt.get("property_id", ""), opt.get("booking_url", "")
+        )
+        lines += [
+            opt.get("property_name", "Cabin"),
+            f"  {opt.get('bedrooms', 0)} bed · {opt.get('bathrooms', 0)} bath",
+            f"  Base rent: {_fmt(float(opt.get('base_rent', 0)))}",
+            f"  Fees:      {_fmt(float(opt.get('fees', 0)))}",
+            f"  Taxes:     {_fmt(float(opt.get('taxes', 0)))}",
+            f"  Total:     {_fmt(float(opt.get('total_amount', 0)))}",
+            f"  Book here: {book_link}",
+            "",
+        ]
+    lines.append("Reply to this email or call (706) 832-3231 with questions.")
+    return "\n".join(lines)
+
+
+@router.post("/taylor/request")
+async def create_taylor_quote_request(
+    payload: TaylorQuoteCreateRequest,
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """
+    Check availability across all active properties for the requested dates,
+    price each available one via Streamline, and save a pending quote request
+    for Taylor to review and approve.
+    """
+    today = date.today()
+    if payload.check_in < today:
+        raise HTTPException(status_code=400, detail="check_in must be today or later")
+    if payload.check_out <= payload.check_in:
+        raise HTTPException(status_code=400, detail="check_out must be after check_in")
+    nights = (payload.check_out - payload.check_in).days
+    if nights > 30:
+        raise HTTPException(status_code=400, detail="Stay window cannot exceed 30 nights")
+
+    # Load all active properties with Streamline IDs
+    props_result = await db.execute(
+        select(Property).where(
+            Property.is_active.is_(True),
+            Property.streamline_property_id.isnot(None),
+        )
+    )
+    properties = list(props_result.scalars().all())
+
+    # Build hero image lookup: property_id → URL
+    hero_result = await db.execute(
+        select(PropertyImage).where(
+            PropertyImage.property_id.in_([p.id for p in properties]),
+            PropertyImage.status == "ingested",
+        ).order_by(PropertyImage.is_hero.desc(), PropertyImage.display_order)
+    )
+    all_images = list(hero_result.scalars().all())
+    # Keep only the best image per property
+    hero_map: dict[str, str] = {}
+    for img in all_images:
+        key = str(img.property_id)
+        if key not in hero_map:
+            hero_map[key] = img.sovereign_url or img.legacy_url
+
+    # Quote each property.  Primary path: sovereign fast-quote service (SQL ledger, same engine
+    # as /api/direct-booking/quote).  Fallback path: deterministic quote (Streamline rate card)
+    # for properties whose SQL ledger is not yet fully configured.
+    property_options: list[dict[str, Any]] = []
+    storefront_base = settings.storefront_base_url.rstrip("/")
+    sl_client = StreamlineClient()
+    try:
+        for prop in properties:
+            guests = (payload.adults or 2) + (payload.children or 0)
+            slug = prop.slug or ""
+            booking_url = (
+                f"{storefront_base}/cabins/{slug}"
+                f"?checkin={payload.check_in.isoformat()}"
+                f"&checkout={payload.check_out.isoformat()}"
+                f"&adults={payload.adults}"
+            )
+
+            # --- Primary: sovereign fast-quote (SQL ledger) ---
+            try:
+                breakdown = await calculate_locked_fast_quote_breakdown(
+                    db,
+                    prop.id,
+                    payload.check_in,
+                    payload.check_out,
+                    guests,
+                    adults=payload.adults,
+                    children=payload.children,
+                    pets=payload.pets,
+                )
+                fees_total = float(breakdown.cleaning + breakdown.admin_fee + breakdown.pet_fee)
+                property_options.append({
+                    "property_id": str(prop.id),
+                    "property_name": prop.name,
+                    "slug": slug,
+                    "bedrooms": prop.bedrooms or 0,
+                    "bathrooms": float(prop.bathrooms or 0),
+                    "max_guests": prop.max_guests or 0,
+                    "hero_image_url": hero_map.get(str(prop.id)),
+                    "base_rent": float(breakdown.rent),
+                    "fees": fees_total,
+                    "taxes": float(breakdown.taxes),
+                    "total_amount": float(breakdown.total),
+                    "nights": nights,
+                    "pricing_source": breakdown.pricing_source,
+                    "line_items": list(breakdown.line_items),
+                    "booking_url": booking_url,
+                })
+                continue
+
+            except FastQuoteError as exc:
+                if exc.code != "pricing_ledger_incomplete":
+                    # Genuine availability / capacity block — property is unavailable.
+                    log.info(
+                        "taylor_property_unavailable",
+                        property_name=prop.name,
+                        property_id=str(prop.id),
+                        code=exc.code,
+                        detail=exc.message,
+                    )
+                    continue
+                # SQL ledger not yet configured for this property — fall through to
+                # the deterministic Streamline rate-card path below.
+                log.info(
+                    "taylor_property_pricing_fallback",
+                    property_name=prop.name,
+                    property_id=str(prop.id),
+                    reason=exc.code,
+                )
+
+            except Exception as exc:
+                log.warning(
+                    "taylor_property_fast_quote_error",
+                    property_name=prop.name,
+                    property_id=str(prop.id),
+                    error=str(exc)[:300],
+                )
+                continue
+
+            # --- Fallback: deterministic quote via Streamline rate card ---
+            try:
+                det = await sl_client.get_deterministic_quote(
+                    str(prop.id),
+                    payload.check_in,
+                    payload.check_out,
+                    db,
+                    adults=payload.adults,
+                    children=payload.children,
+                    pets=payload.pets,
+                )
+            except Exception as exc:
+                log.warning(
+                    "taylor_property_fallback_error",
+                    property_name=prop.name,
+                    property_id=str(prop.id),
+                    error=str(exc)[:300],
+                )
+                continue
+
+            if det.get("availability_status") != "available":
+                log.info(
+                    "taylor_property_unavailable",
+                    property_name=prop.name,
+                    property_id=str(prop.id),
+                    code="streamline_unavailable",
+                    detail=str(det.get("unavailable_dates", [])),
+                )
+                continue
+
+            property_options.append({
+                "property_id": str(prop.id),
+                "property_name": prop.name,
+                "slug": slug,
+                "bedrooms": prop.bedrooms or 0,
+                "bathrooms": float(prop.bathrooms or 0),
+                "max_guests": prop.max_guests or 0,
+                "hero_image_url": hero_map.get(str(prop.id)),
+                "base_rent": det["base_rent"],
+                "fees": det["fees"],
+                "taxes": det["taxes"],
+                "total_amount": det["total_amount"],
+                "nights": nights,
+                "pricing_source": det.get("pricing_source", "streamline_live"),
+                "line_items": [],
+                "booking_url": booking_url,
+            })
+    finally:
+        await sl_client.close()
+
+    req = TaylorQuoteRequest(
+        guest_email=str(payload.guest_email),
+        check_in=payload.check_in,
+        check_out=payload.check_out,
+        nights=nights,
+        adults=payload.adults,
+        children=payload.children,
+        pets=payload.pets,
+        status=TaylorQuoteStatus.PENDING_APPROVAL.value,
+        property_options=property_options,
+    )
+    db.add(req)
+    await db.commit()
+    await db.refresh(req)
+
+    return {
+        "id": str(req.id),
+        "status": req.status,
+        "guest_email": req.guest_email,
+        "check_in": str(req.check_in),
+        "check_out": str(req.check_out),
+        "nights": req.nights,
+        "adults": req.adults,
+        "children": req.children,
+        "pets": req.pets,
+        "available_property_count": len(property_options),
+        "property_options": property_options,
+        "created_at": req.created_at.isoformat() if req.created_at else None,
+    }
+
+
+@router.get("/taylor/pending")
+async def list_taylor_quote_requests(
+    db: AsyncSession = Depends(get_db),
+    limit: int = Query(default=50, ge=1, le=200),
+) -> dict[str, Any]:
+    """List pending and recently sent Taylor quote requests."""
+    from sqlalchemy import desc
+    result = await db.execute(
+        select(TaylorQuoteRequest)
+        .order_by(desc(TaylorQuoteRequest.created_at))
+        .limit(limit)
+    )
+    rows = list(result.scalars().all())
+    return {
+        "requests": [
+            {
+                "id": str(r.id),
+                "status": r.status,
+                "guest_email": r.guest_email,
+                "check_in": str(r.check_in),
+                "check_out": str(r.check_out),
+                "nights": r.nights,
+                "adults": r.adults,
+                "children": r.children,
+                "pets": r.pets,
+                "available_property_count": len(r.property_options or []),
+                "property_options": r.property_options or [],
+                "approved_by": r.approved_by,
+                "sent_at": r.sent_at.isoformat() if r.sent_at else None,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+            }
+            for r in rows
+        ],
+        "total": len(rows),
+    }
+
+
+@router.get("/taylor/{request_id}")
+async def get_taylor_quote_request(
+    request_id: UUID,
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    result = await db.execute(
+        select(TaylorQuoteRequest).where(TaylorQuoteRequest.id == request_id)
+    )
+    req = result.scalar_one_or_none()
+    if not req:
+        raise HTTPException(status_code=404, detail="Taylor quote request not found")
+    return {
+        "id": str(req.id),
+        "status": req.status,
+        "guest_email": req.guest_email,
+        "check_in": str(req.check_in),
+        "check_out": str(req.check_out),
+        "nights": req.nights,
+        "adults": req.adults,
+        "children": req.children,
+        "pets": req.pets,
+        "available_property_count": len(req.property_options or []),
+        "property_options": req.property_options or [],
+        "approved_by": req.approved_by,
+        "sent_at": req.sent_at.isoformat() if req.sent_at else None,
+        "created_at": req.created_at.isoformat() if req.created_at else None,
+    }
+
+
+@router.post("/taylor/{request_id}/approve")
+async def approve_taylor_quote_request(
+    request_id: UUID,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Approve and send the multi-property quote email to the guest."""
+    result = await db.execute(
+        select(TaylorQuoteRequest).where(TaylorQuoteRequest.id == request_id)
+    )
+    req = result.scalar_one_or_none()
+    if not req:
+        raise HTTPException(status_code=404, detail="Taylor quote request not found")
+    if req.status != TaylorQuoteStatus.PENDING_APPROVAL.value:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Request is already '{req.status}' — cannot approve again",
+        )
+    if not req.property_options:
+        raise HTTPException(
+            status_code=422,
+            detail="No available properties to quote — cannot send an empty quote",
+        )
+    if not is_email_configured():
+        raise HTTPException(status_code=503, detail="Email delivery is not configured")
+
+    # ── Step A: mint one GuestQuote per property option ──────────────────
+    # Pricing is frozen from the stored JSONB — guests see exactly what Taylor
+    # reviewed.  48-hour TTL gives guests overnight to decide.
+    TAYLOR_TTL_HOURS = 48
+    storefront_base = settings.storefront_base_url.rstrip("/")
+
+    # Build property_name lookup alongside the quote objects so we can include
+    # human-readable names in the response without re-querying the options list.
+    property_name_map: dict[str, str] = {}
+    quotes: list[GuestQuote] = []
+
+    for opt in req.property_options:
+        prop_id_str: str = opt["property_id"]
+        property_name_map[prop_id_str] = opt.get("property_name", "")
+
+        base_rent  = Decimal(str(opt.get("base_rent", "0")))
+        taxes      = Decimal(str(opt.get("taxes",     "0")))
+        fees       = Decimal(str(opt.get("fees",      "0")))
+        total      = base_rent + taxes + fees
+
+        q = GuestQuote(
+            target_property_id      = prop_id_str,
+            property_id             = UUID(prop_id_str),
+            guest_email             = req.guest_email,
+            check_in                = req.check_in,
+            check_out               = req.check_out,
+            nights                  = req.nights,
+            adults                  = req.adults,
+            children                = req.children,
+            pets                    = req.pets,
+            base_rent               = base_rent,
+            taxes                   = taxes,
+            fees                    = fees,
+            total_amount            = total,
+            base_price              = float(base_rent),
+            ai_adjusted_price       = float(total),
+            sovereign_narrative     = "",
+            campaign                = "taylor",
+            quote_breakdown         = {
+                "base_rent":        str(base_rent),
+                "taxes":            str(taxes),
+                "fees":             str(fees),
+                "total":            str(total),
+                "pricing_source":   opt.get("pricing_source", "taylor"),
+                "nightly_breakdown": None,
+            },
+            source_snapshot         = {
+                "resolved_property_id":   prop_id_str,
+                "resolved_property_name": opt.get("property_name", ""),
+                "pricing_source":         opt.get("pricing_source", "taylor"),
+                "taylor_request_id":      str(req.id),
+            },
+            stripe_payment_link_url = opt.get("stripe_payment_link_url"),
+            expires_at              = datetime.utcnow() + timedelta(hours=TAYLOR_TTL_HOURS),
+            status                  = GuestQuoteStatus.PENDING,
+        )
+        db.add(q)
+        quotes.append(q)
+
+    # Flush to get auto-generated UUIDs without committing — if email fails we
+    # rollback cleanly and no orphaned GuestQuote rows are persisted.
+    await db.flush()
+
+    # ── Step B: build per-property quote URL map ──────────────────────────
+    quote_url_map: dict[str, str] = {
+        str(q.property_id): f"{storefront_base}/quote/{q.id}"
+        for q in quotes
+    }
+
+    # ── Step C: build and send the email ─────────────────────────────────
+    nights = req.nights
+    subject = (
+        f"Your cabin quote: {req.check_in.strftime('%b %-d')} – "
+        f"{req.check_out.strftime('%b %-d, %Y')} "
+        f"({nights} night{'s' if nights != 1 else ''})"
+    )
+    html_body = _build_taylor_email_html(req, quote_url_map=quote_url_map)
+    text_body = _build_taylor_email_text(req, quote_url_map=quote_url_map)
+
+    sent = send_email(
+        to=req.guest_email,
+        subject=subject,
+        html_body=html_body,
+        text_body=text_body,
+    )
+    if not sent:
+        # HTTPException causes the session context manager to rollback — the
+        # flushed GuestQuote rows are never committed.
+        raise HTTPException(
+            status_code=502,
+            detail="Quote email dispatch failed. Check SMTP configuration and delivery logs.",
+        )
+
+    # ── Step D: commit everything atomically ──────────────────────────────
+    actor = (
+        request.headers.get("x-user-email")
+        or request.headers.get("x-user-id")
+        or "taylor"
+    )
+    req.status      = TaylorQuoteStatus.SENT.value
+    req.approved_by = actor
+    req.sent_at     = datetime.utcnow()
+    await db.commit()
+
+    # ── Step E: return quote URLs for logging / command-center display ────
+    return {
+        "status":         "sent",
+        "request_id":     str(req.id),
+        "guest_email":    req.guest_email,
+        "approved_by":    req.approved_by,
+        "sent_at":        req.sent_at.isoformat() if req.sent_at else None,
+        "property_count": len(req.property_options),
+        "guest_quotes": [
+            {
+                "property_id":   str(q.property_id),
+                "property_name": property_name_map.get(str(q.property_id), ""),
+                "quote_id":      str(q.id),
+                "quote_url":     quote_url_map[str(q.property_id)],
+                "expires_at":    q.expires_at.isoformat(),
+            }
+            for q in quotes
+        ],
+    }
 
 
 @router.get("/{quote_id}")

--- a/fortress-guest-platform/backend/core/config.py
+++ b/fortress-guest-platform/backend/core/config.py
@@ -2,6 +2,7 @@
 Application configuration using Pydantic Settings.
 """
 
+import os
 from pathlib import Path
 from urllib.parse import SplitResult, urlsplit, urlunsplit
 
@@ -15,7 +16,11 @@ DEFAULT_HISTORIAN_BLUEPRINT_PATH = str(
 DEFAULT_HERMES_SYSTEM_PROMPT_PATH = str(
     Path(__file__).resolve().parents[3] / "docs" / "paperclip" / "AGENTS.md"
 )
-ALLOWED_POSTGRES_DATABASES = frozenset({"fortress_prod", "fortress_shadow"})
+# fortress_shadow_test is the dedicated test database (Phase G.1.5).
+# It mirrors fortress_shadow's schema but is safe to write test fixtures to.
+ALLOWED_POSTGRES_DATABASES = frozenset(
+    {"fortress_prod", "fortress_shadow", "fortress_db", "fortress_shadow_test"}
+)
 # Loopback plus dual-lane 200G RoCE /30 backplane (node-1 .1, node-2 .2 per lane).
 ALLOWED_POSTGRES_HOSTS = frozenset(
     {
@@ -233,6 +238,26 @@ class Settings(BaseSettings):
         return urlsplit(runtime_uri).path.removeprefix("/")
 
     @property
+    def test_database_url(self) -> str | None:
+        """Async DSN for the isolated test database (fortress_shadow_test).
+
+        Set TEST_DATABASE_URL to redirect conftest fixtures away from the
+        production fortress_shadow DB. When unset, tests fall back to the
+        runtime DB (fortress_shadow) with a warning emitted by conftest.
+
+        The URL must use fortress_api as the role (runtime user), not
+        fortress_admin — so tests exercise the same permission surface as
+        the application.
+
+        Example:
+            TEST_DATABASE_URL=postgresql://fortress_api:fortress@127.0.0.1:5432/fortress_shadow_test
+        """
+        raw = os.getenv("TEST_DATABASE_URL", "").strip()
+        if not raw:
+            return None
+        return self._rewrite_database_driver(raw, async_driver=True)
+
+    @property
     def sovereign_quote_signing_enabled(self) -> bool:
         return bool(self.sovereign_quote_signing_key.strip())
 
@@ -246,6 +271,14 @@ class Settings(BaseSettings):
     # Command Center
     command_center_url: str = Field(default="http://localhost:9800")
     frontend_url: str = Field(default="https://crog-ai.com")
+    command_center_ingress_hosts: str = Field(
+        default="",
+        alias="COMMAND_CENTER_INGRESS_HOSTS",
+        description=(
+            "Comma-separated extra hostnames allowed for Command Center /api ingress "
+            "(e.g. LAN staging: 192.168.0.100,192.168.0.114)."
+        ),
+    )
 
     # AI Models — Local (DGX)
     ollama_base_url: str = Field(default="http://192.168.0.100:11434")
@@ -434,6 +467,11 @@ class Settings(BaseSettings):
         default="mock",
         alias="ACQUISITION_B2C_CONTACT_PROVIDER",
         description="B2C owner contact provider stage inserted after Apollo: mock|propertyradar|trellis.",
+    )
+    recursive_agent_loop_enabled: bool = Field(
+        default=True,
+        alias="RECURSIVE_AGENT_LOOP_ENABLED",
+        description="Enables the cross-vertical recursive intelligence flywheel (V1/V2/V3 signal bus).",
     )
     concierge_shadow_draft_enabled: bool = Field(
         default=False,
@@ -675,6 +713,14 @@ class Settings(BaseSettings):
     stripe_webhook_secret: str = Field(default="", alias="STRIPE_WEBHOOK_SECRET")
     stripe_connect_webhook_secret: str = Field(default="")
     stripe_dispute_webhook_secret: str = Field(default="")
+    stripe_connect_client_id: str = Field(
+        default="",
+        alias="STRIPE_CONNECT_CLIENT_ID",
+        description=(
+            "Stripe Connect application client_id (ca_...). "
+            "Required for Standard OAuth Connect. Not needed for Express accounts."
+        ),
+    )
     reservation_hold_ttl_minutes: int = Field(
         default=15,
         description="Checkout hold duration before reservation_holds expire.",
@@ -685,6 +731,14 @@ class Settings(BaseSettings):
 
     # Reservation Webhooks (HMAC shared secret for POST /api/webhooks/reservations)
     reservation_webhook_secret: str = Field(default="")
+
+    # Streamline inbound webhook (POST /api/webhooks/streamline) — optional dedicated secret.
+    # When empty, HMAC verification uses reservation_webhook_secret (same as /reservations).
+    streamline_webhook_secret: str = Field(
+        default="",
+        alias="STREAMLINE_WEBHOOK_SECRET",
+        description="HMAC secret for Streamline payload vault webhooks; falls back to reservation_webhook_secret.",
+    )
 
     # Channex (or compatible headless channel manager) — POST /api/webhooks/channex
     channex_webhook_secret: str = Field(default="", alias="CHANNEX_WEBHOOK_SECRET")
@@ -708,6 +762,16 @@ class Settings(BaseSettings):
     LEGAL_PROPORTIONALITY_MODE: str = "strict"  # 'strict' or 'advisory'
     LEGAL_GRAPH_MAX_NODES: int = 1500  # VRAM memory protection for the Swarm
     LEGAL_VAULT_ROOT: str = "/mnt/fortress_nas/sectors/legal"
+    nas_work_orders_root: str = Field(
+        default="/mnt/fortress_nas/work_orders",
+        alias="NAS_WORK_ORDERS_ROOT",
+        description="NAS mount path for work order photo storage.",
+    )
+    nas_acquisitions_root: str = Field(
+        default="/mnt/fortress_nas/acquisitions",
+        alias="NAS_ACQUISITIONS_ROOT",
+        description="NAS mount path for acquisition document storage.",
+    )
 
     # ==========================================
     # COURTLISTENER / JURISPRUDENCE ENGINE
@@ -762,7 +826,7 @@ class Settings(BaseSettings):
     message_send_start_hour: int = Field(default=8)
     message_send_end_hour: int = Field(default=21)
 
-    # Email / SMTP
+    # Email / SMTP (kept for IMAP inbound paths that still reference smtp_user)
     smtp_host: str = Field(default="smtp.gmail.com")
     smtp_port: int = Field(default=587)
     smtp_user: str = Field(default="")
@@ -770,6 +834,11 @@ class Settings(BaseSettings):
     email_from_name: str = Field(default="Cabin Rentals of Georgia")
     email_from_address: str = Field(default="")
     email_user: str = Field(default="")
+
+    # Gmail API (OAuth2) — outbound sending via Gmail API instead of SMTP
+    gmail_client_id: str = Field(default="", alias="GMAIL_CLIENT_ID")
+    gmail_client_secret: str = Field(default="", alias="GMAIL_CLIENT_SECRET")
+    gmail_refresh_token: str = Field(default="", alias="GMAIL_REFRESH_TOKEN")
 
     # IMAP (Email Bridge)
     imap_host: str = Field(default="imap.gmail.com")
@@ -782,6 +851,15 @@ class Settings(BaseSettings):
     mailplus_imap_host: str = Field(default="")
     mailplus_imap_port: int = Field(default=993)
     mailplus_imap_password: str = Field(default="")
+
+    # Legal Email Intake (dedicated MailPlus inbox for legal correspondence)
+    legal_mailplus_host: str = Field(default="", alias="LEGAL_MAILPLUS_HOST")
+    legal_mailplus_port: int = Field(default=993, alias="LEGAL_MAILPLUS_PORT")
+    legal_mailplus_user: str = Field(default="", alias="LEGAL_MAILPLUS_USER")
+    legal_mailplus_password: str = Field(default="", alias="LEGAL_MAILPLUS_PASSWORD")
+    legal_mailplus_folder: str = Field(default="INBOX", alias="LEGAL_MAILPLUS_FOLDER")
+    legal_email_poll_interval: int = Field(default=120, alias="LEGAL_EMAIL_POLL_INTERVAL")
+    legal_email_intake_enabled: bool = Field(default=False, alias="LEGAL_EMAIL_INTAKE_ENABLED")
 
     # Twilio
     twilio_account_sid: str = Field(default="")
@@ -894,10 +972,37 @@ class Settings(BaseSettings):
     staff_notification_email: str = Field(default="")
     staff_notification_phone: str = Field(default="")
 
+    # ── Owner Statement System (Phase F) ─────────────────────────────────────
+    #
+    # CROG_STATEMENTS_PARALLEL_MODE (default: True)
+    #   When True, the send_approved_statements_job cron fires but does NOT
+    #   send any emails to real owners. Statements are generated normally on
+    #   the 12th but the 15th send is suppressed. Set to False ONLY after
+    #   Phase G validation has completed and the product owner has approved
+    #   the production cutover.
+    crog_statements_parallel_mode: bool = Field(
+        default=True,
+        alias="CROG_STATEMENTS_PARALLEL_MODE",
+    )
+    #
+    # OWNER_STATEMENT_ALERT_EMAIL (required for monitoring)
+    #   Email address that receives a run-summary after every cron fire
+    #   (both the generation job and the send job). Leave empty to disable
+    #   alert emails (useful in dev environments).
+    owner_statement_alert_email: str = Field(
+        default="",
+        alias="OWNER_STATEMENT_ALERT_EMAIL",
+    )
+
     # Keywords
     urgent_keywords_list: str = Field(default="emergency,urgent,broken,flood,fire,leak,police")
 
-    @field_validator("stripe_secret_key", "stripe_webhook_secret", mode="before")
+    @field_validator(
+        "stripe_secret_key",
+        "stripe_webhook_secret",
+        "stripe_connect_client_id",
+        mode="before",
+    )
     @classmethod
     def _normalize_stripe_secrets(cls, value: str) -> str:
         return (value or "").strip()

--- a/fortress-guest-platform/backend/models/pricing.py
+++ b/fortress-guest-platform/backend/models/pricing.py
@@ -1,4 +1,29 @@
-"""Pydantic contracts for the sovereign Fast Quote pipeline."""
+"""
+Pydantic contracts for the Sovereign Fast Quote pipeline.
+
+These schemas serve double-duty:
+
+1. **Runtime**: Validate incoming quote requests and serialize outgoing responses
+   for both the ``/api/quote`` and ``/api/v1/checkout/quote`` endpoints.
+
+2. **AI Forensics**: The Godhead Swarm's ``agent_hermes`` LLM receives the
+   serialized ``QuoteResponse`` (specifically the ``line_items`` array) inside
+   an Evidence Packet when auditing Legacy-vs-DGX pricing parity.  Each
+   ``QuoteLineItem`` provides **semantic meaning** — the AI does not need to
+   reverse-engineer math; it reads items like::
+
+       {"description": "Pet Cleaning Fee", "amount": 150.00, "type": "fee"}
+
+   If a line item is missing from the DGX response but present in the Legacy
+   payload, Hermes flags the discrepancy and may auto-generate a
+   ``LearnedRule`` to correct the Quote Engine at runtime.
+
+The **Universal Ledger** format in ``storefront_checkout.py`` extends these
+primitives with ``is_taxable``, ``id``, and ``summary`` fields for the
+frontend checkout sidebar.  Storefront checkout uses its own fee loop with
+the same optional-fee rules; the fast-quote pipeline uses ``calculate_fast_quote``
+in ``pricing_service.py``.
+"""
 
 from __future__ import annotations
 
@@ -14,6 +39,21 @@ TWO_PLACES = Decimal("0.01")
 
 
 class QuoteRequest(BaseModel):
+    """
+    Inbound quote request parameters.
+
+    Used by:
+      - ``POST /api/quote`` (fast_quote endpoint)
+      - ``calculate_fast_quote()`` in the sovereign pricing pipeline
+      - ``agent_paper_clip()`` in the Godhead Swarm (shadow audit intake)
+
+    The ``pets`` field directly controls whether pet-related fees and deposits
+    appear in the response.  ``adults + children`` determines the extra-guest
+    fee threshold (currently > 4 adults triggers a per-night surcharge).
+
+    ``selected_add_on_ids`` lists fee UUIDs (as strings) the caller wants included
+    in the quote; optional fees are excluded unless their id appears here.
+    """
     model_config = ConfigDict(extra="forbid")
 
     property_id: UUID
@@ -22,9 +62,25 @@ class QuoteRequest(BaseModel):
     adults: int = Field(ge=1)
     children: int = Field(ge=0)
     pets: int = Field(ge=0)
+    selected_add_on_ids: list[str] = Field(default_factory=list)
 
 
 class QuoteLineItem(BaseModel):
+    """
+    A single pricing row in the quote response.
+
+    This is the atomic unit of pricing transparency.  The ``type`` field gives
+    both the frontend and the AI agent semantic context:
+
+      - **rent**: Base nightly accommodation total.
+      - **fee**: Mandatory property fees (cleaning, pet cleaning, extra guest).
+      - **tax**: Government-mandated lodging taxes.
+      - **discount**: Yield adjustments, AI-learned corrections, or promotions.
+
+    ``agent_hermes`` uses this schema to build its Evidence Packet.  If a known
+    fee type (e.g. cleaning) is absent from the DGX ``line_items`` but present
+    in the Legacy payload, Hermes infers a ``LearnedRule`` to close the gap.
+    """
     model_config = ConfigDict(extra="forbid")
 
     description: str
@@ -37,6 +93,24 @@ class QuoteLineItem(BaseModel):
 
 
 class QuoteResponse(BaseModel):
+    """
+    Complete quote response from the sovereign pricing pipeline.
+
+    ``line_items`` is the source of truth — every dollar charged appears as a
+    ``QuoteLineItem``.  ``total_amount`` is the pre-computed grand total; the
+    frontend must display this value directly and never sum line items
+    client-side (prevents floating-point rounding drift).
+
+    This response is fed directly to the Godhead Swarm in two flows:
+
+    1. **Shadow Router**: ``agent_paper_clip`` compares ``total_amount`` (in
+       cents) against the Legacy total.  If they differ, the full ``line_items``
+       array is forwarded through Claw → Hermes → Nemo.
+
+    2. **Universal Ledger**: ``storefront_checkout.py`` maps these line items
+       into the extended ``LedgerLineItem`` format (with ``is_taxable``, ``id``)
+       and groups them with a ``LedgerSummary`` for the checkout sidebar.
+    """
     model_config = ConfigDict(extra="forbid")
 
     property_id: UUID

--- a/fortress-guest-platform/backend/services/pricing_service.py
+++ b/fortress-guest-platform/backend/services/pricing_service.py
@@ -2,25 +2,66 @@
 
 from __future__ import annotations
 
+import operator
+import structlog
 from collections import OrderedDict
 from datetime import date
 from decimal import Decimal, ROUND_HALF_UP
 from typing import Iterable
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import select, text as sql_text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.models.financial_primitives import Fee, PropertyFee, PropertyTax, Tax
+from backend.models.learned_rule import LearnedRule
 from backend.models.pricing import QuoteLineItem, QuoteRequest, QuoteResponse
 from backend.models.pricing_override import PricingOverride
 from backend.models.property import Property
 from backend.services.quote_builder import QuoteBuilderError, build_local_rent_quote
 from backend.services.sovereign_yield_authority import SovereignYieldAuthority
 
+_learned_rules_logger = structlog.get_logger("learned_rules_engine")
+
 
 TWO_PLACES = Decimal("0.01")
 ONE_HUNDRED = Decimal("100.00")
+
+# Processing Fee rules — verified against Streamline vault data (2026):
+#   Non-VRBO:  6% of taxable base (rent + cleaning + party fees)
+#   VRBO/HA:   $59.95 flat cap  ("Processing Fee all but HA/VRBO" in Streamline)
+# The storefront checkout only handles non-VRBO bookings; VRBO reservations
+# arrive via Streamline (booking_source='HA-OLB') and are capped server-side.
+PROCESSING_FEE_RATE = Decimal("6.000")
+PROCESSING_FEE_VRBO_CAP = Decimal("59.95")
+_VRBO_SOURCES = frozenset(["ha-olb", "vrbo", "homeaway", "ha"])
+
+
+def calculate_processing_fee(taxable_base: Decimal, booking_source: str | None = None) -> Decimal:
+    """Return the correct Processing Fee given taxable base and booking source.
+
+    Non-VRBO: 6% of taxable base (no cap).
+    VRBO/HA:  min(6% of taxable_base, $59.95) — but in practice Streamline
+              applies the cap before the reservation reaches us.
+    """
+    raw = _to_money(taxable_base * PROCESSING_FEE_RATE / ONE_HUNDRED)
+    if (booking_source or "").lower().strip() in _VRBO_SOURCES:
+        return min(raw, PROCESSING_FEE_VRBO_CAP)
+    return raw
+
+
+# Fees excluded from the taxable base used for Processing Fee and County/State Tax.
+# ADW and DOT Tax are non-taxable per Streamline invoice structure.
+_NONTAXABLE_FEE_PATTERNS = frozenset(["damage waiver", "dot tax"])
+
+
+def _is_nontaxable_fee(name: str) -> bool:
+    lower = (name or "").lower()
+    return any(p in lower for p in _NONTAXABLE_FEE_PATTERNS)
+
+
+def _is_dot_tax_fee(name: str) -> bool:
+    return "dot tax" in (name or "").lower()
 
 
 class PricingError(ValueError):
@@ -75,6 +116,35 @@ async def _load_applicable_fees(
         .order_by(Fee.name.asc())
     )
     return list((await db.execute(stmt)).scalars().all())
+
+
+async def _load_optional_fee_ids(db: AsyncSession) -> set[str]:
+    """Raw SQL lookup for optional fee IDs, bypassing ORM metadata cache.
+
+    If a fee's ``is_optional`` column is TRUE in the database, it MUST be
+    excluded from the base quote unless its UUID appears in
+    ``selected_optional_ids`` — same gatekeeper rule as ``storefront_checkout``.
+    """
+    try:
+        rows = (
+            await db.execute(
+                sql_text("SELECT id::text FROM fees WHERE is_optional = true")
+            )
+        ).fetchall()
+        return {r[0] for r in rows}
+    except Exception:
+        return set()
+
+
+def _fee_name_matches_check_in_out_intercept(name: str | None) -> bool:
+    """Mirror storefront_checkout hard-intercept for early/late check-in/out."""
+    fee_name_lower = (name or "").lower()
+    return (
+        "check-in" in fee_name_lower
+        or "check-out" in fee_name_lower
+        or "early" in fee_name_lower
+        or "late" in fee_name_lower
+    )
 
 
 def _matching_override_for_night(
@@ -142,17 +212,99 @@ def _build_fee_line_items(
     *,
     pets: int,
     fees: list[Fee],
-) -> tuple[list[QuoteLineItem], Decimal]:
-    standard_fees = [fee for fee in fees if not bool(fee.is_pet_fee)]
+    base_rent: Decimal = Decimal("0.00"),
+    nights: int = 1,
+    pct_fee_cache: dict[str, dict] | None = None,
+    selected_optional_ids: set[str] | None = None,
+    optional_fee_ids: set[str] | None = None,
+) -> tuple[list[QuoteLineItem], Decimal, Decimal]:
+    """Two-pass fee builder: flat fees first, then percentage fees on taxable base.
+
+    The Processing Fee (percentage type) is calculated on the taxable base:
+    (base_rent + cleaning + party fees). ADW and DOT Tax are excluded from the
+    taxable base, matching Streamline's exact invoice structure.
+    DOT Tax flat_amount is a per-night rate multiplied by nights.
+    Optional fees are excluded unless their ID is in selected_optional_ids.
+    The optional_fee_ids set (from raw SQL) takes precedence over ORM attributes
+    to prevent metadata-cache leaks.
+
+    Returns (line_items, total_fees, taxable_flat_total).
+    """
+    opt_ids = optional_fee_ids or set()
+    # Mandatory ledger rows: exclude optional (DB + ORM), pet-only rows used when
+    # pets>0, and check-in/out lines handled by the hard-intercept below.
+    standard_fees = [
+        fee for fee in fees
+        if not bool(fee.is_pet_fee)
+        and str(fee.id) not in opt_ids
+        and not getattr(fee, "is_optional", False)
+        and not _fee_name_matches_check_in_out_intercept(fee.name)
+    ]
     if not standard_fees:
         raise PricingError("Property fee ledger is missing")
 
+    cache = pct_fee_cache or {}
+    selected_opt = selected_optional_ids or set()
     line_items: list[QuoteLineItem] = []
     total_fees = Decimal("0.00")
+    flat_fee_total = Decimal("0.00")
+    taxable_flat_total = Decimal("0.00")
+    deferred_pct_fees: list[tuple] = []
+
+    # Pass 1 — flat fees (Cleaning, ADW, etc.; optional fees only if selected)
     for fee in fees:
         if bool(fee.is_pet_fee) and pets < 1:
             continue
-        amount = _to_money(Decimal(str(fee.flat_amount)))
+
+        fee_id_str = str(fee.id)
+
+        # Hard intercept: Streamline-style early/late check-in/out must never be
+        # mandatory; only include when explicitly selected (matches storefront).
+        if _fee_name_matches_check_in_out_intercept(fee.name):
+            if fee_id_str not in selected_opt:
+                continue
+
+        is_optional = fee_id_str in opt_ids or getattr(fee, "is_optional", False)
+        if is_optional and fee_id_str not in selected_opt:
+            continue
+
+        fee_type = getattr(fee, "fee_type", None)
+        pct_rate = getattr(fee, "percentage_rate", None)
+
+        if fee_type is None and str(fee.id) in cache:
+            fee_type = cache[str(fee.id)]["fee_type"]
+            pct_rate = cache[str(fee.id)]["percentage_rate"]
+
+        fee_type = fee_type or "flat"
+
+        if fee_type == "percentage" and pct_rate is not None:
+            deferred_pct_fees.append((fee, Decimal(str(pct_rate))))
+            continue
+
+        raw_amount = Decimal(str(fee.flat_amount))
+        if _is_dot_tax_fee(fee.name):
+            amount = _to_money(raw_amount * nights)
+        else:
+            amount = _to_money(raw_amount)
+        if amount == Decimal("0.00"):
+            continue
+        total_fees += amount
+        flat_fee_total += amount
+        if not _is_nontaxable_fee(fee.name):
+            taxable_flat_total += amount
+        line_items.append(
+            QuoteLineItem(
+                description=fee.name,
+                amount=amount,
+                type="fee",
+            )
+        )
+
+    # Pass 2 — percentage fees on taxable base only (rent + cleaning + party fees).
+    # ADW and DOT Tax are excluded from pct_base per Streamline invoice structure.
+    pct_base = base_rent + taxable_flat_total
+    for fee, rate in deferred_pct_fees:
+        amount = _to_money(pct_base * rate / ONE_HUNDRED)
         if amount == Decimal("0.00"):
             continue
         total_fees += amount
@@ -163,7 +315,8 @@ def _build_fee_line_items(
                 type="fee",
             )
         )
-    return line_items, _to_money(total_fees)
+
+    return line_items, _to_money(total_fees), _to_money(taxable_flat_total)
 
 
 def _build_tax_line_items(
@@ -190,6 +343,115 @@ def _build_tax_line_items(
             )
         )
     return line_items, _to_money(total_taxes)
+
+
+_CONDITION_OPS = {
+    ">": operator.gt,
+    ">=": operator.ge,
+    "<": operator.lt,
+    "<=": operator.le,
+    "==": operator.eq,
+    "!=": operator.ne,
+}
+
+
+def _evaluate_trigger_condition(
+    condition: dict,
+    context: dict,
+) -> bool:
+    """
+    Evaluate a learned rule's trigger_condition against request context.
+
+    Condition format: {"field": "op value"} e.g. {"days_to_arrival": ">30", "pets": ">0"}
+    Empty condition = always matches (global rule).
+    """
+    if not condition:
+        return True
+
+    for field, expr in condition.items():
+        actual = context.get(field)
+        if actual is None:
+            return False
+
+        expr_str = str(expr).strip()
+        matched_op = None
+        for op_str in sorted(_CONDITION_OPS, key=len, reverse=True):
+            if expr_str.startswith(op_str):
+                matched_op = op_str
+                break
+
+        if matched_op is None:
+            try:
+                return float(actual) == float(expr_str)
+            except (ValueError, TypeError):
+                return False
+
+        threshold_str = expr_str[len(matched_op):].strip()
+        try:
+            return _CONDITION_OPS[matched_op](float(actual), float(threshold_str))
+        except (ValueError, TypeError):
+            return False
+
+    return True
+
+
+async def _load_active_learned_rules(
+    db: AsyncSession,
+    property_id: UUID,
+) -> list[LearnedRule]:
+    stmt = (
+        select(LearnedRule)
+        .where(LearnedRule.status == "active")
+        .where(
+            (LearnedRule.property_id == property_id)
+            | (LearnedRule.property_id.is_(None))
+        )
+        .order_by(LearnedRule.confidence_score.desc())
+    )
+    return list((await db.execute(stmt)).scalars().all())
+
+
+def _apply_learned_rules(
+    rules: list[LearnedRule],
+    subtotal: Decimal,
+    context: dict,
+) -> tuple[list[QuoteLineItem], Decimal]:
+    line_items: list[QuoteLineItem] = []
+    total_adjustment = Decimal("0.00")
+
+    for rule in rules:
+        if not _evaluate_trigger_condition(rule.trigger_condition or {}, context):
+            continue
+
+        if rule.adjustment_type == "flat_fee":
+            amount = _to_money(Decimal(str(rule.adjustment_value)))
+        elif rule.adjustment_type == "percentage":
+            amount = _to_money(subtotal * Decimal(str(rule.adjustment_value)))
+        else:
+            continue
+
+        if amount == Decimal("0.00"):
+            continue
+
+        total_adjustment += amount
+        display_name = (rule.rule_name or "learned_adjustment").replace("_", " ").title()
+        line_items.append(
+            QuoteLineItem(
+                description=f"{display_name} (AI Learned)",
+                amount=amount,
+                type="discount" if amount < 0 else "fee",
+            )
+        )
+
+        _learned_rules_logger.info(
+            "learned_rule_applied",
+            rule_id=str(rule.id),
+            rule_name=rule.rule_name,
+            adjustment=float(amount),
+            confidence=rule.confidence_score,
+        )
+
+    return line_items, _to_money(total_adjustment)
 
 
 async def calculate_fast_quote(
@@ -237,16 +499,44 @@ async def calculate_fast_quote(
         rent_quote.nightly_breakdown,
         overrides,
     )
-    fee_line_items, total_fees = _build_fee_line_items(
+    adjusted_rent = _to_money(rent_quote.rent + total_adjustment)
+    optional_fee_ids = await _load_optional_fee_ids(db)
+    fee_line_items, total_fees, taxable_flat_fee_total = _build_fee_line_items(
         pets=request.pets,
         fees=fees,
+        base_rent=adjusted_rent,
+        nights=nights,
+        optional_fee_ids=optional_fee_ids,
+        selected_optional_ids=set(request.selected_add_on_ids),
     )
-    adjusted_rent = _to_money(rent_quote.rent + total_adjustment)
+
+    # --- Godhead Phase 3: Self-Healing Learned Rules ---
+    learned_rules = await _load_active_learned_rules(db, request.property_id)
+    days_to_arrival = (request.check_in - date.today()).days
+    rule_context = {
+        "days_to_arrival": days_to_arrival,
+        "nights": nights,
+        "guests": total_guests,
+        "adults": request.adults,
+        "children": request.children,
+        "pets": request.pets,
+    }
+    pre_tax_subtotal = _to_money(adjusted_rent + total_fees)
+    learned_line_items, learned_adjustment = _apply_learned_rules(
+        learned_rules,
+        pre_tax_subtotal,
+        rule_context,
+    )
+    pre_tax_subtotal = _to_money(pre_tax_subtotal + learned_adjustment)
+
+    # Tax base = rent + cleaning + party fees only.
+    # ADW, DOT Tax, and Processing Fee are excluded per Streamline invoice structure.
+    tax_base = _to_money(adjusted_rent + taxable_flat_fee_total)
     tax_line_items, total_tax_amount = _build_tax_line_items(
-        tax_base=_to_money(adjusted_rent + total_fees),
+        tax_base=tax_base,
         taxes=taxes,
     )
-    total_amount = _to_money(adjusted_rent + total_fees + total_tax_amount)
+    total_amount = _to_money(pre_tax_subtotal + total_tax_amount)
 
     nightly_rate = (rent_quote.rent / Decimal(nights)).quantize(TWO_PLACES) if nights else Decimal("0.00")
     line_items = [
@@ -257,6 +547,7 @@ async def calculate_fast_quote(
         ),
         *override_line_items,
         *fee_line_items,
+        *learned_line_items,
         *tax_line_items,
     ]
 


### PR DESCRIPTION
Ships the VRS guest quote engine with Streamline calendar integration, Taylor owner-portal quote approval workflow, and Stripe checkout for direct bookings.

Backend changes:
- api/vrs_quotes (+688): 12 endpoints — quote generation, Streamline calendar/quote/refresh, Taylor approval workflow, quote checkout
- models/pricing: QuoteRequest/QuoteResponse extensions (+75)
- services/pricing_service: 8 new pricing-engine functions (+300)
- core/config: new settings fields (ALLOWED_POSTGRES_DATABASES, test_database_url, command_center_ingress_hosts, stripe_connect_client_id, recursive_agent_loop_enabled)
- config.py root: fabric IP corrections + get_ollama_endpoints helper

Note: recursive_agent_loop_enabled is a 3-line inert setting definition. It is not wired to anything yet — that happens in a future ops-workers-sensors branch. Having the setting present now is harmless.

Merge with Create a merge commit.
