### PR TITLE
chore(schema-audit): add utility + lifespan wiring

### DIFF
--- a/fortress-guest-platform/backend/core/schema_audit.py
+++ b/fortress-guest-platform/backend/core/schema_audit.py
@@ -1,0 +1,72 @@
+"""
+Pre-Flight Schema Audit — Validates that the database schema matches
+the SQLAlchemy model contract at startup.
+
+If a mapped column is missing from the physical table, the API logs a
+CRITICAL error and raises, preventing a half-broken site from serving
+requests that would crash on the first ORM query.
+"""
+
+from __future__ import annotations
+
+import structlog
+from sqlalchemy import inspect as sa_inspect, text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+logger = structlog.get_logger()
+
+CRITICAL_TABLES = {
+    "properties": [
+        "id", "name", "slug", "county", "city_limits", "is_active",
+        "streamline_property_id", "rate_card", "bedrooms", "bathrooms",
+    ],
+    "reservations": [
+        "id", "confirmation_code", "property_id", "guest_id",
+        "check_in_date", "check_out_date", "status", "total_amount",
+    ],
+}
+
+
+async def run_schema_audit(engine: AsyncEngine) -> None:
+    """Compare physical DB columns against expected model columns.
+
+    Raises RuntimeError if critical columns are missing, preventing
+    the API from starting in a broken state.
+    """
+    missing: list[str] = []
+
+    async with engine.connect() as conn:
+        for table, expected_cols in CRITICAL_TABLES.items():
+            result = await conn.execute(
+                text(
+                    "SELECT column_name FROM information_schema.columns "
+                    "WHERE table_name = :tbl"
+                ),
+                {"tbl": table},
+            )
+            actual_cols = {row[0] for row in result.fetchall()}
+
+            if not actual_cols:
+                logger.warning("schema_audit_table_missing", table=table)
+                continue
+
+            for col in expected_cols:
+                if col not in actual_cols:
+                    missing.append(f"{table}.{col}")
+                    logger.critical(
+                        "schema_audit_column_missing",
+                        table=table,
+                        column=col,
+                        hint="Run the Alembic migration or manually ALTER TABLE",
+                    )
+
+    if missing:
+        msg = (
+            f"SCHEMA AUDIT FAILED — {len(missing)} column(s) missing from the "
+            f"database: {', '.join(missing)}. Run `alembic upgrade head` or apply "
+            f"the migration manually before starting the API."
+        )
+        logger.critical("schema_audit_fatal", missing=missing)
+        raise RuntimeError(msg)
+
+    logger.info("schema_audit_passed", tables_checked=len(CRITICAL_TABLES))

--- a/fortress-guest-platform/backend/main.py
+++ b/fortress-guest-platform/backend/main.py
@@ -379,6 +379,15 @@ async def lifespan(app: FastAPI):
     try:
         await init_db()
         logger.info("database_initialized")
+
+        from backend.core.schema_audit import run_schema_audit
+        from backend.core.database import get_async_engine
+        await run_schema_audit(get_async_engine())
+    except RuntimeError as e:
+        if "SCHEMA AUDIT FAILED" in str(e):
+            logger.critical("startup_aborted_schema_mismatch", error=str(e))
+            raise
+        logger.warning("database_init_skipped", error=str(e), note="App will run without DB - configure DATABASE_URL")
     except Exception as e:
         logger.warning("database_init_skipped", error=str(e), note="App will run without DB - configure DATABASE_URL")
 


### PR DESCRIPTION
Ships backend/core/schema_audit.py plus re-adds the lifespan startup wiring stripped during foundation PR #11. Runs on startup after DB init, fails fast on schema mismatch with SCHEMA AUDIT FAILED. Changes: schema_audit.py (new, 72 lines) + main.py (9 lines re-added). Merge with Create a merge commit.