### PR TITLE
feat(ops-workers): drift sentry + hermes sync + legal intake + revenue consumer

### DIFF
--- a/fortress-guest-platform/backend/core/worker.py
+++ b/fortress-guest-platform/backend/core/worker.py
@@ -546,8 +546,80 @@ async def startup(ctx: dict[str, Any]) -> None:
             "streamline_availability_sync_started",
             interval_seconds=max(300, int(settings.streamline_sync_interval)),
         )
+        from backend.workers.drift_sentry import drift_sentry_loop
+        drift_task = asyncio.create_task(
+            drift_sentry_loop(),
+            name="drift_sentry_task",
+        )
+        ctx["drift_sentry_task"] = drift_task
+        drift_task.add_done_callback(
+            lambda t: _log_background_task_result("drift_sentry_task", t),
+        )
+        logger.info("drift_sentry_started_in_worker")
+
     else:
         logger.info("streamline_availability_sync_disabled", reason="streamline_not_configured")
+
+    from backend.workers.hermes_sync import hermes_sync_loop
+    hermes_task = asyncio.create_task(
+        hermes_sync_loop(),
+        name="hermes_sync_task",
+    )
+    ctx["hermes_sync_task"] = hermes_task
+    hermes_task.add_done_callback(
+        lambda t: _log_background_task_result("hermes_sync_task", t),
+    )
+    logger.info("hermes_sync_started_in_worker")
+
+    if settings.recursive_agent_loop_enabled:
+        from backend.workers.recursive_agent_loop import recursive_agent_loop
+        ral_task = asyncio.create_task(
+            recursive_agent_loop(),
+            name="recursive_agent_loop_task",
+        )
+        ctx["recursive_agent_loop_task"] = ral_task
+        ral_task.add_done_callback(
+            lambda t: _log_background_task_result("recursive_agent_loop_task", t),
+        )
+        logger.info("recursive_agent_loop_started_in_worker",
+                    interval=os.getenv("RECURSIVE_LOOP_INTERVAL", "1800"))
+    else:
+        logger.info("recursive_agent_loop_disabled")
+
+    if settings.legal_email_intake_enabled:
+        from backend.services.legal_email_intake import run_legal_intake_loop
+        legal_intake_task = asyncio.create_task(
+            run_legal_intake_loop(),
+            name="legal_intake_task",
+        )
+        ctx["legal_intake_task"] = legal_intake_task
+        legal_intake_task.add_done_callback(
+            lambda t: _log_background_task_result("legal_intake_task", t),
+        )
+        logger.info("legal_email_intake_started_in_worker",
+                    interval=settings.legal_email_poll_interval)
+    else:
+        logger.info("legal_email_intake_disabled")
+
+    reservation_confirmed_task = asyncio.create_task(
+        _reservation_confirmed_consumer_loop(),
+        name="reservation_confirmed_consumer_task",
+    )
+    ctx["reservation_confirmed_consumer_task"] = reservation_confirmed_task
+    reservation_confirmed_task.add_done_callback(
+        lambda t: _log_background_task_result("reservation_confirmed_consumer_task", t),
+    )
+    logger.info("reservation_confirmed_consumer_wired")
+
+    payout_sweep_task = asyncio.create_task(
+        _payout_sweep_loop(),
+        name="payout_sweep_task",
+    )
+    ctx["payout_sweep_task"] = payout_sweep_task
+    payout_sweep_task.add_done_callback(
+        lambda t: _log_background_task_result("payout_sweep_task", t),
+    )
+    logger.info("payout_sweep_loop_started")
 
 
 async def shutdown(ctx: dict[str, Any]) -> None:
@@ -611,6 +683,11 @@ async def shutdown(ctx: dict[str, Any]) -> None:
     if availability_task is not None:
         availability_task.cancel()
         await asyncio.gather(availability_task, return_exceptions=True)
+
+    payout_sweep_task = ctx.get("payout_sweep_task")
+    if payout_sweep_task is not None:
+        payout_sweep_task.cancel()
+        await asyncio.gather(payout_sweep_task, return_exceptions=True)
 
     streamline_vrs = ctx.get("streamline_vrs")
     if streamline_vrs is not None:
@@ -931,6 +1008,30 @@ async def _hunter_queue_sweep_loop() -> None:
         except Exception as exc:
             logger.error("hunter_queue_sweep_loop_error", error=str(exc)[:400])
         await asyncio.sleep(interval)
+
+
+async def _payout_sweep_loop() -> None:
+    """
+    Daily payout sweep that runs at 6am ET. Checks every hour whether the
+    6am window has been hit and triggers the sweep once per day.
+    """
+    import pytz
+    _ET = pytz.timezone("America/New_York")
+    _last_sweep_date = None
+    while True:
+        try:
+            now_et = datetime.now(_ET)
+            today = now_et.date()
+            if now_et.hour >= 6 and _last_sweep_date != today:
+                from backend.services.payout_scheduler import run_payout_sweep
+                result = await run_payout_sweep()
+                _last_sweep_date = today
+                logger.info("payout_sweep_daily_complete", **{k: str(v) for k, v in result.items()})
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.error("payout_sweep_loop_error", error=str(exc)[:400])
+        await asyncio.sleep(3600)  # check every hour
 
 
 async def _streamline_availability_sync_loop(streamline_vrs: StreamlineVRS) -> None:
@@ -1682,6 +1783,166 @@ async def run_seo_remap_grading_job(ctx: dict[str, Any], job_id: str) -> dict[st
     return await _with_job(job_id, int(ctx.get("job_try", 1)), runner)
 
 
+async def run_work_order_sync_job(ctx: dict[str, Any], job_id: str) -> dict[str, Any]:
+    """
+    On-demand Streamline work order sync.
+
+    Fetches all maintenance tickets from Streamline VRS, upserts new ones into
+    work_orders, and updates status on existing ones.  This mirrors the Phase 4
+    logic in StreamlineVRS.run_full_sync() but is callable independently.
+
+    Payload options (all optional):
+      dry_run (bool) – log targets but skip DB writes; default: false
+    """
+    async def runner(db, job: AsyncJobRun) -> dict[str, Any]:
+        from backend.integrations.streamline_vrs import StreamlineVRS
+        from backend.models.workorder import WorkOrder
+        from backend.models.property import Property
+        from sqlalchemy import select
+
+        payload = job.payload_json or {}
+        dry_run = bool(payload.get("dry_run", False))
+
+        vrs = StreamlineVRS()
+        if not vrs.is_configured:
+            return {"error": "Streamline VRS not configured", "synced": 0}
+
+        remote_wos = await vrs.fetch_work_orders()
+        created, updated, skipped = 0, 0, 0
+
+        for rwo in remote_wos:
+            sl_id = str(rwo.get("streamline_id", "")).strip()
+            if not sl_id:
+                skipped += 1
+                continue
+
+            if dry_run:
+                logger.info("work_order_sync_dry_run", streamline_id=sl_id, subject=rwo.get("subject"))
+                skipped += 1
+                continue
+
+            result = await db.execute(select(WorkOrder).where(WorkOrder.title == f"SL-{sl_id}"))
+            existing = result.scalar_one_or_none()
+
+            if existing:
+                if rwo.get("status"):
+                    existing.status = rwo["status"]  # type: ignore[assignment]
+                updated += 1
+            else:
+                prop_result = await db.execute(
+                    select(Property).where(Property.streamline_property_id == str(rwo.get("unit_id", "")))
+                )
+                prop = prop_result.scalar_one_or_none()
+                from backend.models.workorder import WorkOrder as WO
+                wo = WO(
+                    ticket_number=f"SL-{sl_id}",
+                    title=f"SL-{sl_id}",
+                    description=rwo.get("description") or rwo.get("subject", "No description"),
+                    category=rwo.get("category", "other") or "other",
+                    priority=rwo.get("priority", "medium") or "medium",
+                    status="open",
+                    property_id=prop.id if prop else None,
+                    created_by="streamline_sync",
+                )
+                db.add(wo)
+                created += 1
+
+        if not dry_run:
+            await db.commit()
+
+        return {
+            "dry_run": dry_run,
+            "fetched": len(remote_wos),
+            "created": created,
+            "updated": updated,
+            "skipped": skipped,
+        }
+
+    return await _with_job(job_id, int(ctx.get("job_try", 1)), runner)
+
+
+async def run_seo_property_sweep_job(ctx: dict[str, Any], job_id: str) -> dict[str, Any]:
+    """
+    Sweep all active properties without an active SEO draft and submit them to
+    the extraction pipeline. Each property gets one SEOPatch in "drafted" status
+    per rubric. Properties already in ACTIVE_PATCH_STATUSES are skipped.
+
+    Payload options (all optional):
+      limit  (int)  – max properties to process; default: all
+      dry_run (bool) – log targets but skip extraction; default: false
+    """
+    async def runner(db, job: AsyncJobRun) -> dict[str, Any]:
+        from backend.services.seo_extraction_service import SEOExtractionSwarm
+        from backend.models.seo_patch import SEOPatch, SEORubric
+        from backend.models.property import Property
+        from sqlalchemy import select, exists as sa_exists
+
+        ACTIVE_PATCH_STATUSES = (
+            "drafted", "grading", "needs_rewrite", "pending_human", "deployed",
+        )
+
+        payload = job.payload_json or {}
+        limit = int(payload["limit"]) if payload.get("limit") is not None else None
+        dry_run = bool(payload.get("dry_run", False))
+
+        # Find active rubric
+        rubric = (
+            await db.execute(
+                select(SEORubric).where(SEORubric.status == "active").order_by(SEORubric.created_at.desc()).limit(1)
+            )
+        ).scalar_one_or_none()
+
+        if rubric is None:
+            return {"error": "No active rubric found — run seed_seo_rubrics.py first", "processed": 0}
+
+        # Properties that already have an active patch
+        subq = select(SEOPatch.property_id).where(
+            SEOPatch.status.in_(ACTIVE_PATCH_STATUSES),
+            SEOPatch.property_id.isnot(None),
+        ).scalar_subquery()
+
+        q = (
+            select(Property)
+            .where(Property.is_active.is_(True))
+            .where(~Property.id.in_(subq))
+            .order_by(Property.name)
+        )
+        if limit:
+            q = q.limit(limit)
+
+        result = await db.execute(q)
+        properties = result.scalars().all()
+
+        if dry_run:
+            return {
+                "dry_run": True,
+                "targets": [{"id": str(p.id), "name": p.name} for p in properties],
+                "count": len(properties),
+            }
+
+        swarm = SEOExtractionSwarm(db)
+        processed, skipped = 0, 0
+        for prop in properties:
+            try:
+                result = await swarm.generate_initial_seo_draft(prop.id)
+                if result:
+                    processed += 1
+                else:
+                    skipped += 1
+            except Exception as exc:
+                logger.warning("seo_sweep_property_failed", property_id=str(prop.id), error=str(exc)[:200])
+                skipped += 1
+
+        return {
+            "processed": processed,
+            "skipped": skipped,
+            "total_candidates": len(properties),
+            "rubric_id": str(rubric.id),
+        }
+
+    return await _with_job(job_id, int(ctx.get("job_try", 1)), runner)
+
+
 async def run_deep_entity_swarm_job(ctx: dict[str, Any], job_id: str) -> dict[str, Any]:
     async def runner(db, job: AsyncJobRun) -> dict[str, Any]:
         from backend.services.deep_entity_swarm import run_deep_entity_swarm
@@ -1689,6 +1950,131 @@ async def run_deep_entity_swarm_job(ctx: dict[str, Any], job_id: str) -> dict[st
         return await run_deep_entity_swarm(db, payload=job.payload_json or {})
 
     return await _with_job(job_id, int(ctx.get("job_try", 1)), runner)
+
+
+async def _reservation_confirmed_consumer_loop() -> None:
+    """
+    Redpanda/Kafka consumer for the ``reservation.confirmed`` topic.
+
+    Sends a booking confirmation email to the guest for every confirmed
+    reservation.  Runs as a long-lived background task started by the ARQ
+    worker startup hook — identical lifecycle to the other background loops.
+    """
+    import json
+
+    from aiokafka import AIOKafkaConsumer
+
+    from backend.core.event_publisher import REDPANDA_BROKER
+    from backend.models.property import Property
+    from backend.models.reservation import Reservation
+    from backend.services.smtp_dispatcher import SMTPDispatcher
+
+    TOPIC = "reservation.confirmed"
+    GROUP_ID = "arq-booking-confirmation-mailer"
+
+    logger.info(
+        "reservation_confirmed_consumer_starting", topic=TOPIC, group_id=GROUP_ID
+    )
+    dispatcher = SMTPDispatcher()
+
+    consumer = AIOKafkaConsumer(
+        TOPIC,
+        bootstrap_servers=REDPANDA_BROKER,
+        group_id=GROUP_ID,
+        value_deserializer=lambda v: json.loads(v.decode("utf-8")),
+        auto_offset_reset="earliest",
+        enable_auto_commit=True,
+    )
+
+    try:
+        await consumer.start()
+        logger.info("reservation_confirmed_consumer_started", topic=TOPIC)
+
+        async for msg in consumer:
+            try:
+                payload: dict = msg.value or {}
+                reservation_id = payload.get("reservation_id")
+                if not reservation_id:
+                    continue
+
+                async with AsyncSessionLocal() as db:
+                    res = await db.get(Reservation, reservation_id)
+                    if not res:
+                        logger.warning(
+                            "reservation_confirmed_consumer_not_found",
+                            reservation_id=reservation_id,
+                        )
+                        continue
+
+                    guest_email = (res.guest_email or "").strip()
+                    if not guest_email:
+                        logger.warning(
+                            "reservation_confirmed_consumer_no_email",
+                            reservation_id=reservation_id,
+                        )
+                        continue
+
+                    prop = (
+                        await db.get(Property, res.property_id)
+                        if res.property_id
+                        else None
+                    )
+                    property_name = prop.name if prop else "Your Cabin"
+
+                    nights_val = None
+                    if hasattr(res, "nights_count") and res.nights_count:
+                        nights_val = res.nights_count
+                    elif res.check_in_date and res.check_out_date:
+                        nights_val = (res.check_out_date - res.check_in_date).days
+
+                    quote_data: dict = {
+                        "property_name": property_name,
+                        "confirmation_code": res.confirmation_code
+                        or payload.get("confirmation_code", ""),
+                        "check_in_date": (
+                            res.check_in_date.isoformat()
+                            if res.check_in_date
+                            else payload.get("check_in_date", "")
+                        ),
+                        "check_out_date": (
+                            res.check_out_date.isoformat()
+                            if res.check_out_date
+                            else payload.get("check_out_date", "")
+                        ),
+                        "nights": nights_val,
+                        "total_amount": float(
+                            res.total_amount or payload.get("total_amount", 0)
+                        ),
+                    }
+
+                    result = await dispatcher.send_confirmation(guest_email, quote_data)
+                    logger.info(
+                        "reservation_confirmation_email_dispatched",
+                        reservation_id=reservation_id,
+                        to=guest_email,
+                        success=result.get("success"),
+                        error=result.get("error"),
+                    )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.error(
+                    "reservation_confirmed_consumer_message_error",
+                    error=str(exc)[:400],
+                )
+
+    except asyncio.CancelledError:
+        logger.info("reservation_confirmed_consumer_cancelled")
+    except Exception as exc:
+        logger.error(
+            "reservation_confirmed_consumer_fatal", error=str(exc)[:400]
+        )
+    finally:
+        try:
+            await consumer.stop()
+        except Exception:
+            pass
+        logger.info("reservation_confirmed_consumer_stopped")
 
 
 class WorkerSettings:
@@ -1721,10 +2107,24 @@ class WorkerSettings:
         run_seo_redirect_batch_job,
         run_seo_fallback_swarm_job,
         run_seo_remap_grading_job,
+        run_seo_property_sweep_job,
+        run_work_order_sync_job,
         run_deep_entity_swarm_job,
         refactor_legacy_html_task,
         ingest_property_media,
+        # Phase F — Owner Statement jobs (also registered as cron below)
+        generate_monthly_statements_job,
+        send_approved_statements_job,
     ]
+    # Phase F cron schedule — times in America/New_York (ARQ evaluates against
+    # the WorkerSettings.timezone attribute, so cron values are local ET times)
+    #   12th at 06:00 ET — generate draft statements for previous month
+    #   15th at 09:30 ET — email all approved-but-not-yet-emailed statements
+    cron_jobs = [
+        arq_cron(generate_monthly_statements_job, day=12, hour=6,  minute=0,  second=0, run_at_startup=False),
+        arq_cron(send_approved_statements_job,    day=15, hour=9,  minute=30, second=0, run_at_startup=False),
+    ]
+    timezone = _pytz.timezone("America/New_York")
     redis_settings = get_arq_redis_settings()
     queue_name = settings.arq_queue_name
     max_jobs = settings.arq_concurrency

--- a/fortress-guest-platform/backend/services/legal_email_intake.py
+++ b/fortress-guest-platform/backend/services/legal_email_intake.py
@@ -1,0 +1,676 @@
+"""
+Legal Email Intake — Autonomous MailPlus Ingestion Pipeline
+============================================================
+Polls a dedicated MailPlus inbox for incoming legal correspondence,
+triages each email through the local LLM, links to active cases,
+creates correspondence + timeline records, and auto-ingests attachments
+into the E-Discovery vault.
+
+Pipeline per email:
+  1. IMAP UNSEEN fetch
+  2. LLM triage → {is_legal, category, case_slug_guess, case_number_extracted, …}
+  3. Case match: (a) regex case# from subject → legal.cases, (b) slug fuzzy-match
+  4. Insert into legal.email_intake_queue (dedup by message_uid SHA-256)
+  5. If linked: legal.correspondence row + legal.timeline_events row
+  6. Attachments → process_vault_upload() (privilege-shielded, vectorized)
+  7. Training capture → llm_training_captures flywheel
+
+DB: fortress_db via LegacySession (same as all other legal API services)
+Schema bootstrap: CREATE TABLE IF NOT EXISTS on first patrol cycle — no Alembic needed.
+
+Run standalone:
+  cd ~/Fortress-Prime/fortress-guest-platform
+  .uv-venv/bin/python -m backend.services.legal_email_intake
+"""
+from __future__ import annotations
+
+import asyncio
+import email as email_lib
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+from email.header import decode_header
+from pathlib import Path
+from typing import Optional
+
+import httpx
+import structlog
+
+from backend.core.config import settings
+from backend.services.the_captain import (
+    _decode_header_value,
+    _extract_plain_body,
+    _extract_sender_email,
+    _fetch_unseen_from_inbox,
+    _parse_triage_json,
+)
+from backend.services.ediscovery_agent import LegacySession
+from backend.services.swarm_service import submit_chat_completion
+
+logger = structlog.get_logger(service="legal_email_intake")
+
+# ──────────────────────────────────────────────────────────────────────────────
+# LLM triage prompt
+# ──────────────────────────────────────────────────────────────────────────────
+
+LEGAL_TRIAGE_SYSTEM_PROMPT = """You are the Legal Intake Officer for Fortress Prime, an AI legal operations platform for Cabin Rentals of Georgia.
+
+Read the email and determine:
+1. Is this email legal in nature (court filing, opposing counsel correspondence, expert witness communication, discovery material, insurance claim, settlement negotiation, contract, subpoena, or any formal legal matter)?
+2. What category best describes it?
+3. Can you extract a case number from the subject or body?
+4. What is the case slug guess (lowercase-hyphenated name of the case if mentioned)?
+5. What type of document or communication is this?
+
+Respond ONLY with valid JSON — no markdown, no explanation:
+{
+  "is_legal": true/false,
+  "category": "court_filing|opposing_counsel|client_correspondence|expert_witness|discovery_material|insurance|settlement|contract|subpoena|unknown",
+  "case_number_extracted": "the case number if found, e.g. 2024-CV-001234, otherwise empty string",
+  "case_slug_guess": "kebab-case guess at the case name, e.g. 'johnson-v-cabin-rentals', otherwise empty string",
+  "document_type": "brief|motion|demand_letter|deposition_notice|interrogatory|subpoena|correspondence|contract|invoice|other",
+  "summary": "1-2 sentence description of the email content",
+  "urgency": "low|medium|high|critical"
+}
+
+Examples of LEGAL: court notices, demand letters, subpoenas, correspondence from attorneys, discovery requests, settlement offers, contracts for legal services, insurance claims.
+Examples of NOT LEGAL: booking inquiries, guest reviews, marketing emails, maintenance reports, general business correspondence."""
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Schema bootstrap (fortress_db / LegacySession)
+# ──────────────────────────────────────────────────────────────────────────────
+
+_BOOTSTRAP_DDLS = [
+    """
+    CREATE TABLE IF NOT EXISTS legal.email_intake_queue (
+        id               SERIAL PRIMARY KEY,
+        message_uid      TEXT UNIQUE NOT NULL,
+        sender_email     TEXT NOT NULL,
+        sender_name      TEXT,
+        subject          TEXT,
+        body_text        TEXT,
+        case_slug        TEXT,
+        triage_result    JSONB,
+        intake_status    TEXT NOT NULL DEFAULT 'pending',
+        attachment_count INT  DEFAULT 0,
+        correspondence_id INT,
+        received_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+        processed_at     TIMESTAMPTZ,
+        created_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS ix_legal_email_intake_status
+        ON legal.email_intake_queue (intake_status)
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS ix_legal_email_intake_case
+        ON legal.email_intake_queue (case_slug)
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS ix_legal_email_intake_rcvd
+        ON legal.email_intake_queue (received_at DESC)
+    """,
+]
+
+_schema_bootstrapped = False
+
+
+async def _bootstrap_intake_schema() -> None:
+    global _schema_bootstrapped
+    if _schema_bootstrapped:
+        return
+    from sqlalchemy import text
+    async with LegacySession() as session:
+        for ddl in _BOOTSTRAP_DDLS:
+            await session.execute(text(ddl))
+        await session.commit()
+    _schema_bootstrapped = True
+    logger.info("legal_intake_schema_bootstrapped")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# IMAP config
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _get_legal_inbox_config() -> Optional[dict]:
+    host = settings.legal_mailplus_host
+    user = settings.legal_mailplus_user
+    password = settings.legal_mailplus_password
+    if not host or not user or not password:
+        return None
+    return {
+        "name": "LegalMailPlus",
+        "host": host,
+        "port": settings.legal_mailplus_port,
+        "user": user,
+        "password": password,
+        "folder": settings.legal_mailplus_folder,
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# IMAP fetch — uses the_captain's _fetch_unseen_from_inbox with folder override
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _fetch_unseen_legal_emails(inbox: dict, max_emails: int = 30) -> list[dict]:
+    """Fetch UNSEEN from MailPlus legal inbox; supports folder selection."""
+    import imaplib
+
+    emails = []
+    mail = None
+    folder = inbox.get("folder", "INBOX")
+    try:
+        mail = imaplib.IMAP4_SSL(inbox["host"], inbox["port"])
+        mail.login(inbox["user"], inbox["password"])
+        mail.select(folder)
+
+        _, msg_nums = mail.search(None, "UNSEEN")
+        if not msg_nums or not msg_nums[0]:
+            return []
+
+        msg_ids = msg_nums[0].split()
+        logger.info("legal_intake_unseen_found", count=len(msg_ids), folder=folder)
+
+        for mid in msg_ids[:max_emails]:
+            try:
+                _, data = mail.fetch(mid, "(RFC822)")
+                raw_bytes = data[0][1]
+                msg = email_lib.message_from_bytes(raw_bytes)
+
+                subject = _decode_header_value(msg.get("Subject", ""))
+                sender = _decode_header_value(msg.get("From", ""))
+                body = _extract_plain_body(msg)
+
+                # Count attachments
+                attachment_count = 0
+                attachment_data: list[dict] = []
+                if msg.is_multipart():
+                    for part in msg.walk():
+                        disp = str(part.get("Content-Disposition", ""))
+                        if "attachment" in disp:
+                            fname = part.get_filename() or "attachment"
+                            fname = _decode_header_value(fname)
+                            content_bytes = part.get_payload(decode=True)
+                            ctype = part.get_content_type() or "application/octet-stream"
+                            if content_bytes:
+                                attachment_count += 1
+                                attachment_data.append({
+                                    "file_name": fname,
+                                    "mime_type": ctype,
+                                    "file_bytes": content_bytes,
+                                })
+
+                emails.append({
+                    "subject":          subject,
+                    "sender":           sender,
+                    "sender_email":     _extract_sender_email(sender),
+                    "body":             body,
+                    "inbox":            inbox["name"],
+                    "imap_id":          mid,
+                    "attachment_count": attachment_count,
+                    "attachments":      attachment_data,
+                    "raw_bytes":        raw_bytes,
+                })
+
+                mail.store(mid, "+FLAGS", "\\Seen")
+
+            except Exception as exc:
+                logger.warning("legal_intake_fetch_error", mid=str(mid), error=str(exc)[:200])
+
+    except Exception as exc:
+        logger.error("legal_intake_imap_error", inbox=inbox["name"], error=str(exc)[:200])
+    finally:
+        if mail:
+            try:
+                mail.close()
+                mail.logout()
+            except Exception:
+                pass
+
+    return emails
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# LLM triage
+# ──────────────────────────────────────────────────────────────────────────────
+
+async def _triage_legal_email(subject: str, sender: str, body: str) -> Optional[dict]:
+    prompt = f"""EMAIL TO CLASSIFY:
+From: {sender}
+Subject: {subject}
+
+Body:
+{body[:3000]}
+
+Classify this email now."""
+
+    raw: Optional[str] = None
+
+    # Tier 1: local Ollama (sovereign, fast)
+    try:
+        async with httpx.AsyncClient(timeout=120) as client:
+            resp = await client.post(
+                f"{settings.ollama_base_url.rstrip('/')}/api/chat",
+                json={
+                    "model": settings.ollama_fast_model,
+                    "messages": [
+                        {"role": "system", "content": LEGAL_TRIAGE_SYSTEM_PROMPT},
+                        {"role": "user", "content": prompt},
+                    ],
+                    "stream": False,
+                    "options": {"temperature": 0.05, "num_predict": 384},
+                },
+            )
+            if resp.status_code == 200:
+                raw = resp.json().get("message", {}).get("content", "").strip()
+    except Exception as exc:
+        logger.debug("legal_triage_ollama_failed", error=str(exc)[:100])
+
+    # Tier 2: LiteLLM gateway
+    if not raw:
+        try:
+            response = await submit_chat_completion(
+                prompt=prompt,
+                model=settings.openai_model,
+                system_message=LEGAL_TRIAGE_SYSTEM_PROMPT,
+                timeout_s=30.0,
+                extra_payload={"temperature": 0.05, "max_tokens": 384},
+            )
+            choices = response.get("choices") or []
+            if choices:
+                raw = (((choices[0] or {}).get("message") or {}).get("content") or "").strip()
+        except Exception as exc:
+            logger.debug("legal_triage_gateway_failed", error=str(exc)[:100])
+
+    if not raw:
+        return None
+    return _parse_triage_json(raw)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Case linking
+# ──────────────────────────────────────────────────────────────────────────────
+
+_CASE_NUMBER_RE = re.compile(r"\b(\d{2,4}-[A-Z]{2,4}-\d{3,8})\b")
+
+
+async def _find_matching_case(triage: dict, subject: str) -> Optional[str]:
+    """Try to link an email to an active case slug in fortress_db."""
+    from sqlalchemy import text as sqltext
+
+    # 1) Explicit case number extracted by LLM
+    cn_from_triage = (triage.get("case_number_extracted") or "").strip()
+    # 2) Regex extraction from subject as backup
+    m = _CASE_NUMBER_RE.search(subject)
+    cn_from_subject = m.group(1) if m else ""
+
+    async with LegacySession() as session:
+        # Try by case_number (exact, then ILIKE)
+        for cn in filter(None, [cn_from_triage, cn_from_subject]):
+            row = await session.execute(
+                sqltext("SELECT case_slug FROM legal.cases WHERE case_number ILIKE :cn LIMIT 1"),
+                {"cn": f"%{cn}%"},
+            )
+            hit = row.fetchone()
+            if hit:
+                return hit[0]
+
+        # Fuzzy slug guess from LLM
+        slug_guess = (triage.get("case_slug_guess") or "").strip().lower()
+        if slug_guess:
+            row = await session.execute(
+                sqltext("SELECT case_slug FROM legal.cases WHERE case_slug ILIKE :sg LIMIT 1"),
+                {"sg": f"%{slug_guess}%"},
+            )
+            hit = row.fetchone()
+            if hit:
+                return hit[0]
+
+    return None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# legal.correspondence + legal.timeline_events inserts
+# ──────────────────────────────────────────────────────────────────────────────
+
+async def _record_correspondence(
+    case_slug: str,
+    subject: str,
+    body: str,
+    sender_email: str,
+    sender_name: str,
+    category: str,
+    session,
+) -> Optional[int]:
+    from sqlalchemy import text as sqltext
+    try:
+        row = await session.execute(
+            sqltext("SELECT id FROM legal.cases WHERE case_slug = :slug LIMIT 1"),
+            {"slug": case_slug},
+        )
+        case_row = row.fetchone()
+        if not case_row:
+            return None
+
+        result = await session.execute(
+            sqltext("""
+                INSERT INTO legal.correspondence
+                    (case_id, subject, body, direction, comm_type,
+                     recipient, recipient_email, status)
+                VALUES (:cid, :subject, :body, 'inbound', 'email',
+                        :sender, :email, 'received')
+                RETURNING id
+            """),
+            {
+                "cid":     case_row[0],
+                "subject": (subject or "")[:500],
+                "body":    (body or "")[:32000],
+                "sender":  (sender_name or sender_email)[:200],
+                "email":   sender_email[:200],
+            },
+        )
+        row2 = result.fetchone()
+        await session.commit()
+        return row2[0] if row2 else None
+    except Exception as exc:
+        logger.warning("record_correspondence_error", error=str(exc)[:200])
+        return None
+
+
+async def _record_timeline_event(
+    case_slug: str,
+    subject: str,
+    sender_email: str,
+    session,
+) -> None:
+    from sqlalchemy import text as sqltext
+    try:
+        await session.execute(
+            sqltext("""
+                INSERT INTO legal.timeline_events
+                    (case_slug, event_date, description, source_evidence_id)
+                VALUES (:slug, CURRENT_DATE, :desc, NULL)
+            """),
+            {
+                "slug": case_slug,
+                "desc": f"[Email Intake] {subject or 'No subject'} — from {sender_email}",
+            },
+        )
+        await session.commit()
+    except Exception as exc:
+        logger.warning("record_timeline_error", error=str(exc)[:200])
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Attachment ingestion into E-Discovery vault
+# ──────────────────────────────────────────────────────────────────────────────
+
+async def _ingest_attachments(attachments: list[dict], case_slug: str) -> int:
+    """Push each attachment through the privilege-shielded vault pipeline."""
+    from backend.services.legal_ediscovery import process_vault_upload
+    ingested = 0
+    async with LegacySession() as session:
+        for att in attachments:
+            try:
+                result = await process_vault_upload(
+                    db=session,
+                    case_slug=case_slug,
+                    file_bytes=att["file_bytes"],
+                    file_name=att["file_name"],
+                    mime_type=att["mime_type"],
+                )
+                if result.get("status") != "duplicate":
+                    ingested += 1
+                logger.info(
+                    "legal_intake_attachment_ingested",
+                    case_slug=case_slug,
+                    file_name=att["file_name"],
+                    status=result.get("status"),
+                )
+            except Exception as exc:
+                logger.warning(
+                    "legal_intake_attachment_error",
+                    file_name=att.get("file_name"),
+                    error=str(exc)[:200],
+                )
+    return ingested
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Training flywheel capture
+# ──────────────────────────────────────────────────────────────────────────────
+
+async def _capture_to_flywheel(
+    subject: str,
+    triage: dict,
+    case_slug: Optional[str],
+) -> None:
+    try:
+        from backend.services.ai_router import _capture_interaction
+        prompt = f"Legal email intake: subject='{subject}', triage={json.dumps(triage)}"
+        response = (
+            f"Classified as {triage.get('category', 'unknown')} legal correspondence. "
+            f"Case link: {case_slug or 'unlinked'}. "
+            f"Document type: {triage.get('document_type', 'unknown')}. "
+            f"Summary: {triage.get('summary', '')}."
+        )
+        await _capture_interaction(
+            source_module="legal_email_intake",
+            prompt=prompt,
+            response=response,
+            model_label=f"triage/{settings.ollama_fast_model}",
+        )
+    except Exception:
+        pass
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Per-email processing
+# ──────────────────────────────────────────────────────────────────────────────
+
+async def process_legal_email(em: dict) -> dict:
+    """Full pipeline for one email dict from the IMAP fetch."""
+    from sqlalchemy import text as sqltext
+
+    subject       = em.get("subject", "")
+    sender        = em.get("sender", "")
+    sender_email  = em.get("sender_email", sender)
+    body          = em.get("body", "")
+    attachments   = em.get("attachments", [])
+    att_count     = em.get("attachment_count", 0)
+
+    # Stable dedup key
+    uid_source = f"{sender_email}|{subject}|{body[:200]}"
+    message_uid = hashlib.sha256(uid_source.encode()).hexdigest()
+
+    # Triage
+    triage = await _triage_legal_email(subject, sender, body)
+    if not triage:
+        logger.warning("legal_triage_failed", subject=subject[:60])
+        # Still queue the email for manual review — don't discard on LLM failure
+        triage = {"is_legal": True, "category": "triage_failed", "urgency": "normal"}
+
+    is_legal = triage.get("is_legal", False)
+    category = triage.get("category", "unknown")
+
+    logger.info(
+        "legal_email_triaged",
+        subject=subject[:60],
+        is_legal=is_legal,
+        category=category,
+        urgency=triage.get("urgency"),
+    )
+
+    if not is_legal:
+        return {"action": "not_legal", "subject": subject[:60], "category": category}
+
+    # Case matching
+    case_slug = await _find_matching_case(triage, subject)
+    intake_status = "linked" if case_slug else "unlinked"
+
+    async with LegacySession() as session:
+        # Dedup insert
+        try:
+            await session.execute(
+                sqltext("""
+                    INSERT INTO legal.email_intake_queue
+                        (message_uid, sender_email, sender_name, subject, body_text,
+                         case_slug, triage_result, intake_status, attachment_count,
+                         processed_at)
+                    VALUES (:uid, :email, :name, :subject, :body,
+                            :slug, CAST(:triage AS JSONB), :status, :att_count, now())
+                    ON CONFLICT (message_uid) DO NOTHING
+                """),
+                {
+                    "uid":       message_uid,
+                    "email":     sender_email[:200],
+                    "name":      (sender or "")[:200],
+                    "subject":   (subject or "")[:500],
+                    "body":      (body or "")[:32000],
+                    "slug":      case_slug,
+                    "triage":    json.dumps(triage),
+                    "status":    intake_status,
+                    "att_count": att_count,
+                },
+            )
+            await session.commit()
+        except Exception as exc:
+            logger.warning("legal_intake_queue_insert_error", error=str(exc)[:200])
+            return {"action": "db_error", "subject": subject[:60]}
+
+        correspondence_id: Optional[int] = None
+        if case_slug:
+            correspondence_id = await _record_correspondence(
+                case_slug=case_slug,
+                subject=subject,
+                body=body,
+                sender_email=sender_email,
+                sender_name=sender,
+                category=category,
+                session=session,
+            )
+            await _record_timeline_event(case_slug, subject, sender_email, session)
+
+            if correspondence_id:
+                await session.execute(
+                    sqltext("""
+                        UPDATE legal.email_intake_queue
+                        SET correspondence_id = :cid
+                        WHERE message_uid = :uid
+                    """),
+                    {"cid": correspondence_id, "uid": message_uid},
+                )
+                await session.commit()
+
+    # Attachment E-Discovery ingestion
+    att_ingested = 0
+    if attachments and case_slug:
+        att_ingested = await _ingest_attachments(attachments, case_slug)
+
+    # Training flywheel
+    await _capture_to_flywheel(subject, triage, case_slug)
+
+    logger.info(
+        "legal_email_processed",
+        subject=subject[:60],
+        case_slug=case_slug,
+        status=intake_status,
+        attachments_ingested=att_ingested,
+    )
+
+    return {
+        "action":           "legal_email_ingested",
+        "subject":          subject[:60],
+        "case_slug":        case_slug,
+        "intake_status":    intake_status,
+        "correspondence_id": correspondence_id,
+        "attachments_ingested": att_ingested,
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Patrol cycle + infinite loop
+# ──────────────────────────────────────────────────────────────────────────────
+
+async def run_legal_intake_patrol() -> dict:
+    """Run one full patrol cycle. Safe to call on demand."""
+    await _bootstrap_intake_schema()
+
+    inbox = _get_legal_inbox_config()
+    if not inbox:
+        logger.info("legal_intake_no_credentials")
+        return {"status": "no_credentials", "processed": 0}
+
+    emails = await asyncio.to_thread(_fetch_unseen_legal_emails, inbox)
+
+    if not emails:
+        return {"status": "clear", "processed": 0}
+
+    stats = {"processed": 0, "linked": 0, "unlinked": 0, "not_legal": 0, "errors": 0}
+
+    for em in emails:
+        try:
+            result = await process_legal_email(em)
+            stats["processed"] += 1
+            action = result.get("action", "")
+            if action == "legal_email_ingested":
+                if result.get("intake_status") == "linked":
+                    stats["linked"] += 1
+                else:
+                    stats["unlinked"] += 1
+            elif action == "not_legal":
+                stats["not_legal"] += 1
+            else:
+                stats["errors"] += 1
+        except Exception as exc:
+            stats["errors"] += 1
+            logger.error("legal_intake_patrol_email_error", error=str(exc)[:200])
+
+    logger.info("legal_intake_patrol_complete", **stats)
+    return {"status": "patrol_complete", **stats}
+
+
+async def run_legal_intake_loop() -> None:
+    """Infinite polling loop — started by ARQ worker startup."""
+    interval = settings.legal_email_poll_interval
+    logger.info(
+        "legal_intake_loop_started",
+        poll_interval=interval,
+        inbox_configured=bool(settings.legal_mailplus_host),
+    )
+
+    await asyncio.sleep(15)  # brief startup delay
+
+    while True:
+        try:
+            result = await run_legal_intake_patrol()
+            if result.get("processed", 0) > 0:
+                logger.info("legal_intake_patrol_report", **result)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.error("legal_intake_loop_error", error=str(exc)[:200])
+
+        await asyncio.sleep(interval)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Standalone entry point
+# ──────────────────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    async def _main() -> None:
+        inbox = _get_legal_inbox_config()
+        if not inbox:
+            print("No legal MailPlus credentials configured.")
+            print("Set LEGAL_MAILPLUS_HOST, LEGAL_MAILPLUS_USER, LEGAL_MAILPLUS_PASSWORD in .env")
+            return
+        print(f"Legal inbox: {inbox['user']}@{inbox['host']}:{inbox['port']} [{inbox['folder']}]")
+        print("Running single patrol...\n")
+        result = await run_legal_intake_patrol()
+        print(json.dumps(result, indent=2, default=str))
+
+    asyncio.run(_main())

--- a/fortress-guest-platform/backend/workers/drift_sentry.py
+++ b/fortress-guest-platform/backend/workers/drift_sentry.py
@@ -1,0 +1,213 @@
+"""
+Drift Sentry — Autonomous rate/tax coefficient verification worker.
+
+Runs every 5 minutes, picks 3 random active cabins, fetches live
+Streamline rate cards, and compares nightly rates + fee structures
+against the locally cached rate_card in the properties table.
+Discrepancies are auto-healed and logged to the drift_audit log.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import random
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+import structlog
+from sqlalchemy import select, update, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.core.config import settings
+from backend.core.database import AsyncSessionLocal
+from backend.integrations.streamline_vrs import StreamlineVRS
+from backend.models.property import Property
+from backend.services.ledger import COUNTY_RATES, get_county_rates
+
+logger = structlog.get_logger(service="drift_sentry")
+
+SAMPLE_SIZE = 3
+INTERVAL_SECONDS = 300  # 5 minutes
+
+
+def _deprioritize() -> None:
+    """Lower CPU priority so this worker never contends with request handlers."""
+    try:
+        os.nice(10)
+    except (OSError, AttributeError):
+        pass
+
+
+async def _pick_random_cabins(db: AsyncSession, n: int) -> list[Any]:
+    result = await db.execute(
+        select(Property.id, Property.name, Property.slug, Property.streamline_property_id,
+               Property.rate_card, Property.county)
+        .where(Property.is_active.is_(True))
+        .where(Property.streamline_property_id.isnot(None))
+        .order_by(func.random())
+        .limit(n)
+    )
+    return result.all()
+
+
+def _extract_nightly_rates(rate_card: dict | None) -> dict[str, float]:
+    """Build date→rate map from a local rate_card JSONB blob."""
+    if not rate_card:
+        return {}
+    rates_list = rate_card.get("rates") or []
+    out: dict[str, float] = {}
+    for entry in rates_list:
+        if not isinstance(entry, dict):
+            continue
+        d = entry.get("start_date") or entry.get("date")
+        r = entry.get("nightly") or entry.get("nightly_rate") or entry.get("rate")
+        if d and r:
+            try:
+                out[str(d)] = float(r)
+            except (ValueError, TypeError):
+                pass
+    return out
+
+
+def _compare_rates(
+    local: dict[str, float], live: dict[str, float]
+) -> list[dict[str, Any]]:
+    """Return list of drift entries where local != live."""
+    drifts = []
+    for date_key, live_rate in live.items():
+        local_rate = local.get(date_key)
+        if local_rate is None:
+            drifts.append({"date": date_key, "local": None, "live": live_rate, "type": "missing_local"})
+        elif abs(local_rate - live_rate) > 0.01:
+            drifts.append({"date": date_key, "local": local_rate, "live": live_rate, "type": "rate_mismatch"})
+    return drifts
+
+
+def _verify_tax_coefficients(county: str | None) -> list[dict[str, Any]]:
+    """Verify that we have tax rates for this county."""
+    issues = []
+    key = (county or "").strip().lower()
+    if not key:
+        issues.append({"field": "county", "issue": "missing", "detail": "Property has no county assigned"})
+    elif key not in COUNTY_RATES:
+        issues.append({
+            "field": "county", "issue": "unknown_jurisdiction",
+            "detail": f"County '{county}' not in COUNTY_RATES — falling back to Fannin defaults",
+        })
+    return issues
+
+
+async def _audit_cabin(
+    vrs: StreamlineVRS, db: AsyncSession,
+    prop_id: Any, prop_name: str, prop_slug: str,
+    streamline_id: str, local_rate_card: dict | None, county: str | None,
+) -> dict[str, Any]:
+    """Audit a single cabin against Streamline live data."""
+    report: dict[str, Any] = {
+        "property": prop_name,
+        "slug": prop_slug,
+        "streamline_id": streamline_id,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "rate_drifts": [],
+        "tax_issues": [],
+        "healed": False,
+    }
+
+    try:
+        unit_id = int(streamline_id)
+        live_data = await vrs.fetch_property_rates(unit_id)
+
+        live_rates_raw = live_data.get("rates") or []
+        live_rate_map: dict[str, float] = {}
+        for entry in live_rates_raw:
+            if isinstance(entry, dict):
+                d = entry.get("start_date") or entry.get("date")
+                r = entry.get("nightly") or entry.get("nightly_rate") or entry.get("rate")
+                if d and r:
+                    try:
+                        live_rate_map[str(d)] = float(r)
+                    except (ValueError, TypeError):
+                        pass
+
+        local_rate_map = _extract_nightly_rates(local_rate_card)
+        report["rate_drifts"] = _compare_rates(local_rate_map, live_rate_map)
+
+        if report["rate_drifts"]:
+            await db.execute(
+                update(Property)
+                .where(Property.id == prop_id)
+                .values(rate_card=live_data, updated_at=datetime.now(timezone.utc).replace(tzinfo=None))
+            )
+            await db.commit()
+            report["healed"] = True
+            logger.warning(
+                "drift_sentry_rate_healed",
+                property=prop_name,
+                drift_count=len(report["rate_drifts"]),
+            )
+
+    except Exception as exc:
+        report["rate_drifts"] = [{"error": str(exc)[:300]}]
+        logger.error("drift_sentry_streamline_error", property=prop_name, error=str(exc)[:300])
+
+    report["tax_issues"] = _verify_tax_coefficients(county)
+    if report["tax_issues"]:
+        logger.warning("drift_sentry_tax_issue", property=prop_name, issues=report["tax_issues"])
+
+    return report
+
+
+async def run_drift_sentry_cycle() -> list[dict[str, Any]]:
+    """Execute one full drift sentry cycle. Returns audit reports."""
+    if not settings.streamline_api_key or not settings.streamline_api_secret:
+        logger.info("drift_sentry_skipped", reason="streamline_not_configured")
+        return []
+
+    vrs = StreamlineVRS()
+    reports = []
+
+    async with AsyncSessionLocal() as db:
+        cabins = await _pick_random_cabins(db, SAMPLE_SIZE)
+        if not cabins:
+            logger.info("drift_sentry_no_cabins")
+            return []
+
+        logger.info("drift_sentry_cycle_start", cabin_count=len(cabins))
+
+        for prop_id, prop_name, prop_slug, streamline_id, rate_card, county in cabins:
+            report = await _audit_cabin(
+                vrs, db, prop_id, prop_name, prop_slug,
+                str(streamline_id), rate_card, county,
+            )
+            reports.append(report)
+            await asyncio.sleep(1)
+
+    total_drifts = sum(len(r["rate_drifts"]) for r in reports)
+    total_healed = sum(1 for r in reports if r["healed"])
+    total_tax_issues = sum(len(r["tax_issues"]) for r in reports)
+
+    logger.info(
+        "drift_sentry_cycle_complete",
+        cabins_audited=len(reports),
+        rate_drifts=total_drifts,
+        auto_healed=total_healed,
+        tax_issues=total_tax_issues,
+    )
+    return reports
+
+
+async def drift_sentry_loop() -> None:
+    """Infinite loop — call from ARQ startup or standalone process."""
+    _deprioritize()
+    logger.info("drift_sentry_started", interval=INTERVAL_SECONDS, sample_size=SAMPLE_SIZE)
+
+    while True:
+        try:
+            await run_drift_sentry_cycle()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.error("drift_sentry_loop_error", error=str(exc)[:400])
+        await asyncio.sleep(INTERVAL_SECONDS)

--- a/fortress-guest-platform/backend/workers/hermes_sync.py
+++ b/fortress-guest-platform/backend/workers/hermes_sync.py
@@ -1,0 +1,561 @@
+"""
+Hermes Sync Worker — Offline booking buffer retry agent.
+
+When a storefront checkout succeeds at the Stripe layer but the
+Streamline PMS push fails, the booking is saved to `pending_sync`.
+Hermes retries every 60 seconds until Streamline acknowledges.
+
+After 10 failed attempts the record is flagged 'failed' and an
+alert is logged for manual intervention — the guest's payment was
+already captured by Stripe, so the booking WILL be honoured regardless.
+
+After a successful sync, Hermes runs a parity audit: it calls
+fetch_live_quote() with the confirmation_id to compare Streamline's
+total against the local ledger.  Discrepancies are routed through a
+3-tier queue:
+  - delta == 0          → INFO log, ParityAudit confirmed
+  - 0 < |delta| ≤ $10  → auto-resolved FinancialApproval + variance adjustment
+  - |delta| > $10       → pending FinancialApproval + NeMo Observer alert
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from datetime import datetime, timezone
+from decimal import Decimal, ROUND_HALF_UP
+from uuid import uuid4
+
+import structlog
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.core.config import settings
+from backend.core.database import AsyncSessionLocal
+from backend.models.financial_approval import FinancialApproval
+from backend.models.pending_sync import PendingSync
+from backend.models.parity_audit import ParityAudit
+
+logger = structlog.get_logger(service="hermes_sync")
+
+INTERVAL_SECONDS = 60
+MAX_ATTEMPTS = 10
+AUTO_RESOLVE_THRESHOLD_CENTS = 1000  # ≤ $10.00
+
+
+def _deprioritize() -> None:
+    try:
+        os.nice(10)
+    except (OSError, AttributeError):
+        pass
+
+
+def _decimal_to_cents(value: Decimal) -> int:
+    """Convert a dollar Decimal to integer cents with half-up rounding."""
+    return int((value * 100).to_integral_value(rounding=ROUND_HALF_UP))
+
+
+async def _run_parity_audit(
+    db: AsyncSession,
+    reservation_id: str,
+    confirmation_code: str,
+    local_total: Decimal,
+    local_breakdown: dict,
+) -> None:
+    """Compare local ledger total with Streamline's GetReservationPrice total.
+
+    3-tier resolution:
+      1. delta_cents == 0           → confirmed (INFO)
+      2. 0 < |delta_cents| ≤ 1000  → auto_resolved FinancialApproval + variance line
+      3. |delta_cents| > 1000       → pending FinancialApproval + NeMo Observer alert
+    """
+    try:
+        from backend.services.streamline_client import StreamlineClient
+
+        client = StreamlineClient()
+        try:
+            result = await client.fetch_live_quote(confirmation_code)
+        finally:
+            await client.close()
+
+        if result is None:
+            logger.warning(
+                "parity_audit_skipped_no_data",
+                reservation_id=reservation_id,
+                confirmation_id=confirmation_code,
+            )
+            return
+
+        local_cents = _decimal_to_cents(local_total)
+        streamline_cents = _decimal_to_cents(result.streamline_total)
+        delta_cents = abs(streamline_cents - local_cents)
+
+        streamline_breakdown = {
+            "total": str(result.streamline_total),
+            "total_cents": streamline_cents,
+            "taxes": str(result.streamline_taxes),
+            "rent": str(result.streamline_rent),
+            "fees": [
+                {"name": f.name, "amount": str(f.amount), "type": f.fee_type, "bucket": f.bucket}
+                for f in result.fees
+            ],
+        }
+
+        # ── Tier 1: Exact match ─────────────────────────────────────
+        if delta_cents == 0:
+            audit = ParityAudit(
+                id=uuid4(),
+                reservation_id=reservation_id,
+                confirmation_id=confirmation_code,
+                local_total=local_total,
+                streamline_total=result.streamline_total,
+                delta=Decimal("0.00"),
+                local_breakdown=local_breakdown,
+                streamline_breakdown=streamline_breakdown,
+                status="confirmed",
+            )
+            db.add(audit)
+            await db.commit()
+            logger.info(
+                "parity_confirmed",
+                reservation_id=reservation_id,
+                confirmation_id=confirmation_code,
+            )
+
+        # ── Tier 2: Minor variance (≤ $10) — auto-resolve ──────────
+        elif delta_cents <= AUTO_RESOLVE_THRESHOLD_CENTS:
+            delta_dec = Decimal(delta_cents) / Decimal(100)
+
+            audit = ParityAudit(
+                id=uuid4(),
+                reservation_id=reservation_id,
+                confirmation_id=confirmation_code,
+                local_total=local_total,
+                streamline_total=result.streamline_total,
+                delta=delta_dec,
+                local_breakdown=local_breakdown,
+                streamline_breakdown=streamline_breakdown,
+                status="auto_resolved",
+            )
+            db.add(audit)
+
+            variance_direction = "under" if streamline_cents > local_cents else "over"
+            context = {
+                "local_breakdown": local_breakdown,
+                "streamline_breakdown": streamline_breakdown,
+                "variance_direction": variance_direction,
+                "auto_resolution": {
+                    "type": "system_variance_adjustment",
+                    "description": (
+                        f"Auto-resolved {variance_direction}-charge of "
+                        f"${delta_dec:.2f} (Δ{delta_cents}¢)"
+                    ),
+                    "proposed_entry": {
+                        "debit_account": "Streamline Variance" if variance_direction == "under" else "Guest Receivable",
+                        "credit_account": "Guest Receivable" if variance_direction == "under" else "Streamline Variance",
+                        "amount_cents": delta_cents,
+                    },
+                },
+            }
+
+            approval = FinancialApproval(
+                id=uuid4(),
+                reservation_id=reservation_id,
+                status="auto_resolved",
+                discrepancy_type="parity_drift",
+                local_total_cents=local_cents,
+                streamline_total_cents=streamline_cents,
+                delta_cents=delta_cents,
+                context_payload=context,
+                resolved_by="hermes_auto_resolver",
+                resolved_at=datetime.now(timezone.utc),
+            )
+            db.add(approval)
+            await db.commit()
+
+            logger.info(
+                "parity_auto_resolved",
+                reservation_id=reservation_id,
+                confirmation_id=confirmation_code,
+                delta_cents=delta_cents,
+                direction=variance_direction,
+            )
+
+        # ── Tier 3: Material discrepancy (> $10) — queue for review ─
+        else:
+            delta_dec = Decimal(delta_cents) / Decimal(100)
+
+            audit = ParityAudit(
+                id=uuid4(),
+                reservation_id=reservation_id,
+                confirmation_id=confirmation_code,
+                local_total=local_total,
+                streamline_total=result.streamline_total,
+                delta=delta_dec,
+                local_breakdown=local_breakdown,
+                streamline_breakdown=streamline_breakdown,
+                status="discrepancy",
+            )
+            db.add(audit)
+
+            context = {
+                "local_breakdown": local_breakdown,
+                "streamline_breakdown": streamline_breakdown,
+                "severity": "material",
+                "requires_commander_review": True,
+            }
+
+            approval = FinancialApproval(
+                id=uuid4(),
+                reservation_id=reservation_id,
+                status="pending",
+                discrepancy_type="parity_drift",
+                local_total_cents=local_cents,
+                streamline_total_cents=streamline_cents,
+                delta_cents=delta_cents,
+                context_payload=context,
+            )
+            db.add(approval)
+            await db.commit()
+
+            logger.critical(
+                "parity_breach_queued",
+                reservation_id=reservation_id,
+                confirmation_id=confirmation_code,
+                local_cents=local_cents,
+                streamline_cents=streamline_cents,
+                delta_cents=delta_cents,
+            )
+
+            await _stream_to_nemo_observer(
+                reservation_id=reservation_id,
+                confirmation_id=confirmation_code,
+                local_total=str(local_total),
+                streamline_total=str(result.streamline_total),
+                delta=str(delta_dec),
+                local_breakdown=local_breakdown,
+                streamline_breakdown=streamline_breakdown,
+            )
+
+        await _auto_learn_fees(db, result.fees)
+
+    except Exception as exc:
+        logger.error(
+            "parity_audit_error",
+            reservation_id=reservation_id,
+            confirmation_id=confirmation_code,
+            error=str(exc)[:400],
+        )
+
+
+async def _stream_to_nemo_observer(
+    reservation_id: str,
+    confirmation_id: str,
+    local_total: str,
+    streamline_total: str,
+    delta: str,
+    local_breakdown: dict,
+    streamline_breakdown: dict,
+) -> None:
+    """Fire-and-forget: send discrepancy to the NeMo Observer for root-cause analysis."""
+    try:
+        from backend.agents.nemo_observer import NemoObserver
+
+        observer = NemoObserver()
+        analysis = await observer.analyze_discrepancy(
+            reservation_id=reservation_id,
+            confirmation_id=confirmation_id,
+            local_total=local_total,
+            streamline_total=streamline_total,
+            delta=delta,
+            local_breakdown=local_breakdown,
+            streamline_breakdown=streamline_breakdown,
+        )
+
+        if analysis:
+            logger.info(
+                "nemo_observer_verdict",
+                reservation_id=reservation_id,
+                root_cause=analysis.get("root_cause"),
+                confidence=analysis.get("confidence"),
+                recommendation=analysis.get("recommendation"),
+                discrepant_items=len(analysis.get("discrepant_items", [])),
+            )
+    except Exception as exc:
+        logger.warning(
+            "nemo_observer_hook_error",
+            reservation_id=reservation_id,
+            error=str(exc)[:300],
+        )
+
+
+async def _auto_learn_fees(db: AsyncSession, fees: list) -> None:
+    """Insert any unknown fee names into the local fees table with is_active=false."""
+    for fee in fees:
+        if fee.fee_type != "fee":
+            continue
+        try:
+            existing = await db.execute(
+                text("SELECT id FROM fees WHERE LOWER(name) = LOWER(:name) LIMIT 1"),
+                {"name": fee.name},
+            )
+            if existing.scalar_one_or_none() is None:
+                await db.execute(
+                    text(
+                        "INSERT INTO fees (id, name, flat_amount, fee_type, is_active, created_at, updated_at) "
+                        "VALUES (:id, :name, :amount, 'flat', false, NOW(), NOW()) "
+                        "ON CONFLICT DO NOTHING"
+                    ),
+                    {
+                        "id": str(uuid4()),
+                        "name": fee.name,
+                        "amount": float(fee.amount),
+                    },
+                )
+                await db.commit()
+                logger.warning(
+                    "new_streamline_fee_discovered",
+                    fee_name=fee.name,
+                    fee_amount=str(fee.amount),
+                    streamline_id=fee.streamline_id,
+                )
+        except Exception as exc:
+            logger.warning(
+                "auto_learn_fee_error",
+                fee_name=fee.name,
+                error=str(exc)[:200],
+            )
+
+
+async def _process_one(db: AsyncSession, row: PendingSync) -> bool:
+    """Attempt to sync a single pending record to Streamline.
+
+    The Reverse Push (Phase 4): Instead of letting Streamline calculate
+    its own price, we push the local ``grand_total_cents`` as a fixed
+    price override.  This reduces Streamline to a dumb calendar/reporting
+    database — the sovereign ledger dictates the financial terms.
+
+    Returns True if sync succeeded (or was skipped because Streamline
+    is not configured), False on failure.
+    """
+    if not settings.streamline_api_key or not settings.streamline_api_secret:
+        row.status = "synced"
+        row.resolved_at = datetime.now(timezone.utc)
+        await db.commit()
+        logger.info("hermes_sync_skipped_no_streamline", reservation_id=str(row.reservation_id))
+        return True
+
+    from backend.integrations.streamline_vrs import StreamlineVRS
+    vrs = StreamlineVRS()
+
+    try:
+        payload = row.payload or {}
+        confirmation_code = payload.get("confirmation_code")
+
+        if row.sync_type == "create_reservation" and settings.streamline_sovereign_bridge_settlement_enabled:
+            pushed = await _reverse_push_to_streamline(db, row, vrs, payload)
+            if pushed:
+                return True
+
+        if confirmation_code:
+            result = await vrs.fetch_reservation_info(confirmation_code)
+            if result:
+                row.status = "synced"
+                row.resolved_at = datetime.now(timezone.utc)
+                await db.commit()
+                logger.info(
+                    "hermes_sync_confirmed",
+                    reservation_id=str(row.reservation_id),
+                    confirmation=confirmation_code,
+                )
+
+                local_total = Decimal(str(payload.get("total_amount", "0.00")))
+                local_breakdown = payload.get("price_breakdown", {})
+                await _run_parity_audit(
+                    db,
+                    str(row.reservation_id),
+                    confirmation_code,
+                    local_total,
+                    local_breakdown,
+                )
+
+                return True
+
+        row.status = "synced"
+        row.resolved_at = datetime.now(timezone.utc)
+        await db.commit()
+        logger.info(
+            "hermes_sync_local_only",
+            reservation_id=str(row.reservation_id),
+            note="Reservation exists in local DB; Streamline sync deferred to batch worker",
+        )
+        return True
+
+    except Exception as exc:
+        row.attempt_count += 1
+        row.last_error = str(exc)[:500]
+
+        if row.attempt_count >= MAX_ATTEMPTS:
+            row.status = "failed"
+            logger.critical(
+                "hermes_sync_exhausted",
+                reservation_id=str(row.reservation_id),
+                attempts=row.attempt_count,
+                error=str(exc)[:300],
+            )
+        else:
+            logger.warning(
+                "hermes_sync_retry",
+                reservation_id=str(row.reservation_id),
+                attempt=row.attempt_count,
+                error=str(exc)[:300],
+            )
+
+        await db.commit()
+        return False
+
+
+async def _reverse_push_to_streamline(
+    db: AsyncSession,
+    row: PendingSync,
+    vrs: "StreamlineVRS",
+    payload: dict,
+) -> bool:
+    """Push the sovereign reservation to Streamline with a fixed price override.
+
+    Sends the local ``amount_cents`` as ``price`` / ``rent_amount`` with
+    ``price_type=fixed`` so Streamline records our total instead of
+    computing its own.
+    """
+    from backend.models.property import Property
+    from backend.models.reservation import Reservation
+
+    reservation = await db.get(Reservation, row.reservation_id)
+    if reservation is None:
+        return False
+
+    prop = await db.get(Property, reservation.property_id)
+    if prop is None or not (prop.streamline_property_id or "").strip():
+        return False
+
+    try:
+        unit_id = int(str(prop.streamline_property_id).strip())
+    except ValueError:
+        return False
+
+    method = (settings.streamline_sovereign_bridge_reservation_method or "").strip()
+    if not method:
+        return False
+
+    amount_cents = payload.get("amount_cents")
+    if amount_cents is None and reservation.total_amount is not None:
+        amount_cents = int(
+            (Decimal(str(reservation.total_amount)) * 100)
+            .to_integral_value(rounding=ROUND_HALF_UP)
+        )
+
+    push_params: dict[str, str] = {
+        "unit_id": str(unit_id),
+        "startdate": reservation.check_in_date.strftime("%m/%d/%Y"),
+        "enddate": reservation.check_out_date.strftime("%m/%d/%Y"),
+        "confirmation_code": str(reservation.confirmation_code or ""),
+        "guest_email": str(reservation.guest_email or ""),
+        "guest_name": str(reservation.guest_name or ""),
+        "notes": (
+            f"SOVEREIGN_REVERSE_PUSH confirmation={reservation.confirmation_code} "
+            f"pi={payload.get('stripe_payment_intent_id', 'N/A')}"
+        ),
+    }
+
+    if amount_cents and amount_cents > 0:
+        total_dollars = f"{amount_cents / 100:.2f}"
+        push_params["price"] = total_dollars
+        push_params["rent_amount"] = total_dollars
+        push_params["price_type"] = "fixed"
+
+    raw = await vrs.dispatch_sovereign_write_rpc(
+        method,
+        push_params,
+        log_name="hermes_reverse_push",
+        log_context={
+            "reservation_id": str(row.reservation_id),
+            "unit_id": unit_id,
+        },
+    )
+
+    if raw.get("ok") and not raw.get("skipped"):
+        row.status = "synced"
+        row.resolved_at = datetime.now(timezone.utc)
+        await db.commit()
+        logger.info(
+            "hermes_reverse_push_success",
+            reservation_id=str(row.reservation_id),
+            unit_id=unit_id,
+            amount_cents=amount_cents,
+            confirmation=reservation.confirmation_code,
+        )
+
+        local_total = Decimal(str(reservation.total_amount or "0.00"))
+        await _run_parity_audit(
+            db,
+            str(row.reservation_id),
+            str(reservation.confirmation_code),
+            local_total,
+            payload.get("price_breakdown", {}),
+        )
+        return True
+
+    logger.warning(
+        "hermes_reverse_push_failed",
+        reservation_id=str(row.reservation_id),
+        raw_reason=str(raw.get("reason") or raw.get("error") or "unknown")[:300],
+    )
+    return False
+
+
+async def run_hermes_cycle() -> dict:
+    """Process all pending sync records. Returns summary stats."""
+    async with AsyncSessionLocal() as db:
+        stmt = (
+            select(PendingSync)
+            .where(PendingSync.status == "pending")
+            .order_by(PendingSync.created_at.asc())
+            .limit(20)
+        )
+        rows = (await db.execute(stmt)).scalars().all()
+
+        if not rows:
+            return {"pending": 0, "synced": 0, "failed": 0}
+
+        synced = 0
+        failed = 0
+        for row in rows:
+            success = await _process_one(db, row)
+            if success:
+                synced += 1
+            else:
+                failed += 1
+            await asyncio.sleep(0.5)
+
+        logger.info(
+            "hermes_cycle_complete",
+            processed=len(rows),
+            synced=synced,
+            failed=failed,
+        )
+        return {"pending": len(rows), "synced": synced, "failed": failed}
+
+
+async def hermes_sync_loop() -> None:
+    """Infinite loop — run from ARQ worker startup."""
+    _deprioritize()
+    logger.info("hermes_sync_started", interval=INTERVAL_SECONDS)
+
+    while True:
+        try:
+            await run_hermes_cycle()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.error("hermes_sync_loop_error", error=str(exc)[:400])
+        await asyncio.sleep(INTERVAL_SECONDS)

--- a/fortress-guest-platform/backend/workers/revenue_consumer.py
+++ b/fortress-guest-platform/backend/workers/revenue_consumer.py
@@ -1,0 +1,281 @@
+"""
+Revenue Consumer — Iron Dome journal posting from ``trust.revenue.staged``.
+
+Consumes Kafka/Redpanda messages published by ``POST /api/admin/reconcile-revenue``
+and reservation webhooks, then writes balanced ``journal_entries`` +
+``journal_line_items`` rows (DR Cash 1010, CR Owner Trust 2000, CR PM Revenue 4100).
+
+Run (from ``fortress-guest-platform``)::
+
+    python -m backend.workers.revenue_consumer
+
+Environment
+-----------
+- ``KAFKA_BROKER_URL`` — bootstrap servers (default matches ``EventPublisher``).
+- ``REVENUE_CONSUMER_GROUP_ID`` — default ``fortress-revenue-consumer``.
+- ``REVENUE_CONSUMER_TOPIC`` — default ``trust.revenue.staged``.
+- ``REVENUE_CONSUMER_AUTO_OFFSET_RESET`` — ``earliest`` or ``latest`` (default ``earliest``).
+- ``REVENUE_DEFAULT_PM_PCT`` — when ``management_splits`` has no row for the unit (default ``35``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import signal
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Any
+
+import structlog
+from aiokafka import AIOKafkaConsumer
+from aiokafka.errors import KafkaError
+from aiokafka.structs import OffsetAndMetadata, TopicPartition
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.core.database import AsyncSessionLocal
+from backend.core.event_publisher import REDPANDA_BROKER
+
+logger = structlog.get_logger(service="revenue_consumer")
+_stdlib_log = logging.getLogger(__name__)
+
+TOPIC_DEFAULT = "trust.revenue.staged"
+
+
+def _bootstrap() -> str:
+    return (os.getenv("KAFKA_BROKER_URL") or REDPANDA_BROKER).strip()
+
+
+def _group_id() -> str:
+    return (os.getenv("REVENUE_CONSUMER_GROUP_ID") or "fortress-revenue-consumer").strip()
+
+
+def _topic() -> str:
+    return (os.getenv("REVENUE_CONSUMER_TOPIC") or TOPIC_DEFAULT).strip()
+
+
+def _auto_offset() -> str:
+    v = (os.getenv("REVENUE_CONSUMER_AUTO_OFFSET_RESET") or "earliest").strip().lower()
+    return v if v in {"latest", "earliest"} else "earliest"
+
+
+def _default_pm_pct() -> float:
+    raw = (os.getenv("REVENUE_DEFAULT_PM_PCT") or "35").strip()
+    try:
+        v = float(raw)
+        return max(0.0, min(100.0, v))
+    except ValueError:
+        return 35.0
+
+
+async def _already_journaled(db: AsyncSession, confirmation_code: str) -> bool:
+    result = await db.execute(
+        text(
+            """
+            SELECT 1 FROM journal_entries
+            WHERE reference_id = :code
+              AND reference_type = 'reservation_revenue'
+            LIMIT 1
+            """
+        ),
+        {"code": confirmation_code},
+    )
+    return result.first() is not None
+
+
+async def _resolve_split(db: AsyncSession, streamline_unit_id: str) -> tuple[float, float]:
+    """Return (owner_pct, pm_pct) summing to 100."""
+    row = (
+        await db.execute(
+            text(
+                """
+                SELECT owner_pct, pm_pct
+                FROM management_splits
+                WHERE property_id = :pid
+                LIMIT 1
+                """
+            ),
+            {"pid": streamline_unit_id},
+        )
+    ).first()
+    if row is not None:
+        owner = float(row.owner_pct or 0)
+        pm = float(row.pm_pct or 0)
+        if owner > 0 or pm > 0:
+            s = owner + pm
+            if s > 0 and abs(s - 100.0) > 0.01:
+                owner = round(100.0 * owner / s, 2)
+                pm = round(100.0 - owner, 2)
+            return owner, pm
+    pm = _default_pm_pct()
+    return round(100.0 - pm, 2), pm
+
+
+async def process_revenue_payload(db: AsyncSession, payload: dict[str, Any]) -> bool:
+    """
+    Insert one balanced journal entry for ``trust.revenue.staged`` payload.
+
+    Returns True if a row was written or idempotently skipped; False to retry.
+    """
+    code = str(payload.get("confirmation_code") or "").strip()
+    unit_id = str(payload.get("property_id") or "").strip()
+    try:
+        total = float(payload.get("total_amount") or 0)
+    except (TypeError, ValueError):
+        total = 0.0
+
+    if not code or not unit_id or total <= 0:
+        logger.warning("revenue_payload_invalid", payload=payload)
+        return True
+
+    if await _already_journaled(db, code):
+        logger.info("revenue_already_journaled", confirmation_code=code)
+        return True
+
+    owner_pct, pm_pct = await _resolve_split(db, unit_id)
+    total_d = Decimal(str(total)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    pm_amt = (total_d * Decimal(str(pm_pct)) / Decimal("100")).quantize(
+        Decimal("0.01"), rounding=ROUND_HALF_UP
+    )
+    owner_amt = (total_d - pm_amt).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+    desc = f"Reservation revenue — {code} (owner {owner_pct:.0f}% / PM {pm_pct:.0f}%)"
+
+    je_row = await db.execute(
+        text(
+            """
+            INSERT INTO journal_entries
+                (property_id, entry_date, description, reference_type, reference_id)
+            VALUES (:pid, CURRENT_DATE, :desc, 'reservation_revenue', :ref)
+            RETURNING id
+            """
+        ),
+        {"pid": unit_id, "desc": desc, "ref": code},
+    )
+    je_id = je_row.scalar()
+
+    amt_float = float(total_d)
+    o_float = float(owner_amt)
+    p_float = float(pm_amt)
+
+    await db.execute(
+        text(
+            """
+            INSERT INTO journal_line_items (journal_entry_id, account_id, debit, credit)
+            VALUES
+                (:je, (SELECT id FROM accounts WHERE code = '1010'), :cash, 0),
+                (:je, (SELECT id FROM accounts WHERE code = '2000'), 0, :owner),
+                (:je, (SELECT id FROM accounts WHERE code = '4100'), 0, :pm)
+            """
+        ),
+        {"je": je_id, "cash": amt_float, "owner": o_float, "pm": p_float},
+    )
+    await db.commit()
+    logger.info(
+        "revenue_journaled",
+        confirmation_code=code,
+        journal_entry_id=str(je_id),
+        total=amt_float,
+        owner_liability=o_float,
+        pm_revenue=p_float,
+        unit_id=unit_id,
+    )
+    return True
+
+
+async def _commit_offset(consumer: AIOKafkaConsumer, msg: Any) -> None:
+    tp = TopicPartition(msg.topic, msg.partition)
+    await consumer.commit({tp: OffsetAndMetadata(msg.offset + 1, "")})
+
+
+async def handle_message(consumer: AIOKafkaConsumer, msg: Any) -> None:
+    tp = msg.topic
+    offset = msg.offset
+    try:
+        payload = msg.value if isinstance(msg.value, dict) else json.loads(msg.value.decode("utf-8"))
+    except Exception as exc:
+        logger.error("revenue_bad_json", error=str(exc)[:200], topic=tp, offset=offset)
+        await _commit_offset(consumer, msg)
+        return
+
+    try:
+        async with AsyncSessionLocal() as db:
+            try:
+                ok = await process_revenue_payload(db, payload)
+            except Exception as exc:
+                await db.rollback()
+                logger.exception("revenue_process_failed", error=str(exc)[:500])
+                return
+    except Exception:
+        logger.exception("revenue_session_failed")
+        return
+
+    if ok:
+        await _commit_offset(consumer, msg)
+
+
+async def run_consumer_loop(stop: asyncio.Event) -> None:
+    bootstrap = _bootstrap()
+    if not bootstrap:
+        raise RuntimeError("KAFKA_BROKER_URL is not set")
+
+    topic = _topic()
+    consumer = AIOKafkaConsumer(
+        topic,
+        bootstrap_servers=bootstrap,
+        group_id=_group_id(),
+        enable_auto_commit=False,
+        auto_offset_reset=_auto_offset(),
+        value_deserializer=lambda b: json.loads(b.decode("utf-8")),
+    )
+    await consumer.start()
+    logger.info(
+        "revenue_consumer_started",
+        bootstrap=bootstrap,
+        topic=topic,
+        group_id=_group_id(),
+        auto_offset_reset=_auto_offset(),
+    )
+    try:
+        while not stop.is_set():
+            try:
+                result = await consumer.getmany(timeout_ms=1000, max_records=16)
+            except KafkaError as exc:
+                logger.warning("revenue_poll_error", error=str(exc)[:200])
+                await asyncio.sleep(1.0)
+                continue
+
+            if not result:
+                await asyncio.sleep(0.05)
+                continue
+
+            for _tp, batch in result.items():
+                for msg in batch:
+                    await handle_message(consumer, msg)
+    finally:
+        await consumer.stop()
+        logger.info("revenue_consumer_stopped")
+
+
+async def main() -> None:
+    stop = asyncio.Event()
+
+    def _shutdown() -> None:
+        stop.set()
+
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(sig, _shutdown)
+        except NotImplementedError:
+            signal.signal(signal.SIGINT, lambda *_: stop.set())
+            signal.signal(signal.SIGTERM, lambda *_: stop.set())
+            break
+
+    await run_consumer_loop(stop)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Ships 4 new background worker/service modules plus worker.py startup wiring (400 lines). New: drift_sentry (213L), hermes_sync (561L), revenue_consumer (281L, module-only), legal_email_intake (676L). worker.py additions: drift_sentry_loop, hermes_sync_loop, legal_intake_task, recursive_agent_loop, reservation_confirmed_consumer_loop, payout_sweep_loop. main.py NOT modified (SRC poisoned with pre-refactor stale imports). All modules audited for secrets: clean. Merge with Create a merge commit.