### PR TITLE
chore(secrets): remove hardcoded sk-fortress-master-123 default

### DIFF
--- a/fortress-guest-platform/backend/services/legal_council.py
+++ b/fortress-guest-platform/backend/services/legal_council.py
@@ -76,7 +76,13 @@ LEGAL_ALLOWED_VECTOR_COLLECTIONS = frozenset({"legal_library", "legal_ediscovery
 from backend.core.config import settings as _cfg
 
 _LITELLM_BASE = getattr(_cfg, "litellm_base_url", "http://127.0.0.1:8002/v1").rstrip("/")
-_LITELLM_KEY = getattr(_cfg, "litellm_master_key", "sk-fortress-master-123")
+_raw_litellm_key = getattr(_cfg, "litellm_master_key", None) or os.getenv("LITELLM_MASTER_KEY")
+if not _raw_litellm_key:
+    raise RuntimeError(
+        "LITELLM_MASTER_KEY is not configured — set litellm_master_key in settings "
+        "or export LITELLM_MASTER_KEY env var before starting the service"
+    )
+_LITELLM_KEY = _raw_litellm_key
 
 # ── Frontier model endpoints (all route through local LiteLLM gateway) ──────
 ANTHROPIC_PROXY   = os.getenv("ANTHROPIC_PROXY_URL",  _LITELLM_BASE).rstrip("/")


### PR DESCRIPTION
Removes hardcoded sk-fortress-master-123 fallback from legal_council.py line 79. Replaces with explicit config-or-env lookup that fails fast with RuntimeError if neither litellm_master_key setting nor LITELLM_MASTER_KEY env var is set. Fresh checkouts without configuration fail at startup with clear message. Key remains valid on live LiteLLM until operationally rotated tomorrow. Follow-up: chore/secrets-rotation-live branch. Merge with Create a merge commit.