### PR TITLE
chore(security): gitignore runtime configs + litellm template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,22 @@ fortress-guest-platform/backend/scripts/review_namespace_batch*.json
 fortress-guest-platform/backend/scripts/seo_migration_candidates*.json
 fortress-guest-platform/backend/scripts/seo_migration_map_dry_run.json
 fortress-guest-platform/backend/scripts/seo_orphan_report_dry_run.json
+
+# Runtime operational state
+.defcon_state
+
+# LiteLLM runtime config — contains master_key, use deploy/litellm_config.yaml as template
+/litellm_config.yaml
+/litellm_config.yaml.bak
+
+# Python artifacts
+__pycache__/
+*.pyc
+*.pyo
+
+# SQLite runtime databases
+*.db
+*.db-journal
+
+# Background process output
+nohup.out

--- a/fortress-guest-platform/.gitignore
+++ b/fortress-guest-platform/.gitignore
@@ -27,3 +27,14 @@ backend/tests/fixtures/crog_output/*.pdf
 # Financial data — never commit PDFs or backup SQL from scripts/
 backend/scripts/*.pdf
 backend/scripts/g1_5_backup_*.sql
+
+# Runtime operational state
+.defcon_state
+
+# Python artifacts
+__pycache__/
+*.pyc
+*.pyo
+
+# Background process output
+nohup.out

--- a/litellm_config.yaml.example
+++ b/litellm_config.yaml.example
@@ -1,0 +1,52 @@
+# litellm_config.yaml — template / example
+#
+# To use:
+#   1. Copy this file to litellm_config.yaml (gitignored, never committed)
+#   2. Set LITELLM_MASTER_KEY env var: export LITELLM_MASTER_KEY='sk-...'
+#   3. Set provider API keys as env vars (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.)
+#      and replace os.environ/FILL_IN_PROVIDER_API_KEY with the correct var name
+#   4. Start LiteLLM: litellm --config litellm_config.yaml --port 8002 --host 127.0.0.1
+#
+# The actual active config on production lives at repo root (gitignored).
+# This .example lives in the repo to document config shape and model roster.
+
+model_list:
+  - model_name: claude-sonnet-4-6
+    litellm_params:
+      model: anthropic/claude-sonnet-4-6
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+  - model_name: claude-opus-4-6
+    litellm_params:
+      model: anthropic/claude-opus-4-6
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+  - model_name: gpt-4o
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: os.environ/OPENAI_API_KEY
+
+  - model_name: grok-4
+    litellm_params:
+      model: xai/grok-4.20-reasoning
+      api_key: os.environ/XAI_API_KEY
+
+  - model_name: gemini-2.5-pro
+    litellm_params:
+      model: gemini/gemini-2.5-pro
+      api_key: os.environ/GEMINI_API_KEY
+
+  - model_name: deepseek-chat
+    litellm_params:
+      model: deepseek/deepseek-chat
+      api_key: os.environ/DEEPSEEK_API_KEY
+
+  - model_name: deepseek-reasoner
+    litellm_params:
+      model: deepseek/deepseek-reasoner
+      api_key: os.environ/DEEPSEEK_API_KEY
+
+general_settings:
+  master_key: ${LITELLM_MASTER_KEY}  # Required: export before starting LiteLLM
+  drop_params: true
+  request_timeout: 180


### PR DESCRIPTION
Salvage Round 2, PR 1 of N — secrets hygiene foundation.

Working-tree audit discovered files missed in Round 1, including an actively-running `litellm_config.yaml` at repo root containing a live master key in plaintext. This PR establishes the protection pattern.

## Changes

- Root `.gitignore`: anchored `/litellm_config.yaml` and `.bak` (preserves tracked `deploy/litellm_config.yaml`), plus `__pycache__`, `*.pyc/.pyo`, `*.db/.db-journal`, `nohup.out`
- `fortress-guest-platform/.gitignore`: `__pycache__`, `*.pyc/.pyo`, `nohup.out`
- `litellm_config.yaml.example` (new): committable template with per-provider env-var refs (ANTHROPIC_API_KEY, OPENAI_API_KEY, XAI_API_KEY, GEMINI_API_KEY, DEEPSEEK_API_KEY) and usage header

## Follow-up

- Actual live LiteLLM master key remains in untracked root config; rotation scheduled for post-deploy
- 6 src/ files contain hardcoded miner_bot password; scrub commits pending in subsequent Round 2 PRs

## Merge strategy
Please use Create a merge commit.
