### PR TITLE
chore(security): scrub miner_bot password from all 26 src/ files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ __pycache__/
 
 # Background process output
 nohup.out
+
+# Backup files
+*.bak

--- a/fortress-guest-platform/.env.example
+++ b/fortress-guest-platform/.env.example
@@ -7,6 +7,7 @@
 # ---------------------------------------------------------------------------
 POSTGRES_API_URI=postgresql://fortress_api:REPLACE_ME@127.0.0.1:5432/fortress_prod
 POSTGRES_ADMIN_URI=postgresql://fortress_admin:REPLACE_ME@127.0.0.1:5432/fortress_prod
+MINER_BOT_DB_PASSWORD=REPLACE_ME
 
 # Auth: provide RS256 keys in PEM or base64-encoded PEM form.
 JWT_RSA_PRIVATE_KEY=

--- a/src/active_vision.py
+++ b/src/active_vision.py
@@ -4,11 +4,16 @@ import psycopg2
 import random
 import socket
 
+_MINER_BOT_PASSWORD = os.getenv("MINER_BOT_DB_PASSWORD")
+if not _MINER_BOT_PASSWORD:
+    raise RuntimeError("MINER_BOT_DB_PASSWORD env var required")
+
+
 # CONFIG: Connect back to Captain (Spark-2)
 DB_HOST = "192.168.0.100"  # Captain's IP
 DB_NAME = "fortress_db"
 DB_USER = "miner_bot"
-DB_PASS = "190AntiochCemeteryRD!!!"
+DB_PASS = _MINER_BOT_PASSWORD
 IMAGE_DIR = "/home/admin/fortress-prime/images_to_process"
 
 def get_db():

--- a/src/active_vision_nas.py
+++ b/src/active_vision_nas.py
@@ -4,11 +4,16 @@ import psycopg2
 import socket
 import sys
 
+_MINER_BOT_PASSWORD = os.getenv("MINER_BOT_DB_PASSWORD")
+if not _MINER_BOT_PASSWORD:
+    raise RuntimeError("MINER_BOT_DB_PASSWORD env var required")
+
+
 # CONFIG
 DB_HOST = "192.168.0.100"
 DB_NAME = "fortress_db"
 DB_USER = "miner_bot"
-DB_PASS = "190AntiochCemeteryRD!!!"
+DB_PASS = _MINER_BOT_PASSWORD
 IMAGE_DIR = "/mnt/fortress_ai/raw_images"
 
 def get_db():

--- a/src/add_safety_valve.py
+++ b/src/add_safety_valve.py
@@ -7,6 +7,11 @@ import os
 import sys
 from dotenv import load_dotenv
 
+_MINER_BOT_PASSWORD = os.getenv("MINER_BOT_DB_PASSWORD")
+if not _MINER_BOT_PASSWORD:
+    raise RuntimeError("MINER_BOT_DB_PASSWORD env var required")
+
+
 load_dotenv()
 
 try:
@@ -20,7 +25,7 @@ DB_HOST = os.getenv("DB_HOST", "localhost")
 DB_NAME = os.getenv("DB_NAME", "fortress_db")
 DB_PORT = int(os.getenv("DB_PORT", "5432"))
 ADMIN_USER = os.getenv("ADMIN_DB_USER", "miner_bot")
-ADMIN_PASS = os.getenv("ADMIN_DB_PASS", "190AntiochCemeteryRD!!!")
+ADMIN_PASS = os.getenv("ADMIN_DB_PASS", _MINER_BOT_PASSWORD)
 
 print("🛡️  FORTRESS PRIME - Safety Valve Installation")
 print("=" * 80)

--- a/src/analyst_brain.py
+++ b/src/analyst_brain.py
@@ -13,6 +13,11 @@ import requests
 from typing import Tuple, Optional
 from dotenv import load_dotenv
 
+_MINER_BOT_PASSWORD = os.getenv("MINER_BOT_DB_PASSWORD")
+if not _MINER_BOT_PASSWORD:
+    raise RuntimeError("MINER_BOT_DB_PASSWORD env var required")
+
+
 # Load environment variables
 load_dotenv()
 
@@ -45,7 +50,7 @@ def get_schema() -> str:
             database=DB_NAME,
             port=int(DB_PORT),
             user=os.getenv("ADMIN_DB_USER", "miner_bot"),
-            password=os.getenv("ADMIN_DB_PASS", "190AntiochCemeteryRD!!!")
+            password=os.getenv("ADMIN_DB_PASS", _MINER_BOT_PASSWORD)
         )
         cur = admin_conn.cursor()
         

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -8,6 +8,11 @@ import time
 import sys
 from streamlit_option_menu import option_menu
 
+_MINER_BOT_PASSWORD = os.getenv("MINER_BOT_DB_PASSWORD")
+if not _MINER_BOT_PASSWORD:
+    raise RuntimeError("MINER_BOT_DB_PASSWORD env var required")
+
+
 # --- CONFIGURATION ---
 st.set_page_config(page_title="FORTRESS PRIME", page_icon="🛡️", layout="wide")
 
@@ -399,7 +404,7 @@ st.markdown("""
 # --- BACKEND FUNCTIONS ---
 def get_db_conn():
     try:
-        return psycopg2.connect(host="localhost", database="fortress_db", user="miner_bot", password="190AntiochCemeteryRD!!!")
+        return psycopg2.connect(host="localhost", database="fortress_db", user="miner_bot", password=_MINER_BOT_PASSWORD)
     except:
         return None
 

--- a/src/dashboard_v2.py
+++ b/src/dashboard_v2.py
@@ -4,10 +4,15 @@ import psycopg2
 import subprocess
 import os
 
+_MINER_BOT_PASSWORD = os.getenv("MINER_BOT_DB_PASSWORD")
+if not _MINER_BOT_PASSWORD:
+    raise RuntimeError("MINER_BOT_DB_PASSWORD env var required")
+
+
 st.set_page_config(layout="wide")
 st.title("Fortress Prime")
 
-def get_conn(): return psycopg2.connect(host="localhost", database="fortress_db", user="miner_bot", password="190AntiochCemeteryRD!!!")
+def get_conn(): return psycopg2.connect(host="localhost", database="fortress_db", user="miner_bot", password=_MINER_BOT_PASSWORD)
 
 t1, t2, t3 = st.tabs(["Signals", "System", "Audit"])
 

--- a/src/data_router.py
+++ b/src/data_router.py
@@ -10,6 +10,11 @@ from typing import Optional, Dict, Any
 from datetime import datetime
 from dotenv import load_dotenv
 
+_MINER_BOT_PASSWORD = os.getenv("MINER_BOT_DB_PASSWORD")
+if not _MINER_BOT_PASSWORD:
+    raise RuntimeError("MINER_BOT_DB_PASSWORD env var required")
+
+
 load_dotenv()
 
 try:
@@ -26,7 +31,7 @@ DB_HOST = os.getenv("DB_HOST", "localhost")
 DB_NAME = os.getenv("DB_NAME", "fortress_db")
 DB_PORT = int(os.getenv("DB_PORT", "5432"))
 ADMIN_USER = os.getenv("ADMIN_DB_USER", "miner_bot")
-ADMIN_PASS = os.getenv("ADMIN_DB_PASS", "190AntiochCemeteryRD!!!")
+ADMIN_PASS = os.getenv("ADMIN_DB_PASS", _MINER_BOT_PASSWORD)
 
 # SQLAlchemy Setup
 DATABASE_URL = f"postgresql://{ADMIN_USER}:{ADMIN_PASS}@{DB_HOST}:{DB_PORT}/{DB_NAME}"

--- a/src/enrichment_service.py
+++ b/src/enrichment_service.py
@@ -12,6 +12,11 @@ from typing import Optional, Dict, Any
 from datetime import datetime, timedelta
 from dotenv import load_dotenv
 
+_MINER_BOT_PASSWORD = os.getenv("MINER_BOT_DB_PASSWORD")
+if not _MINER_BOT_PASSWORD:
+    raise RuntimeError("MINER_BOT_DB_PASSWORD env var required")
+
+
 try:
     from sqlalchemy import create_engine, Column, Integer, String, Numeric, Date, Text, DateTime, Enum as SQLEnum
     from sqlalchemy.ext.declarative import declarative_base
@@ -28,7 +33,7 @@ DB_HOST = os.getenv("DB_HOST", "localhost")
 DB_NAME = os.getenv("DB_NAME", "fortress_db")
 DB_PORT = int(os.getenv("DB_PORT", "5432"))
 ADMIN_USER = os.getenv("ADMIN_DB_USER", "miner_bot")
-ADMIN_PASS = os.getenv("ADMIN_DB_PASS", "190AntiochCemeteryRD!!!")
+ADMIN_PASS = os.getenv("ADMIN_DB_PASS", _MINER_BOT_PASSWORD)
 
 # Spark-1 (Ollama) Configuration
 WORKER_IP = "192.168.0.104"

--- a/src/extract_invoices.py
+++ b/src/extract_invoices.py
@@ -6,8 +6,13 @@ import shutil
 from datetime import datetime
 import re
 
+_MINER_BOT_PASSWORD = os.getenv("MINER_BOT_DB_PASSWORD")
+if not _MINER_BOT_PASSWORD:
+    raise RuntimeError("MINER_BOT_DB_PASSWORD env var required")
+
+
 # --- CONFIGURATION ---
-DB_PASS = "190AntiochCemeteryRD!!!"
+DB_PASS = _MINER_BOT_PASSWORD
 OUTPUT_DIR = "/mnt/fortress_data/invoices"
 
 def get_db_connection():

--- a/src/extract_trade_signals.py
+++ b/src/extract_trade_signals.py
@@ -7,8 +7,13 @@ from PIL import Image
 import io
 import re
 
+_MINER_BOT_PASSWORD = os.getenv("MINER_BOT_DB_PASSWORD")
+if not _MINER_BOT_PASSWORD:
+    raise RuntimeError("MINER_BOT_DB_PASSWORD env var required")
+
+
 # --- CONFIGURATION ---
-DB_PASS = "190AntiochCemeteryRD!!!"
+DB_PASS = _MINER_BOT_PASSWORD
 CHART_DIR = "/mnt/fortress_data/charts"
 
 def get_db_connection():

--- a/src/extract_trade_signals_v2.py
+++ b/src/extract_trade_signals_v2.py
@@ -7,8 +7,13 @@ import pytesseract
 import io
 from datetime import datetime
 
+_MINER_BOT_PASSWORD = os.getenv("MINER_BOT_DB_PASSWORD")
+if not _MINER_BOT_PASSWORD:
+    raise RuntimeError("MINER_BOT_DB_PASSWORD env var required")
+
+
 # --- CONFIGURATION ---
-DB_PASS = "190AntiochCemeteryRD!!!"
+DB_PASS = _MINER_BOT_PASSWORD
 CHART_DIR = "/mnt/fortress_data/charts"
 
 def get_db_connection():

--- a/src/indexer_service.py
+++ b/src/indexer_service.py
@@ -3,8 +3,13 @@ import psycopg2
 import pypdf
 import sys
 
+_MINER_BOT_PASSWORD = os.getenv("MINER_BOT_DB_PASSWORD")
+if not _MINER_BOT_PASSWORD:
+    raise RuntimeError("MINER_BOT_DB_PASSWORD env var required")
+
+
 # --- CONFIGURATION ---
-DB_PASS = "190AntiochCemeteryRD!!!"
+DB_PASS = _MINER_BOT_PASSWORD
 LEGAL_PATH = "/mnt/fortress_data/legal_archive"
 BUSINESS_PATH = "/mnt/fortress_data/documents/Cabin Rentals Of Georgia"
 # We scan the root documents for Knight specific business folders too

--- a/src/ingest_deep_archive.py
+++ b/src/ingest_deep_archive.py
@@ -5,10 +5,15 @@ import psycopg2
 from datetime import datetime
 import re
 
+_MINER_BOT_PASSWORD = os.getenv("MINER_BOT_DB_PASSWORD")
+if not _MINER_BOT_PASSWORD:
+    raise RuntimeError("MINER_BOT_DB_PASSWORD env var required")
+
+
 # --- CONFIGURATION ---
 # Note: The path handles the brackets and spaces
 TARGET_DIR = "/mnt/fortress_mail/@local/1026/1026/Maildir/.[Gmail].All Mail/cur"
-DB_PASS = "190AntiochCemeteryRD!!!"
+DB_PASS = _MINER_BOT_PASSWORD
 
 def get_db_connection():
     return psycopg2.connect(host="localhost", database="fortress_db", user="miner_bot", password=DB_PASS)

--- a/src/ingest_market.py
+++ b/src/ingest_market.py
@@ -5,9 +5,14 @@ import psycopg2
 from datetime import datetime
 import re
 
+_MINER_BOT_PASSWORD = os.getenv("MINER_BOT_DB_PASSWORD")
+if not _MINER_BOT_PASSWORD:
+    raise RuntimeError("MINER_BOT_DB_PASSWORD env var required")
+
+
 # --- CONFIGURATION ---
 TARGET_DIR = "/mnt/fortress_mail/@local/1026/1026/Maildir/.MARKET_INTELLIGENCE/cur"
-DB_PASS = "190AntiochCemeteryRD!!!"
+DB_PASS = _MINER_BOT_PASSWORD
 
 def get_db_connection():
     return psycopg2.connect(host="localhost", database="fortress_db", user="miner_bot", password=DB_PASS)

--- a/src/init_db.py
+++ b/src/init_db.py
@@ -1,4 +1,10 @@
+import os
 import psycopg2
+
+_MINER_BOT_PASSWORD = os.getenv("MINER_BOT_DB_PASSWORD")
+if not _MINER_BOT_PASSWORD:
+    raise RuntimeError("MINER_BOT_DB_PASSWORD env var required")
+
 
 try:
     # Connect (VS Code handles the '!!!' safely)
@@ -6,7 +12,7 @@ try:
         host='localhost', 
         database='fortress_db', 
         user='miner_bot', 
-        password='190AntiochCemeteryRD!!!'
+        password=_MINER_BOT_PASSWORD
     )
     cur = conn.cursor()
     

--- a/src/init_gold_db.py
+++ b/src/init_gold_db.py
@@ -8,6 +8,11 @@ import psycopg2
 import os
 from dotenv import load_dotenv
 
+_MINER_BOT_PASSWORD = os.getenv("MINER_BOT_DB_PASSWORD")
+if not _MINER_BOT_PASSWORD:
+    raise RuntimeError("MINER_BOT_DB_PASSWORD env var required")
+
+
 # Load environment variables
 load_dotenv()
 
@@ -15,7 +20,7 @@ load_dotenv()
 DB_HOST = os.getenv("DB_HOST", "localhost")
 DB_NAME = os.getenv("DB_NAME", "fortress_db")
 DB_USER = os.getenv("DB_USER", "miner_bot")
-DB_PASS = os.getenv("DB_PASS", "190AntiochCemeteryRD!!!")
+DB_PASS = os.getenv("DB_PASS", _MINER_BOT_PASSWORD)
 
 def get_db_connection():
     """Establish database connection."""

--- a/src/init_schema.py
+++ b/src/init_schema.py
@@ -1,8 +1,14 @@
+import os
 import psycopg2
+
+_MINER_BOT_PASSWORD = os.getenv("MINER_BOT_DB_PASSWORD")
+if not _MINER_BOT_PASSWORD:
+    raise RuntimeError("MINER_BOT_DB_PASSWORD env var required")
+
 
 try:
     # Connect to the Vault
-    conn = psycopg2.connect(host="localhost", database="fortress_db", user="miner_bot", password="190AntiochCemeteryRD!!!")
+    conn = psycopg2.connect(host="localhost", database="fortress_db", user="miner_bot", password=_MINER_BOT_PASSWORD)
     cur = conn.cursor()
     
     print("🏗️  BUILDING DATABASE SCHEMA...")

--- a/src/mailplus_sentinel.py
+++ b/src/mailplus_sentinel.py
@@ -18,6 +18,11 @@ from typing import Iterable, List, Tuple
 import psycopg2
 from psycopg2.extras import execute_batch
 
+_MINER_BOT_PASSWORD = os.getenv("MINER_BOT_DB_PASSWORD")
+if not _MINER_BOT_PASSWORD:
+    raise RuntimeError("MINER_BOT_DB_PASSWORD env var required")
+
+
 
 MAILPLUS_ROOT = "/home/admin/fortress-prime/mnt/synology/MailPlus"
 
@@ -127,7 +132,7 @@ def _get_db_connection():
     host = os.getenv("FORTRESS_DB_HOST", "localhost")
     db = os.getenv("FORTRESS_DB_NAME", "fortress_db")
     user = os.getenv("FORTRESS_DB_USER", "miner_bot")
-    password = os.getenv("FORTRESS_DB_PASS", "190AntiochCemeteryRD!!!")
+    password = os.getenv("FORTRESS_DB_PASS", _MINER_BOT_PASSWORD)
     return psycopg2.connect(host=host, database=db, user=user, password=password)
 
 

--- a/src/map_real_estate.py
+++ b/src/map_real_estate.py
@@ -1,8 +1,14 @@
+import os
 import psycopg2
 import re
 from collections import Counter
 
-DB_PASS = "190AntiochCemeteryRD!!!"
+_MINER_BOT_PASSWORD = os.getenv("MINER_BOT_DB_PASSWORD")
+if not _MINER_BOT_PASSWORD:
+    raise RuntimeError("MINER_BOT_DB_PASSWORD env var required")
+
+
+DB_PASS = _MINER_BOT_PASSWORD
 
 def get_db_connection():
     return psycopg2.connect(host="localhost", database="fortress_db", user="miner_bot", password=DB_PASS)

--- a/src/market_agent.py
+++ b/src/market_agent.py
@@ -1,13 +1,19 @@
+import os
 import psycopg2
 import time
 import random
 import datetime
 
+_MINER_BOT_PASSWORD = os.getenv("MINER_BOT_DB_PASSWORD")
+if not _MINER_BOT_PASSWORD:
+    raise RuntimeError("MINER_BOT_DB_PASSWORD env var required")
+
+
 # CONFIG
 DB_HOST = "localhost"
 DB_NAME = "fortress_db"
 DB_USER = "miner_bot"
-DB_PASS = "190AntiochCemeteryRD!!!"
+DB_PASS = _MINER_BOT_PASSWORD
 
 # TRACKING LIST (Your Favorites)
 tickers = {

--- a/src/market_feeder.py
+++ b/src/market_feeder.py
@@ -1,9 +1,15 @@
 import time
 import random
+import os
 import psycopg2
 from datetime import datetime
 
-conn = psycopg2.connect(host="localhost", database="fortress_db", user="miner_bot", password="190AntiochCemeteryRD!!!")
+_MINER_BOT_PASSWORD = os.getenv("MINER_BOT_DB_PASSWORD")
+if not _MINER_BOT_PASSWORD:
+    raise RuntimeError("MINER_BOT_DB_PASSWORD env var required")
+
+
+conn = psycopg2.connect(host="localhost", database="fortress_db", user="miner_bot", password=_MINER_BOT_PASSWORD)
 cur = conn.cursor()
 
 print("📈 MARKET FEEDER ACTIVE (Press Ctrl+C to stop)...")

--- a/src/mining_rig.py
+++ b/src/mining_rig.py
@@ -16,6 +16,11 @@ from datetime import datetime
 from typing import Optional, Dict, Any, List
 from dotenv import load_dotenv
 
+_MINER_BOT_PASSWORD = os.getenv("MINER_BOT_DB_PASSWORD")
+if not _MINER_BOT_PASSWORD:
+    raise RuntimeError("MINER_BOT_DB_PASSWORD env var required")
+
+
 # Load environment variables
 load_dotenv()
 
@@ -25,7 +30,7 @@ DB_HOST = os.getenv("DB_HOST", "localhost")
 DB_NAME = os.getenv("DB_NAME", "fortress_db")
 # Use admin credentials for write operations (mining requires INSERT/UPDATE)
 DB_USER = os.getenv("ADMIN_DB_USER") or os.getenv("DB_USER", "miner_bot")
-DB_PASS = os.getenv("ADMIN_DB_PASS") or os.getenv("DB_PASS", "190AntiochCemeteryRD!!!")
+DB_PASS = os.getenv("ADMIN_DB_PASS") or os.getenv("DB_PASS", _MINER_BOT_PASSWORD)
 
 # Inference Engine: Spark-1 (Ollama)
 WORKER_IP = "192.168.0.104"

--- a/src/mining_rig_with_router.py
+++ b/src/mining_rig_with_router.py
@@ -14,13 +14,18 @@ from dotenv import load_dotenv
 # Import the router
 from data_router import route_incoming_data, create_tables
 
+_MINER_BOT_PASSWORD = os.getenv("MINER_BOT_DB_PASSWORD")
+if not _MINER_BOT_PASSWORD:
+    raise RuntimeError("MINER_BOT_DB_PASSWORD env var required")
+
+
 load_dotenv()
 
 # Configuration - Sovereign Cluster Topology
 DB_HOST = os.getenv("DB_HOST", "localhost")
 DB_NAME = os.getenv("DB_NAME", "fortress_db")
 DB_USER = os.getenv("ADMIN_DB_USER") or os.getenv("DB_USER", "miner_bot")
-DB_PASS = os.getenv("ADMIN_DB_PASS") or os.getenv("DB_PASS", "190AntiochCemeteryRD!!!")
+DB_PASS = os.getenv("ADMIN_DB_PASS") or os.getenv("DB_PASS", _MINER_BOT_PASSWORD)
 
 # Inference Engine: Spark-1 (Ollama)
 WORKER_IP = "192.168.0.104"

--- a/src/pulse_agent.py
+++ b/src/pulse_agent.py
@@ -3,13 +3,18 @@ import psycopg2
 import subprocess
 import os
 
+_MINER_BOT_PASSWORD = os.getenv("MINER_BOT_DB_PASSWORD")
+if not _MINER_BOT_PASSWORD:
+    raise RuntimeError("MINER_BOT_DB_PASSWORD env var required")
+
+
 # --- CONFIG ---
 # Use environment variables when running in Docker, fallback to defaults
 NODE_NAME = os.getenv("NODE_NAME", "spark-1")
 DB_HOST = os.getenv("DB_HOST", "192.168.0.100")  # Address of Spark-2 or postgres container
 DB_NAME = os.getenv("DB_NAME", "fortress_db")
 DB_USER = os.getenv("DB_USER", "miner_bot")
-DB_PASS = os.getenv("DB_PASS", "190AntiochCemeteryRD!!!")
+DB_PASS = os.getenv("DB_PASS", _MINER_BOT_PASSWORD)
 INTERVAL = int(os.getenv("INTERVAL", "5"))  # Update every 5 seconds (Turbo Mode)
 
 def get_hw_stats():

--- a/src/telemetry_agent.py
+++ b/src/telemetry_agent.py
@@ -4,9 +4,14 @@ import time
 import socket
 import os
 
+_MINER_BOT_PASSWORD = os.getenv("MINER_BOT_DB_PASSWORD")
+if not _MINER_BOT_PASSWORD:
+    raise RuntimeError("MINER_BOT_DB_PASSWORD env var required")
+
+
 # --- CONFIGURATION ---
 DB_HOST = "127.0.0.1" 
-DB_PASS = "190AntiochCemeteryRD!!!"
+DB_PASS = _MINER_BOT_PASSWORD
 HOSTNAME = socket.gethostname()
 
 def run_agent():

--- a/src/watcher_service.py
+++ b/src/watcher_service.py
@@ -8,6 +8,11 @@ import re
 import logging
 from datetime import datetime
 
+_MINER_BOT_PASSWORD = os.getenv("MINER_BOT_DB_PASSWORD")
+if not _MINER_BOT_PASSWORD:
+    raise RuntimeError("MINER_BOT_DB_PASSWORD env var required")
+
+
 # --- ENTERPRISE CONFIGURATION ---
 # "Hot Data" Input - Files here will be ingested AND MOVED.
 WATCH_FOLDER = "/mnt/fortress_data/market_input"
@@ -15,7 +20,7 @@ WATCH_FOLDER = "/mnt/fortress_data/market_input"
 PROCESSED_FOLDER = "/mnt/fortress_data/market_input/Processed"
 
 # Database & AI Credentials
-DB_PASS = "190AntiochCemeteryRD!!!"
+DB_PASS = _MINER_BOT_PASSWORD
 OLLAMA_API_URL = "http://localhost:11434/api"
 LOG_FILE = "/home/admin/fortress-prime/logs/watcher.log"
 


### PR DESCRIPTION
Scrubs hardcoded miner_bot Postgres password from all 26 affected src/ files. Initial scan identified 5 files; expanded scan found 21 more using `DB_PASS = "..."` pattern plus `os.getenv(..., "...")` fallbacks.

All 26 now use `MINER_BOT_DB_PASSWORD` env var + RuntimeError guard.

## The fallback concern

Several files used `os.getenv("DB_PASS", "<hardcoded>")` — this pattern silently uses the hardcoded password whenever the env var is unset, giving false "we're using env vars" confidence.

## Files (26 total)
dashboard.py, dashboard_v2.py, init_schema.py, init_db.py, market_feeder.py, active_vision.py, active_vision_nas.py, add_safety_valve.py, analyst_brain.py, data_router.py, enrichment_service.py, extract_invoices.py, extract_trade_signals.py, extract_trade_signals_v2.py, indexer_service.py, ingest_deep_archive.py, ingest_market.py, init_gold_db.py, mailplus_sentinel.py, map_real_estate.py, market_agent.py, mining_rig.py, mining_rig_with_router.py, pulse_agent.py, telemetry_agent.py, watcher_service.py

## Merge strategy
Create a merge commit.
