### PR TITLE
feat(iron-dome): Phase 2 privilege filter

### DIFF
--- a/fortress-guest-platform/backend/alembic/versions/4bc59a1ee4df_add_restricted_captures_table.py
+++ b/fortress-guest-platform/backend/alembic/versions/4bc59a1ee4df_add_restricted_captures_table.py
@@ -1,0 +1,72 @@
+"""add restricted_captures table
+
+Revision ID: 4bc59a1ee4df
+Revises: i5a1_obp_payout_columns
+Create Date: 2026-04-18
+
+Parallel table to llm_training_captures for privileged content that is
+retained for audit but never exported to training JSONL. Part of Iron
+Dome Phase 2 (privilege filter).
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "4bc59a1ee4df"
+down_revision = "i5a1_obp_payout_columns"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "restricted_captures",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("prompt", sa.Text, nullable=False),
+        sa.Column("response", sa.Text, nullable=False),
+        sa.Column("source_persona", sa.String(128), nullable=True),
+        sa.Column("source_module", sa.String(128), nullable=True),
+        sa.Column("restriction_reason", sa.String(256), nullable=False),
+        sa.Column(
+            "matched_patterns",
+            postgresql.ARRAY(sa.String),
+            nullable=False,
+            server_default="{}",
+        ),
+        sa.Column("capture_metadata", postgresql.JSONB, nullable=True),
+    )
+
+    op.create_index(
+        "idx_restricted_captures_created_at",
+        "restricted_captures",
+        ["created_at"],
+    )
+    op.create_index(
+        "idx_restricted_captures_source_persona",
+        "restricted_captures",
+        ["source_persona"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_restricted_captures_source_persona",
+        table_name="restricted_captures",
+    )
+    op.drop_index(
+        "idx_restricted_captures_created_at",
+        table_name="restricted_captures",
+    )
+    op.drop_table("restricted_captures")

--- a/fortress-guest-platform/backend/services/privilege_filter.py
+++ b/fortress-guest-platform/backend/services/privilege_filter.py
@@ -1,0 +1,141 @@
+"""
+Privilege filter for training capture routing.
+
+Invoked at every capture write site to classify content by sensitivity.
+Routes to one of: llm_training_captures (training set),
+restricted_captures (retained but excluded from training), or BLOCK.
+
+Phase 2 of Iron Dome architecture. Must ship before
+nightly_distillation_exporter is enabled, otherwise privileged legal
+content accumulates in training set.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class CaptureRoute(str, Enum):
+    """Where to route a capture."""
+    ALLOW = "allow"
+    RESTRICTED = "restricted"
+    BLOCK = "block"
+
+
+@dataclass(frozen=True)
+class CaptureDecision:
+    """Filter decision with audit trail."""
+    route: CaptureRoute
+    reason: str
+    matched_patterns: tuple[str, ...] = ()
+
+
+LEGAL_PERSONAS: frozenset[str] = frozenset({
+    "senior_litigator",
+    "contract_auditor",
+    "statutory_scholar",
+    "ediscovery_forensic",
+    "devils_advocate",
+    "compliance_officer",
+    "local_counsel",
+    "risk_assessor",
+    "chief_justice",
+})
+
+PRIVILEGED_MODULES: frozenset[str] = frozenset({
+    "legal_council",
+    "ediscovery_agent",
+    "legal_email_intake",
+    "legal_intake",
+})
+
+PRIVILEGE_MARKERS: tuple[str, ...] = (
+    "[PRIVILEGED]",
+    "[ATTORNEY-CLIENT]",
+    "[WORK PRODUCT]",
+    "ATTORNEY-CLIENT PRIVILEGED",
+    "ATTORNEY WORK PRODUCT",
+)
+
+BLOCK_PATTERNS: tuple[tuple[str, re.Pattern], ...] = (
+    ("ssn", re.compile(r"\b\d{3}-\d{2}-\d{4}\b")),
+    ("credit_card", re.compile(r"\b(?:\d[ -]*?){13,19}\b")),
+    ("bank_routing", re.compile(r"\b\d{9}\b(?=.*(?:routing|aba))", re.IGNORECASE)),
+)
+
+
+def classify_for_capture(
+    prompt: str,
+    response: str,
+    source_persona: str | None = None,
+    source_module: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> CaptureDecision:
+    """
+    Classify a capture for routing.
+
+    Called at every write site to llm_training_captures. Defaults to
+    RESTRICTED on any signal of privilege — training set is conservative.
+    """
+    metadata = metadata or {}
+
+    override = metadata.get("restriction_override")
+    if override in {CaptureRoute.ALLOW.value, CaptureRoute.RESTRICTED.value, CaptureRoute.BLOCK.value}:
+        logger.warning(
+            "privilege_filter.override route=%s persona=%s module=%s",
+            override, source_persona, source_module,
+        )
+        return CaptureDecision(
+            route=CaptureRoute(override),
+            reason="admin_override",
+        )
+
+    block_matches: list[str] = []
+    combined_text = f"{prompt}\n{response}"
+    for pattern_name, pattern in BLOCK_PATTERNS:
+        if pattern.search(combined_text):
+            block_matches.append(pattern_name)
+
+    if block_matches:
+        logger.info(
+            "privilege_filter.block patterns=%s persona=%s module=%s",
+            block_matches, source_persona, source_module,
+        )
+        return CaptureDecision(
+            route=CaptureRoute.BLOCK,
+            reason="pii_pattern_matched",
+            matched_patterns=tuple(block_matches),
+        )
+
+    restrict_reasons: list[str] = []
+
+    if source_persona and source_persona in LEGAL_PERSONAS:
+        restrict_reasons.append(f"legal_persona:{source_persona}")
+
+    if source_module and source_module in PRIVILEGED_MODULES:
+        restrict_reasons.append(f"privileged_module:{source_module}")
+
+    if metadata.get("privilege_marker"):
+        restrict_reasons.append("metadata_privilege_marker")
+
+    for marker in PRIVILEGE_MARKERS:
+        if marker in prompt or marker in response:
+            restrict_reasons.append(f"text_marker:{marker}")
+            break
+
+    if restrict_reasons:
+        return CaptureDecision(
+            route=CaptureRoute.RESTRICTED,
+            reason="|".join(restrict_reasons),
+            matched_patterns=tuple(restrict_reasons),
+        )
+
+    return CaptureDecision(
+        route=CaptureRoute.ALLOW,
+        reason="no_privilege_signal",
+    )

--- a/fortress-guest-platform/backend/tests/test_privilege_filter.py
+++ b/fortress-guest-platform/backend/tests/test_privilege_filter.py
@@ -1,0 +1,127 @@
+"""Tests for the privilege filter."""
+import pytest
+
+from backend.services.privilege_filter import (
+    classify_for_capture,
+    CaptureRoute,
+    LEGAL_PERSONAS,
+)
+
+
+class TestLegalPersonas:
+    def test_each_legal_persona_routes_to_restricted(self):
+        for persona in LEGAL_PERSONAS:
+            result = classify_for_capture(
+                prompt="What is the standard of review?",
+                response="De novo review applies.",
+                source_persona=persona,
+            )
+            assert result.route == CaptureRoute.RESTRICTED
+            assert persona in result.reason
+
+
+class TestPrivilegedModules:
+    def test_legal_council_module_routes_to_restricted(self):
+        result = classify_for_capture(
+            prompt="analyze this contract",
+            response="the termination clause is ambiguous",
+            source_module="legal_council",
+        )
+        assert result.route == CaptureRoute.RESTRICTED
+        assert "legal_council" in result.reason
+
+    def test_ediscovery_module_routes_to_restricted(self):
+        result = classify_for_capture(
+            prompt="review these documents",
+            response="document 47 is responsive",
+            source_module="ediscovery_agent",
+        )
+        assert result.route == CaptureRoute.RESTRICTED
+
+
+class TestExplicitMarkers:
+    def test_privileged_marker_in_response_routes_to_restricted(self):
+        result = classify_for_capture(
+            prompt="analyze this",
+            response="[PRIVILEGED] this analysis is confidential",
+        )
+        assert result.route == CaptureRoute.RESTRICTED
+
+    def test_attorney_client_marker_routes_to_restricted(self):
+        result = classify_for_capture(
+            prompt="review",
+            response="ATTORNEY-CLIENT PRIVILEGED communication",
+        )
+        assert result.route == CaptureRoute.RESTRICTED
+
+    def test_metadata_privilege_marker_routes_to_restricted(self):
+        result = classify_for_capture(
+            prompt="benign",
+            response="benign response",
+            metadata={"privilege_marker": True},
+        )
+        assert result.route == CaptureRoute.RESTRICTED
+
+
+class TestBlockPatterns:
+    def test_ssn_in_prompt_blocks(self):
+        result = classify_for_capture(
+            prompt="tenant ssn 123-45-6789 applied",
+            response="application processed",
+        )
+        assert result.route == CaptureRoute.BLOCK
+        assert "ssn" in result.matched_patterns
+
+    def test_ssn_in_response_blocks(self):
+        result = classify_for_capture(
+            prompt="look up the tenant",
+            response="found record for 987-65-4321",
+        )
+        assert result.route == CaptureRoute.BLOCK
+
+    def test_credit_card_blocks(self):
+        result = classify_for_capture(
+            prompt="process this card",
+            response="4532-1234-5678-9012 authorized",
+        )
+        assert result.route == CaptureRoute.BLOCK
+
+
+class TestAllow:
+    def test_generic_prompt_allows(self):
+        result = classify_for_capture(
+            prompt="what time is checkout",
+            response="checkout is at 11am",
+            source_persona="concierge_worker",
+            source_module="concierge",
+        )
+        assert result.route == CaptureRoute.ALLOW
+
+    def test_no_context_allows(self):
+        result = classify_for_capture(
+            prompt="weather today",
+            response="sunny, 72 degrees",
+        )
+        assert result.route == CaptureRoute.ALLOW
+
+
+class TestBlockTakesPrecedenceOverRestricted:
+    def test_ssn_from_legal_persona_still_blocks(self):
+        result = classify_for_capture(
+            prompt="client ssn is 111-22-3333",
+            response="noted",
+            source_persona="senior_litigator",
+        )
+        assert result.route == CaptureRoute.BLOCK
+
+
+class TestAdminOverride:
+    def test_override_to_allow_works(self):
+        result = classify_for_capture(
+            prompt="anything",
+            response="anything",
+            source_persona="senior_litigator",
+            metadata={"restriction_override": "allow"},
+        )
+        assert result.route == CaptureRoute.ALLOW
+        assert result.reason == "admin_override"


### PR DESCRIPTION
Privilege filter module + tests + migration. Iron Dome Phase 2.

Prevents privileged legal content from entering llm_training_captures. Filter routes captures to ALLOW / RESTRICTED / BLOCK based on source persona, source module, text markers, metadata flag, and PII patterns.

Runtime integration (ai_router and legal_council wiring) ships in a separate PR — this one is filter + schema in isolation so bugs are findable without integration noise.

Create a merge commit.