### PR TITLE
feat(iron-dome): FINETUNE_MIN_DATE guard in nightly_finetune.py

### DIFF
--- a/fortress-guest-platform/.env.example
+++ b/fortress-guest-platform/.env.example
@@ -81,3 +81,14 @@ OWNER_STATEMENT_ALERT_EMAIL=
 # it to the current alembic head.
 # Without this variable, conftest.py warns and tests fall back to fortress_shadow.
 TEST_DATABASE_URL=postgresql://fortress_api:fortress@127.0.0.1:5432/fortress_shadow_test
+
+# ---------------------------------------------------------------------------
+# Iron Dome Phase 2 — Training data cutoff
+# Never consume JSONL files older than this date for fine-tuning.
+# Set to the date Phase 2 privilege filter shipped (2026-04-18).
+# Pre-filter exports from 2026-04-11 and 2026-04-14 contained active
+# litigation content (SUV2026000013) and were quarantined to NAS.
+# This date guard prevents re-contamination if quarantined files ever
+# reappear in the training_logs directory.
+# ---------------------------------------------------------------------------
+FINETUNE_MIN_DATE=2026-04-18

--- a/src/nightly_finetune.py
+++ b/src/nightly_finetune.py
@@ -74,6 +74,7 @@ NUM_EPOCHS           = int(os.getenv("FINETUNE_EPOCHS",        "1"))
 LEARNING_RATE        = float(os.getenv("FINETUNE_LR",          "2e-4"))
 PUSH_OLLAMA          = os.getenv("FINETUNE_PUSH_OLLAMA",       "false").lower() == "true"
 VLLM_CONTAINER       = os.getenv("VLLM_CONTAINER_NAME",        "vllm-70b-captain")
+MIN_DATE             = date.fromisoformat(os.getenv("FINETUNE_MIN_DATE", "2026-04-18"))
 
 # LoRA target modules for Llama architecture
 LORA_TARGET_MODULES = [
@@ -169,7 +170,10 @@ def load_training_data(rolling_days: int) -> list[dict]:
     today = date.today()
     records: list[dict] = []
     for offset in range(rolling_days):
-        day = (today - timedelta(days=offset)).isoformat()
+        day_date = today - timedelta(days=offset)
+        if day_date < MIN_DATE:
+            continue  # never consume pre-filter data
+        day = day_date.isoformat()
         path = INTERACTION_LOG_DIR / f"{day}.jsonl"
         if not path.exists():
             continue


### PR DESCRIPTION
Adds minimum-date cutoff to `load_training_data()` so pre-Phase-2 JSONL files can never be consumed for fine-tuning even if they reappear.

**Why:** Audit of existing NAS JSONLs before enabling the Phase 3 timer found active litigation content (SUV2026000013 — Generali v. CROG) in exports from 2026-04-11 (6 hits) and 2026-04-14 (74 hits). Both quarantined. Phase 2 privilege filter (PRs #47/#48) prevents future contamination — this guard prevents historical re-contamination.

**Changes:** `MIN_DATE` config var reads `FINETUNE_MIN_DATE` env (default `2026-04-18`). Loop skips any date before cutoff. `.env.example` documents the variable and the contamination event.

Create a merge commit.