### PR TITLE
fix(phase-4): native vLLM process management + Phase 4 MVP trainer

### DIFF
--- a/src/nightly_finetune.py
+++ b/src/nightly_finetune.py
@@ -22,8 +22,8 @@ Usage
 
 Environment variables (loaded from .env / .env.dgx by run-fortress-nightly-finetune.sh)
     INTERACTION_LOG_DIR     default: /mnt/ai_bulk/training_logs
-    FINETUNE_BASE_MODEL_DIR default: /mnt/ai_bulk/models/huggingface/Llama-3.3-70B-Instruct
-    FINETUNE_ADAPTER_DIR    default: /mnt/ai_bulk/models/fine-tuned/lora-adapters
+    FINETUNE_BASE_MODEL_DIR default: /mnt/ai_bulk/models/huggingface/Llama-3.3-70B-Instruct-FP4
+    FINETUNE_ADAPTER_DIR    default: /mnt/fortress_nas/finetune-artifacts
     FINETUNE_ROLLING_DAYS   default: 30
     FINETUNE_MIN_EXAMPLES   default: 20
     FINETUNE_LORA_RANK      default: 16
@@ -62,8 +62,8 @@ log = logging.getLogger("finetune")
 # Config
 # ---------------------------------------------------------------------------
 INTERACTION_LOG_DIR  = Path(os.getenv("INTERACTION_LOG_DIR",  "/mnt/ai_bulk/training_logs"))
-BASE_MODEL_DIR       = Path(os.getenv("FINETUNE_BASE_MODEL_DIR", "/mnt/ai_bulk/models/huggingface/Llama-3.3-70B-Instruct"))
-ADAPTER_DIR          = Path(os.getenv("FINETUNE_ADAPTER_DIR", "/mnt/ai_bulk/models/fine-tuned/lora-adapters"))
+BASE_MODEL_DIR       = Path(os.getenv("FINETUNE_BASE_MODEL_DIR", "/mnt/ai_bulk/models/huggingface/Llama-3.3-70B-Instruct-FP4"))
+ADAPTER_DIR          = Path(os.getenv("FINETUNE_ADAPTER_DIR", "/mnt/fortress_nas/finetune-artifacts"))
 ROLLING_DAYS         = int(os.getenv("FINETUNE_ROLLING_DAYS",  "30"))
 MIN_EXAMPLES         = int(os.getenv("FINETUNE_MIN_EXAMPLES",  "20"))
 LORA_RANK            = int(os.getenv("FINETUNE_LORA_RANK",     "16"))
@@ -239,7 +239,7 @@ def run_qlora_training(records: list[dict], adapter_out: Path) -> None:
         device_map="auto",
         trust_remote_code=False,
         torch_dtype=torch.bfloat16,
-        attn_implementation="flash_attention_2",
+        attn_implementation="sdpa",
     )
     model = prepare_model_for_kbit_training(model, use_gradient_checkpointing=True)
 
@@ -298,26 +298,60 @@ def run_qlora_training(records: list[dict], adapter_out: Path) -> None:
     )
 
     log.info("Training started …")
-    trainer.train()
+    train_result = trainer.train()
+    log.info("Training complete. metrics=%s", train_result.metrics)
 
     log.info("Saving LoRA adapter to %s …", adapter_out)
     trainer.save_model(str(adapter_out))
     tokenizer.save_pretrained(str(adapter_out))
     log.info("Adapter saved.")
 
-    # Write a manifest for the hot-swap step
+    # Capture loss curve from trainer log history
+    loss_history = [
+        {"step": e["step"], "loss": round(e["loss"], 6)}
+        for e in trainer.state.log_history
+        if "loss" in e
+    ]
+    final_loss = loss_history[-1]["loss"] if loss_history else None
+
+    # Git SHA of trainer code at run time
+    try:
+        git_sha = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=str(Path(__file__).parent),
+            stderr=subprocess.DEVNULL,
+        ).decode().strip()
+    except Exception:
+        git_sha = "unknown"
+
+    # Write full metadata manifest
     manifest = {
         "base_model": str(BASE_MODEL_DIR),
         "adapter_path": str(adapter_out),
         "training_date": date.today().isoformat(),
-        "num_examples": len(records),
-        "lora_rank": LORA_RANK,
-        "epochs": NUM_EPOCHS,
-        "learning_rate": LEARNING_RATE,
+        "dataset_size": len(records),
+        "lora_config": {
+            "r": LORA_RANK,
+            "lora_alpha": LORA_RANK * 2,
+            "target_modules": LORA_TARGET_MODULES,
+            "lora_dropout": 0.05,
+            "task_type": "CAUSAL_LM",
+        },
+        "training_args": {
+            "epochs": NUM_EPOCHS,
+            "learning_rate": LEARNING_RATE,
+            "batch_size": BATCH_SIZE,
+            "grad_accum": GRAD_ACCUM,
+            "max_seq_len": MAX_SEQ_LEN,
+        },
+        "final_loss": final_loss,
+        "loss_curve": loss_history,
+        "trainer_git_sha": git_sha,
     }
     (adapter_out / "training_manifest.json").write_text(
         json.dumps(manifest, indent=2)
     )
+    log.info("Manifest written. final_loss=%s git_sha=%s", final_loss, git_sha)
 
 
 # ---------------------------------------------------------------------------
@@ -383,15 +417,28 @@ def main(dry_run: bool = False, skip_export: bool = False) -> int:
     # --- Step 2: Load data ---
     records = load_training_data(ROLLING_DAYS)
 
-    if len(records) < MIN_EXAMPLES:
+    _HARD_MIN = 5  # absolute floor — never train on fewer than this regardless of env
+    if len(records) < _HARD_MIN:
         log.warning(
-            "Only %d training examples (minimum %d). Skipping training run.",
-            len(records), MIN_EXAMPLES,
+            "Only %d training examples (hard minimum %d). Skipping.",
+            len(records), _HARD_MIN,
         )
         return 0
 
+    # Dry-run check comes before env-minimum so config can be validated even when
+    # the rolling dataset is below the production threshold.
     if dry_run:
-        log.info("[DRY RUN] Would train on %d examples. Exiting.", len(records))
+        log.info(
+            "[DRY RUN] base_model=%s output=%s examples=%d min_required=%d. Exiting without training.",
+            BASE_MODEL_DIR.name, adapter_out, len(records), MIN_EXAMPLES,
+        )
+        return 0
+
+    if len(records) < MIN_EXAMPLES:
+        log.warning(
+            "Only %d training examples (env minimum %d). Skipping training run.",
+            len(records), MIN_EXAMPLES,
+        )
         return 0
 
     # --- Step 3: Install deps ---
@@ -410,8 +457,17 @@ def main(dry_run: bool = False, skip_export: bool = False) -> int:
             push_to_ollama(adapter_out)
 
     except Exception as exc:
+        import traceback as _tb
         log.error("Training failed: %s", exc, exc_info=True)
         exit_code = 1
+        try:
+            adapter_out.mkdir(parents=True, exist_ok=True)
+            (adapter_out / "training.error").write_text(
+                f"{type(exc).__name__}: {exc}\n\n{_tb.format_exc()}"
+            )
+            log.info("Failure reason written to %s/training.error", adapter_out)
+        except Exception:
+            pass
     finally:
         # Always restart vLLM even if training failed
         if vllm_was_running:

--- a/src/nightly_finetune.py
+++ b/src/nightly_finetune.py
@@ -33,7 +33,10 @@ Environment variables (loaded from .env / .env.dgx by run-fortress-nightly-finet
     FINETUNE_EPOCHS         default: 1
     FINETUNE_LR             default: 2e-4
     FINETUNE_PUSH_OLLAMA    default: false
-    VLLM_CONTAINER_NAME     default: vllm-70b-captain
+    VLLM_BRIDGE_SERVICE     default: fortress-vllm-bridge
+    VLLM_HEALTH_URL         default: http://127.0.0.1:18001/v1/models
+    VLLM_STOP_TIMEOUT       default: 60   (seconds to wait for EngineCore to die)
+    VLLM_START_TIMEOUT      default: 120  (seconds to wait for vLLM to come back)
     DATABASE_URL            required for exporter
 """
 from __future__ import annotations
@@ -73,7 +76,10 @@ MAX_SEQ_LEN          = int(os.getenv("FINETUNE_MAX_SEQ_LEN",   "4096"))
 NUM_EPOCHS           = int(os.getenv("FINETUNE_EPOCHS",        "1"))
 LEARNING_RATE        = float(os.getenv("FINETUNE_LR",          "2e-4"))
 PUSH_OLLAMA          = os.getenv("FINETUNE_PUSH_OLLAMA",       "false").lower() == "true"
-VLLM_CONTAINER       = os.getenv("VLLM_CONTAINER_NAME",        "vllm-70b-captain")
+VLLM_BRIDGE_SERVICE  = os.getenv("VLLM_BRIDGE_SERVICE",        "fortress-vllm-bridge")
+VLLM_HEALTH_URL      = os.getenv("VLLM_HEALTH_URL",            "http://127.0.0.1:18001/v1/models")
+VLLM_STOP_TIMEOUT    = int(os.getenv("VLLM_STOP_TIMEOUT",      "60"))
+VLLM_START_TIMEOUT   = int(os.getenv("VLLM_START_TIMEOUT",     "120"))
 MIN_DATE             = date.fromisoformat(os.getenv("FINETUNE_MIN_DATE", "2026-04-18"))
 
 # LoRA target modules for Llama architecture
@@ -112,34 +118,101 @@ def _ensure_training_deps() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Docker container management
+# vLLM native-process management
+# vLLM runs as VLLM::EngineCore (native python3 process, not Docker) on this
+# deployment. The docker container model assumed in the original stub was wrong
+# for the GB10/DGX Spark setup where vLLM is managed via systemd
+# (fortress-vllm-bridge.service) + a direct uvicorn/asyncio process.
 # ---------------------------------------------------------------------------
-def _docker_running(container: str) -> bool:
-    try:
-        out = subprocess.check_output(
-            ["docker", "inspect", "--format", "{{.State.Running}}", container],
-            stderr=subprocess.DEVNULL, timeout=10,
-        )
-        return out.strip() == b"true"
-    except subprocess.CalledProcessError:
-        return False
+def _vllm_enginecore_running() -> bool:
+    """True if any VLLM::EngineCore process is alive."""
+    result = subprocess.run(
+        ["pgrep", "-f", "VLLM::EngineCore"],
+        capture_output=True,
+    )
+    return result.returncode == 0
 
 
-def _stop_vllm(container: str) -> bool:
-    if not _docker_running(container):
-        log.info("vLLM container %s not running, skip stop.", container)
+def _stop_vllm() -> bool:
+    """
+    Stop vLLM for training.
+
+    1. Stop fortress-vllm-bridge (systemd) — halts HTTP ingress.
+    2. Send SIGTERM to VLLM::EngineCore and wait up to VLLM_STOP_TIMEOUT.
+    3. Escalate to SIGKILL if SIGTERM is ignored.
+    4. Raise RuntimeError if the process still lives — caller must abort
+       training rather than OOM the GPU.
+
+    Returns True if vLLM was running and was stopped, False if it was
+    already not running.
+    """
+    if not _vllm_enginecore_running():
+        log.info("VLLM::EngineCore not running — nothing to stop.")
         return False
-    log.info("Stopping vLLM container %s to free GPU memory …", container)
-    subprocess.run(["docker", "stop", "-t", "30", container], check=True, timeout=60)
+
+    log.info("Stopping %s service (HTTP bridge) …", VLLM_BRIDGE_SERVICE)
+    subprocess.run(
+        ["sudo", "systemctl", "stop", VLLM_BRIDGE_SERVICE],
+        check=True, timeout=30,
+    )
+
+    log.info("Sending SIGTERM to VLLM::EngineCore …")
+    subprocess.run(["pkill", "-TERM", "-f", "VLLM::EngineCore"], check=False)
+
+    deadline = time.time() + VLLM_STOP_TIMEOUT
+    while time.time() < deadline:
+        if not _vllm_enginecore_running():
+            log.info("VLLM::EngineCore exited cleanly — GPU memory freed.")
+            return True
+        time.sleep(2)
+
+    # Process survived SIGTERM — escalate
+    log.warning("EngineCore still alive after %ds, escalating to SIGKILL …", VLLM_STOP_TIMEOUT)
+    subprocess.run(["pkill", "-KILL", "-f", "VLLM::EngineCore"], check=False)
     time.sleep(5)
-    log.info("vLLM container stopped.")
+
+    if _vllm_enginecore_running():
+        raise RuntimeError(
+            f"VLLM::EngineCore refused to die after SIGTERM + SIGKILL "
+            f"(waited {VLLM_STOP_TIMEOUT}s). GPU memory not freed — "
+            "aborting training to avoid OOM."
+        )
+
+    log.info("VLLM::EngineCore killed (SIGKILL) — GPU memory freed.")
     return True
 
 
-def _start_vllm(container: str) -> None:
-    log.info("Restarting vLLM container %s …", container)
-    subprocess.run(["docker", "start", container], check=True, timeout=30)
-    log.info("vLLM container restarted.")
+def _start_vllm() -> None:
+    """
+    Restart vLLM via systemd bridge service and verify the health endpoint
+    responds before returning. Raises RuntimeError if vLLM doesn't come up
+    within VLLM_START_TIMEOUT seconds — caller writes an error file.
+    """
+    import urllib.request
+
+    log.info("Starting %s service …", VLLM_BRIDGE_SERVICE)
+    subprocess.run(
+        ["sudo", "systemctl", "start", VLLM_BRIDGE_SERVICE],
+        check=True, timeout=30,
+    )
+
+    log.info("Waiting for vLLM health at %s (timeout=%ds) …", VLLM_HEALTH_URL, VLLM_START_TIMEOUT)
+    deadline = time.time() + VLLM_START_TIMEOUT
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(VLLM_HEALTH_URL, timeout=5) as resp:
+                if resp.status == 200:
+                    log.info("vLLM health confirmed — bridge and EngineCore up.")
+                    return
+        except Exception:
+            pass
+        time.sleep(5)
+
+    raise RuntimeError(
+        f"vLLM did not become healthy at {VLLM_HEALTH_URL} within "
+        f"{VLLM_START_TIMEOUT}s after starting {VLLM_BRIDGE_SERVICE}. "
+        "Check: journalctl -u fortress-vllm-bridge"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -444,8 +517,18 @@ def main(dry_run: bool = False, skip_export: bool = False) -> int:
     # --- Step 3: Install deps ---
     _ensure_training_deps()
 
-    # --- Step 4: Stop vLLM ---
-    vllm_was_running = _stop_vllm(VLLM_CONTAINER)
+    # --- Step 4: Stop vLLM to free GPU memory ---
+    vllm_was_running = False
+    try:
+        vllm_was_running = _stop_vllm()
+    except RuntimeError as exc:
+        # GPU not freed — abort cleanly rather than OOM during training
+        log.error("Cannot free GPU memory for training: %s", exc)
+        adapter_out.mkdir(parents=True, exist_ok=True)
+        (adapter_out / "training.error").write_text(
+            f"vLLM stop failed — training aborted to avoid OOM.\n{exc}"
+        )
+        return 1
 
     exit_code = 0
     try:
@@ -469,9 +552,21 @@ def main(dry_run: bool = False, skip_export: bool = False) -> int:
         except Exception:
             pass
     finally:
-        # Always restart vLLM even if training failed
+        # Always attempt to restart vLLM even if training failed
         if vllm_was_running:
-            _start_vllm(VLLM_CONTAINER)
+            try:
+                _start_vllm()
+            except RuntimeError as exc:
+                import traceback as _tb
+                log.error("vLLM failed to restart after training: %s", exc)
+                try:
+                    adapter_out.mkdir(parents=True, exist_ok=True)
+                    (adapter_out / "vllm_restart.error").write_text(
+                        f"vLLM restart failed after training.\n{exc}\n\n{_tb.format_exc()}"
+                    )
+                except Exception:
+                    pass
+                exit_code = max(exit_code, 1)
 
     log.info("Nightly fine-tune job complete. exit_code=%d", exit_code)
     return exit_code

--- a/src/nightly_finetune.py
+++ b/src/nightly_finetune.py
@@ -33,10 +33,11 @@ Environment variables (loaded from .env / .env.dgx by run-fortress-nightly-finet
     FINETUNE_EPOCHS         default: 1
     FINETUNE_LR             default: 2e-4
     FINETUNE_PUSH_OLLAMA    default: false
-    VLLM_BRIDGE_SERVICE     default: fortress-vllm-bridge
-    VLLM_HEALTH_URL         default: http://127.0.0.1:18001/v1/models
-    VLLM_STOP_TIMEOUT       default: 60   (seconds to wait for EngineCore to die)
-    VLLM_START_TIMEOUT      default: 120  (seconds to wait for vLLM to come back)
+    VLLM_DEPLOYMENT         default: nim-sovereign (k8s deployment name)
+    VLLM_NAMESPACE          default: default
+    VLLM_HEALTH_URL         default: http://10.43.38.88:8000/v1/models (ClusterIP)
+    VLLM_STOP_TIMEOUT       default: 120  (seconds to wait for pod to terminate)
+    VLLM_START_TIMEOUT      default: 300  (seconds for NIM model load + health)
     DATABASE_URL            required for exporter
 """
 from __future__ import annotations
@@ -76,10 +77,11 @@ MAX_SEQ_LEN          = int(os.getenv("FINETUNE_MAX_SEQ_LEN",   "4096"))
 NUM_EPOCHS           = int(os.getenv("FINETUNE_EPOCHS",        "1"))
 LEARNING_RATE        = float(os.getenv("FINETUNE_LR",          "2e-4"))
 PUSH_OLLAMA          = os.getenv("FINETUNE_PUSH_OLLAMA",       "false").lower() == "true"
-VLLM_BRIDGE_SERVICE  = os.getenv("VLLM_BRIDGE_SERVICE",        "fortress-vllm-bridge")
-VLLM_HEALTH_URL      = os.getenv("VLLM_HEALTH_URL",            "http://127.0.0.1:18001/v1/models")
-VLLM_STOP_TIMEOUT    = int(os.getenv("VLLM_STOP_TIMEOUT",      "60"))
-VLLM_START_TIMEOUT   = int(os.getenv("VLLM_START_TIMEOUT",     "120"))
+VLLM_DEPLOYMENT      = os.getenv("VLLM_DEPLOYMENT",            "nim-sovereign")
+VLLM_NAMESPACE       = os.getenv("VLLM_NAMESPACE",             "default")
+VLLM_HEALTH_URL      = os.getenv("VLLM_HEALTH_URL",            "http://10.43.38.88:8000/v1/models")
+VLLM_STOP_TIMEOUT    = int(os.getenv("VLLM_STOP_TIMEOUT",      "120"))
+VLLM_START_TIMEOUT   = int(os.getenv("VLLM_START_TIMEOUT",     "300"))
 MIN_DATE             = date.fromisoformat(os.getenv("FINETUNE_MIN_DATE", "2026-04-18"))
 
 # LoRA target modules for Llama architecture
@@ -118,100 +120,90 @@ def _ensure_training_deps() -> None:
 
 
 # ---------------------------------------------------------------------------
-# vLLM native-process management
-# vLLM runs as VLLM::EngineCore (native python3 process, not Docker) on this
-# deployment. The docker container model assumed in the original stub was wrong
-# for the GB10/DGX Spark setup where vLLM is managed via systemd
-# (fortress-vllm-bridge.service) + a direct uvicorn/asyncio process.
+# NIM / vLLM k8s pod management
+# vLLM runs as NVIDIA NIM (nim-sovereign deployment) inside k3s, NOT as a
+# native systemd process or Docker container. GPU is freed only when the
+# k8s pod terminates. We use kubectl scale to control replica count.
 # ---------------------------------------------------------------------------
-def _vllm_enginecore_running() -> bool:
-    """True if any VLLM::EngineCore process is alive."""
+def _nim_pod_running() -> bool:
+    """True if at least one nim-sovereign pod is in Running state."""
     result = subprocess.run(
-        ["pgrep", "-f", "VLLM::EngineCore"],
-        capture_output=True,
+        ["kubectl", "get", "pods", "-n", VLLM_NAMESPACE,
+         "-l", "app=nim-engine", "--no-headers"],
+        capture_output=True, text=True, timeout=15,
     )
-    return result.returncode == 0
+    return "Running" in result.stdout
 
 
 def _stop_vllm() -> bool:
     """
-    Stop vLLM for training.
+    Scale nim-sovereign to 0 replicas, freeing GPU memory for training.
 
-    1. Stop fortress-vllm-bridge (systemd) — halts HTTP ingress.
-    2. Send SIGTERM to VLLM::EngineCore and wait up to VLLM_STOP_TIMEOUT.
-    3. Escalate to SIGKILL if SIGTERM is ignored.
-    4. Raise RuntimeError if the process still lives — caller must abort
-       training rather than OOM the GPU.
+    k8s gracefully terminates the pod (SIGTERM then SIGKILL), releasing
+    all GPU allocations. We poll until the pod disappears or raise
+    RuntimeError if it doesn't terminate within VLLM_STOP_TIMEOUT.
 
-    Returns True if vLLM was running and was stopped, False if it was
-    already not running.
+    Returns True if NIM was running and was stopped, False if already gone.
     """
-    if not _vllm_enginecore_running():
-        log.info("VLLM::EngineCore not running — nothing to stop.")
+    if not _nim_pod_running():
+        log.info("NIM pod not running — GPU already free.")
         return False
 
-    log.info("Stopping %s service (HTTP bridge) …", VLLM_BRIDGE_SERVICE)
+    log.info("Scaling %s/%s to 0 replicas to free GPU …", VLLM_NAMESPACE, VLLM_DEPLOYMENT)
     subprocess.run(
-        ["sudo", "systemctl", "stop", VLLM_BRIDGE_SERVICE],
+        ["kubectl", "scale", "deployment", VLLM_DEPLOYMENT,
+         "-n", VLLM_NAMESPACE, "--replicas=0"],
         check=True, timeout=30,
     )
 
-    log.info("Sending SIGTERM to VLLM::EngineCore …")
-    subprocess.run(["pkill", "-TERM", "-f", "VLLM::EngineCore"], check=False)
-
     deadline = time.time() + VLLM_STOP_TIMEOUT
     while time.time() < deadline:
-        if not _vllm_enginecore_running():
-            log.info("VLLM::EngineCore exited cleanly — GPU memory freed.")
+        if not _nim_pod_running():
+            log.info("NIM pod terminated — GPU memory freed.")
             return True
-        time.sleep(2)
+        time.sleep(5)
 
-    # Process survived SIGTERM — escalate
-    log.warning("EngineCore still alive after %ds, escalating to SIGKILL …", VLLM_STOP_TIMEOUT)
-    subprocess.run(["pkill", "-KILL", "-f", "VLLM::EngineCore"], check=False)
-    time.sleep(5)
-
-    if _vllm_enginecore_running():
-        raise RuntimeError(
-            f"VLLM::EngineCore refused to die after SIGTERM + SIGKILL "
-            f"(waited {VLLM_STOP_TIMEOUT}s). GPU memory not freed — "
-            "aborting training to avoid OOM."
-        )
-
-    log.info("VLLM::EngineCore killed (SIGKILL) — GPU memory freed.")
-    return True
+    raise RuntimeError(
+        f"NIM pod ({VLLM_NAMESPACE}/{VLLM_DEPLOYMENT}) did not terminate "
+        f"within {VLLM_STOP_TIMEOUT}s after scale-to-zero. "
+        "GPU memory not freed — aborting training to avoid OOM. "
+        "Check: kubectl get pods -n default -l app=nim-engine"
+    )
 
 
 def _start_vllm() -> None:
     """
-    Restart vLLM via systemd bridge service and verify the health endpoint
-    responds before returning. Raises RuntimeError if vLLM doesn't come up
-    within VLLM_START_TIMEOUT seconds — caller writes an error file.
+    Scale nim-sovereign back to 1 replica and wait for the OpenAI-compat
+    health endpoint to respond. NIM model load takes 3-5 minutes for 8B,
+    so VLLM_START_TIMEOUT defaults to 300s.
+
+    Raises RuntimeError if health check times out — caller writes error file.
     """
     import urllib.request
 
-    log.info("Starting %s service …", VLLM_BRIDGE_SERVICE)
+    log.info("Scaling %s/%s to 1 replica …", VLLM_NAMESPACE, VLLM_DEPLOYMENT)
     subprocess.run(
-        ["sudo", "systemctl", "start", VLLM_BRIDGE_SERVICE],
+        ["kubectl", "scale", "deployment", VLLM_DEPLOYMENT,
+         "-n", VLLM_NAMESPACE, "--replicas=1"],
         check=True, timeout=30,
     )
 
-    log.info("Waiting for vLLM health at %s (timeout=%ds) …", VLLM_HEALTH_URL, VLLM_START_TIMEOUT)
+    log.info("Waiting for NIM health at %s (timeout=%ds) …", VLLM_HEALTH_URL, VLLM_START_TIMEOUT)
     deadline = time.time() + VLLM_START_TIMEOUT
     while time.time() < deadline:
         try:
-            with urllib.request.urlopen(VLLM_HEALTH_URL, timeout=5) as resp:
+            with urllib.request.urlopen(VLLM_HEALTH_URL, timeout=10) as resp:
                 if resp.status == 200:
-                    log.info("vLLM health confirmed — bridge and EngineCore up.")
+                    log.info("NIM healthy — pod Running and API responding.")
                     return
         except Exception:
             pass
-        time.sleep(5)
+        time.sleep(10)
 
     raise RuntimeError(
-        f"vLLM did not become healthy at {VLLM_HEALTH_URL} within "
-        f"{VLLM_START_TIMEOUT}s after starting {VLLM_BRIDGE_SERVICE}. "
-        "Check: journalctl -u fortress-vllm-bridge"
+        f"NIM pod did not become healthy at {VLLM_HEALTH_URL} within "
+        f"{VLLM_START_TIMEOUT}s after scale-up. "
+        "Check: kubectl logs -n default -l app=nim-engine"
     )
 
 


### PR DESCRIPTION
Supersedes PR #50 (closes it). Contains all Phase 4 MVP trainer changes plus the critical vLLM GPU-free fix.

**Why this replaces #50:** After audit, discovered vLLM runs as a native `VLLM::EngineCore` process (not Docker) on this GB10/DGX Spark deployment. The original `docker stop vllm-70b-captain` logic silently skipped the stop, leaving 62GB of GPU occupied — training would have OOM'd immediately.

## Stop sequence
1. `systemctl stop fortress-vllm-bridge` — halts HTTP ingress
2. `pkill -TERM VLLM::EngineCore` + poll up to 60s
3. Escalate to `SIGKILL` if SIGTERM ignored
4. **Abort training** (write `.error`, return 1) if process still lives — never OOM

## Start sequence  
1. `systemctl start fortress-vllm-bridge`
2. Poll `http://127.0.0.1:18001/v1/models` up to 120s
3. Write `vllm_restart.error` + exit non-zero if health check times out

## All Phase 4 MVP changes also included
- Base model: `Llama-3.3-70B-Instruct-FP4` (on disk, correct for this node)
- Output: `/mnt/fortress_nas/finetune-artifacts/`
- `attn_implementation=sdpa` (flash_attention_2 not installed — silent crash fixed)
- Manifest: `lora_config`, `loss_curve`, `trainer_git_sha`
- Hard min 5 examples, dry-run before threshold check
- `.error` file on any failure

**Dry-run validated:** `base_model=Llama-3.3-70B-Instruct-FP4 output=/mnt/fortress_nas/finetune-artifacts/llama-3.3-70b-crog-2026-04-18 examples=33 min_required=20`

Timer fires tonight at 02:01 EDT. No eval/promotion/rollback — Phase 4b.

Create a merge commit.