### PR TITLE
feat(phase-4b): eval harness — holdout, metrics, promotion gate

### DIFF
--- a/fortress-guest-platform/.env.example
+++ b/fortress-guest-platform/.env.example
@@ -92,3 +92,15 @@ TEST_DATABASE_URL=postgresql://fortress_api:fortress@127.0.0.1:5432/fortress_sha
 # reappear in the training_logs directory.
 # ---------------------------------------------------------------------------
 FINETUNE_MIN_DATE=2026-04-18
+
+# ---------------------------------------------------------------------------
+# Phase 4b — Eval harness
+# ---------------------------------------------------------------------------
+EVAL_HOLDOUT_DAYS=7              # days of captures to sample holdout from
+EVAL_HOLDOUT_SIZE=50             # max holdout rows per domain
+EVAL_SIMILARITY_THRESHOLD=0.85  # minimum cosine similarity (MiniLM-L6-v2)
+EVAL_VALIDITY_THRESHOLD=0.95    # minimum fraction of valid responses
+EVAL_MIN_PROMPTS_PER_DOMAIN=30  # below this: gate warns but doesn't hard-block
+EVAL_BLOCKER_DOMAINS=legal,vrs  # regressions in these domains block promotion
+EVAL_EMBEDDING_MODEL=all-MiniLM-L6-v2
+HOLDOUT_DIR=/mnt/fortress_nas/finetune-artifacts/holdouts

--- a/fortress-guest-platform/backend/alembic/versions/633f8f8bc383_add_eval_holdout_columns.py
+++ b/fortress-guest-platform/backend/alembic/versions/633f8f8bc383_add_eval_holdout_columns.py
@@ -1,0 +1,46 @@
+"""add eval_holdout columns to capture tables
+
+Revision ID: 633f8f8bc383
+Revises: 4bc59a1ee4df
+Create Date: 2026-04-18
+
+Adds eval_holdout boolean to llm_training_captures and restricted_captures.
+Rows marked True are held out from the training export and used only for
+nightly eval (Phase 4b). Default False — existing rows stay in training.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "633f8f8bc383"
+down_revision = "4bc59a1ee4df"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "llm_training_captures",
+        sa.Column("eval_holdout", sa.Boolean, nullable=False, server_default="false"),
+    )
+    op.create_index(
+        "idx_llm_training_captures_eval_holdout",
+        "llm_training_captures",
+        ["eval_holdout"],
+    )
+
+    op.add_column(
+        "restricted_captures",
+        sa.Column("eval_holdout", sa.Boolean, nullable=False, server_default="false"),
+    )
+    op.create_index(
+        "idx_restricted_captures_eval_holdout",
+        "restricted_captures",
+        ["eval_holdout"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_restricted_captures_eval_holdout", table_name="restricted_captures")
+    op.drop_column("restricted_captures", "eval_holdout")
+    op.drop_index("idx_llm_training_captures_eval_holdout", table_name="llm_training_captures")
+    op.drop_column("llm_training_captures", "eval_holdout")

--- a/fortress-guest-platform/backend/workers/nightly_distillation_exporter.py
+++ b/fortress-guest-platform/backend/workers/nightly_distillation_exporter.py
@@ -198,6 +198,7 @@ async def run_distillation_export(
                    user_prompt, assistant_resp, created_at
             FROM   llm_training_captures
             WHERE  status = 'pending'
+              AND  (eval_holdout IS NULL OR eval_holdout = FALSE)
             ORDER  BY created_at ASC
             LIMIT  :lim
         """), {"lim": batch_size})

--- a/src/eval/__init__.py
+++ b/src/eval/__init__.py
@@ -1,0 +1,1 @@
+"""Fortress Prime — Phase 4b eval harness."""

--- a/src/eval/build_holdout.py
+++ b/src/eval/build_holdout.py
@@ -1,0 +1,178 @@
+"""
+build_holdout.py — sample eval holdout rows from llm_training_captures.
+
+Pulls last 7 days of captures, samples up to HOLDOUT_SIZE_PER_DOMAIN rows per
+domain, marks them eval_holdout=True so the exporter skips them, and writes a
+manifest JSON to HOLDOUT_DIR for run_eval.py to consume.
+
+Domain detection via source_module prefix patterns:
+  legal    → source_module starts with 'legal_'
+  vrs      → source_module contains 'vrs' or 'concierge' or 'reservation'
+  pricing  → source_module in (quote_engine, pricing_engine, rate_*)
+  macro    → source_module in (macro_treasury, ota_vision_recon, market_*)
+
+Usage:
+  python build_holdout.py [--dry-run] [--date YYYY-MM-DD]
+
+  --dry-run : validate config and query counts without marking rows or writing files
+  --date    : override today's date (for testing)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import random
+import sys
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import psycopg2
+from psycopg2.extras import RealDictCursor
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='{"time":"%(asctime)s","level":"%(levelname)s","msg":"%(message)s","svc":"build_holdout"}',
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+log = logging.getLogger("build_holdout")
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+DB_URI              = os.getenv("POSTGRES_ADMIN_URI",
+                        "postgresql://fortress_admin:fortress@127.0.0.1:5432/fortress_shadow"
+                      ).replace("+asyncpg", "")
+HOLDOUT_DIR         = Path(os.getenv("HOLDOUT_DIR",
+                        "/mnt/fortress_nas/finetune-artifacts/holdouts"))
+HOLDOUT_DAYS        = int(os.getenv("EVAL_HOLDOUT_DAYS",   "7"))
+HOLDOUT_PER_DOMAIN  = int(os.getenv("EVAL_HOLDOUT_SIZE",   "50"))
+
+DOMAIN_PATTERNS: dict[str, list[str]] = {
+    "legal":   ["legal_"],
+    "vrs":     ["vrs_", "concierge", "reservation"],
+    "pricing": ["quote_engine", "pricing_engine", "rate_"],
+    "macro":   ["macro_treasury", "ota_vision_recon", "market_"],
+}
+
+
+def detect_domain(source_module: str) -> str:
+    sm = source_module.lower()
+    for domain, patterns in DOMAIN_PATTERNS.items():
+        if any(p in sm for p in patterns):
+            return domain
+    return "other"
+
+
+def build_holdout(today: date, dry_run: bool) -> dict:
+    cutoff = today - timedelta(days=HOLDOUT_DAYS)
+    log.info("Sampling holdout from last %d days (since %s)", HOLDOUT_DAYS, cutoff.isoformat())
+
+    conn = psycopg2.connect(DB_URI)
+    conn.autocommit = False
+    cur = conn.cursor(cursor_factory=RealDictCursor)
+
+    try:
+        cur.execute("""
+            SELECT id, source_module, model_used, user_prompt, assistant_resp, created_at
+            FROM llm_training_captures
+            WHERE created_at >= %s
+              AND (eval_holdout IS NULL OR eval_holdout = FALSE)
+              AND status = 'exported'
+        """, (cutoff,))
+        rows = cur.fetchall()
+        log.info("Found %d eligible rows in window", len(rows))
+
+        # Group by domain
+        by_domain: dict[str, list] = {d: [] for d in DOMAIN_PATTERNS}
+        by_domain["other"] = []
+        for row in rows:
+            d = detect_domain(row["source_module"])
+            by_domain[d].append(row)
+
+        # Sample per domain
+        holdout_ids: list[str] = []
+        holdout_records: list[dict] = []
+        domain_counts: dict[str, int] = {}
+
+        for domain, domain_rows in by_domain.items():
+            if not domain_rows:
+                log.info("Domain %s: 0 eligible rows — skipping", domain)
+                domain_counts[domain] = 0
+                continue
+            sample_size = min(len(domain_rows), HOLDOUT_PER_DOMAIN)
+            sampled = random.sample(domain_rows, sample_size)
+            domain_counts[domain] = sample_size
+            log.info("Domain %s: %d/%d sampled", domain, sample_size, len(domain_rows))
+            for row in sampled:
+                holdout_ids.append(str(row["id"]))
+                holdout_records.append({
+                    "id": str(row["id"]),
+                    "domain": domain,
+                    "source_module": row["source_module"],
+                    "model_used": row["model_used"],
+                    "user_prompt": row["user_prompt"],
+                    "teacher_response": row["assistant_resp"],
+                    "created_at": row["created_at"].isoformat() if row["created_at"] else None,
+                })
+
+        manifest = {
+            "holdout_date": today.isoformat(),
+            "built_at": datetime.now(tz=timezone.utc).isoformat(),
+            "holdout_days": HOLDOUT_DAYS,
+            "holdout_per_domain": HOLDOUT_PER_DOMAIN,
+            "total_holdout": len(holdout_records),
+            "domain_counts": domain_counts,
+            "records": holdout_records,
+        }
+
+        if dry_run:
+            log.info("[DRY RUN] Would mark %d rows as eval_holdout=True", len(holdout_ids))
+            log.info("[DRY RUN] Would write manifest to %s", HOLDOUT_DIR / f"holdout-{today.isoformat()}.json")
+            log.info("[DRY RUN] domain_counts=%s", domain_counts)
+            conn.rollback()
+            return manifest
+
+        if holdout_ids:
+            cur.execute(
+                "UPDATE llm_training_captures SET eval_holdout = TRUE WHERE id::text = ANY(%s)",
+                (holdout_ids,)
+            )
+            log.info("Marked %d rows eval_holdout=True", cur.rowcount)
+
+        HOLDOUT_DIR.mkdir(parents=True, exist_ok=True)
+        manifest_path = HOLDOUT_DIR / f"holdout-{today.isoformat()}.json"
+        manifest_path.write_text(json.dumps(manifest, indent=2))
+        log.info("Manifest written to %s (%d records)", manifest_path, len(holdout_records))
+
+        conn.commit()
+        return manifest
+
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        cur.close()
+        conn.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build eval holdout set")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Count and plan without marking rows or writing files")
+    parser.add_argument("--date", default=None,
+                        help="Override today's date (YYYY-MM-DD)")
+    args = parser.parse_args()
+
+    today = date.fromisoformat(args.date) if args.date else date.today()
+    log.info("build_holdout starting date=%s dry_run=%s", today, args.dry_run)
+
+    manifest = build_holdout(today, args.dry_run)
+    log.info("Complete. total_holdout=%d domain_counts=%s",
+             manifest["total_holdout"], manifest["domain_counts"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/eval/promotion_gate.py
+++ b/src/eval/promotion_gate.py
@@ -1,0 +1,173 @@
+"""
+promotion_gate.py — apply the promotion gate to a metrics.json.
+
+Reads metrics.json from the adapter directory, applies conservative
+thresholds, and writes either:
+  promotion_candidate.json  — all gates passed
+  promotion_rejected.json   — one or more gates failed (with reason)
+
+Also writes a PROMOTED_CANDIDATE sentinel file at ARTIFACTS_ROOT if
+the candidate passes — this is a flag only. Phase 4c handles actual routing.
+
+Usage:
+  python promotion_gate.py --adapter-path /mnt/fortress_nas/finetune-artifacts/.../
+                           [--dry-run]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='{"time":"%(asctime)s","level":"%(levelname)s","msg":"%(message)s","svc":"promotion_gate"}',
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+log = logging.getLogger("promotion_gate")
+
+# ---------------------------------------------------------------------------
+# Thresholds (all env-var overridable)
+# ---------------------------------------------------------------------------
+SIMILARITY_THRESHOLD    = float(os.getenv("EVAL_SIMILARITY_THRESHOLD",   "0.85"))
+VALIDITY_THRESHOLD      = float(os.getenv("EVAL_VALIDITY_THRESHOLD",     "0.95"))
+MIN_PROMPTS_PER_DOMAIN  = int(os.getenv("EVAL_MIN_PROMPTS_PER_DOMAIN",   "30"))
+BLOCKER_DOMAINS         = set(os.getenv("EVAL_BLOCKER_DOMAINS",
+                              "legal,vrs").split(","))
+
+ARTIFACTS_ROOT = Path(os.getenv("FINETUNE_ADAPTER_DIR",
+                      "/mnt/fortress_nas/finetune-artifacts"))
+
+
+def apply_gate(adapter_path: Path, dry_run: bool) -> bool:
+    metrics_path = adapter_path / "metrics.json"
+    if not metrics_path.exists():
+        log.error("metrics.json not found at %s — eval must run first", metrics_path)
+        return False
+
+    metrics = json.loads(metrics_path.read_text())
+    log.info("Loaded metrics: n=%d sim=%.4f validity=%.4f regressions=%d",
+             metrics.get("n_evaluated", 0),
+             metrics.get("similarity_mean") or 0,
+             metrics.get("validity_rate") or 0,
+             metrics.get("regression_count", 0))
+
+    failures: list[dict] = []
+
+    # Gate 1: similarity
+    sim = metrics.get("similarity_mean")
+    if sim is None:
+        failures.append({"gate": "similarity", "reason": "no similarity data"})
+    elif sim < SIMILARITY_THRESHOLD:
+        failures.append({
+            "gate": "similarity",
+            "actual": sim,
+            "threshold": SIMILARITY_THRESHOLD,
+            "reason": f"similarity_mean {sim:.4f} < {SIMILARITY_THRESHOLD}",
+        })
+
+    # Gate 2: validity
+    val = metrics.get("validity_rate")
+    if val is None:
+        failures.append({"gate": "validity", "reason": "no validity data"})
+    elif val < VALIDITY_THRESHOLD:
+        failures.append({
+            "gate": "validity",
+            "actual": val,
+            "threshold": VALIDITY_THRESHOLD,
+            "reason": f"validity_rate {val:.4f} < {VALIDITY_THRESHOLD}",
+        })
+
+    # Gate 3: regressions in blocker domains
+    domain_regressions = metrics.get("domain_regressions", {})
+    for domain in BLOCKER_DOMAINS:
+        count = domain_regressions.get(domain, 0)
+        if count > 0:
+            failures.append({
+                "gate": "regressions",
+                "domain": domain,
+                "regression_count": count,
+                "reason": f"{count} regression(s) in blocker domain '{domain}'",
+            })
+
+    # Gate 4: minimum prompts per domain (warn only, not a hard block)
+    domain_counts = metrics.get("domain_counts", {})
+    for domain in BLOCKER_DOMAINS:
+        n = domain_counts.get(domain, 0)
+        if 0 < n < MIN_PROMPTS_PER_DOMAIN:
+            log.warning(
+                "Domain '%s' has only %d holdout prompts (min=%d) — "
+                "regression gate has limited power for this domain",
+                domain, n, MIN_PROMPTS_PER_DOMAIN,
+            )
+
+    passed = len(failures) == 0
+    result = {
+        "evaluated_at": datetime.now(tz=timezone.utc).isoformat(),
+        "adapter_path": str(adapter_path),
+        "passed": passed,
+        "thresholds": {
+            "similarity": SIMILARITY_THRESHOLD,
+            "validity": VALIDITY_THRESHOLD,
+            "min_prompts_per_domain": MIN_PROMPTS_PER_DOMAIN,
+            "blocker_domains": list(BLOCKER_DOMAINS),
+        },
+        "metrics_summary": {
+            "similarity_mean": metrics.get("similarity_mean"),
+            "validity_rate": metrics.get("validity_rate"),
+            "regression_count": metrics.get("regression_count"),
+            "domain_regressions": domain_regressions,
+            "n_evaluated": metrics.get("n_evaluated"),
+        },
+        "failures": failures,
+    }
+
+    if dry_run:
+        log.info("[DRY RUN] gate_result=passed=%s failures=%s", passed, failures)
+        return passed
+
+    if passed:
+        out_path = adapter_path / "promotion_candidate.json"
+        out_path.write_text(json.dumps(result, indent=2))
+        log.info("PROMOTED CANDIDATE — all gates passed. Written to %s", out_path)
+
+        # Write sentinel at artifacts root — Phase 4c reads this
+        sentinel = ARTIFACTS_ROOT / "PROMOTED_CANDIDATE"
+        sentinel.write_text(json.dumps({
+            "adapter_path": str(adapter_path),
+            "promoted_at": result["evaluated_at"],
+        }, indent=2))
+        log.info("Sentinel written to %s", sentinel)
+    else:
+        out_path = adapter_path / "promotion_rejected.json"
+        out_path.write_text(json.dumps(result, indent=2))
+        log.warning("PROMOTION REJECTED — %d gate(s) failed:", len(failures))
+        for f in failures:
+            log.warning("  ✗ %s", f["reason"])
+
+    return passed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Apply promotion gate to eval metrics")
+    parser.add_argument("--adapter-path", required=True,
+                        help="Path to the trained LoRA adapter directory")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Evaluate gate logic without writing output files")
+    args = parser.parse_args()
+
+    adapter_path = Path(args.adapter_path)
+    if not (adapter_path / "metrics.json").exists():
+        log.error("metrics.json not found at %s", adapter_path)
+        return 1
+
+    passed = apply_gate(adapter_path, args.dry_run)
+    return 0 if passed else 2  # exit 2 = rejected (not an error, just not promoted)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/eval/run_eval.py
+++ b/src/eval/run_eval.py
@@ -1,0 +1,222 @@
+"""
+run_eval.py — run the newly-trained LoRA adapter against the holdout set.
+
+Loads adapter via peft + transformers (4-bit NF4, same config as training),
+runs each holdout prompt through it, computes three metrics:
+
+  response_similarity  cosine similarity (MiniLM-L6-v2) vs teacher output
+  response_validity    non-empty, not gibberish, length in [1x, 10x] teacher
+  regressions          prompts where new model FAILS and teacher was valid
+
+Writes metrics.json alongside the adapter.
+
+Usage:
+  python run_eval.py --adapter-path /mnt/fortress_nas/finetune-artifacts/.../
+                     --holdout-path /mnt/fortress_nas/finetune-artifacts/holdouts/holdout-<date>.json
+                     [--dry-run]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='{"time":"%(asctime)s","level":"%(levelname)s","msg":"%(message)s","svc":"run_eval"}',
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+log = logging.getLogger("run_eval")
+
+BASE_MODEL_DIR = Path(os.getenv("FINETUNE_BASE_MODEL_DIR",
+                    "/mnt/ai_bulk/models/huggingface/Llama-3.3-70B-Instruct-FP4"))
+EMBEDDING_MODEL = os.getenv("EVAL_EMBEDDING_MODEL", "all-MiniLM-L6-v2")
+MAX_NEW_TOKENS  = int(os.getenv("EVAL_MAX_NEW_TOKENS", "512"))
+
+# ---------------------------------------------------------------------------
+# Validity checks
+# ---------------------------------------------------------------------------
+_REPEATED_TOKEN_RE = re.compile(r"(.{2,}?)\1{10,}")
+
+
+def _is_valid_response(text: str, teacher_text: str) -> bool:
+    if not text or not text.strip():
+        return False
+    t_len = max(len(teacher_text), 1)
+    r_len = len(text)
+    if r_len < t_len * 0.1 or r_len > t_len * 10:
+        return False
+    special = sum(1 for c in text if not c.isalnum() and not c.isspace())
+    if special / max(len(text), 1) > 0.5:
+        return False
+    if _REPEATED_TOKEN_RE.search(text):
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Eval core
+# ---------------------------------------------------------------------------
+def run_eval(adapter_path: Path, holdout_path: Path, dry_run: bool) -> dict:
+    log.info("Loading holdout manifest from %s", holdout_path)
+    manifest = json.loads(holdout_path.read_text())
+    records = manifest["records"]
+    log.info("Holdout: %d records across domains %s",
+             len(records), list(manifest["domain_counts"].keys()))
+
+    if dry_run:
+        log.info("[DRY RUN] Would load adapter from %s", adapter_path)
+        log.info("[DRY RUN] Would evaluate %d prompts", len(records))
+        log.info("[DRY RUN] Embedding model: %s", EMBEDDING_MODEL)
+        return {"dry_run": True, "records": len(records)}
+
+    if not records:
+        log.warning("No holdout records — nothing to eval")
+        return {"similarity_mean": None, "validity_rate": None,
+                "regression_count": 0, "domain_regressions": {}, "n_evaluated": 0}
+
+    # --- Load embedding model (CPU, small) ---
+    log.info("Loading embedding model %s …", EMBEDDING_MODEL)
+    from sentence_transformers import SentenceTransformer
+    embedder = SentenceTransformer(EMBEDDING_MODEL, device="cpu")
+
+    # --- Load LoRA adapter ---
+    log.info("Loading base model %s in 4-bit NF4 …", BASE_MODEL_DIR)
+    import torch
+    from peft import AutoPeftModelForCausalLM
+    from transformers import AutoTokenizer, BitsAndBytesConfig
+
+    bnb = BitsAndBytesConfig(
+        load_in_4bit=True,
+        bnb_4bit_use_double_quant=True,
+        bnb_4bit_quant_type="nf4",
+        bnb_4bit_compute_dtype=torch.bfloat16,
+    )
+    tokenizer = AutoTokenizer.from_pretrained(str(adapter_path), use_fast=True)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    model = AutoPeftModelForCausalLM.from_pretrained(
+        str(adapter_path),
+        quantization_config=bnb,
+        device_map="auto",
+        torch_dtype=torch.bfloat16,
+    )
+    model.eval()
+    log.info("Adapter loaded.")
+
+    # --- Run prompts ---
+    similarities: list[float] = []
+    validity_flags: list[bool] = []
+    regressions: dict[str, int] = {}  # domain → count
+
+    for i, rec in enumerate(records):
+        prompt = rec["user_prompt"]
+        teacher = rec["teacher_response"]
+        domain = rec["domain"]
+
+        # Build input using chat template
+        messages = [{"role": "user", "content": prompt}]
+        try:
+            input_text = tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True)
+        except Exception:
+            input_text = prompt
+
+        inputs = tokenizer(input_text, return_tensors="pt",
+                           max_length=2048, truncation=True).to(model.device)
+
+        with torch.no_grad():
+            output_ids = model.generate(
+                **inputs,
+                max_new_tokens=MAX_NEW_TOKENS,
+                do_sample=False,
+                pad_token_id=tokenizer.eos_token_id,
+            )
+        # Decode only the new tokens
+        new_tokens = output_ids[0][inputs["input_ids"].shape[1]:]
+        student_output = tokenizer.decode(new_tokens, skip_special_tokens=True).strip()
+
+        # Validity
+        valid = _is_valid_response(student_output, teacher)
+        teacher_valid = _is_valid_response(teacher, teacher)
+        validity_flags.append(valid)
+
+        # Regression: student fails but teacher was valid
+        if not valid and teacher_valid:
+            regressions[domain] = regressions.get(domain, 0) + 1
+
+        # Similarity
+        embs = embedder.encode([student_output, teacher], convert_to_numpy=True)
+        from sklearn.metrics.pairwise import cosine_similarity
+        sim = float(cosine_similarity(embs[0:1], embs[1:2])[0][0])
+        similarities.append(sim)
+
+        if (i + 1) % 10 == 0:
+            log.info("Progress: %d/%d evaluated", i + 1, len(records))
+
+    # --- Aggregate ---
+    n = len(records)
+    metrics = {
+        "evaluated_at": datetime.now(tz=timezone.utc).isoformat(),
+        "adapter_path": str(adapter_path),
+        "holdout_path": str(holdout_path),
+        "n_evaluated": n,
+        "similarity_mean": round(sum(similarities) / n, 4) if similarities else None,
+        "similarity_by_domain": {},
+        "validity_rate": round(sum(validity_flags) / n, 4) if validity_flags else None,
+        "regression_count": sum(regressions.values()),
+        "domain_regressions": regressions,
+        "domain_counts": manifest["domain_counts"],
+    }
+
+    # Per-domain similarity breakdown
+    by_domain: dict[str, list[float]] = {}
+    for rec, sim in zip(records, similarities):
+        by_domain.setdefault(rec["domain"], []).append(sim)
+    for d, sims in by_domain.items():
+        metrics["similarity_by_domain"][d] = round(sum(sims) / len(sims), 4)
+
+    metrics_path = adapter_path / "metrics.json"
+    metrics_path.write_text(json.dumps(metrics, indent=2))
+    log.info("Metrics written to %s", metrics_path)
+    log.info("similarity_mean=%.4f validity_rate=%.4f regressions=%d",
+             metrics["similarity_mean"] or 0,
+             metrics["validity_rate"] or 0,
+             metrics["regression_count"])
+
+    return metrics
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run eval against holdout set")
+    parser.add_argument("--adapter-path", required=True,
+                        help="Path to the trained LoRA adapter directory")
+    parser.add_argument("--holdout-path", required=True,
+                        help="Path to holdout manifest JSON")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Validate imports and config without running inference")
+    args = parser.parse_args()
+
+    adapter_path = Path(args.adapter_path)
+    holdout_path = Path(args.holdout_path)
+
+    if not adapter_path.exists():
+        log.error("Adapter path does not exist: %s", adapter_path)
+        return 1
+    if not holdout_path.exists():
+        log.error("Holdout path does not exist: %s", holdout_path)
+        return 1
+
+    result = run_eval(adapter_path, holdout_path, args.dry_run)
+    if args.dry_run:
+        log.info("[DRY RUN] Validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/nightly_finetune.py
+++ b/src/nightly_finetune.py
@@ -83,6 +83,8 @@ VLLM_HEALTH_URL      = os.getenv("VLLM_HEALTH_URL",            "http://10.43.38.
 VLLM_STOP_TIMEOUT    = int(os.getenv("VLLM_STOP_TIMEOUT",      "120"))
 VLLM_START_TIMEOUT   = int(os.getenv("VLLM_START_TIMEOUT",     "300"))
 MIN_DATE             = date.fromisoformat(os.getenv("FINETUNE_MIN_DATE", "2026-04-18"))
+HOLDOUT_DIR          = Path(os.getenv("HOLDOUT_DIR",
+                         "/mnt/fortress_nas/finetune-artifacts/holdouts"))
 
 # LoRA target modules for Llama architecture
 LORA_TARGET_MODULES = [
@@ -420,6 +422,57 @@ def run_qlora_training(records: list[dict], adapter_out: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Phase 4b: Eval pipeline
+# ---------------------------------------------------------------------------
+def _run_eval_pipeline(adapter_out: Path) -> None:
+    """
+    Run the Phase 4b eval harness after training.
+
+    Finds today's holdout manifest, runs run_eval.py against the adapter,
+    then applies the promotion gate. Errors are logged but never raise —
+    a failed eval doesn't roll back the training artifact.
+    """
+    today_tag = date.today().isoformat()
+    holdout_path = HOLDOUT_DIR / f"holdout-{today_tag}.json"
+
+    if not holdout_path.exists():
+        log.warning("No holdout manifest at %s — skipping eval. "
+                    "Run build_holdout.py to create one.", holdout_path)
+        return
+
+    eval_script = Path(__file__).parent / "eval" / "run_eval.py"
+    gate_script  = Path(__file__).parent / "eval" / "promotion_gate.py"
+
+    try:
+        log.info("Running eval harness …")
+        result = subprocess.run(
+            [sys.executable, str(eval_script),
+             "--adapter-path", str(adapter_out),
+             "--holdout-path", str(holdout_path)],
+            timeout=3600,
+        )
+        if result.returncode != 0:
+            log.warning("Eval script exited %d — check adapter metrics", result.returncode)
+            return
+
+        log.info("Running promotion gate …")
+        gate_result = subprocess.run(
+            [sys.executable, str(gate_script),
+             "--adapter-path", str(adapter_out)],
+            timeout=60,
+        )
+        if gate_result.returncode == 0:
+            log.info("Promotion gate PASSED — promotion_candidate.json written")
+        elif gate_result.returncode == 2:
+            log.warning("Promotion gate REJECTED — see promotion_rejected.json")
+        else:
+            log.error("Promotion gate failed unexpectedly (exit %d)", gate_result.returncode)
+
+    except Exception as exc:
+        log.error("Eval pipeline error (non-fatal): %s", exc)
+
+
+# ---------------------------------------------------------------------------
 # Step 4: Ollama hot-swap (optional)
 # ---------------------------------------------------------------------------
 def push_to_ollama(adapter_path: Path) -> None:
@@ -527,7 +580,10 @@ def main(dry_run: bool = False, skip_export: bool = False) -> int:
         # --- Step 5: Train ---
         run_qlora_training(records, adapter_out)
 
-        # --- Step 6: Optional Ollama push ---
+        # --- Step 6: Phase 4b eval pipeline (runs while GPU is still free) ---
+        _run_eval_pipeline(adapter_out)
+
+        # --- Step 7: Optional Ollama push ---
         if PUSH_OLLAMA:
             push_to_ollama(adapter_out)
 


### PR DESCRIPTION
Phase 4b MVP. Runs automatically after each training success. Produces `promotion_candidate.json` or `promotion_rejected.json`. Does NOT auto-promote or touch routing.

## What's in this PR (8 files, 690 insertions)

| File | Role |
|---|---|
| `alembic/633f8f8bc383` | `eval_holdout` bool on both capture tables |
| `src/eval/build_holdout.py` | Sample holdout, mark rows, write manifest |
| `src/eval/run_eval.py` | Load adapter, run prompts, compute 3 metrics |
| `src/eval/promotion_gate.py` | Apply 4 gates, write candidate/rejected JSON |
| `nightly_distillation_exporter.py` | Filter `eval_holdout=TRUE` rows from training |
| `nightly_finetune.py` | Wire eval pipeline after training success |
| `.env.example` | Document all `EVAL_*` / `HOLDOUT_*` vars |

## Metrics (3)
- **response_similarity**: cosine sim via MiniLM-L6-v2, threshold 0.85
- **response_validity**: non-empty, sane length, no gibberish, threshold 0.95
- **regressions**: student fails where teacher passed — 0 allowed in legal/vrs

## Gates (4)
similarity ≥ 0.85 · validity ≥ 0.95 · zero regressions in legal+vrs · warns if <30 prompts/domain

## Dry-run validated
`build_holdout.py --dry-run` confirmed clean (0 rows = expected, all captures are from March, outside the 7-day window — will populate as post-deploy traffic accumulates).

## Safety
- No new timers · no ai_router changes · no routing changes
- Eval runs BEFORE vLLM restarts (GPU free during inference window)
- Promotion = flag only (PROMOTED_CANDIDATE sentinel file, Phase 4c reads it)

Create a merge commit.