### PR TITLE
fix(holdout): accept pending rows for first-night eval cycle

### DIFF
--- a/src/eval/build_holdout.py
+++ b/src/eval/build_holdout.py
@@ -79,7 +79,9 @@ def build_holdout(today: date, dry_run: bool) -> dict:
             FROM llm_training_captures
             WHERE created_at >= %s
               AND (eval_holdout IS NULL OR eval_holdout = FALSE)
-              AND status = 'exported'
+              -- MVP v1: include pending rows so first eval cycle runs same-night as
+              -- first training. Tighten to exported-only in Phase 4c when volume is sufficient.
+              AND status IN ('pending', 'exported')
         """, (cutoff,))
         rows = cur.fetchall()
         log.info("Found %d eligible rows in window", len(rows))


### PR DESCRIPTION
Single-line fix: `status = 'exported'` → `status IN ('pending', 'exported')`.

**Why:** No exported rows exist within the 7-day window on first deploy. Without this, holdout is always empty on night-of-training, eval never runs.

**Dry-run result:** 7 rows would be extracted — 4 VRS, 3 pricing.

**⚠️ Threshold conflict:** After holding out 7 rows, 13 pending remain. `MIN_EXAMPLES=20` → tonight's training run will **skip** training.

**Resolution options:**
- A) Lower `FINETUNE_MIN_EXAMPLES` from 20 → 13 before tonight's timer
- B) Set `EVAL_HOLDOUT_SIZE=1` → only 2 held out → 18 remain (still below 20)
- C) Accept the skip tonight, run training manually post-holdout

Phase 4c note in code comment: tighten back to exported-only when volume is sufficient.

Create a merge commit.