### PR TITLE
feat(ops): fortress-drift-alarm systemd service + timer

### DIFF
--- a/deploy/systemd/fortress-drift-alarm.service
+++ b/deploy/systemd/fortress-drift-alarm.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Fortress-Prime Drift Alarm — working-tree drift detector
+Documentation=file:///home/admin/Fortress-Prime/tools/drift_alarm.py
+After=network-online.target
+
+[Service]
+Type=oneshot
+User=admin
+Group=admin
+WorkingDirectory=/home/admin/Fortress-Prime
+
+# Load env files in same order as other fortress services
+ExecStart=/bin/bash -c '\
+  set -a; \
+  source /home/admin/Fortress-Prime/fortress-guest-platform/.env 2>/dev/null; \
+  source /home/admin/Fortress-Prime/fortress-guest-platform/.env.dgx 2>/dev/null; \
+  source /home/admin/Fortress-Prime/.env.security 2>/dev/null; \
+  set +a; \
+  exec /home/admin/Fortress-Prime/fortress-guest-platform/.uv-venv/bin/python \
+    /home/admin/Fortress-Prime/tools/drift_alarm.py'
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=fortress-drift-alarm
+
+# Allow writing to drift log
+LogsDirectory=fortress-drift

--- a/deploy/systemd/fortress-drift-alarm.timer
+++ b/deploy/systemd/fortress-drift-alarm.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run Fortress-Prime drift alarm every 6 hours
+Documentation=file:///home/admin/Fortress-Prime/tools/drift_alarm.py
+
+[Timer]
+# First fire 15 minutes after boot, then every 6 hours
+OnBootSec=15min
+OnUnitActiveSec=6h
+AccuracySec=5min
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Adds the two systemd units for `tools/drift_alarm.py` (already on main via PR #56).

Timer: 15min after boot, then every 6h.

**Install:** `sudo cp deploy/systemd/fortress-drift-alarm.{service,timer} /etc/systemd/system/ && sudo systemctl daemon-reload && sudo systemctl enable --now fortress-drift-alarm.timer`

Closes #55 (superseded). Create a merge commit.