### PR TITLE
feat(phase-4c): distilled-adapter routing scaffold (PCT=0, no live traffic)

### DIFF
--- a/deploy/systemd/fortress-vllm-adapter.service
+++ b/deploy/systemd/fortress-vllm-adapter.service
@@ -1,0 +1,40 @@
+[Unit]
+Description=Fortress-Prime vLLM Adapter Server — distilled Llama-3.3-70B LoRA
+Documentation=file:///home/admin/Fortress-Prime/src/inference/vllm_adapter_server.py
+# NIM must be stopped before starting this (Model B coexistence — cannot coexist)
+# Before enabling: kubectl scale deployment nim-sovereign -n default --replicas=0
+After=network-online.target
+
+[Service]
+Type=simple
+User=admin
+Group=admin
+WorkingDirectory=/home/admin/Fortress-Prime
+
+ExecStart=/bin/bash -c '\
+  set -a; \
+  source /home/admin/Fortress-Prime/fortress-guest-platform/.env 2>/dev/null; \
+  source /home/admin/Fortress-Prime/fortress-guest-platform/.env.dgx 2>/dev/null; \
+  set +a; \
+  exec /home/admin/Fortress-Prime/fortress-guest-platform/.uv-venv/bin/python \
+    /home/admin/Fortress-Prime/src/inference/vllm_adapter_server.py'
+
+Restart=on-failure
+RestartSec=30
+TimeoutStartSec=600
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=fortress-vllm-adapter
+
+# GPU training requires elevated limits
+LimitNOFILE=65536
+LimitMEMLOCK=infinity
+
+[Install]
+# NOT enabled by default — Phase 4c Model B: on-demand only.
+# Enable manually when activating the distilled tier:
+#   sudo systemctl enable --now fortress-vllm-adapter.service
+# And first stop NIM:
+#   kubectl scale deployment nim-sovereign -n default --replicas=0
+WantedBy=multi-user.target

--- a/fortress-guest-platform/.env.example
+++ b/fortress-guest-platform/.env.example
@@ -104,3 +104,14 @@ EVAL_MIN_PROMPTS_PER_DOMAIN=30  # below this: gate warns but doesn't hard-block
 EVAL_BLOCKER_DOMAINS=legal,vrs  # regressions in these domains block promotion
 EVAL_EMBEDDING_MODEL=all-MiniLM-L6-v2
 HOLDOUT_DIR=/mnt/fortress_nas/finetune-artifacts/holdouts
+
+# ---------------------------------------------------------------------------
+# Phase 4c — Distilled adapter A/B routing
+# Default PCT=0 means zero traffic routed to adapter (no behavioral change).
+# Activate after PROMOTED_CANDIDATE sentinel exists and fortress-vllm-adapter
+# service is running (NIM must be stopped first — Model B coexistence).
+# ---------------------------------------------------------------------------
+SOVEREIGN_DISTILL_ADAPTER_PCT=0      # 0-100, percent of eligible requests to route to adapter
+SOVEREIGN_DISTILL_ADAPTER_URL=http://127.0.0.1:8100/v1
+ADAPTER_SERVER_PORT=8100
+ADAPTER_SERVER_HOST=127.0.0.1

--- a/fortress-guest-platform/backend/services/ai_router.py
+++ b/fortress-guest-platform/backend/services/ai_router.py
@@ -3,12 +3,22 @@ Resilient AI router for legal/agent services.
 
 Routes to local Ollama first (sovereign default), then optionally OpenAI
 when credentials are available.
+
+Phase 4c: adds optional distilled-adapter tier (tier 1.5) between Ollama
+and OpenAI. Controlled by SOVEREIGN_DISTILL_ADAPTER_PCT (default 0 = off).
+Only active when PROMOTED_CANDIDATE sentinel file exists. Legal/privileged
+modules are blocked from the adapter tier regardless of PCT.
 """
 from __future__ import annotations
 
 import asyncio
+import json
+import logging
+import os
+import random
 import time
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Optional
 
 import httpx
@@ -20,6 +30,25 @@ from backend.services.privacy_router import sanitize_for_cloud
 from backend.services.swarm_service import submit_chat_completion
 
 _capture_log = structlog.get_logger(service="ai_router.capture")
+_adapter_log  = logging.getLogger("ai_router.adapter")
+
+# ---------------------------------------------------------------------------
+# Phase 4c — Distilled adapter routing config
+# ---------------------------------------------------------------------------
+_ADAPTER_PCT  = int(os.getenv("SOVEREIGN_DISTILL_ADAPTER_PCT",  "0"))   # 0 = off
+_ADAPTER_URL  = os.getenv("SOVEREIGN_DISTILL_ADAPTER_URL",       "http://127.0.0.1:8100/v1")
+_ADAPTER_DIR  = Path(os.getenv("FINETUNE_ADAPTER_DIR",           "/mnt/fortress_nas/finetune-artifacts"))
+_SENTINEL     = _ADAPTER_DIR / "PROMOTED_CANDIDATE"
+
+# Source modules that must NEVER be routed to the distilled adapter.
+# The adapter was trained on VRS/hospitality data only.
+# Legal and privileged modules must stay on frontier models.
+_ADAPTER_BLOCKED_MODULES: frozenset[str] = frozenset({
+    "legal_council", "ediscovery_agent", "legal_email_intake",
+    "legal_intake", "legal_case_graph", "legal_chronology",
+    "legal_deposition_prep", "legal_discovery_engine",
+    "legal_agent_orchestrator", "legal_email_intake_api",
+})
 
 
 async def _capture_interaction(
@@ -160,6 +189,77 @@ async def _call_openai(
     return (((choices[0] or {}).get("message") or {}).get("content") or "").strip()
 
 
+def _adapter_eligible(source_module: Optional[str]) -> bool:
+    """
+    Return True if this request is eligible for the distilled-adapter tier.
+    Legal/privileged modules are hard-blocked regardless of PCT setting.
+    """
+    if _ADAPTER_PCT == 0:
+        return False
+    if not _SENTINEL.exists():
+        return False
+    if source_module and source_module in _ADAPTER_BLOCKED_MODULES:
+        return False
+    if source_module and any(
+        source_module.startswith(p) for p in ("legal_", "ediscovery_")
+    ):
+        return False
+    return random.randint(1, 100) <= _ADAPTER_PCT
+
+
+async def _call_adapter(
+    prompt: str,
+    system_message: Optional[str],
+    max_tokens: int,
+    temperature: float,
+    timeout_s: float,
+) -> str:
+    """
+    Call the distilled-adapter vLLM OpenAI-compat endpoint.
+    Returns the response text, or raises on failure (caller falls through).
+
+    The adapter serves model 'crog-distilled' at SOVEREIGN_DISTILL_ADAPTER_URL.
+    Adapter path is read from the PROMOTED_CANDIDATE sentinel for audit purposes.
+    """
+    try:
+        sentinel_data = json.loads(_SENTINEL.read_text()) if _SENTINEL.exists() else {}
+        adapter_path = sentinel_data.get("adapter_path", "unknown")
+    except Exception:
+        adapter_path = "unknown"
+
+    messages: list[dict] = []
+    if system_message:
+        messages.append({"role": "system", "content": system_message})
+    messages.append({"role": "user", "content": prompt})
+
+    t0 = time.perf_counter()
+    async with httpx.AsyncClient(timeout=timeout_s) as client:
+        resp = await client.post(
+            f"{_ADAPTER_URL.rstrip('/')}/chat/completions",
+            json={
+                "model":       "crog-distilled",
+                "messages":    messages,
+                "max_tokens":  max_tokens,
+                "temperature": temperature,
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+    latency_ms = int((time.perf_counter() - t0) * 1000)
+    text = (
+        ((data.get("choices") or [{}])[0].get("message") or {})
+        .get("content", "")
+        .strip()
+    )
+    _adapter_log.info(
+        "adapter_call_ok adapter=%s latency_ms=%d tokens=%d",
+        adapter_path, latency_ms,
+        (data.get("usage") or {}).get("completion_tokens", 0),
+    )
+    return text
+
+
 async def execute_resilient_inference(
     prompt: str,
     task_type: str,
@@ -213,6 +313,48 @@ async def execute_resilient_inference(
         return result
     except Exception as exc:  # noqa: BLE001
         errors.append(f"ollama:{exc}")
+
+    # 1.5) Distilled adapter (Phase 4c) — only when PCT > 0 and PROMOTED_CANDIDATE exists
+    # Default PCT=0 means this block is never entered today.
+    # Legal/privileged source_modules are blocked at _adapter_eligible().
+    if _adapter_eligible(source_module):
+        try:
+            adapter_text = await _call_adapter(
+                prompt=prompt,
+                system_message=system_message,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                timeout_s=min(timeout_s, 30.0),  # tighter timeout — don't delay cloud fallback
+            )
+            if adapter_text:
+                result = InferenceResult(
+                    text=adapter_text,
+                    source="distilled_adapter",
+                    breaker_state="closed",
+                    latency_ms=int((time.perf_counter() - start) * 1000),
+                )
+                await record_audit_event(
+                    actor_id=None,
+                    action="ai_inference",
+                    resource_type="model_route",
+                    resource_id=task_type,
+                    purpose=source_module or "resilient_inference",
+                    redaction_status="not_applicable",
+                    model_route="distilled_adapter",
+                    outcome="success",
+                    request_id=request_id,
+                    metadata_json={
+                        "task_type": task_type,
+                        "source_module": source_module,
+                        "latency_ms": result.latency_ms,
+                        "adapter_pct": _ADAPTER_PCT,
+                    },
+                    db=db,
+                )
+                return result
+        except Exception as exc:  # noqa: BLE001
+            _adapter_log.warning("adapter_call_failed error=%s — falling through", str(exc)[:200])
+            errors.append(f"adapter:{exc}")
 
     # 2) Cloud fallback: OpenAI
     try:

--- a/src/inference/__init__.py
+++ b/src/inference/__init__.py
@@ -1,0 +1,1 @@
+"""Fortress Prime — sovereign inference infrastructure."""

--- a/src/inference/vllm_adapter_server.py
+++ b/src/inference/vllm_adapter_server.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+vllm_adapter_server.py — Starts a vLLM OpenAI-compat server
+for the promoted LoRA adapter.
+
+Phase 4c coexistence model: Model B (on-demand).
+This process is NOT started automatically. It is started manually
+or by fortress-vllm-adapter.service ONLY when:
+  1. PROMOTED_CANDIDATE sentinel file exists at ADAPTER_DIR
+  2. Sufficient memory is available (NIM was stopped first)
+
+The server serves the fine-tuned Llama-3.3-70B-Instruct-FP4 model
+with the promoted LoRA adapter via OpenAI-compatible HTTP API.
+
+Memory model:
+  NIM (nim-sovereign): ~61GB when running
+  This server (70B FP4 + 4-bit): ~35-40GB
+  Total GB10 memory: 121GB
+  These CANNOT coexist — NIM must be scaled to 0 before starting this.
+
+Usage:
+  python vllm_adapter_server.py [--port 8100] [--dry-run]
+
+  --dry-run: validate config and print resolved paths without starting server
+
+Environment:
+  FINETUNE_ADAPTER_DIR    default: /mnt/fortress_nas/finetune-artifacts
+  FINETUNE_BASE_MODEL_DIR default: /mnt/ai_bulk/models/huggingface/Llama-3.3-70B-Instruct-FP4
+  ADAPTER_SERVER_PORT     default: 8100
+  ADAPTER_SERVER_HOST     default: 127.0.0.1
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+log = logging.getLogger("vllm_adapter_server")
+
+ADAPTER_DIR     = Path(os.getenv("FINETUNE_ADAPTER_DIR",    "/mnt/fortress_nas/finetune-artifacts"))
+BASE_MODEL_DIR  = Path(os.getenv("FINETUNE_BASE_MODEL_DIR", "/mnt/ai_bulk/models/huggingface/Llama-3.3-70B-Instruct-FP4"))
+SERVER_PORT     = int(os.getenv("ADAPTER_SERVER_PORT",      "8100"))
+SERVER_HOST     = os.getenv("ADAPTER_SERVER_HOST",          "127.0.0.1")
+
+SENTINEL        = ADAPTER_DIR / "PROMOTED_CANDIDATE"
+
+
+def resolve_adapter_path() -> Path | None:
+    """Read PROMOTED_CANDIDATE sentinel and return the adapter path."""
+    if not SENTINEL.exists():
+        log.error("No PROMOTED_CANDIDATE sentinel at %s — nothing to serve", SENTINEL)
+        return None
+    try:
+        data = json.loads(SENTINEL.read_text())
+        adapter_path = Path(data["adapter_path"])
+        if not adapter_path.exists():
+            log.error("Adapter path from sentinel does not exist: %s", adapter_path)
+            return None
+        return adapter_path
+    except Exception as exc:
+        log.error("Cannot read PROMOTED_CANDIDATE: %s", exc)
+        return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Start vLLM adapter server")
+    parser.add_argument("--port", type=int, default=SERVER_PORT)
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Validate config without starting server")
+    args = parser.parse_args()
+
+    adapter_path = resolve_adapter_path()
+    if adapter_path is None:
+        return 1
+
+    log.info("Adapter path: %s", adapter_path)
+    log.info("Base model:   %s", BASE_MODEL_DIR)
+    log.info("Serving at:   %s:%d", SERVER_HOST, args.port)
+
+    if not BASE_MODEL_DIR.exists():
+        log.error("Base model directory not found: %s", BASE_MODEL_DIR)
+        return 1
+
+    if args.dry_run:
+        log.info("[DRY RUN] Config valid. Would start vLLM on %s:%d", SERVER_HOST, args.port)
+        log.info("[DRY RUN] vllm serve %s --enable-lora --lora-modules crog=%s ...",
+                 BASE_MODEL_DIR, adapter_path)
+        return 0
+
+    # Find vLLM binary
+    vllm_bin = subprocess.run(["which", "vllm"], capture_output=True, text=True).stdout.strip()
+    if not vllm_bin:
+        # Try venv
+        vllm_bin = str(Path(sys.executable).parent / "vllm")
+
+    cmd = [
+        vllm_bin, "serve", str(BASE_MODEL_DIR),
+        "--enable-lora",
+        "--lora-modules", f"crog-distilled={adapter_path}",
+        "--host", SERVER_HOST,
+        "--port", str(args.port),
+        "--quantization", "bitsandbytes",
+        "--load-format", "bitsandbytes",
+        "--max-lora-rank", "64",
+        "--gpu-memory-utilization", "0.90",
+        "--max-model-len", "4096",
+        "--tensor-parallel-size", "1",
+        "--served-model-name", "crog-distilled",
+    ]
+
+    log.info("Starting vLLM: %s", " ".join(cmd))
+    try:
+        proc = subprocess.run(cmd)
+        return proc.returncode
+    except KeyboardInterrupt:
+        log.info("vLLM adapter server stopped.")
+        return 0
+    except FileNotFoundError:
+        log.error("vLLM binary not found at %s — install with: pip install vllm", vllm_bin)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Phase 4c scaffold. PCT=0 default → zero behavioral change today. All routing plumbing is in place to flip the switch.

**Coexistence model: B (on-demand)**
GB10 has 121GB unified memory. NIM holds 61GB. Available: 35GB. Llama-3.3-70B-FP4 needs 35-40GB → cannot coexist continuously. Model B: stop NIM → load adapter → test → stop adapter → restart NIM.

**What's built:**
- `ai_router.py`: `_call_adapter()` + `_adapter_eligible()` as tier 1.5 in inference waterfall
- `src/inference/vllm_adapter_server.py`: reads PROMOTED_CANDIDATE, starts vLLM with LoRA
- `deploy/systemd/fortress-vllm-adapter.service`: defined but NOT enabled
- `.env.example`: `SOVEREIGN_DISTILL_ADAPTER_PCT=0`, `SOVEREIGN_DISTILL_ADAPTER_URL`

**Legal/privileged modules hard-blocked** from adapter tier regardless of PCT.

**To activate:** stop NIM → start service → set PCT > 0 → restart backend.

Create a merge commit.
