### PR TITLE
feat(phase-2.5): model registry + health-aware routing

### DIFF
--- a/fortress-guest-platform/backend/api/system_health.py
+++ b/fortress-guest-platform/backend/api/system_health.py
@@ -218,6 +218,13 @@ async def build_system_health_payload(db: AsyncSession) -> dict[str, Any]:
 
     collected_ms = int((time.perf_counter() - t0) * 1000)
 
+    # Phase 2.5: model registry health snapshot
+    try:
+        from backend.services.model_registry import registry as _mr
+        model_registry_snapshot = _mr.health_snapshot()
+    except Exception:
+        model_registry_snapshot = {"loaded": False, "nodes": []}
+
     return {
         "status": status,
         "service": "fortress_system_health",
@@ -230,6 +237,7 @@ async def build_system_health_payload(db: AsyncSession) -> dict[str, Any]:
             "postgres": pg_rows if pg_rows else ({"connected": 1} if postgres_ok else {}),
             "qdrant": qdrant,
         },
+        "model_registry": model_registry_snapshot,
     }
 
 

--- a/fortress-guest-platform/backend/main.py
+++ b/fortress-guest-platform/backend/main.py
@@ -376,6 +376,14 @@ async def lifespan(app: FastAPI):
         version="1.0.0",
     )
 
+    # Phase 2.5: initialise model registry (non-fatal if atlas missing)
+    try:
+        from backend.services.model_registry import initialise as _init_registry
+        _init_registry()
+        logger.info("model_registry_initialized")
+    except Exception as _mr_exc:
+        logger.warning("model_registry_init_skipped", error=str(_mr_exc))
+
     try:
         await init_db()
         logger.info("database_initialized")

--- a/fortress-guest-platform/backend/services/ai_router.py
+++ b/fortress-guest-platform/backend/services/ai_router.py
@@ -4,6 +4,10 @@ Resilient AI router for legal/agent services.
 Routes to local Ollama first (sovereign default), then optionally OpenAI
 when credentials are available.
 
+Phase 2.5: replaces hardcoded ollama_base_url with model_registry which
+health-probes all cluster nodes and routes to the healthiest endpoint for
+the requested model. On NoHealthyEndpoint, falls through to cloud.
+
 Phase 4c: adds optional distilled-adapter tier (tier 1.5) between Ollama
 and OpenAI. Controlled by SOVEREIGN_DISTILL_ADAPTER_PCT (default 0 = off).
 Only active when PROMOTED_CANDIDATE sentinel file exists. Legal/privileged
@@ -23,6 +27,8 @@ from typing import Any, Optional
 
 import httpx
 import structlog
+
+from backend.services.model_registry import NoHealthyEndpoint, registry as _model_registry
 
 from backend.core.config import settings
 from backend.services.openshell_audit import record_audit_event
@@ -128,10 +134,44 @@ class InferenceResult:
     error: Optional[str] = None
 
 
+_DEEP_TASK_TYPES = {"legal", "reasoning", "analysis"}
+
 def _preferred_ollama_model(task_type: str) -> str:
-    if task_type in {"legal", "reasoning", "analysis"}:
+    if task_type in _DEEP_TASK_TYPES:
         return settings.ollama_deep_model
     return settings.ollama_fast_model
+
+
+def _tier_for_task(task_type: str) -> str:
+    """Map task_type to model registry tier name."""
+    if task_type in _DEEP_TASK_TYPES:
+        return "deep"
+    return "fast"
+
+
+def _ollama_base_url_for(model: str, tier: Optional[str] = None) -> str:
+    """
+    Return Ollama base URL for the given model.
+
+    Phase 2.5: prefers model_registry for health-aware routing.
+    Falls back to settings.ollama_base_url if registry has no healthy node
+    (registry not loaded, atlas missing, or all nodes down).
+    """
+    try:
+        return _model_registry.get_endpoint_for_model(model, tier=tier)
+    except NoHealthyEndpoint as exc:
+        import logging as _log
+        _log.getLogger("ai_router").warning(
+            "model_registry.no_healthy_endpoint model=%s tier=%s — using config fallback: %s",
+            model, tier, str(exc)[:120],
+        )
+        return settings.ollama_base_url
+    except Exception as exc:
+        import logging as _log
+        _log.getLogger("ai_router").warning(
+            "model_registry.error model=%s — using config fallback: %s", model, str(exc)[:120]
+        )
+        return settings.ollama_base_url
 
 
 async def _call_ollama(
@@ -142,8 +182,10 @@ async def _call_ollama(
     max_tokens: int,
     temperature: float,
     timeout_s: float,
+    tier: Optional[str] = None,
 ) -> str:
-    url = f"{settings.ollama_base_url.rstrip('/')}/api/chat"
+    base_url = _ollama_base_url_for(model, tier=tier)
+    url = f"{base_url.rstrip('/')}/api/chat"
     messages = []
     if system_message:
         messages.append({"role": "system", "content": system_message})
@@ -284,6 +326,7 @@ async def execute_resilient_inference(
             max_tokens=max_tokens,
             temperature=temperature,
             timeout_s=timeout_s,
+            tier=_tier_for_task(task_type),
         )
         result = InferenceResult(
             text=text,

--- a/fortress-guest-platform/backend/services/model_registry.py
+++ b/fortress-guest-platform/backend/services/model_registry.py
@@ -1,0 +1,290 @@
+"""
+model_registry.py — Sovereign model registry with health-aware routing.
+
+Phase 2.5 of Iron Dome. Replaces hardcoded ollama_base_url in ai_router
+with a live-probed, latency-ranked endpoint selector.
+
+Architecture:
+  - Loaded from fortress_atlas.yaml cluster.nodes section at startup
+  - Background thread probes each node's /api/tags every 30s
+  - get_endpoint_for_model() returns the healthiest URL for a given model
+  - Raises NoHealthyEndpoint when no node is available (triggers cloud fallback)
+
+Safety contract:
+  - Module import never raises — logs error, falls back to empty registry
+  - Health probe exceptions are caught and counted as failures
+  - No crash can propagate from probe thread to request path
+"""
+from __future__ import annotations
+
+import logging
+import os
+import statistics
+import threading
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import httpx
+import yaml
+
+log = logging.getLogger("model_registry")
+
+_ATLAS_PATH = Path(os.getenv(
+    "FORTRESS_ATLAS_PATH",
+    str(Path(__file__).resolve().parents[5] / "fortress_atlas.yaml"),
+))
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+class NoHealthyEndpoint(Exception):
+    """Raised when no healthy node hosts the requested model."""
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class EndpointState:
+    node_id:              str
+    ollama_url:           str
+    models:               list[str]      # model names this node has
+    tier_affinity:        list[str]      # which tiers this node serves
+    reachable:            bool           = False
+    consecutive_failures: int            = 0
+    last_latency_ms:      float          = 9999.0
+    last_success_at:      Optional[datetime] = None
+    latency_history:      list[float]    = field(default_factory=list)
+
+    @property
+    def healthy(self) -> bool:
+        return self.reachable and self.consecutive_failures < _FAILURE_THRESHOLD
+
+    @property
+    def rolling_latency_ms(self) -> float:
+        if not self.latency_history:
+            return self.last_latency_ms
+        return statistics.mean(self.latency_history[-20:])
+
+    def record_success(self, latency_ms: float) -> None:
+        self.reachable = True
+        self.consecutive_failures = 0
+        self.last_latency_ms = latency_ms
+        self.last_success_at = datetime.now(tz=timezone.utc)
+        self.latency_history.append(latency_ms)
+        if len(self.latency_history) > 100:
+            self.latency_history = self.latency_history[-100:]
+
+    def record_failure(self) -> None:
+        self.reachable = False
+        self.consecutive_failures += 1
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+_PROBE_INTERVAL   = 30   # seconds
+_PROBE_TIMEOUT    = 3    # seconds
+_FAILURE_THRESHOLD = 3   # consecutive failures → unhealthy
+
+class ModelRegistry:
+    def __init__(self) -> None:
+        self._endpoints: list[EndpointState] = []
+        self._tier_routing: dict[str, list[str]] = {}  # tier → [node_id priority order]
+        self._lock = threading.Lock()
+        self._probe_thread: Optional[threading.Thread] = None
+        self._loaded = False
+
+    # ------------------------------------------------------------------
+    # Startup
+    # ------------------------------------------------------------------
+
+    def load_from_atlas(self, atlas_path: Path = _ATLAS_PATH) -> None:
+        """
+        Parse fortress_atlas.yaml cluster section and populate the registry.
+        Never raises — logs error and leaves registry empty (cloud-only fallback).
+        """
+        try:
+            with open(atlas_path) as f:
+                atlas = yaml.safe_load(f)
+        except FileNotFoundError:
+            log.warning("model_registry: atlas not found at %s — running empty (cloud fallback)", atlas_path)
+            return
+        except yaml.YAMLError as exc:
+            log.error("model_registry: atlas parse error: %s — running empty", exc)
+            return
+
+        try:
+            cluster = (atlas or {}).get("fortress_prime", {}).get("cluster", {})
+            nodes_cfg = cluster.get("nodes", [])
+            tier_routing_cfg = cluster.get("tier_routing", {})
+
+            global _PROBE_INTERVAL, _PROBE_TIMEOUT, _FAILURE_THRESHOLD
+            _PROBE_INTERVAL    = cluster.get("probe_interval_seconds", _PROBE_INTERVAL)
+            _PROBE_TIMEOUT     = cluster.get("probe_timeout_seconds", _PROBE_TIMEOUT)
+            _FAILURE_THRESHOLD = cluster.get("healthy_failure_threshold", _FAILURE_THRESHOLD)
+
+            endpoints: list[EndpointState] = []
+            for node in nodes_cfg:
+                node_id = node["id"]
+                tiers_for_node = [
+                    tier for tier, node_ids in tier_routing_cfg.items()
+                    if node_id in node_ids
+                ]
+                endpoints.append(EndpointState(
+                    node_id=node_id,
+                    ollama_url=node["ollama_url"],
+                    models=[m["name"] for m in node.get("models", [])],
+                    tier_affinity=tiers_for_node,
+                ))
+
+            with self._lock:
+                self._endpoints = endpoints
+                self._tier_routing = tier_routing_cfg
+                self._loaded = True
+
+            log.info("model_registry: loaded %d nodes from %s", len(endpoints), atlas_path)
+        except Exception as exc:
+            log.error("model_registry: atlas structure error: %s — running empty", exc)
+
+    def start_probe_thread(self) -> None:
+        """Start background health probe thread (daemon — dies with main process)."""
+        if self._probe_thread and self._probe_thread.is_alive():
+            return
+        t = threading.Thread(target=self._probe_loop, daemon=True, name="model-registry-probe")
+        t.start()
+        self._probe_thread = t
+        log.info("model_registry: probe thread started (interval=%ds)", _PROBE_INTERVAL)
+
+    # ------------------------------------------------------------------
+    # Health probing
+    # ------------------------------------------------------------------
+
+    def _probe_loop(self) -> None:
+        while True:
+            try:
+                self._probe_all()
+            except Exception as exc:
+                log.error("model_registry: probe_loop error: %s", exc)
+            time.sleep(_PROBE_INTERVAL)
+
+    def _probe_all(self) -> None:
+        with self._lock:
+            endpoints = list(self._endpoints)
+        for ep in endpoints:
+            self._probe_one(ep)
+
+    def _probe_one(self, ep: EndpointState) -> None:
+        """Probe a single endpoint's /api/tags. Update state in-place (thread-safe)."""
+        t0 = time.perf_counter()
+        try:
+            with httpx.Client(timeout=_PROBE_TIMEOUT) as client:
+                resp = client.get(f"{ep.ollama_url.rstrip('/')}/api/tags")
+                resp.raise_for_status()
+                # Optionally refresh model list from live response
+                data = resp.json()
+                live_models = [m["name"] for m in data.get("models", [])]
+                latency_ms = (time.perf_counter() - t0) * 1000
+
+            with self._lock:
+                ep.record_success(latency_ms)
+                if live_models:
+                    ep.models = live_models
+
+            log.debug("probe ok node=%s latency=%.0fms models=%d",
+                      ep.node_id, latency_ms, len(ep.models))
+
+        except Exception as exc:
+            with self._lock:
+                ep.record_failure()
+            log.warning("probe failed node=%s failures=%d error=%s",
+                        ep.node_id, ep.consecutive_failures, str(exc)[:80])
+
+    # ------------------------------------------------------------------
+    # Routing
+    # ------------------------------------------------------------------
+
+    def get_endpoint_for_model(
+        self,
+        model_name: str,
+        tier: Optional[str] = None,
+    ) -> str:
+        """
+        Return the Ollama URL of the healthiest node that has model_name.
+
+        If tier is provided, prefer nodes in the tier's routing order.
+        Among healthy nodes, pick the one with lowest rolling latency.
+
+        Raises NoHealthyEndpoint if no healthy node has the model.
+        """
+        with self._lock:
+            candidates = [
+                ep for ep in self._endpoints
+                if ep.healthy and model_name in ep.models
+            ]
+            tier_order = self._tier_routing.get(tier or "", []) if tier else []
+
+        if not candidates:
+            raise NoHealthyEndpoint(
+                f"No healthy node has model '{model_name}' "
+                f"(tier={tier}, checked {len(self._endpoints)} nodes)"
+            )
+
+        # Sort: first by tier affinity order, then by rolling latency
+        def _rank(ep: EndpointState) -> tuple[int, float]:
+            try:
+                priority = tier_order.index(ep.node_id)
+            except ValueError:
+                priority = 999  # not in preferred list → lowest priority
+            return (priority, ep.rolling_latency_ms)
+
+        best = min(candidates, key=_rank)
+        log.debug("routed model=%s tier=%s → node=%s latency=%.0fms",
+                  model_name, tier, best.node_id, best.rolling_latency_ms)
+        return best.ollama_url
+
+    # ------------------------------------------------------------------
+    # Observability
+    # ------------------------------------------------------------------
+
+    def health_snapshot(self) -> dict:
+        """Return JSON-serialisable health state for /api/v1/system-health."""
+        with self._lock:
+            endpoints = list(self._endpoints)
+        return {
+            "loaded": self._loaded,
+            "nodes": [
+                {
+                    "id": ep.node_id,
+                    "url": ep.ollama_url,
+                    "healthy": ep.healthy,
+                    "reachable": ep.reachable,
+                    "consecutive_failures": ep.consecutive_failures,
+                    "rolling_latency_ms": round(ep.rolling_latency_ms, 1),
+                    "last_success_at": (
+                        ep.last_success_at.isoformat() if ep.last_success_at else None
+                    ),
+                    "models": ep.models,
+                }
+                for ep in endpoints
+            ],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton (lazy-initialised in lifespan)
+# ---------------------------------------------------------------------------
+
+registry = ModelRegistry()
+
+
+def initialise(atlas_path: Path = _ATLAS_PATH) -> None:
+    """Call once from FastAPI lifespan startup."""
+    registry.load_from_atlas(atlas_path)
+    registry.start_probe_thread()

--- a/fortress-guest-platform/backend/tests/test_model_registry.py
+++ b/fortress-guest-platform/backend/tests/test_model_registry.py
@@ -1,0 +1,202 @@
+"""Tests for model_registry.py — Phase 2.5."""
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from backend.services.model_registry import (
+    EndpointState,
+    ModelRegistry,
+    NoHealthyEndpoint,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_ep(node_id: str, models: list[str], healthy: bool = True,
+             latency: float = 50.0, failures: int = 0) -> EndpointState:
+    ep = EndpointState(
+        node_id=node_id,
+        ollama_url=f"http://192.168.0.10{node_id[-1]}:11434",
+        models=models,
+        tier_affinity=["fast", "deep"],
+    )
+    if healthy:
+        ep.reachable = True
+        ep.consecutive_failures = failures
+        ep.last_latency_ms = latency
+        ep.latency_history = [latency]
+        ep.last_success_at = datetime.now(tz=timezone.utc)
+    else:
+        ep.reachable = False
+        ep.consecutive_failures = 5  # over threshold
+    return ep
+
+
+def _make_registry(*endpoints: EndpointState, tier_routing: dict | None = None) -> ModelRegistry:
+    r = ModelRegistry()
+    r._endpoints = list(endpoints)
+    r._tier_routing = tier_routing or {}
+    r._loaded = True
+    return r
+
+
+# ---------------------------------------------------------------------------
+# EndpointState
+# ---------------------------------------------------------------------------
+
+class TestEndpointState:
+    def test_healthy_when_reachable_and_low_failures(self):
+        ep = _make_ep("spark-1", ["qwen2.5:7b"], healthy=True, failures=0)
+        assert ep.healthy is True
+
+    def test_unhealthy_when_consecutive_failures_at_threshold(self):
+        ep = _make_ep("spark-1", ["qwen2.5:7b"], healthy=True, failures=3)
+        assert ep.healthy is False  # 3 >= threshold of 3
+
+    def test_unhealthy_when_unreachable(self):
+        ep = _make_ep("spark-1", ["qwen2.5:7b"], healthy=False)
+        assert ep.healthy is False
+
+    def test_record_success_clears_failures(self):
+        ep = _make_ep("spark-1", ["qwen2.5:7b"], healthy=False)
+        ep.consecutive_failures = 5
+        ep.record_success(42.0)
+        assert ep.consecutive_failures == 0
+        assert ep.reachable is True
+        assert ep.last_success_at is not None
+
+    def test_record_failure_increments(self):
+        ep = _make_ep("spark-1", ["qwen2.5:7b"])
+        ep.record_failure()
+        ep.record_failure()
+        assert ep.consecutive_failures == 2
+
+    def test_rolling_latency_uses_history(self):
+        # _make_ep seeds history with [50.0], then we add 100 and 200 → [50, 100, 200] mean=116.7
+        ep = _make_ep("spark-1", ["qwen2.5:7b"], latency=50.0)
+        ep.record_success(100.0)
+        ep.record_success(200.0)
+        assert ep.rolling_latency_ms == pytest.approx((50.0 + 100.0 + 200.0) / 3, abs=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Routing
+# ---------------------------------------------------------------------------
+
+class TestGetEndpointForModel:
+    def test_returns_healthy_endpoint(self):
+        ep = _make_ep("spark-1", ["qwen2.5:7b"])
+        r = _make_registry(ep)
+        url = r.get_endpoint_for_model("qwen2.5:7b")
+        assert "192.168" in url
+
+    def test_raises_when_model_not_in_registry(self):
+        ep = _make_ep("spark-1", ["qwen2.5:7b"])
+        r = _make_registry(ep)
+        with pytest.raises(NoHealthyEndpoint):
+            r.get_endpoint_for_model("deepseek-r1:70b")
+
+    def test_raises_when_all_unhealthy(self):
+        ep1 = _make_ep("spark-1", ["deepseek-r1:70b"], healthy=False)
+        ep2 = _make_ep("spark-4", ["deepseek-r1:70b"], healthy=False)
+        r = _make_registry(ep1, ep2)
+        with pytest.raises(NoHealthyEndpoint):
+            r.get_endpoint_for_model("deepseek-r1:70b")
+
+    def test_raises_when_registry_empty(self):
+        r = ModelRegistry()
+        with pytest.raises(NoHealthyEndpoint):
+            r.get_endpoint_for_model("qwen2.5:7b")
+
+    def test_picks_lowest_latency_among_healthy(self):
+        slow = _make_ep("spark-1", ["deepseek-r1:70b"], latency=300.0)
+        fast = _make_ep("spark-4", ["deepseek-r1:70b"], latency=80.0)
+        r = _make_registry(slow, fast)
+        url = r.get_endpoint_for_model("deepseek-r1:70b")
+        # fast (spark-4) has lower latency and no tier preference → should win
+        assert url == fast.ollama_url
+
+    def test_tier_routing_overrides_latency_within_preference(self):
+        # spark-1 is preferred by tier but slower; spark-4 faster but not preferred
+        spark1 = _make_ep("spark-1", ["deepseek-r1:70b"], latency=200.0)
+        spark4 = _make_ep("spark-4", ["deepseek-r1:70b"], latency=50.0)
+        routing = {"deep": ["spark-1", "spark-4"]}
+        r = _make_registry(spark1, spark4, tier_routing=routing)
+        # With tier="deep": spark-1 gets priority=0, spark-4 gets priority=1
+        url = r.get_endpoint_for_model("deepseek-r1:70b", tier="deep")
+        assert url == spark1.ollama_url
+
+    def test_unhealthy_skipped_even_if_tier_preferred(self):
+        # spark-1 preferred but unhealthy — should fall to spark-4
+        spark1 = _make_ep("spark-1", ["deepseek-r1:70b"], healthy=False)
+        spark4 = _make_ep("spark-4", ["deepseek-r1:70b"], latency=50.0)
+        routing = {"deep": ["spark-1", "spark-4"]}
+        r = _make_registry(spark1, spark4, tier_routing=routing)
+        url = r.get_endpoint_for_model("deepseek-r1:70b", tier="deep")
+        assert url == spark4.ollama_url
+
+    def test_consecutive_failures_threshold(self):
+        # At threshold (3) → unhealthy
+        ep = _make_ep("spark-1", ["qwen2.5:7b"], healthy=True, failures=3)
+        r = _make_registry(ep)
+        with pytest.raises(NoHealthyEndpoint):
+            r.get_endpoint_for_model("qwen2.5:7b")
+
+    def test_recovery_after_success(self):
+        ep = _make_ep("spark-1", ["qwen2.5:7b"], healthy=False)
+        ep.consecutive_failures = 5
+        ep.record_success(30.0)
+        r = _make_registry(ep)
+        url = r.get_endpoint_for_model("qwen2.5:7b")
+        assert url == ep.ollama_url
+
+
+# ---------------------------------------------------------------------------
+# Atlas loading
+# ---------------------------------------------------------------------------
+
+class TestLoadFromAtlas:
+    def test_loads_nodes_from_valid_atlas(self, tmp_path: Path):
+        atlas = {
+            "fortress_prime": {
+                "cluster": {
+                    "nodes": [
+                        {
+                            "id": "spark-2",
+                            "ollama_url": "http://192.168.0.100:11434",
+                            "models": [
+                                {"name": "qwen2.5:7b", "tier": "fast"},
+                            ],
+                        }
+                    ],
+                    "tier_routing": {"fast": ["spark-2"]},
+                }
+            }
+        }
+        p = tmp_path / "atlas.yaml"
+        p.write_text(yaml.dump(atlas))
+        r = ModelRegistry()
+        r.load_from_atlas(p)
+        assert r._loaded is True
+        assert len(r._endpoints) == 1
+        assert r._endpoints[0].node_id == "spark-2"
+
+    def test_missing_atlas_leaves_registry_empty(self, tmp_path: Path):
+        r = ModelRegistry()
+        r.load_from_atlas(tmp_path / "nonexistent.yaml")
+        assert r._loaded is False
+        assert r._endpoints == []
+
+    def test_malformed_atlas_leaves_registry_empty(self, tmp_path: Path):
+        p = tmp_path / "bad.yaml"
+        p.write_text(": invalid: yaml: [")
+        r = ModelRegistry()
+        r.load_from_atlas(p)
+        assert r._loaded is False

--- a/fortress_atlas.yaml
+++ b/fortress_atlas.yaml
@@ -398,3 +398,88 @@ fortress_prime:
         to: "dev"
         condition: "Query about property improvements or construction on existing rentals"
         action: "Route to DEV with CROG property reference"
+
+  # =========================================================================
+  # CLUSTER TOPOLOGY (Phase 2.5 addition — April 18, 2026)
+  # Real node→model mapping as verified by live probing.
+  # IPs below are LAN management addresses (192.168.0.x).
+  # model_registry.py reads this section on startup.
+  # =========================================================================
+  cluster:
+    probe_interval_seconds: 30
+    healthy_failure_threshold: 3   # consecutive failures before marking unhealthy
+    probe_timeout_seconds: 3
+
+    nodes:
+      - id: spark-2
+        label: "Captain"
+        role: "control_plane + fast_tier + training"
+        management_ip: "192.168.0.100"
+        ollama_url: "http://192.168.0.100:11434"
+        models:
+          - name: "qwen2.5:7b"
+            tier: "fast"
+          - name: "qwen2.5:0.5b"
+            tier: "fast"
+          - name: "nomic-embed-text:latest"
+            tier: "embed"
+
+      - id: spark-1
+        label: "Muscle"
+        role: "primary_heavy_reasoning"
+        management_ip: "192.168.0.104"
+        ollama_url: "http://192.168.0.104:11434"
+        models:
+          - name: "deepseek-r1:70b"
+            tier: "deep"
+          - name: "qwen2.5:32b"
+            tier: "mid"
+          - name: "llama3.2-vision:90b"
+            tier: "vision"
+          - name: "qwen2.5:7b"
+            tier: "fast"
+          - name: "llava:latest"
+            tier: "vision"
+          - name: "mistral:latest"
+            tier: "mid"
+          - name: "nomic-embed-text:latest"
+            tier: "embed"
+
+      - id: spark-3
+        label: "Ocular"
+        role: "vision_specialist"
+        management_ip: "192.168.0.105"
+        ollama_url: "http://192.168.0.105:11434"
+        models:
+          - name: "llama3.2-vision:90b"
+            tier: "vision"
+          - name: "llama3.2-vision:latest"
+            tier: "vision"
+          - name: "nomic-embed-text:latest"
+            tier: "embed"
+
+      - id: spark-4
+        label: "Sovereign"
+        role: "deep_reasoning_redundancy"
+        management_ip: "192.168.0.106"
+        ollama_url: "http://192.168.0.106:11434"
+        models:
+          - name: "deepseek-r1:70b"
+            tier: "deep"
+          - name: "qwen2.5:32b"
+            tier: "mid"
+          - name: "llava:latest"
+            tier: "vision"
+          - name: "mistral:latest"
+            tier: "mid"
+          - name: "nomic-embed-text:latest"
+            tier: "embed"
+
+    # Tier routing policy: which tiers prefer which nodes (in order)
+    tier_routing:
+      fast:   ["spark-2", "spark-1"]          # spark-2 primary; spark-1 overflow
+      mid:    ["spark-1", "spark-4"]           # active-active
+      deep:   ["spark-1", "spark-4"]           # active-active
+      vision: ["spark-3", "spark-1"]           # spark-3 primary; spark-1 overflow
+      embed:  ["spark-2", "spark-1", "spark-4", "spark-3"]  # any node
+


### PR DESCRIPTION
Fixes broken sovereign tier. ai_router was calling spark-2 for deepseek-r1:70b which doesn't exist there — every deep-tier call was falling through to cloud. This PR replaces the hardcoded endpoint with a live-probed, latency-ranked registry across all 4 cluster nodes.

**18/18 tests passing.**

**Files:** model_registry.py (290 lines), tests (202 lines), ai_router changes, system_health extension, fortress_atlas.yaml cluster section, main.py lifespan hook.

Create a merge commit.