### PR TITLE
fix: model_registry atlas path (parents[5] → parents[3])

### DIFF
--- a/fortress-guest-platform/backend/services/model_registry.py
+++ b/fortress-guest-platform/backend/services/model_registry.py
@@ -34,7 +34,7 @@ log = logging.getLogger("model_registry")
 
 _ATLAS_PATH = Path(os.getenv(
     "FORTRESS_ATLAS_PATH",
-    str(Path(__file__).resolve().parents[5] / "fortress_atlas.yaml"),
+    str(Path(__file__).resolve().parents[3] / "fortress_atlas.yaml"),
 ))
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
One-line fix. `parents[5]` resolved to `/home/` instead of `/home/admin/Fortress-Prime/`. `parents[3]` is the repo root. Create a merge commit.