### PR TITLE
fix: morning triage — 4 overnight failures

### DIFF
--- a/deploy/journald/fortress-limits.conf
+++ b/deploy/journald/fortress-limits.conf
@@ -1,0 +1,14 @@
+# Journald size and retention limits for Fortress Prime node.
+#
+# Install:
+#   sudo mkdir -p /etc/systemd/journald.conf.d
+#   sudo cp deploy/journald/fortress-limits.conf /etc/systemd/journald.conf.d/
+#   sudo systemctl restart systemd-journald
+#   sudo journalctl --vacuum-size=500M
+#
+# Before this was applied the journal reached 4.1G, causing slow journalctl reads.
+
+[Journal]
+SystemMaxUse=500M
+SystemKeepFree=2G
+MaxRetentionSec=3months

--- a/deploy/systemd/fortress-nightly-labeling.service
+++ b/deploy/systemd/fortress-nightly-labeling.service
@@ -7,7 +7,7 @@ After=network-online.target fortress-backend.service
 Type=oneshot
 User=admin
 Group=admin
-WorkingDirectory=/home/admin/Fortress-Prime
+WorkingDirectory=/home/admin/Fortress-Prime/fortress-guest-platform
 
 ExecStart=/bin/bash -c '\
   set -a; \

--- a/src/nightly_finetune.py
+++ b/src/nightly_finetune.py
@@ -36,8 +36,9 @@ Environment variables (loaded from .env / .env.dgx by run-fortress-nightly-finet
     VLLM_DEPLOYMENT         default: nim-sovereign (k8s deployment name)
     VLLM_NAMESPACE          default: default
     VLLM_HEALTH_URL         default: http://10.43.38.88:8000/v1/models (ClusterIP)
-    VLLM_STOP_TIMEOUT       default: 120  (seconds to wait for pod to terminate)
-    VLLM_START_TIMEOUT      default: 300  (seconds for NIM model load + health)
+    VLLM_STOP_TIMEOUT             default: 120  (seconds to wait for pod to terminate)
+    VLLM_START_TIMEOUT            default: 300  (seconds for NIM model load + health)
+    NIM_TERMINATION_DWELL_SECONDS default: 30   (fixed sleep after pod gone on unified-memory GPUs)
     DATABASE_URL            required for exporter
 """
 from __future__ import annotations
@@ -77,11 +78,13 @@ MAX_SEQ_LEN          = int(os.getenv("FINETUNE_MAX_SEQ_LEN",   "4096"))
 NUM_EPOCHS           = int(os.getenv("FINETUNE_EPOCHS",        "1"))
 LEARNING_RATE        = float(os.getenv("FINETUNE_LR",          "2e-4"))
 PUSH_OLLAMA          = os.getenv("FINETUNE_PUSH_OLLAMA",       "false").lower() == "true"
-VLLM_DEPLOYMENT      = os.getenv("VLLM_DEPLOYMENT",            "nim-sovereign")
-VLLM_NAMESPACE       = os.getenv("VLLM_NAMESPACE",             "default")
-VLLM_HEALTH_URL      = os.getenv("VLLM_HEALTH_URL",            "http://10.43.38.88:8000/v1/models")
-VLLM_STOP_TIMEOUT    = int(os.getenv("VLLM_STOP_TIMEOUT",      "120"))
-VLLM_START_TIMEOUT   = int(os.getenv("VLLM_START_TIMEOUT",     "300"))
+VLLM_DEPLOYMENT              = os.getenv("VLLM_DEPLOYMENT",            "nim-sovereign")
+VLLM_NAMESPACE               = os.getenv("VLLM_NAMESPACE",             "default")
+VLLM_HEALTH_URL              = os.getenv("VLLM_HEALTH_URL",            "http://10.43.38.88:8000/v1/models")
+VLLM_STOP_TIMEOUT            = int(os.getenv("VLLM_STOP_TIMEOUT",      "120"))
+VLLM_START_TIMEOUT           = int(os.getenv("VLLM_START_TIMEOUT",     "300"))
+NIM_TERMINATION_DWELL_SECONDS = int(os.getenv("NIM_TERMINATION_DWELL_SECONDS", "30"))
+_NIM_GPU_RELEASE_TIMEOUT     = 120  # hard ceiling; not configurable
 MIN_DATE             = date.fromisoformat(os.getenv("FINETUNE_MIN_DATE", "2026-04-18"))
 HOLDOUT_DIR          = Path(os.getenv("HOLDOUT_DIR",
                          "/mnt/fortress_nas/finetune-artifacts/holdouts"))
@@ -137,6 +140,94 @@ def _nim_pod_running() -> bool:
     return "Running" in result.stdout
 
 
+def _nim_any_pod_exists() -> bool:
+    """True if any nim-engine pod exists in any state (Running, Terminating, etc.)."""
+    result = subprocess.run(
+        ["kubectl", "get", "pods", "-n", VLLM_NAMESPACE,
+         "-l", "app=nim-engine", "--no-headers"],
+        capture_output=True, text=True, timeout=15,
+    )
+    return bool(result.stdout.strip())
+
+
+def _gpu_free_mib() -> "int | None":
+    """Return free GPU MiB, or None if the card reports [N/A] (GB10 unified memory)."""
+    try:
+        out = subprocess.check_output(
+            ["nvidia-smi", "--query-gpu=memory.free", "--format=csv,noheader,nounits"],
+            timeout=10, text=True,
+        ).strip()
+        first = out.splitlines()[0].strip() if out else ""
+        return None if not first or "[N/A]" in first else int(first)
+    except Exception:
+        return None
+
+
+def _wait_for_gpu_released() -> None:
+    """
+    After kubectl scale-to-zero, block until VRAM is confirmed free.
+
+    Phase 1 — pod termination: poll until no nim-engine pods exist in any
+    state (Running or Terminating). _stop_vllm's loop only checks "Running";
+    a pod stuck in Terminating still holds the CUDA context.
+
+    Phase 2 — VRAM release:
+    - Unified-memory / GB10: nvidia-smi reports [N/A] for memory metrics.
+      Sleep NIM_TERMINATION_DWELL_SECONDS (default 30 s) as a fixed dwell.
+    - Discrete GPU: poll nvidia-smi memory.free until it jumps by >1 GiB,
+      indicating the CUDA context was released.
+
+    Hard ceiling: _NIM_GPU_RELEASE_TIMEOUT (120 s). Raises RuntimeError on
+    timeout so the caller can write a .error file instead of OOMing mid-load.
+    """
+    deadline = time.time() + _NIM_GPU_RELEASE_TIMEOUT
+
+    # Phase 1: wait for pod to vanish entirely (no Terminating stragglers)
+    while time.time() < deadline:
+        if not _nim_any_pod_exists():
+            log.info("NIM pod fully terminated (no pods in any state).")
+            break
+        log.info("NIM pod still exists (may be Terminating) — waiting for full teardown …")
+        time.sleep(3)
+    else:
+        raise RuntimeError(
+            f"NIM pod ({VLLM_NAMESPACE}/{VLLM_DEPLOYMENT}) still present "
+            f"{_NIM_GPU_RELEASE_TIMEOUT}s after scale-to-zero. "
+            "GPU memory not confirmed free — aborting training to avoid OOM. "
+            f"Check: kubectl get pods -n {VLLM_NAMESPACE} -l app=nim-engine"
+        )
+
+    # Phase 2: confirm VRAM released
+    free_mib = _gpu_free_mib()
+    if free_mib is None:
+        # GB10 / unified-memory: nvidia-smi can't report discrete VRAM
+        dwell = NIM_TERMINATION_DWELL_SECONDS
+        log.info(
+            "Unified-memory GPU detected (nvidia-smi N/A) — "
+            "sleeping %ds for CUDA context teardown (NIM_TERMINATION_DWELL_SECONDS).", dwell,
+        )
+        time.sleep(dwell)
+        log.info("GPU dwell complete — proceeding with model load.")
+    else:
+        # Discrete GPU: poll until free memory jumps (NIM CUDA context released)
+        log.info("GPU free before dwell: %d MiB — polling for release …", free_mib)
+        prev = free_mib
+        while time.time() < deadline:
+            time.sleep(5)
+            curr = _gpu_free_mib()
+            if curr is None:
+                log.info("GPU switched to N/A reporting — assuming released.")
+                return
+            if curr >= prev + 1024:
+                log.info("GPU memory released: %d MiB → %d MiB — proceeding.", prev, curr)
+                return
+            prev = curr
+        log.warning(
+            "GPU memory polling reached %ds ceiling (%d MiB free) — proceeding anyway.",
+            _NIM_GPU_RELEASE_TIMEOUT, prev,
+        )
+
+
 def _stop_vllm() -> bool:
     """
     Scale nim-sovereign to 0 replicas, freeing GPU memory for training.
@@ -161,15 +252,17 @@ def _stop_vllm() -> bool:
     deadline = time.time() + VLLM_STOP_TIMEOUT
     while time.time() < deadline:
         if not _nim_pod_running():
-            log.info("NIM pod terminated — GPU memory freed.")
+            log.info("NIM pod no longer Running — waiting for full teardown and GPU release …")
+            _wait_for_gpu_released()
+            log.info("GPU memory confirmed free — proceeding with training.")
             return True
         time.sleep(5)
 
     raise RuntimeError(
-        f"NIM pod ({VLLM_NAMESPACE}/{VLLM_DEPLOYMENT}) did not terminate "
+        f"NIM pod ({VLLM_NAMESPACE}/{VLLM_DEPLOYMENT}) did not leave Running state "
         f"within {VLLM_STOP_TIMEOUT}s after scale-to-zero. "
         "GPU memory not freed — aborting training to avoid OOM. "
-        "Check: kubectl get pods -n default -l app=nim-engine"
+        f"Check: kubectl get pods -n {VLLM_NAMESPACE} -l app=nim-engine"
     )
 
 

--- a/src/tests/test_nightly_finetune_nim.py
+++ b/src/tests/test_nightly_finetune_nim.py
@@ -1,0 +1,153 @@
+"""Integration tests for NIM GPU lifecycle management in nightly_finetune.
+
+Mocks kubectl and nvidia-smi; verifies that _wait_for_gpu_released blocks
+correctly for each GPU type and raises on timeout.
+"""
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import nightly_finetune as ft
+
+
+# ---------------------------------------------------------------------------
+# _nim_any_pod_exists
+# ---------------------------------------------------------------------------
+class TestNimAnyPodExists:
+    def _run(self, stdout: str) -> bool:
+        with patch("nightly_finetune.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout=stdout)
+            return ft._nim_any_pod_exists()
+
+    def test_running_pod(self):
+        assert self._run("nim-sovereign-abc   1/1   Running   0   5h\n") is True
+
+    def test_terminating_pod(self):
+        # Terminating state must still block Phase 1
+        assert self._run("nim-sovereign-abc   0/1   Terminating   0   5h\n") is True
+
+    def test_no_pods(self):
+        assert self._run("") is False
+
+    def test_whitespace_only(self):
+        assert self._run("   \n  ") is False
+
+
+# ---------------------------------------------------------------------------
+# _gpu_free_mib
+# ---------------------------------------------------------------------------
+class TestGpuFreeMib:
+    def test_reports_numeric_value(self):
+        with patch("nightly_finetune.subprocess.check_output", return_value="45000\n"):
+            assert ft._gpu_free_mib() == 45000
+
+    def test_unified_memory_na(self):
+        with patch("nightly_finetune.subprocess.check_output", return_value="[N/A]\n"):
+            assert ft._gpu_free_mib() is None
+
+    def test_empty_output(self):
+        with patch("nightly_finetune.subprocess.check_output", return_value=""):
+            assert ft._gpu_free_mib() is None
+
+    def test_subprocess_error_returns_none(self):
+        with patch("nightly_finetune.subprocess.check_output", side_effect=Exception("no gpu")):
+            assert ft._gpu_free_mib() is None
+
+    def test_multiline_takes_first(self):
+        with patch("nightly_finetune.subprocess.check_output", return_value="30000\n20000\n"):
+            assert ft._gpu_free_mib() == 30000
+
+
+# ---------------------------------------------------------------------------
+# _wait_for_gpu_released
+# ---------------------------------------------------------------------------
+class TestWaitForGpuReleased:
+    def test_unified_memory_sleeps_dwell(self, monkeypatch):
+        """GB10 path: pod gone + nvidia-smi N/A → sleep exactly dwell seconds."""
+        monkeypatch.setattr(ft, "NIM_TERMINATION_DWELL_SECONDS", 7)
+        sleep_calls: list[float] = []
+
+        with (
+            patch("nightly_finetune._nim_any_pod_exists", return_value=False),
+            patch("nightly_finetune._gpu_free_mib", return_value=None),
+            patch("nightly_finetune.time.sleep", side_effect=lambda s: sleep_calls.append(s)),
+        ):
+            ft._wait_for_gpu_released()
+
+        assert 7 in sleep_calls, f"expected dwell sleep of 7s, got {sleep_calls}"
+
+    def test_discrete_gpu_returns_on_memory_jump(self, monkeypatch):
+        """Discrete GPU: poll free memory → large jump → return without error."""
+        monkeypatch.setattr(ft, "NIM_TERMINATION_DWELL_SECONDS", 30)
+        free_values = iter([5000, 5100, 66000])  # 61 GiB jump on third poll
+
+        with (
+            patch("nightly_finetune._nim_any_pod_exists", return_value=False),
+            patch("nightly_finetune._gpu_free_mib", side_effect=lambda: next(free_values)),
+            patch("nightly_finetune.time.sleep"),
+        ):
+            ft._wait_for_gpu_released()  # must not raise
+
+    def test_discrete_gpu_na_mid_poll_treated_as_released(self, monkeypatch):
+        """If nvidia-smi switches to N/A mid-poll, treat as context released."""
+        monkeypatch.setattr(ft, "NIM_TERMINATION_DWELL_SECONDS", 30)
+        free_values = iter([5000, None])  # second call returns N/A
+
+        with (
+            patch("nightly_finetune._nim_any_pod_exists", return_value=False),
+            patch("nightly_finetune._gpu_free_mib", side_effect=lambda: next(free_values)),
+            patch("nightly_finetune.time.sleep"),
+        ):
+            ft._wait_for_gpu_released()  # must not raise
+
+    def test_pod_never_gone_raises_runtime_error(self, monkeypatch):
+        """If pod never disappears within 120s ceiling, raise RuntimeError."""
+        monkeypatch.setattr(ft, "_NIM_GPU_RELEASE_TIMEOUT", 0.05)
+
+        with (
+            patch("nightly_finetune._nim_any_pod_exists", return_value=True),
+            patch("nightly_finetune.time.sleep"),  # no-op sleep so loop spins fast
+        ):
+            with pytest.raises(RuntimeError, match="still present"):
+                ft._wait_for_gpu_released()
+
+    def test_terminating_pod_blocks_phase1_then_proceeds(self, monkeypatch):
+        """Pod in Terminating state should extend Phase 1 until fully gone."""
+        monkeypatch.setattr(ft, "NIM_TERMINATION_DWELL_SECONDS", 1)
+        # Two calls return True (pod Terminating), third returns False (gone)
+        exists_seq = iter([True, True, False])
+        sleep_calls: list[float] = []
+
+        with (
+            patch("nightly_finetune._nim_any_pod_exists", side_effect=lambda: next(exists_seq)),
+            patch("nightly_finetune._gpu_free_mib", return_value=None),
+            patch("nightly_finetune.time.sleep", side_effect=lambda s: sleep_calls.append(s)),
+        ):
+            ft._wait_for_gpu_released()
+
+        phase1_sleeps = [s for s in sleep_calls if s == 3]
+        assert len(phase1_sleeps) >= 2, "expected at least 2 phase-1 poll sleeps"
+
+    def test_stop_vllm_calls_wait_for_gpu_released(self, monkeypatch):
+        """_stop_vllm must call _wait_for_gpu_released after pod leaves Running."""
+        wait_called = []
+
+        def fake_wait():
+            wait_called.append(True)
+
+        with (
+            patch("nightly_finetune._nim_pod_running", side_effect=[True, False]),
+            patch("nightly_finetune._wait_for_gpu_released", side_effect=fake_wait),
+            patch("nightly_finetune.subprocess.run"),
+            patch("nightly_finetune.time.sleep"),
+        ):
+            result = ft._stop_vllm()
+
+        assert result is True
+        assert wait_called, "_wait_for_gpu_released was not called by _stop_vllm"

--- a/tools/drift_alarm.py
+++ b/tools/drift_alarm.py
@@ -64,6 +64,9 @@ UNTRACKED_WARN    = int(os.getenv("UNTRACKED_WARN",        "10"))
 UNTRACKED_ALERT   = int(os.getenv("UNTRACKED_ALERT",       "50"))
 STALE_HOURS       = int(os.getenv("MODIFIED_STALE_HOURS",  "48"))
 
+_DRIFT_LOG_FALLBACK         = Path.home() / "fortress-drift.log"
+_DRIFT_LOG_WARNED_SENTINEL  = Path.home() / ".fortress_drift_perm_warned"
+
 TWILIO_SID    = os.getenv("TWILIO_ACCOUNT_SID")
 TWILIO_TOKEN  = os.getenv("TWILIO_AUTH_TOKEN")
 TWILIO_FROM   = os.getenv("TWILIO_PHONE_NUMBER")
@@ -186,11 +189,19 @@ def _append_log(message: str) -> None:
     try:
         with open(DRIFT_LOG, "a") as fh:
             fh.write(line)
-    except PermissionError:
-        log.warning("Cannot write to %s — check permissions", DRIFT_LOG)
-        # Fallback: write to home dir
-        fallback = Path.home() / "fortress-drift.log"
-        with open(fallback, "a") as fh:
+    except OSError:
+        # Warn once across runs via a sentinel file; subsequent runs fall back silently.
+        if not _DRIFT_LOG_WARNED_SENTINEL.exists():
+            log.warning(
+                "Cannot write to %s — falling back to %s. "
+                "Fix: sudo touch %s && sudo chown admin:admin %s",
+                DRIFT_LOG, _DRIFT_LOG_FALLBACK, DRIFT_LOG, DRIFT_LOG,
+            )
+            try:
+                _DRIFT_LOG_WARNED_SENTINEL.touch()
+            except OSError:
+                pass
+        with open(_DRIFT_LOG_FALLBACK, "a") as fh:
             fh.write(line)
 
 


### PR DESCRIPTION
## Summary

- **Bug 1 (labeling CWD)**: `WorkingDirectory` was one level too high in `fortress-nightly-labeling.service` — changed to `fortress-guest-platform/` so Python can resolve the `backend` package. This is why `capture_labels` had 0 rows this morning and 53 captures went unlabeled.
- **Bug 2 (NIM VRAM race)**: `_stop_vllm()` declared GPU free the moment a pod left _Running_ state, but a pod in _Terminating_ still holds its CUDA context. Last night's 1-second gap OOMed the 70B load. Added `_wait_for_gpu_released()` with two-phase gating: (1) spin until no pods exist in _any_ state, (2) fixed 30 s dwell for GB10 unified-memory or nvidia-smi poll for discrete GPUs. Hard 120 s ceiling → RuntimeError + `.error` file.
- **Bug 3 (drift log noise)**: Permission fallback was already writing to `~/fortress-drift.log` but the `WARNING` fired every 6-hour run. Now uses a sentinel file (`~/.fortress_drift_perm_warned`) so it warns exactly once. Also broadened `PermissionError` → `OSError`.
- **Bug 4 (journal size)**: Added `deploy/journald/fortress-limits.conf` capping journal at 500 MB / 3 months. Was 4.1 G, causing slow `journalctl` reads.

## Post-merge actions required on spark-node-2

```bash
# Bug 1 — deploy updated service unit and catch up missed captures
sudo cp deploy/systemd/fortress-nightly-labeling.service /etc/systemd/system/
sudo systemctl daemon-reload
sudo systemctl start fortress-nightly-labeling  # recovers 53 pending captures

# Bug 3 — fix the underlying permission issue
sudo touch /var/log/fortress-drift.log && sudo chown admin:admin /var/log/fortress-drift.log
rm -f ~/.fortress_drift_perm_warned  # optional: re-arm the one-time warning

# Bug 4 — install journald cap and vacuum existing logs
sudo mkdir -p /etc/systemd/journald.conf.d
sudo cp deploy/journald/fortress-limits.conf /etc/systemd/journald.conf.d/
sudo systemctl restart systemd-journald
sudo journalctl --vacuum-size=500M
```

## Test plan

- [x] 15 unit tests in `src/tests/test_nightly_finetune_nim.py` — all pass
  - `_nim_any_pod_exists`: Running, Terminating, empty, whitespace-only
  - `_gpu_free_mib`: numeric, N/A, empty, subprocess error, multiline
  - `_wait_for_gpu_released`: GB10 dwell, discrete GPU memory jump, N/A mid-poll, pod-never-gone timeout, Terminating→gone phase-1 blocking, `_stop_vllm` integration
- [ ] After merge: manually trigger `fortress-nightly-labeling` and confirm captures are labeled
- [ ] Verify tonight's `fortress-nightly-finetune` succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)