### PR TITLE
feat(judge): stage Qwen2.5-7B-Instruct to NAS + locator alias map

### DIFF
--- a/src/judge/base_model_locator.py
+++ b/src/judge/base_model_locator.py
@@ -33,6 +33,17 @@ _MODEL_ALIASES: dict[str, list[str]] = {
     "deepseek-r1:70b": ["deepseek-ai--DeepSeek-R1-Distill-Llama-70B"],
 }
 
+# Maps friendly names → actual directory names on NAS (flat, no HF double-dash format).
+# The NAS direct search uses these before falling back to the generic name transform.
+_NAS_ALIASES: dict[str, list[str]] = {
+    "qwen2.5:7b":               ["Qwen2.5-7B-Instruct"],
+    "Qwen/Qwen2.5-7B-Instruct": ["Qwen2.5-7B-Instruct"],
+    "qwen2.5:0.5b":             ["Qwen2.5-0.5B-Instruct"],
+    "qwen2.5:1.5b":             ["Qwen2.5-1.5B-Instruct"],
+    "qwen2.5:32b":              ["Qwen2.5-32B-Instruct"],
+    "deepseek-r1:70b":          ["DeepSeek-R1-Distill-Llama-70B"],
+}
+
 
 def _hf_dir_for_model(model_name: str, cache_root: Path) -> Optional[Path]:
     """Find a model's HF cache directory under cache_root."""
@@ -91,11 +102,15 @@ def find_base_model(model_name: str) -> Optional[Path]:
     """
     log.info("Searching for base model: %s", model_name)
 
-    # 1. NAS direct — look for model directory
-    nas_direct = _NAS_MODELS / model_name.replace(":", "-").replace("/", "-")
-    if nas_direct.exists() and (nas_direct / "config.json").exists():
-        log.info("Found %s on NAS at %s", model_name, nas_direct)
-        return nas_direct
+    # 1. NAS direct — check known aliases first, then fall back to generic name transform
+    nas_candidates: list[Path] = [
+        _NAS_MODELS / alias for alias in _NAS_ALIASES.get(model_name, [])
+    ]
+    nas_candidates.append(_NAS_MODELS / model_name.replace(":", "-").replace("/", "-"))
+    for nas_path in nas_candidates:
+        if nas_path.exists() and (nas_path / "config.json").exists():
+            log.info("Found %s on NAS at %s", model_name, nas_path)
+            return nas_path
 
     # 2. ai_bulk HF cache
     found = _hf_dir_for_model(model_name, _HF_CACHE_AI_BULK)


### PR DESCRIPTION
## Summary

- **NAS staging**: Downloaded `Qwen/Qwen2.5-7B-Instruct` (BF16 safetensors) to `/mnt/fortress_nas/models/Qwen2.5-7B-Instruct/` — 15 GiB, 4 shards, no symlinks. Permanent staging so judge training has zero external dependencies going forward.
- **Locator fix**: `base_model_locator.py` NAS step previously transformed `qwen2.5:7b` → `qwen2.5-7b` (generic colon-to-dash), which would never match `Qwen2.5-7B-Instruct`. Added `_NAS_ALIASES` dict that maps friendly names and full HF repo IDs to their actual NAS directory names, checked before the generic transform.

## Files changed

`src/judge/base_model_locator.py` — +20 / -5
- Added `_NAS_ALIASES: dict[str, list[str]]` for `qwen2.5:7b`, `Qwen/Qwen2.5-7B-Instruct`, and stubs for 0.5b / 1.5b / 32b / deepseek-r1:70b
- Updated `find_base_model()` step 1 to check NAS aliases before the generic name transform

## Staged weights (NAS — not in repo)

```
/mnt/fortress_nas/models/Qwen2.5-7B-Instruct/
  config.json
  generation_config.json
  tokenizer.json
  tokenizer_config.json
  model.safetensors.index.json
  model-00001-of-00004.safetensors  (3.7 GiB)
  model-00002-of-00004.safetensors  (3.6 GiB)
  model-00003-of-00004.safetensors  (3.6 GiB)
  model-00004-of-00004.safetensors  (3.4 GiB)
  Total: 15 GiB
```

## Smoke test

```
$ python3 src/judge/base_model_locator.py qwen2.5:7b
INFO: Found qwen2.5:7b on NAS at /mnt/fortress_nas/models/Qwen2.5-7B-Instruct
Result: /mnt/fortress_nas/models/Qwen2.5-7B-Instruct   exit: 0

$ python3 src/judge/base_model_locator.py Qwen/Qwen2.5-7B-Instruct
INFO: Found Qwen/Qwen2.5-7B-Instruct on NAS at /mnt/fortress_nas/models/Qwen2.5-7B-Instruct
Result: /mnt/fortress_nas/models/Qwen2.5-7B-Instruct   exit: 0
```

## Note for future model staging

When staging a new model to NAS, add its friendly name(s) → directory name to `_NAS_ALIASES` in the same PR as the staging task. The generic transform (`qwen2.5:7b` → `qwen2.5-7b`) is only a last-resort fallback.

⚠️ **Do not merge until Gary signs off** — one-time infrastructure exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)