### PR TITLE
feat(labels): dedup + backfill script for 46 historical exported captures

### DIFF
--- a/src/backfill_label_historical.py
+++ b/src/backfill_label_historical.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""
+backfill_label_historical.py — One-off Godhead labeling for historical exported captures.
+
+Labels only dedup winners (capture_metadata->>'dedup_winner' = 'true') from
+llm_training_captures WHERE status='exported' that have no label yet.
+
+Bypasses the nightly 1-day window. Respects the daily budget cap. Safe to
+re-run: the write_label_sync UPSERT uses ON CONFLICT DO NOTHING.
+
+Usage:
+  python3 src/backfill_label_historical.py [--dry-run]
+
+  --dry-run : query and estimate cost without calling Godhead or writing labels
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import psycopg2
+from psycopg2.extras import RealDictCursor
+
+# Import shared labeling primitives
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "fortress-guest-platform"))
+from backend.services.labeling_pipeline import (
+    DB_URI,
+    _estimate_call_cost,
+    _GODHEAD_TEACHERS,
+    _DEFAULT_TEACHER,
+    call_godhead_sync,
+    check_budget_remaining,
+    write_label_sync,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='{"time":"%(asctime)s","level":"%(levelname)s","msg":"%(message)s","svc":"backfill_label"}',
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+log = logging.getLogger("backfill_label")
+
+_CAPTURE_TABLE = "llm_training_captures"
+
+
+def _fetch_unlabeled_winners(conn: psycopg2.extensions.connection) -> list[Any]:
+    """
+    Return dedup-winner exported captures that have no label yet.
+
+    Winner criteria: capture_metadata->>'dedup_winner' = 'true'.
+    Singletons (capture_metadata IS NULL) are excluded — this script only runs
+    after the dedup tagging step has been applied via dedup_historical_captures().
+    """
+    cur = conn.cursor(cursor_factory=RealDictCursor)
+    cur.execute("""
+        SELECT tc.id::text, tc.task_type, tc.user_prompt, tc.assistant_resp
+        FROM llm_training_captures tc
+        LEFT JOIN capture_labels cl
+          ON cl.capture_id = tc.id
+         AND cl.capture_table = %s
+        WHERE tc.status = 'exported'
+          AND (tc.capture_metadata->>'dedup_winner') = 'true'
+          AND tc.task_type IS NOT NULL
+          AND cl.id IS NULL
+        ORDER BY tc.created_at ASC
+    """, (_CAPTURE_TABLE,))
+    return cur.fetchall()
+
+
+def run(dry_run: bool) -> dict:
+    """Label all unlabeled dedup winners. Returns stats dict."""
+    log.info("backfill_label_start dry_run=%s", dry_run)
+
+    remaining = check_budget_remaining()
+    log.info("budget_remaining=$%.4f", remaining)
+
+    conn = psycopg2.connect(DB_URI)
+    rows = _fetch_unlabeled_winners(conn)
+    conn.close()
+
+    log.info("unlabeled_winners=%d", len(rows))
+
+    n_processed = 0
+    n_labeled   = 0
+    n_skipped   = 0
+    n_errors    = 0
+    spent       = Decimal("0")
+
+    if not rows:
+        log.info("Nothing to label — all dedup winners already have labels.")
+    else:
+        for row in rows:
+            task_type = row["task_type"] or "unknown"
+            n_processed += 1
+
+            est = _estimate_call_cost(
+                _GODHEAD_TEACHERS.get(task_type, _DEFAULT_TEACHER)[0]
+            )
+            if spent + est > remaining:
+                log.warning(
+                    "budget_exhausted spent=$%.4f remaining=$%.4f — stopping.",
+                    spent, remaining,
+                )
+                n_skipped += len(rows) - n_processed + 1
+                break
+
+            if dry_run:
+                log.info(
+                    "[DRY RUN] would label capture_id=%s task=%s est_cost=$%.4f",
+                    row["id"][:8], task_type, est,
+                )
+                spent += est
+                n_labeled += 1
+                continue
+
+            try:
+                model, decision, reasoning, cost = call_godhead_sync(
+                    task_type,
+                    row["user_prompt"] or "",
+                    row["assistant_resp"] or "",
+                )
+                write_label_sync(
+                    row["id"], _CAPTURE_TABLE, task_type,
+                    model, decision, reasoning, cost,
+                )
+                spent += cost
+                n_labeled += 1
+                log.info(
+                    "labeled capture_id=%s task=%s decision=%s cost=$%.4f",
+                    row["id"][:8], task_type, decision, cost,
+                )
+            except Exception as exc:
+                n_errors += 1
+                log.error("label_error capture_id=%s error=%s", row["id"][:8], str(exc)[:200])
+
+    stats = {
+        "processed": n_processed,
+        "labeled": n_labeled,
+        "skipped_budget": n_skipped,
+        "errors": n_errors,
+        "total_cost_usd": float(spent),
+    }
+    log.info("backfill_label_complete stats=%s", stats)
+    return stats
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Backfill Godhead labels for historical captures")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Estimate cost without calling Godhead or writing labels")
+    args = parser.parse_args()
+    result = run(args.dry_run)
+    import json
+    print(json.dumps(result, indent=2, default=str))
+    sys.exit(0 if result["errors"] == 0 else 1)

--- a/src/tests/test_backfill_dedup.py
+++ b/src/tests/test_backfill_dedup.py
@@ -1,0 +1,150 @@
+"""
+Tests for dedup winner-selection stability in backfill_label_historical.
+
+The dedup rule: for each MD5(user_prompt) cluster, the winner is the row
+with the longest assistant_resp, tie-broken by oldest created_at (ASC).
+This must be deterministic: same input → same winner, always.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from hashlib import md5
+
+
+# ---------------------------------------------------------------------------
+# Extracted winner-selection logic (mirrors the SQL ORDER BY in backfill)
+# ---------------------------------------------------------------------------
+
+def select_winner(rows: list[dict]) -> str:
+    """
+    Given a list of rows from the same prompt-hash cluster, return the id
+    of the winner using the same rule as the SQL CTE:
+      ORDER BY LENGTH(assistant_resp) DESC, created_at ASC
+    """
+    return sorted(
+        rows,
+        key=lambda r: (-len(r["assistant_resp"]), r["created_at"]),
+    )[0]["id"]
+
+
+def partition_by_prompt(rows: list[dict]) -> dict[str, list[dict]]:
+    """Group rows by MD5(user_prompt), mirroring the SQL PARTITION BY."""
+    clusters: dict[str, list[dict]] = {}
+    for row in rows:
+        key = md5(row["user_prompt"].encode()).hexdigest()
+        clusters.setdefault(key, []).append(row)
+    return clusters
+
+
+def apply_dedup(rows: list[dict]) -> dict[str, bool]:
+    """Return {id: is_winner} for all rows."""
+    clusters = partition_by_prompt(rows)
+    result: dict[str, bool] = {}
+    for cluster_rows in clusters.values():
+        winner_id = select_winner(cluster_rows)
+        for row in cluster_rows:
+            result[row["id"]] = row["id"] == winner_id
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _ts(s: str) -> datetime:
+    return datetime.fromisoformat(s).replace(tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestSelectWinner:
+    def test_longest_response_wins(self):
+        rows = [
+            {"id": "a", "user_prompt": "same", "assistant_resp": "short",    "created_at": _ts("2026-03-14T10:00:00")},
+            {"id": "b", "user_prompt": "same", "assistant_resp": "much longer response here",  "created_at": _ts("2026-03-14T10:01:00")},
+            {"id": "c", "user_prompt": "same", "assistant_resp": "medium length resp",         "created_at": _ts("2026-03-14T10:02:00")},
+        ]
+        assert select_winner(rows) == "b"
+
+    def test_tiebreak_oldest_wins(self):
+        rows = [
+            {"id": "newer", "user_prompt": "same", "assistant_resp": "equal length!!", "created_at": _ts("2026-03-14T12:00:00")},
+            {"id": "older", "user_prompt": "same", "assistant_resp": "equal length!!", "created_at": _ts("2026-03-14T10:00:00")},
+        ]
+        assert select_winner(rows) == "older"
+
+    def test_singleton_wins(self):
+        rows = [
+            {"id": "only", "user_prompt": "unique", "assistant_resp": "response", "created_at": _ts("2026-03-14T10:00:00")},
+        ]
+        assert select_winner(rows) == "only"
+
+    def test_stable_repeated_calls(self):
+        """Same input → same winner across multiple calls."""
+        rows = [
+            {"id": f"row{i}", "user_prompt": "p", "assistant_resp": "x" * (10 - i), "created_at": _ts(f"2026-03-14T{10+i:02d}:00:00")}
+            for i in range(5)
+        ]
+        first = select_winner(rows)
+        for _ in range(10):
+            assert select_winner(rows) == first, "winner selection is not stable"
+
+    def test_stable_with_shuffled_input(self):
+        """Winner must be the same regardless of row ordering."""
+        import random
+        rows = [
+            {"id": "long",   "user_prompt": "p", "assistant_resp": "a" * 100, "created_at": _ts("2026-03-14T12:00:00")},
+            {"id": "short1", "user_prompt": "p", "assistant_resp": "b" * 10,  "created_at": _ts("2026-03-14T10:00:00")},
+            {"id": "short2", "user_prompt": "p", "assistant_resp": "c" * 10,  "created_at": _ts("2026-03-14T11:00:00")},
+        ]
+        expected = select_winner(rows)
+        for _ in range(20):
+            shuffled = rows[:]
+            random.shuffle(shuffled)
+            assert select_winner(shuffled) == expected
+
+
+class TestApplyDedup:
+    def test_all_singletons_are_winners(self):
+        rows = [
+            {"id": f"r{i}", "user_prompt": f"unique prompt {i}", "assistant_resp": "resp", "created_at": _ts("2026-03-14T10:00:00")}
+            for i in range(5)
+        ]
+        result = apply_dedup(rows)
+        assert all(result.values()), "all singletons should be winners"
+
+    def test_exactly_one_winner_per_cluster(self):
+        rows = [
+            {"id": "a1", "user_prompt": "cluster_a", "assistant_resp": "short",  "created_at": _ts("2026-03-14T10:00:00")},
+            {"id": "a2", "user_prompt": "cluster_a", "assistant_resp": "longer", "created_at": _ts("2026-03-14T10:01:00")},
+            {"id": "a3", "user_prompt": "cluster_a", "assistant_resp": "medium len", "created_at": _ts("2026-03-14T10:02:00")},
+            {"id": "b1", "user_prompt": "cluster_b", "assistant_resp": "x" * 50, "created_at": _ts("2026-03-14T11:00:00")},
+            {"id": "b2", "user_prompt": "cluster_b", "assistant_resp": "x" * 50, "created_at": _ts("2026-03-14T12:00:00")},
+        ]
+        result = apply_dedup(rows)
+        winners = [id_ for id_, w in result.items() if w]
+        assert len(winners) == 2  # one per cluster
+
+    def test_terri_shea_cluster_picks_correct_winner(self):
+        """Simulates the 29-row Terri Shea cluster. The oldest row with the
+        longest response must win, not an arbitrary row."""
+        base_resp = "turnover_json_" + "x" * 200
+        long_resp  = "turnover_json_" + "x" * 300  # this one should win
+
+        rows = [
+            {"id": f"ts{i}", "user_prompt": "Terri Shea checkout", "assistant_resp": base_resp,
+             "created_at": _ts(f"2026-03-14T{17 + i//6:02d}:{(i*10)%60:02d}:00")}
+            for i in range(28)
+        ]
+        # Insert the long-response row at a non-first position
+        rows.insert(14, {
+            "id": "ts_winner",
+            "user_prompt": "Terri Shea checkout",
+            "assistant_resp": long_resp,
+            "created_at": _ts("2026-03-14T18:00:00"),
+        })
+        result = apply_dedup(rows)
+        assert result["ts_winner"] is True
+        assert sum(result.values()) == 1


### PR DESCRIPTION
## Summary

46 exported captures from Feb/Mar have no Godhead labels — the nightly batch's `created_at >= CURRENT_DATE - 1 day` filter never reaches them. Before labeling, an audit found the 2026-03-14 batch contained 29 identical "Terri Shea / Above the Timberline" prompts that would overfit a single checkout scenario if trained on undeduped.

**Dedup result (applied to DB, no migration file needed — `capture_metadata` is a nullable jsonb add):**
| Cluster | Total | Winners | Discarded |
|---|---|---|---|
| Terri Shea checkout (identical prompt) | 29 | 1 | 28 |
| Wedding inquiry / Falling Waters | 5 | 1 | 4 |
| Wedding inquiry / Fallen Timber | 3 | 1 | 2 |
| Buckhorn Lodge exterior | 2 | 1 | 1 |
| macro_treasury dupe | 2 | 1 | 1 |
| 5 unique prompts | 5 | 5 | 0 |
| **Total** | **46** | **10** | **36** |

Winner rule: longest `assistant_resp` per `MD5(user_prompt)` cluster, tie-broken by oldest `created_at`.

## Files

**`src/backfill_label_historical.py`**
- Labels only `capture_metadata->>'dedup_winner' = 'true'` rows from `status='exported'` with no label
- Bypasses 1-day window; respects daily budget cap
- Reuses `call_godhead_sync` + `write_label_sync` from `labeling_pipeline.py`
- Safe to re-run (ON CONFLICT DO NOTHING)

**`src/tests/test_backfill_dedup.py`** — 8 tests
- Winner stability: same input → same winner across 10 repeated calls and 20 shuffled orderings
- Tiebreak correctness, singleton handling, one-winner-per-cluster invariant
- Terri Shea 29-row scenario

## Dry-run result
```
unlabeled_winners=10
processed=10, labeled=10, skipped_budget=0, errors=0
est. total_cost_usd=$0.04
```

## Post-merge: run the actual labeling
```bash
cd ~/Fortress-Prime/fortress-guest-platform
source .env && source .env.dgx
python3 ../src/backfill_label_historical.py
```

⚠️ **Stop before merge** — Gary to confirm dedup counts and dry-run look correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)