### PR TITLE
fix(training): Defect 1 remediation — ASSESSMENT block contamination

### DIFF
--- a/fortress-guest-platform/backend/services/ai_router.py
+++ b/fortress-guest-platform/backend/services/ai_router.py
@@ -86,7 +86,11 @@ async def _capture_interaction(
         import uuid as _uuid
         from sqlalchemy import text
         from backend.core.database import AsyncSessionLocal
-        from backend.services.privilege_filter import classify_for_capture, CaptureRoute
+        from backend.services.privilege_filter import (
+            classify_for_capture,
+            check_training_contamination,
+            CaptureRoute,
+        )
 
         decision = classify_for_capture(
             prompt=prompt,
@@ -98,6 +102,14 @@ async def _capture_interaction(
             _capture_log.info("distillation_capture_blocked reason=%s module=%s",
                               decision.reason, source_module)
             return
+
+        contaminated, contamination_reason = check_training_contamination(prompt, response)
+        if contaminated:
+            _capture_log.warning(
+                "training_contamination_detected reason=%s module=%s — "
+                "capture will be written with training_excluded=true",
+                contamination_reason, source_module,
+            )
 
         async def _insert() -> None:
             async with AsyncSessionLocal() as session:
@@ -113,6 +125,13 @@ async def _capture_interaction(
                     "judge_rsn":   judge_reasoning,
                 }
                 _capture_id = str(_uuid.uuid4())
+                _capture_meta = (
+                    json.dumps({
+                        "training_excluded": True,
+                        "exclusion_reason": contamination_reason,
+                    })
+                    if contaminated else None
+                )
                 if decision.route == CaptureRoute.ALLOW:
                     await session.execute(text("""
                         INSERT INTO llm_training_captures
@@ -120,16 +139,19 @@ async def _capture_interaction(
                              served_by_endpoint, served_vector_store,
                              escalated_from, sovereign_attempt,
                              teacher_endpoint, teacher_model,
-                             task_type, judge_decision, judge_reasoning)
+                             task_type, judge_decision, judge_reasoning,
+                             capture_metadata)
                         VALUES
                             (:id::uuid, :module, :model, :prompt, :response, 'pending',
                              :endpoint, :store,
                              :esc_from, :sov_attempt,
                              :t_endpoint, :t_model,
-                             :task, :judge_dec, :judge_rsn)
+                             :task, :judge_dec, :judge_rsn,
+                             CAST(:capture_meta AS jsonb))
                         ON CONFLICT DO NOTHING
                     """), {"id": _capture_id, "module": source_module[:120], "model": model_label[:120],
                            "prompt": prompt[:32_000], "response": response[:32_000],
+                           "capture_meta": _capture_meta,
                            **_tag})
                 else:  # RESTRICTED
                     await session.execute(text("""

--- a/fortress-guest-platform/backend/services/privilege_filter.py
+++ b/fortress-guest-platform/backend/services/privilege_filter.py
@@ -139,3 +139,51 @@ def classify_for_capture(
         route=CaptureRoute.ALLOW,
         reason="no_privilege_signal",
     )
+
+
+# ---------------------------------------------------------------------------
+# Training contamination detection
+# ---------------------------------------------------------------------------
+
+# Matches the Feb 2026 concierge ASSESSMENT block separator pattern:
+#   \n---\n\n**ASSESSMENT**
+_ASSESSMENT_BLOCK_RE: re.Pattern = re.compile(
+    r"\n---\n\n\*\*ASSESSMENT\*\*",
+    re.IGNORECASE,
+)
+
+# Individual internal metadata markers from the same prompt era.
+# Checked as a fallback if the full separator pattern is absent.
+_INTERNAL_METADATA_MARKERS: tuple[str, ...] = (
+    "**ASSESSMENT**",
+    "**Risk Level:**",
+    "**Strategy Type:**",
+    "**Citations Used:**",
+)
+
+
+def check_training_contamination(prompt: str, response: str) -> tuple[bool, str]:
+    """
+    Detect internal metadata leaked into a stored LLM response.
+
+    Returns (is_contaminated, reason). Never raises.
+
+    Defense-in-depth against the Feb 2026 vrs_concierge defect: the system
+    prompt asked the model to produce a guest-facing response followed by a
+    '---' separator and an internal **ASSESSMENT** block (Risk Level /
+    Strategy Type / Citations Used). The prompt was fixed in Iron Dome
+    (2026-03-01). This check catches recurrence or similar patterns.
+
+    The `prompt` argument is accepted for API symmetry with classify_for_capture
+    but is not currently inspected — contamination lives in the response.
+    """
+    try:
+        if _ASSESSMENT_BLOCK_RE.search(response):
+            return True, "assessment_block_separator"
+        for marker in _INTERNAL_METADATA_MARKERS:
+            if marker in response:
+                tag = marker.strip("*").strip().lower().replace(" ", "_").rstrip(":")
+                return True, f"internal_metadata_marker:{tag}"
+    except Exception:
+        pass
+    return False, ""

--- a/fortress-guest-platform/backend/workers/nightly_distillation_exporter.py
+++ b/fortress-guest-platform/backend/workers/nightly_distillation_exporter.py
@@ -199,6 +199,7 @@ async def run_distillation_export(
             FROM   llm_training_captures
             WHERE  status = 'pending'
               AND  (eval_holdout IS NULL OR eval_holdout = FALSE)
+              AND  (capture_metadata->>'training_excluded') IS DISTINCT FROM 'true'
             ORDER  BY created_at ASC
             LIMIT  :lim
         """), {"lim": batch_size})

--- a/src/tests/test_contamination_filter.py
+++ b/src/tests/test_contamination_filter.py
@@ -1,0 +1,207 @@
+"""
+Tests for check_training_contamination in privilege_filter.py.
+
+Covers:
+  - Known-bad Feb 2026 ASSESSMENT block format (full separator pattern)
+  - Individual internal metadata markers as fallback
+  - Clean responses pass through without false positives
+  - Training export filter: contaminated rows are skipped
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "fortress-guest-platform"))
+from backend.services.privilege_filter import check_training_contamination
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+_CLEAN_GUEST_RESPONSE = """Dear [Guest's Name],
+
+Thank you for your inquiry about Buckhorn Lodge!
+The deck features pressure-treated pine boards with composite railings.
+
+Best regards,
+Taylor Knight
+"""
+
+_ASSESSMENT_BLOCK_RESPONSE = """\
+**Response:**
+
+Dear [Guest's Name],
+
+Thank you for considering Fallen Timber Lodge for your special day!
+
+---
+
+**ASSESSMENT**
+
+- **Risk Level:** Medium
+- **Strategy Type:** Negotiation
+- **Missing Information:** None
+- **Citations Used:** FINANCIAL HARD CONSTRAINTS — Fallen Timber Lodge, Retrieved Context [5], [8]
+"""
+
+_MARKER_ONLY_RESPONSE = """\
+Dear Guest,
+
+Here is our recommendation.
+
+**Risk Level:** Low
+"""
+
+_STRATEGY_TYPE_RESPONSE = """\
+To address your booking:
+
+**Strategy Type:** Direct
+
+We can accommodate your request.
+"""
+
+_CITATIONS_USED_RESPONSE = """\
+Based on our policy review:
+
+**Citations Used:** Property Policy v3, Ops Override Memo
+
+Your stay is confirmed.
+"""
+
+_BARE_ASSESSMENT_HEADER = """\
+**ASSESSMENT**
+- Risk: none
+"""
+
+
+# ---------------------------------------------------------------------------
+# Tests: known-bad Feb 2026 ASSESSMENT format
+# ---------------------------------------------------------------------------
+
+class TestAssessmentBlockSeparator:
+    def test_detects_full_separator_pattern(self):
+        contaminated, reason = check_training_contamination("", _ASSESSMENT_BLOCK_RESPONSE)
+        assert contaminated is True
+        assert reason == "assessment_block_separator"
+
+    def test_case_insensitive_separator(self):
+        response = "\n---\n\n**assessment**\nsome content"
+        contaminated, _ = check_training_contamination("", response)
+        assert contaminated is True
+
+    def test_separator_requires_double_newline(self):
+        """'\n---\n**ASSESSMENT**' without the blank line should not match separator
+        but may match the header marker fallback."""
+        response = "\n---\n**ASSESSMENT**\nsome content"
+        contaminated, _ = check_training_contamination("", response)
+        # Falls through to marker check — should still be caught
+        assert contaminated is True
+
+    def test_prompt_content_does_not_affect_result(self):
+        """Contamination is in the response, not the prompt."""
+        contaminated, _ = check_training_contamination(
+            "What does the deck look like?",
+            _ASSESSMENT_BLOCK_RESPONSE,
+        )
+        assert contaminated is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: individual metadata marker fallbacks
+# ---------------------------------------------------------------------------
+
+class TestInternalMetadataMarkers:
+    def test_risk_level_marker(self):
+        contaminated, reason = check_training_contamination("", _MARKER_ONLY_RESPONSE)
+        assert contaminated is True
+        assert "risk_level" in reason
+
+    def test_strategy_type_marker(self):
+        contaminated, reason = check_training_contamination("", _STRATEGY_TYPE_RESPONSE)
+        assert contaminated is True
+        assert "strategy_type" in reason
+
+    def test_citations_used_marker(self):
+        contaminated, reason = check_training_contamination("", _CITATIONS_USED_RESPONSE)
+        assert contaminated is True
+        assert "citations_used" in reason
+
+    def test_bare_assessment_header(self):
+        contaminated, reason = check_training_contamination("", _BARE_ASSESSMENT_HEADER)
+        assert contaminated is True
+        assert "assessment" in reason
+
+
+# ---------------------------------------------------------------------------
+# Tests: clean responses pass through
+# ---------------------------------------------------------------------------
+
+class TestCleanResponses:
+    def test_normal_guest_response_is_clean(self):
+        contaminated, reason = check_training_contamination("", _CLEAN_GUEST_RESPONSE)
+        assert contaminated is False
+        assert reason == ""
+
+    def test_json_response_with_reasoning_field_is_clean(self):
+        response = '{"cleaning_type": "turnover", "reasoning": "standard 3-night stay"}'
+        contaminated, _ = check_training_contamination("", response)
+        assert contaminated is False
+
+    def test_response_with_markdown_hr_but_no_assessment_is_clean(self):
+        response = "Summary:\n\n---\n\nConclusion: all good."
+        contaminated, _ = check_training_contamination("", response)
+        assert contaminated is False
+
+    def test_empty_response_is_clean(self):
+        contaminated, _ = check_training_contamination("", "")
+        assert contaminated is False
+
+    def test_prompt_containing_markers_does_not_flag_clean_response(self):
+        """Markers in the prompt should not cause false positives on clean responses."""
+        contaminated, _ = check_training_contamination(
+            "Please assess the Risk Level of this situation.",
+            _CLEAN_GUEST_RESPONSE,
+        )
+        assert contaminated is False
+
+    def test_response_mentioning_assessment_in_plain_text_is_clean(self):
+        """'assessment' as an ordinary word should not trigger contamination."""
+        response = "Our risk assessment shows low probability of issues."
+        contaminated, _ = check_training_contamination("", response)
+        assert contaminated is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: training export filter logic
+# ---------------------------------------------------------------------------
+
+class TestExportFilter:
+    def _would_export(self, capture_metadata: dict | None) -> bool:
+        """Mirrors the exporter WHERE clause logic in Python."""
+        if capture_metadata is None:
+            return True
+        return capture_metadata.get("training_excluded") is not True
+
+    def test_clean_capture_is_exported(self):
+        assert self._would_export(None) is True
+        assert self._would_export({}) is True
+        assert self._would_export({"dedup_winner": True}) is True
+
+    def test_excluded_capture_is_skipped(self):
+        assert self._would_export({"training_excluded": True}) is False
+        assert self._would_export({
+            "training_excluded": True,
+            "exclusion_reason": "pre-2026-03-01_assessment_block_leak",
+        }) is False
+
+    def test_dedup_winner_that_is_also_excluded_is_skipped(self):
+        assert self._would_export({
+            "dedup_winner": True,
+            "training_excluded": True,
+            "exclusion_reason": "pre-2026-03-01_assessment_block_leak",
+        }) is False
+
+    def test_string_true_does_not_skip(self):
+        """DB returns the value as a boolean via jsonb; string 'true' is different."""
+        assert self._would_export({"training_excluded": "true"}) is True


### PR DESCRIPTION
## Summary

Remediates the Feb 2026 vrs_concierge defect where the system prompt asked the model to produce both a guest-facing response and an internal `**ASSESSMENT**` block in the same output. The prompt was fixed in Iron Dome (2026-03-01). This PR handles historical data hygiene and adds defense-in-depth.

**No production behavior change** — contaminated captures are still written (audit trail), they're just excluded from training export.

## Actions taken

### Action 1 — Override 2 missed Godhead labels (DB, applied)
Labels `cb76f7d0` (Tesla/Melancholy Moose) and `81911058` (Falling Waters wedding) overridden from `uncertain` → `qc_decision='escalate'` with note explaining ASSESSMENT block contamination was missed. Both captures flagged with `training_excluded=true`.

### Action 2 — Flag 10 contaminated captures (DB, applied)
All 10 ASSESSMENT-contaminated captures (Feb 10–11 2026, all `vrs_agent_dispatcher`) tagged with `capture_metadata = {"training_excluded": true, "exclusion_reason": "pre-2026-03-01_assessment_block_leak"}`. Exactly 10 rows. No false positives.

### Action 3 — Defense-in-depth filter (code)

**`privilege_filter.py`** — `check_training_contamination(prompt, response) → (bool, str)`
- Detects `\n---\n\n**ASSESSMENT**` separator pattern (primary)
- Fallback: individual markers `**Risk Level:**`, `**Strategy Type:**`, `**Citations Used:**`, `**ASSESSMENT**`
- Never raises; returns `(False, "")` on clean input

**`ai_router.py`** — hook in `_capture_interaction`
- Called after `classify_for_capture`
- If contaminated: logs WARNING, sets `capture_metadata = {"training_excluded": true, ...}` on INSERT
- Does not block write — audit trail preserved

**`nightly_distillation_exporter.py`** — export filter
```sql
AND (capture_metadata->>'training_excluded') IS DISTINCT FROM 'true'
```
The 10 historical captures and any future contaminated captures are invisible to nightly export.

### Action 4 — Tests

`src/tests/test_contamination_filter.py` — 18 new tests
- Known-bad Feb 2026 ASSESSMENT block format (full separator + case-insensitive)
- Individual metadata marker fallbacks
- False-positive resistance: JSON reasoning fields, plain HR, empty response, prompt-only markers, plain-text "assessment"
- Export filter logic: clean passes, excluded skips, combined flags, string-'true' edge case

**41/41 tests passing** (18 new + 8 dedup + 15 NIM).

## Verification

```
Total contaminated captures flagged:    10
Label overrides applied:                 2
Tests:                               41/41
```