### PR TITLE
fix(classifier): Defect 3 — Tier 1 override when content contradicts module hint

### DIFF
--- a/docs/IRON_DOME_ARCHITECTURE.md
+++ b/docs/IRON_DOME_ARCHITECTURE.md
@@ -270,6 +270,25 @@ Task classifier live. Three tiers: module hint → keyword pattern → qwen2.5:0
 Three-tier classifier: source hint → keyword → small LLM. Wires into
 ai_router at top of request path. Populates task_type on every capture.
 
+**Defect 3 fix (2026-04-19):** Tier 1 module hint can now be overridden by
+content analysis when the prompt strongly contradicts the module's default
+task type. Currently only fires for `pricing_math`: `quote_engine` is
+multi-purpose — it handles both pricing calculations and property
+description/marketing copy tasks. When a quote_engine prompt contains no
+pricing signal (`_PRICING_PATTERNS`) but clear descriptive signal
+(`_DESCRIPTIVE_PATTERNS`), `_detect_content_mismatch` returns `vrs_concierge`
+instead. Pricing signal always wins if present; the override only fires on
+zero pricing + positive descriptive. See `task_classifier.py`.
+
+**Ambiguous multi-purpose modules:** `quote_engine` defers to keyword content.
+`vrs_agent_dispatcher` stays `vrs_concierge` regardless of pricing keywords —
+the override only fires when Tier 1 resolves to `pricing_math`, not when it
+resolves to `vrs_concierge`. If a `vrs_agent_dispatcher` capture contains
+substantive pricing discussion, that is within-scope for `vrs_concierge`
+(staff pricing guidance is a concierge function). If pricing math becomes a
+distinct vrs sub-task with sufficient volume, add `vrs_pricing` to `_TASK_TYPES`
+and update `_MODULE_TO_TASK` in a separate architectural decision.
+
 ### Phase 4e.3 — Judge scaffolding (DONE, awaiting training data)
 Highest-volume task type, lowest-risk errors, fastest iteration.
 Proves the judge architecture end-to-end before replicating.

--- a/fortress-guest-platform/backend/services/task_classifier.py
+++ b/fortress-guest-platform/backend/services/task_classifier.py
@@ -16,8 +16,10 @@ import os
 import httpx
 
 from backend.services.task_types import (
+    _DESCRIPTIVE_PATTERNS,
     _KEYWORD_PATTERNS,
     _MODULE_TO_TASK,
+    _PRICING_PATTERNS,
     _TASK_TYPES,
 )
 
@@ -38,6 +40,40 @@ Valid task types: {types}
 Prompt: {prompt}
 
 Task type:"""
+
+
+def _detect_content_mismatch(tier1_type: str, prompt: str) -> "str | None":
+    """
+    Override Tier 1 when prompt content strongly contradicts the module hint.
+
+    Currently only fires for pricing_math: quote_engine is multi-purpose —
+    it generates both pricing calculations and property descriptions/marketing
+    copy. When the prompt contains no pricing signal but clear descriptive
+    signal (listing copy, amenity descriptions, "what does X look like"),
+    reclassify to vrs_concierge rather than training the model that
+    marketing copy == pricing_math.
+
+    Returns corrected task_type string or None (keep Tier 1 result).
+
+    Decision logged in docs/IRON_DOME_ARCHITECTURE.md Phase 4e.2.
+    """
+    if tier1_type != "pricing_math":
+        return None
+
+    has_pricing = any(p.search(prompt) for p in _PRICING_PATTERNS)
+    if has_pricing:
+        return None
+
+    has_descriptive = any(p.search(prompt) for p in _DESCRIPTIVE_PATTERNS)
+    if has_descriptive:
+        log.debug(
+            "task_classifier.tier1_override tier1=%s → vrs_concierge "
+            "(descriptive signal, no pricing signal)",
+            tier1_type,
+        )
+        return "vrs_concierge"
+
+    return None
 
 
 def _llm_classify(prompt: str) -> str:
@@ -90,15 +126,20 @@ def classify_task_type(
     Returns a string from _TASK_TYPES. Defaults to "generic" on failure.
     """
     try:
-        # Tier 1: source module
+        # Tier 1: source module — then check for content mismatch
+        tier1: str | None = None
         if source_module and source_module in _MODULE_TO_TASK:
-            return _MODULE_TO_TASK[source_module]
-
-        # Also check prefix — e.g. "legal_council_of_9/seat_1/..." → legal_reasoning
-        if source_module:
+            tier1 = _MODULE_TO_TASK[source_module]
+        elif source_module:
+            # prefix match: "legal_council_of_9/seat_1/..." → legal_reasoning
             for module_key, task in _MODULE_TO_TASK.items():
                 if source_module.startswith(module_key):
-                    return task
+                    tier1 = task
+                    break
+
+        if tier1 is not None:
+            override = _detect_content_mismatch(tier1, prompt)
+            return override if override is not None else tier1
 
         # Tier 2: keyword patterns
         combined = f"{prompt} {response}".lower()

--- a/fortress-guest-platform/backend/services/task_types.py
+++ b/fortress-guest-platform/backend/services/task_types.py
@@ -83,6 +83,45 @@ _MODULE_TO_TASK: dict[str, str] = {
 # Tier 2: keyword patterns → task_type (ordered, first match wins)
 # Case-insensitive — applied to lowercased combined prompt+response.
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Content-signal patterns for Tier 1 override logic
+# These are separate from _KEYWORD_PATTERNS (which are classification rules).
+# Used by _detect_content_mismatch in task_classifier.py to catch modules
+# whose source_module → task_type mapping is ambiguous (e.g. quote_engine
+# sometimes produces property descriptions instead of pricing calculations).
+# ---------------------------------------------------------------------------
+
+# Patterns that indicate the prompt is requesting a pricing calculation.
+# Must be present for a quote_engine capture to stay classified as pricing_math.
+_PRICING_PATTERNS: list[re.Pattern] = [
+    re.compile(r"\bnightly rate\b|\bprice per night\b|\brate per night\b",  re.IGNORECASE),
+    re.compile(r"\bhow much\b.{0,40}\b(?:night|stay|week|total)\b",         re.IGNORECASE),
+    re.compile(r"\bprice this\b|\bprice for\b|\brate for\b|\bquote for\b",  re.IGNORECASE),
+    re.compile(r"\brate.*(?:strategy|multiplier|extraction|adjustment)\b",   re.IGNORECASE),
+    re.compile(r"\bstrike.*(?:type|price|rate)\b|\brate.*strike\b",         re.IGNORECASE),
+    re.compile(r"\$\s*\d+",                                                  re.IGNORECASE),
+    re.compile(r"\btotal cost\b|\bbooking cost\b|\bfee schedule\b",         re.IGNORECASE),
+    re.compile(r"\bcompetitor.*(?:rate|price|nightly)\b",                   re.IGNORECASE),
+]
+
+# Patterns that indicate the prompt is requesting a property description,
+# marketing copy, or factual property information — not a price calculation.
+_DESCRIPTIVE_PATTERNS: list[re.Pattern] = [
+    re.compile(r"what does .{1,60} look like",                                              re.IGNORECASE),
+    re.compile(r"\bdescribe (?:the |this |that |\w+ )?(?:property|cabin|lodge|deck|exterior|interior|room|view|amenit)", re.IGNORECASE),
+    re.compile(r"\bmarketing copy\b|\blisting (?:description|copy)\b|\bproperty description\b", re.IGNORECASE),
+    re.compile(r"\btell me about\b|\bdetails about\b|\binfo(?:rmation)? about\b",          re.IGNORECASE),
+    re.compile(r"\bamenities of\b|\bfeatures of\b",                                        re.IGNORECASE),
+    re.compile(r"\b(?:deck|exterior|interior|views?|outdoor|indoor)\b.{0,40}\b(?:look|appear|feature|material|condition|built|made)\b", re.IGNORECASE),
+    re.compile(r"\bluxury (?:retreat|escape|sanctuary|experience)\b",                      re.IGNORECASE),
+    re.compile(r"\bself[- ]check.?in\b|\bsmart home\b|\bpanoram\w*\b",                    re.IGNORECASE),
+]
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: keyword patterns → task_type (ordered, first match wins)
+# Case-insensitive — applied to lowercased combined prompt+response.
+# ---------------------------------------------------------------------------
 _KEYWORD_PATTERNS: list[tuple[re.Pattern, str]] = [
     (re.compile(r"draft (?:a |the )?brief|opening statement|closing argument"), "brief_drafting"),
     (re.compile(r"analyze|review (?:this |the )contract"), "contract_analysis"),

--- a/src/tests/test_task_classifier_override.py
+++ b/src/tests/test_task_classifier_override.py
@@ -1,0 +1,171 @@
+"""
+Tests for the Tier 1 content-mismatch override in task_classifier.py.
+
+Phase 4e.2 defect: quote_engine maps to pricing_math by module hint,
+but it also handles property description / marketing copy requests.
+The override fires when the prompt has no pricing signal and clear
+descriptive signal — reclassifying to vrs_concierge.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "fortress-guest-platform"))
+from backend.services.task_classifier import classify_task_type, _detect_content_mismatch
+
+
+# ---------------------------------------------------------------------------
+# _detect_content_mismatch unit tests
+# ---------------------------------------------------------------------------
+
+class TestDetectContentMismatch:
+    def test_pricing_prompt_keeps_pricing_math(self):
+        assert _detect_content_mismatch("pricing_math",
+            "Price this property for 3 nights at nightly rate $250") is None
+
+    def test_rate_strategy_keeps_pricing_math(self):
+        assert _detect_content_mismatch("pricing_math",
+            "COMPETITOR VISUAL ANALYSIS: {} \nrate_multiplier extraction strategy") is None
+
+    def test_dollar_amount_keeps_pricing_math(self):
+        assert _detect_content_mismatch("pricing_math",
+            "What would be a $350/night rate for this cabin?") is None
+
+    def test_strike_type_extraction_keeps_pricing_math(self):
+        assert _detect_content_mismatch("pricing_math",
+            'strike_type: "extraction", rate_multiplier: 1.20') is None
+
+    def test_descriptive_no_pricing_overrides_to_vrs_concierge(self):
+        result = _detect_content_mismatch("pricing_math",
+            "What does High Hopes look like? Describe the exterior and amenities.")
+        assert result == "vrs_concierge"
+
+    def test_marketing_copy_request_overrides(self):
+        result = _detect_content_mismatch("pricing_math",
+            "Generate marketing copy for this luxury retreat. "
+            "Property: Above the Timberline. Self check-in, panoramic views.")
+        assert result == "vrs_concierge"
+
+    def test_tell_me_about_amenities_overrides(self):
+        result = _detect_content_mismatch("pricing_math",
+            "Tell me about the amenities of High Hopes cabin.")
+        assert result == "vrs_concierge"
+
+    def test_non_pricing_math_module_never_overrides(self):
+        """Override must not fire for any other task_type."""
+        for task in ("vrs_concierge", "legal_reasoning", "vision_photo",
+                     "market_research", "generic"):
+            assert _detect_content_mismatch(task, "describe the property exterior") is None
+
+    def test_prompt_with_both_signals_keeps_pricing(self):
+        """Pricing signal present → no override even if descriptive language also present."""
+        result = _detect_content_mismatch("pricing_math",
+            "Describe the property and give me a nightly rate for 3 nights.")
+        assert result is None
+
+    def test_empty_prompt_no_override(self):
+        assert _detect_content_mismatch("pricing_math", "") is None
+
+
+# ---------------------------------------------------------------------------
+# Full classify_task_type integration tests
+# ---------------------------------------------------------------------------
+
+class TestClassifyTaskTypeOverride:
+    def _classify(self, module: str, prompt: str) -> str:
+        """Classify with LLM tier mocked out (not needed for these tests)."""
+        with patch("backend.services.task_classifier._llm_classify", return_value="generic"):
+            return classify_task_type(module, prompt)
+
+    # --- Tier 1 wins: pricing keywords confirm module hint ---
+
+    def test_quote_engine_explicit_pricing_stays_pricing_math(self):
+        assert self._classify(
+            "quote_engine",
+            "Price this property for 3 nights. Nightly rate: $275. What is the total?",
+        ) == "pricing_math"
+
+    def test_quote_engine_rate_strategy_stays_pricing_math(self):
+        assert self._classify(
+            "quote_engine",
+            "COMPETITOR VISUAL ANALYSIS: {}\nrate_multiplier: 1.20, strike_type: extraction",
+        ) == "pricing_math"
+
+    def test_quote_engine_dollar_amount_stays_pricing_math(self):
+        assert self._classify(
+            "quote_engine",
+            "Adjust the nightly rate. Current: $320. Competitor avg: $289.",
+        ) == "pricing_math"
+
+    # --- Tier 2 overrides: descriptive prompt from pricing module ---
+
+    def test_quote_engine_what_does_look_like_overrides(self):
+        assert self._classify(
+            "quote_engine",
+            "What does High Hopes look like? Describe exterior and amenities.",
+        ) == "vrs_concierge"
+
+    def test_quote_engine_listing_description_overrides(self):
+        assert self._classify(
+            "quote_engine",
+            "Property: High Hopes\nDates: 2026-05-15 to 2026-05-17\n"
+            "Generate a listing description. Luxury retreat, self check-in, panoramic views.",
+        ) == "vrs_concierge"
+
+    def test_quote_engine_tell_me_about_amenities_overrides(self):
+        assert self._classify(
+            "quote_engine",
+            "Tell me about the amenities of this cabin. Features of the outdoor deck.",
+        ) == "vrs_concierge"
+
+    # --- vrs_agent_dispatcher: pricing keywords do NOT override to pricing_math ---
+
+    def test_vrs_dispatcher_with_pricing_keywords_stays_vrs_concierge(self):
+        """
+        vrs_agent_dispatcher → vrs_concierge via Tier 1.
+        Pricing keywords alone don't trigger override (only pricing_math can be overridden).
+        """
+        assert self._classify(
+            "vrs_agent_dispatcher",
+            "The nightly rate is $250. Price this stay for 3 nights total.",
+        ) == "vrs_concierge"
+
+    def test_vrs_dispatcher_generic_concierge_stays_vrs_concierge(self):
+        assert self._classify(
+            "vrs_agent_dispatcher",
+            "Guest asking about checkout procedures.",
+        ) == "vrs_concierge"
+
+    # --- Legal and other modules unaffected ---
+
+    def test_legal_module_unaffected(self):
+        assert self._classify(
+            "legal_council",
+            "describe the exterior of the property at issue in this case",
+        ) == "legal_reasoning"
+
+    def test_unknown_module_falls_through_to_keyword(self):
+        """Module not in _MODULE_TO_TASK falls to Tier 2 keyword patterns."""
+        result = self._classify(
+            "unknown_module",
+            "Please debug this traceback: AttributeError on line 42",
+        )
+        assert result == "code_debugging"
+
+    # --- Retroactive fix verification: the mislabeled High Hopes capture ---
+
+    def test_high_hopes_marketing_copy_prompt_reclassified(self):
+        """
+        Regression test for capture 308ec10c (label 1881b85f).
+        quote_engine sent a property data packet; response was marketing copy.
+        The new classifier must return vrs_concierge, not pricing_math.
+        """
+        prompt = (
+            "Property: High Hopes\n"
+            "Dates: 2026-05-15 to 2026-05-17\n"
+            "Amenities: self check-in, smart home, panoramic views, luxury retreat\n"
+            "Generate a property description for our listing."
+        )
+        assert self._classify("quote_engine", prompt) == "vrs_concierge"


### PR DESCRIPTION
## Problem

`quote_engine` maps to `pricing_math` via Tier 1 module hint, but it is multi-purpose — it generates both pricing calculations and property description/marketing copy. A High Hopes listing description prompt was stored with `task_type=pricing_math`, misleading the Godhead (which correctly flagged it as `uncertain` due to task type mismatch) and contaminating future judge training.

## Changes

### `task_types.py` — two new pattern lists
- **`_PRICING_PATTERNS`** (8 patterns): nightly rate, price/rate/cost keywords, strike type, dollar amounts — signals a genuine pricing calculation request
- **`_DESCRIPTIVE_PATTERNS`** (8 patterns): "what does X look like", marketing copy, listing/property description, amenity descriptions, deck/exterior detail, luxury retreat markers

### `task_classifier.py` — `_detect_content_mismatch(tier1_type, prompt)`
- Fires **only** when `tier1_type = "pricing_math"` AND no pricing pattern matches AND a descriptive pattern matches
- Returns `"vrs_concierge"`; otherwise returns `None` (keep Tier 1)
- Pricing signal always wins if present — override only fires on zero pricing + positive descriptive
- `classify_task_type` now calls this after resolving Tier 1, before returning

### `docs/IRON_DOME_ARCHITECTURE.md` — Phase 4e.2 updated
- Override logic documented
- Ambiguous multi-purpose module policy: `quote_engine` defers to content; `vrs_agent_dispatcher` stays `vrs_concierge` (pricing is within-scope for concierge)

## Behavior summary

| Input | Before | After |
|---|---|---|
| `quote_engine` + "Price this for 3 nights, $275/night" | `pricing_math` | `pricing_math` ✓ |
| `quote_engine` + "What does High Hopes look like?" | `pricing_math` ✗ | `vrs_concierge` ✓ |
| `quote_engine` + listing description prompt | `pricing_math` ✗ | `vrs_concierge` ✓ |
| `vrs_agent_dispatcher` + pricing keywords | `vrs_concierge` | `vrs_concierge` ✓ |
| `legal_council` + "describe the property" | `legal_reasoning` | `legal_reasoning` ✓ |

## Retroactive DB fix (applied)

| Row | Change |
|---|---|
| `llm_training_captures` `308ec10c` | `task_type` `pricing_math` → `vrs_concierge`; `capture_metadata` tagged with `task_type_reclassified=true` |
| `capture_labels` `1881b85f` | `task_type` `pricing_math` → `vrs_concierge` |

## Tests
**21 new tests, 62 total passing**
- `_detect_content_mismatch` unit tests: pricing keeps pricing, descriptive-only overrides, both signals keeps pricing, empty prompt, all non-pricing-math task types return None
- Full `classify_task_type` integration tests covering all 5 behavior cases above
- Regression test: High Hopes actual prompt → `vrs_concierge`

⚠️ **Stop before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)