### PR TITLE
feat(infra): Phase 5a Part 1 — Qdrant VRS on spark-4 + RAG ingestion audit

### DIFF
--- a/deploy/systemd/fortress-qdrant-vrs.service
+++ b/deploy/systemd/fortress-qdrant-vrs.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=Fortress Prime — Qdrant VRS vector store (spark-4)
+Documentation=file:///home/admin/Fortress-Prime/deploy/systemd/fortress-qdrant-vrs.service
+After=docker.service network-online.target
+Requires=docker.service
+
+[Service]
+Type=simple
+User=admin
+Group=admin
+Restart=always
+RestartSec=10
+
+# Stop and remove any stale container before starting fresh
+ExecStartPre=-/usr/bin/docker stop fortress-qdrant-vrs
+ExecStartPre=-/usr/bin/docker rm fortress-qdrant-vrs
+ExecStart=/usr/bin/docker run \
+  --name fortress-qdrant-vrs \
+  --rm \
+  -p 6333:6333 \
+  -p 6334:6334 \
+  -v /mnt/fortress_nas/qdrant-vrs:/qdrant/storage \
+  qdrant/qdrant:latest
+ExecStop=/usr/bin/docker stop fortress-qdrant-vrs
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=fortress-qdrant-vrs
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/IRON_DOME_ARCHITECTURE.md
+++ b/docs/IRON_DOME_ARCHITECTURE.md
@@ -320,7 +320,29 @@ PLUS captures where judge_decision = escalate on legal tasks (with
 matter-level redaction). Ships after legal_reasoning_judge is mature.
 
 ### Phase 5a — RAG architecture migration (from v4)
-Build domain-isolated stores. Unchanged from v4.
+
+**Part 1 — spark-4 VRS Qdrant LIVE (2026-04-19)**
+- Qdrant `latest` running on spark-4 (192.168.0.106:6333) via Docker
+- Data volume: `/mnt/fortress_nas/qdrant-vrs/` (NAS-backed)
+- systemd unit: `fortress-qdrant-vrs.service` (enabled, starts on boot)
+- Collection `fgp_vrs_knowledge` created: 768d Cosine, 4 payload indexes
+  (`source_table`, `record_id`, `property_id`, `category`) — empty, migration deferred
+- Smoke test passed: write → read → delete round-trip from both spark-4 and spark-2
+- Full ingestion audit: `docs/RAG_INGESTION_AUDIT.md`
+
+**Part 2 — Dual-write (NEXT)**: add `QDRANT_VRS_URL` env var; `VectorizerWorker`
+and `sync_knowledge_base_to_qdrant` write to both spark-2 and spark-4 simultaneously.
+
+**Part 3 — Read cutover (LATER)**: after spark-4 data matches spark-2 (168 points +
+ongoing delta), flip `QDRANT_URL` → spark-4 and `QDRANT_COLLECTION_NAME` → `fgp_vrs_knowledge`.
+Remove dual-write code.
+
+Recommendation: Option A (dual-write) — not Option B (hard cutover) because
+`_qdrant_search` is called on every guest concierge interaction (zero downtime tolerance).
+See `docs/RAG_INGESTION_AUDIT.md` for full write/read site table and rationale.
+
+Legal collections (`legal_library`, `legal_ediscovery`) stay on spark-2 permanently;
+they are NOT in Phase 5a scope.
 
 ### Phase 5b — Node role migration (from v4)
 Move NIM off spark-2. Unchanged from v4.

--- a/docs/RAG_INGESTION_AUDIT.md
+++ b/docs/RAG_INGESTION_AUDIT.md
@@ -1,0 +1,105 @@
+# Fortress Prime — RAG Ingestion Audit
+*Generated 2026-04-19 as part of Phase 5a Part 1. Used to sequence the VRS Qdrant migration.*
+
+## Qdrant instances
+
+| Host | Port | Version | Role |
+|---|---|---|---|
+| spark-2 (192.168.0.100) | 6333/6334 | v1.13.2 | **Current production** — all live traffic |
+| spark-4 (192.168.0.106) | 6333/6334 | latest | **New VRS instance** — empty, ready for cutover |
+
+All writes currently target `settings.qdrant_url` (spark-2).
+
+---
+
+## Write site audit
+
+| file:line | service/worker | collection | trigger / frequency |
+|---|---|---|---|
+| `backend/workers/vectorizer.py:136` | `VectorizerWorker` (arq job) | `fgp_knowledge` | Event-driven: on every `PropertyKnowledge` row insert/update. Batched via arq queue. |
+| `backend/services/knowledge_retriever.py:253,258` | `sync_knowledge_base_to_qdrant()` | `fgp_knowledge` | Manual or admin-triggered full resync. Rebuilds all vectors from `property_knowledge` table. |
+| `backend/services/legal_vector_sync.py:381` | `LegalVectorSync` | `legal_library` | Event-driven: on legal document ingest/update. Uses `qdrant_client` SDK. |
+| `backend/services/legal_vector_sync.py:286` | `reset_qdrant_collection()` | `legal_library` | Manual reset — destructive, admin-only. |
+| `backend/services/legal_ediscovery.py:309` | eDiscovery evidence ingestion | `legal_ediscovery` | On evidence upsert via eDiscovery API route. |
+| `backend/core/vector_db.py:61` | `ensure_qdrant_collection()` | `historical_quotes` | Startup / on-demand collection creation only. |
+| `backend/api/s2s_voice_stream.py:138` | Voice stream handler (read) | `guest_golden_responses` | Read-only search at query time — not a write path. |
+| `backend/api/elevenlabs_tools.py:72` | ElevenLabs tools (read) | `guest_golden_responses` | Read-only search at query time — not a write path. |
+
+**VRS-domain write paths (Phase 5a scope):**
+- `VectorizerWorker → fgp_knowledge` — **primary, high frequency**
+- `sync_knowledge_base_to_qdrant → fgp_knowledge` — secondary, manual
+
+**Out of scope for Phase 5a (legal / finance / agent stays on spark-2):**
+- `legal_library`, `legal_ediscovery`, `historical_quotes`, `guest_golden_responses`
+- All `*_intel`, `email_embeddings`, `fortress_*` collections (market/legal intelligence)
+
+---
+
+## Read site audit
+
+| file:line | service | collection | call frequency |
+|---|---|---|---|
+| `backend/services/knowledge_retriever.py:83` | `_qdrant_search()` | `fgp_knowledge` | **Every concierge/VRS query** — hot path |
+| `backend/services/knowledge_retriever.py:320` | `_qdrant_legal_search()` | `legal_library` | On every legal reasoning request |
+| `backend/services/agentic_orchestrator.py:544` | `OrchestratorAgent` | `fgp_knowledge` (via `knowledge_retriever`) | On every agent turn that needs property context |
+| `backend/services/dgx_tools.py:170` | DGX semantic search tool | `fgp_knowledge` | Agent tool use — moderate |
+| `backend/services/crog_concierge_engine.py:204` | ConciergeEngine | `fgp_knowledge` | Per concierge chat turn |
+| `backend/services/prompt_engineer.py:185` | PromptEngineer | `fgp_knowledge` | Per cloud-bound prompt compilation |
+| `backend/services/damage_workflow.py:118` | DamageWorkflow | `fgp_golden_claims` | On damage claim processing |
+| `backend/services/agent_swarm/nodes.py:97` | AgentSwarm nodes | `historical_quotes` | Per agent swarm invocation |
+| `backend/api/s2s_voice_stream.py:138` | Voice stream | `guest_golden_responses` | Per voice interaction |
+| `backend/api/elevenlabs_tools.py:72` | ElevenLabs tools | `guest_golden_responses` | Per ElevenLabs tool call |
+
+---
+
+## Hardcoded references that must change during cutover
+
+All VRS paths use `settings.qdrant_collection_name` (default: `"fgp_knowledge"`) via `COLLECTION_NAME` in `backend/core/qdrant.py`. This is the **single configuration point** for collection name. The target collection on spark-4 is named `fgp_vrs_knowledge`.
+
+**Two env vars control all VRS Qdrant traffic:**
+```
+QDRANT_URL       → currently points to spark-2
+QDRANT_COLLECTION_NAME → currently "fgp_knowledge"
+```
+
+The legal paths (`legal_vector_sync`, `legal_ediscovery`) hardcode their collection names as module constants and use `settings.qdrant_url` for the host. They are **NOT** controlled by `QDRANT_COLLECTION_NAME` and are unaffected by the VRS cutover.
+
+---
+
+## Cutover strategy recommendation
+
+### Option A — Dual-write (RECOMMENDED)
+
+**Phase 5a Part 2:** Add a secondary write target.
+- Introduce `QDRANT_VRS_URL` env var pointing to spark-4.
+- When `QDRANT_VRS_URL` is set, `VectorizerWorker` and `sync_knowledge_base_to_qdrant` write to both `settings.qdrant_url` (old, `fgp_knowledge`) and `QDRANT_VRS_URL` (new, `fgp_vrs_knowledge`).
+- Run both in parallel for 1–2 weeks; monitor spark-4 ingestion lag.
+
+**Phase 5a Part 3:** Data migration + read cutover.
+- Run `sync_knowledge_base_to_qdrant` against `fgp_vrs_knowledge` to backfill existing 168 points.
+- Once spark-4 point count matches spark-2, flip `QDRANT_URL` to spark-4 and `QDRANT_COLLECTION_NAME` to `fgp_vrs_knowledge`.
+- Remove dual-write code.
+
+**Why not Option B (hard cutover)?**
+The VRS concierge (`_qdrant_search`) is called on every guest interaction — zero downtime tolerance. A hard flip requires atomic migration + env var change in a narrow maintenance window. One bad deployment rolls back cleanly with dual-write; a hard cutover in a failing state degrades all guest queries.
+
+**Why not Option C (dual-read/single-write)?**
+Reading from spark-2 while writing to spark-4 creates a divergence window where concierge reads stale data from spark-2. Dual-write keeps both in sync during transition; dual-read does not.
+
+---
+
+## Current spark-2 collection inventory (21 collections)
+
+VRS-domain (Phase 5a scope):
+- `fgp_knowledge` — 168 points, 768d Cosine, 4 payload indexes
+- `fgp_golden_claims` — (size TBD)
+- `guest_golden_responses`
+
+Legal-domain (out of scope):
+- `legal_library`, `legal_ediscovery`, `legal_headhunter_memory`, `legal_hive_mind_memory`
+
+Market/finance intelligence (out of scope):
+- `raoul_intel`, `jordi_intel`, `permabear_intel`, `fed_watcher_intel`, `lyn_intel`, `black_swan_intel`, `sound_money_intel`, `vol_trader_intel`, `market_intelligence`, `real_estate_intel`
+
+Other:
+- `historical_quotes`, `email_embeddings`, `fortress_knowledge`, `fortress_documents`


### PR DESCRIPTION
## Summary

Provisions spark-4 as the dedicated VRS vector store. No data migration, no write path changes. This PR is infra + audit only — the ingestion cutover is Phase 5a Part 2.

## What's live

Qdrant running on **spark-4 (192.168.0.106:6333)** with collection `fgp_vrs_knowledge`:
- 768-dimensional, Cosine distance
- 4 payload indexes: `source_table`, `record_id`, `property_id`, `category`
- Data on NAS: `/mnt/fortress_nas/qdrant-vrs/`
- systemd unit enabled: `fortress-qdrant-vrs.service`

## Smoke tests

| Test | Result |
|---|---|
| `GET /collections/fgp_vrs_knowledge` from spark-4 | ✅ `status: green` |
| `GET /collections/fgp_vrs_knowledge` from spark-2 | ✅ `status: green` |
| Upsert point (wait=true) | ✅ `status: completed` |
| Read point back | ✅ id + 768-dim vector + payload confirmed |
| Delete point (wait=true) | ✅ `status: completed` |
| Docker logs | ✅ all 200s, no errors |

## RAG ingestion audit (new: `docs/RAG_INGESTION_AUDIT.md`)

**VRS write paths (Phase 5a scope):**
| file | collection | frequency |
|---|---|---|
| `workers/vectorizer.py:136` | `fgp_knowledge` | Event-driven — every PropertyKnowledge upsert |
| `services/knowledge_retriever.py:253` | `fgp_knowledge` | Manual full resync |

**Read hot paths:**
- `_qdrant_search()` in `knowledge_retriever.py:83` — called on every concierge/VRS query
- Also: `agentic_orchestrator`, `dgx_tools`, `crog_concierge_engine`, `prompt_engineer`

**Single control point:** `QDRANT_URL` + `QDRANT_COLLECTION_NAME` env vars route all VRS traffic.

## Cutover recommendation

**Option A (dual-write)** for Phase 5a Part 2:
- Add `QDRANT_VRS_URL` env var → spark-4
- Write to both `QDRANT_URL` (spark-2, `fgp_knowledge`) and `QDRANT_VRS_URL` (spark-4, `fgp_vrs_knowledge`)
- Validate spark-4 content parity, then flip reads and remove dual-write

Hard cutover (Option B) rejected: `_qdrant_search` is on the hot path of every guest interaction — zero downtime tolerance.

## Architecture doc updated

Phase 5a section in `IRON_DOME_ARCHITECTURE.md`: Part 1 marked live, Parts 2 and 3 scoped, legal collections excluded.

⚠️ **Stop before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)