### PR TITLE
feat(rag): Phase 5a Part 2 — snapshot migrate fgp_knowledge → fgp_vrs_knowledge

### DIFF
--- a/docs/IRON_DOME_ARCHITECTURE.md
+++ b/docs/IRON_DOME_ARCHITECTURE.md
@@ -330,8 +330,18 @@ matter-level redaction). Ships after legal_reasoning_judge is mature.
 - Smoke test passed: write → read → delete round-trip from both spark-4 and spark-2
 - Full ingestion audit: `docs/RAG_INGESTION_AUDIT.md`
 
-**Part 2 — Dual-write (NEXT)**: add `QDRANT_VRS_URL` env var; `VectorizerWorker`
-and `sync_knowledge_base_to_qdrant` write to both spark-2 and spark-4 simultaneously.
+**Part 2 — Snapshot migration COMPLETE (2026-04-19)**
+- 168 points migrated from spark-2 `fgp_knowledge` → spark-4 `fgp_vrs_knowledge`
+- Tool: `src/rag/migrate_fgp_to_vrs.py` (scroll 3×64-batch + upsert wait=true)
+- Verification: count parity 168==168 ✓, 10/10 sampled vectors byte-identical ✓
+- Elapsed: 1.2s. Idempotent — safe to re-run with --force.
+- spark-2 `fgp_knowledge` is **NOT modified** — remains source of truth for reads.
+- spark-4 `fgp_vrs_knowledge` is a static snapshot. New writes still go to spark-2
+  until Part 3 (ingestion cutover).
+
+**Part 3 — Ingestion cutover + read flip (NEXT)**: add `QDRANT_VRS_URL` env var;
+`VectorizerWorker` and `sync_knowledge_base_to_qdrant` write to both spark-2 and
+spark-4 simultaneously. Once parity is confirmed stable, flip reads to spark-4.
 
 **Part 3 — Read cutover (LATER)**: after spark-4 data matches spark-2 (168 points +
 ongoing delta), flip `QDRANT_URL` → spark-4 and `QDRANT_COLLECTION_NAME` → `fgp_vrs_knowledge`.

--- a/src/rag/migrate_fgp_to_vrs.py
+++ b/src/rag/migrate_fgp_to_vrs.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""
+migrate_fgp_to_vrs.py — Phase 5a Part 2 snapshot copy.
+
+Copies all points from spark-2 fgp_knowledge (source of truth, read-only)
+to spark-4 fgp_vrs_knowledge (new VRS vector store).
+
+  - Preserves point IDs, vectors, and all payload fields.
+  - Uses scroll + upsert (idempotent — safe to re-run).
+  - Refuses to write if target is non-empty unless --force is given.
+  - Post-migration: verifies count parity and spot-checks 10 random vectors
+    byte-for-byte between source and target.
+
+spark-2 fgp_knowledge remains the active read path until Phase 5a Part 3.
+
+Usage:
+  python3 -m src.rag.migrate_fgp_to_vrs [--dry-run] [--batch-size N] [--force]
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import random
+import sys
+from datetime import datetime, timezone
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='{"time":"%(asctime)s","level":"%(levelname)s","msg":"%(message)s","svc":"migrate_fgp"}',
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+log = logging.getLogger("migrate_fgp")
+
+SOURCE_URL        = "http://192.168.0.100:6333"
+SOURCE_COLLECTION = "fgp_knowledge"
+TARGET_URL        = "http://192.168.0.106:6333"
+TARGET_COLLECTION = "fgp_vrs_knowledge"
+EXPECTED_DIM      = 768
+EXPECTED_DISTANCE = "Cosine"
+VERIFY_SAMPLE_N   = 10
+
+
+# ---------------------------------------------------------------------------
+# Qdrant helpers
+# ---------------------------------------------------------------------------
+
+def _make_client(url: str):
+    from qdrant_client import QdrantClient
+    return QdrantClient(url=url, timeout=60, check_compatibility=False)
+
+
+def _collection_info(client, collection: str) -> tuple[int, int, str]:
+    """Return (points_count, vector_size, distance)."""
+    info = client.get_collection(collection)
+    p = info.config.params
+    return (
+        info.points_count,
+        p.vectors.size,
+        p.vectors.distance.name,  # "Cosine" | "Euclid" | "Dot"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Safety checks
+# ---------------------------------------------------------------------------
+
+def _verify_schemas(source, target) -> tuple[int, int]:
+    """
+    Verify vector dimensions and distance match on both ends.
+    Returns (src_count, tgt_count).
+    Raises ValueError on mismatch.
+    """
+    src_count, src_dim, src_dist = _collection_info(source, SOURCE_COLLECTION)
+    tgt_count, tgt_dim, tgt_dist = _collection_info(target, TARGET_COLLECTION)
+
+    if src_dim != EXPECTED_DIM:
+        raise ValueError(
+            f"Source dimension mismatch: expected {EXPECTED_DIM}, got {src_dim}"
+        )
+    if tgt_dim != EXPECTED_DIM:
+        raise ValueError(
+            f"Target dimension mismatch: expected {EXPECTED_DIM}, got {tgt_dim}"
+        )
+    if src_dist.lower() != EXPECTED_DISTANCE.lower():
+        raise ValueError(
+            f"Source distance mismatch: expected {EXPECTED_DISTANCE}, got {src_dist}"
+        )
+    if tgt_dist.lower() != EXPECTED_DISTANCE.lower():
+        raise ValueError(
+            f"Target distance mismatch: expected {EXPECTED_DISTANCE}, got {tgt_dist}"
+        )
+    if src_count == 0:
+        raise ValueError("Source collection is empty — nothing to migrate")
+
+    return src_count, tgt_count
+
+
+# ---------------------------------------------------------------------------
+# Core migration
+# ---------------------------------------------------------------------------
+
+def _scroll_all(source, batch_size: int) -> list:
+    """Scroll all points from source, return as list of PointStruct."""
+    from qdrant_client.models import PointStruct
+
+    points: list[PointStruct] = []
+    offset = None
+    while True:
+        batch, next_offset = source.scroll(
+            SOURCE_COLLECTION,
+            offset=offset,
+            limit=batch_size,
+            with_vectors=True,
+            with_payload=True,
+        )
+        if not batch:
+            break
+        points.extend(
+            PointStruct(id=p.id, vector=p.vector, payload=p.payload)
+            for p in batch
+        )
+        log.info(
+            "scrolled batch total=%d latest_offset=%s",
+            len(points),
+            str(batch[-1].id)[:8],
+        )
+        if next_offset is None:
+            break
+        offset = next_offset
+    return points
+
+
+def _upsert_batched(target, points: list, batch_size: int) -> int:
+    """Upsert all points to target in batches. Returns total upserted."""
+    total = 0
+    for i in range(0, len(points), batch_size):
+        chunk = points[i : i + batch_size]
+        target.upsert(collection_name=TARGET_COLLECTION, points=chunk, wait=True)
+        total += len(chunk)
+        log.info("upserted %d/%d", total, len(points))
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Post-migration verification
+# ---------------------------------------------------------------------------
+
+def _verify(source, target, src_count: int, tgt_count: int) -> bool:
+    """
+    Two-phase verification:
+    1. Count parity: source count == target count.
+    2. Vector spot-check: 10 random point IDs — vectors must be byte-identical.
+    Returns True if all checks pass.
+    """
+    ok = True
+
+    if tgt_count != src_count:
+        log.error(
+            "COUNT MISMATCH: source=%d target=%d — migration incomplete",
+            src_count, tgt_count,
+        )
+        ok = False
+    else:
+        log.info("count_check PASS: source=%d target=%d", src_count, tgt_count)
+
+    # Sample 10 random IDs from source
+    sample_batch, _ = source.scroll(
+        SOURCE_COLLECTION,
+        limit=max(src_count, VERIFY_SAMPLE_N * 3),
+        with_vectors=True,
+        with_payload=False,
+    )
+    sample_points = random.sample(sample_batch, min(VERIFY_SAMPLE_N, len(sample_batch)))
+    sample_ids = [str(p.id) for p in sample_points]
+    src_vectors = {str(p.id): p.vector for p in sample_points}
+
+    tgt_results = target.retrieve(
+        TARGET_COLLECTION,
+        ids=sample_ids,
+        with_vectors=True,
+        with_payload=False,
+    )
+    tgt_vectors = {str(p.id): p.vector for p in tgt_results}
+
+    mismatches = 0
+    for pid, src_vec in src_vectors.items():
+        tgt_vec = tgt_vectors.get(pid)
+        if tgt_vec is None:
+            log.error("VECTOR_CHECK FAIL: point %s not found on target", pid[:8])
+            mismatches += 1
+        elif src_vec != tgt_vec:
+            log.error("VECTOR_CHECK FAIL: point %s vector mismatch", pid[:8])
+            mismatches += 1
+
+    if mismatches:
+        log.error("vector_check FAIL: %d/%d mismatches", mismatches, len(src_vectors))
+        ok = False
+    else:
+        log.info(
+            "vector_check PASS: %d/%d sampled points match byte-for-byte",
+            len(src_vectors), len(src_vectors),
+        )
+
+    return ok
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+def run(dry_run: bool, batch_size: int, force: bool) -> int:
+    t_start = datetime.now(tz=timezone.utc)
+    log.info(
+        "=== Phase 5a Part 2: fgp_knowledge → fgp_vrs_knowledge ==="
+    )
+    log.info(
+        "source=%s/%s  target=%s/%s  dry_run=%s  batch_size=%d  force=%s",
+        SOURCE_URL, SOURCE_COLLECTION,
+        TARGET_URL, TARGET_COLLECTION,
+        dry_run, batch_size, force,
+    )
+
+    source = _make_client(SOURCE_URL)
+    target = _make_client(TARGET_URL)
+
+    # Schema + count check
+    try:
+        src_count, tgt_count = _verify_schemas(source, target)
+    except ValueError as e:
+        log.error("pre_check_failed: %s", e)
+        return 1
+
+    log.info(
+        "pre_check PASS: source=%d points  target=%d points  dim=%d  dist=%s",
+        src_count, tgt_count, EXPECTED_DIM, EXPECTED_DISTANCE,
+    )
+
+    if dry_run:
+        log.info(
+            "[DRY RUN] Would migrate %d points from %s → %s. No writes performed.",
+            src_count, SOURCE_COLLECTION, TARGET_COLLECTION,
+        )
+        return 0
+
+    # Non-empty target safety check
+    if tgt_count > 0 and not force:
+        log.error(
+            "target already has %d points — use --force to overwrite. "
+            "Migration is idempotent via upsert.",
+            tgt_count,
+        )
+        return 1
+    if tgt_count > 0:
+        log.warning(
+            "target has %d existing points — --force set, proceeding with upsert",
+            tgt_count,
+        )
+
+    # Scroll all from source
+    log.info("scrolling all points from source …")
+    points = _scroll_all(source, batch_size)
+    log.info("scroll complete: %d points fetched", len(points))
+
+    if len(points) != src_count:
+        log.error(
+            "scroll count mismatch: fetched %d but source reports %d",
+            len(points), src_count,
+        )
+        return 1
+
+    # Upsert to target
+    log.info("upserting to target …")
+    upserted = _upsert_batched(target, points, batch_size)
+
+    t_end = datetime.now(tz=timezone.utc)
+    elapsed = (t_end - t_start).total_seconds()
+
+    # Post-migration verification
+    log.info("running post-migration verification …")
+    final_tgt_count, _, _ = _collection_info(target, TARGET_COLLECTION)
+    passed = _verify(source, target, src_count, final_tgt_count)
+
+    log.info(
+        "=== migration complete: upserted=%d elapsed=%.1fs verified=%s ===",
+        upserted, elapsed, "PASS" if passed else "FAIL",
+    )
+
+    return 0 if passed else 2
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Phase 5a Part 2: migrate fgp_knowledge → fgp_vrs_knowledge"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Verify connectivity and counts without writing",
+    )
+    parser.add_argument(
+        "--batch-size", type=int, default=64, metavar="N",
+        help="Points per scroll/upsert batch (default: 64)",
+    )
+    parser.add_argument(
+        "--force", action="store_true",
+        help="Proceed even if target is non-empty (upsert is idempotent)",
+    )
+    args = parser.parse_args()
+    sys.exit(run(args.dry_run, args.batch_size, args.force))

--- a/src/tests/test_migrate_fgp_to_vrs.py
+++ b/src/tests/test_migrate_fgp_to_vrs.py
@@ -1,0 +1,223 @@
+"""
+Tests for migrate_fgp_to_vrs.py — Phase 5a Part 2 snapshot migration.
+
+Mocks both Qdrant clients; tests safety checks, batch pagination,
+force flag, dimension mismatch, and byte-equality verification.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import rag.migrate_fgp_to_vrs as m
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_collection_info(points: int, dim: int = 768, dist: str = "Cosine") -> MagicMock:
+    info = MagicMock()
+    info.points_count = points
+    info.config.params.vectors.size = dim
+    info.config.params.vectors.distance.name = dist
+    return info
+
+
+def _make_point(pid: str, vec: list[float] | None = None) -> MagicMock:
+    p = MagicMock()
+    p.id = pid
+    p.vector = vec or [0.01] * 768
+    p.payload = {"source_table": "test", "record_id": pid}
+    return p
+
+
+# ---------------------------------------------------------------------------
+# _verify_schemas
+# ---------------------------------------------------------------------------
+
+class TestVerifySchemas:
+    def _run(self, src_pts=168, src_dim=768, src_dist="Cosine",
+             tgt_pts=0, tgt_dim=768, tgt_dist="Cosine"):
+        source = MagicMock()
+        target = MagicMock()
+        source.get_collection.return_value = _make_collection_info(src_pts, src_dim, src_dist)
+        target.get_collection.return_value = _make_collection_info(tgt_pts, tgt_dim, tgt_dist)
+        return m._verify_schemas(source, target)
+
+    def test_happy_path(self):
+        src, tgt = self._run()
+        assert src == 168 and tgt == 0
+
+    def test_source_empty_raises(self):
+        with pytest.raises(ValueError, match="empty"):
+            self._run(src_pts=0)
+
+    def test_source_dim_mismatch_raises(self):
+        with pytest.raises(ValueError, match="Source dimension"):
+            self._run(src_dim=1024)
+
+    def test_target_dim_mismatch_raises(self):
+        with pytest.raises(ValueError, match="Target dimension"):
+            self._run(tgt_dim=512)
+
+    def test_source_distance_mismatch_raises(self):
+        with pytest.raises(ValueError, match="Source distance"):
+            self._run(src_dist="Euclid")
+
+    def test_target_distance_mismatch_raises(self):
+        with pytest.raises(ValueError, match="Target distance"):
+            self._run(tgt_dist="Dot")
+
+
+# ---------------------------------------------------------------------------
+# _scroll_all — batch pagination
+# ---------------------------------------------------------------------------
+
+class TestScrollAll:
+    def test_single_batch_no_next_offset(self):
+        """All points fit in one scroll — next_offset is None."""
+        pts = [_make_point(f"id-{i}") for i in range(10)]
+        source = MagicMock()
+        source.scroll.return_value = (pts, None)
+
+        result = m._scroll_all(source, batch_size=64)
+        assert len(result) == 10
+        source.scroll.assert_called_once()
+
+    def test_multi_batch_pagination(self):
+        """Two batches: first returns next_offset, second returns None."""
+        batch1 = [_make_point(f"a{i}") for i in range(3)]
+        batch2 = [_make_point(f"b{i}") for i in range(2)]
+        source = MagicMock()
+        source.scroll.side_effect = [
+            (batch1, "next-cursor"),
+            (batch2, None),
+        ]
+
+        result = m._scroll_all(source, batch_size=3)
+        assert len(result) == 5
+        assert source.scroll.call_count == 2
+        # First call has offset=None, second has offset="next-cursor"
+        first_call = source.scroll.call_args_list[0]
+        assert first_call.kwargs.get("offset") is None or first_call.args[1] is None
+
+    def test_empty_batch_stops_immediately(self):
+        source = MagicMock()
+        source.scroll.return_value = ([], None)
+        result = m._scroll_all(source, batch_size=64)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# run() — empty-target safety check and force flag
+# ---------------------------------------------------------------------------
+
+class TestRunSafetyAndForce:
+    def _patched_run(self, src_pts=168, tgt_pts=0, force=False, dry_run=False):
+        # _scroll_all must return exactly src_pts points to pass the count check
+        fake_points = [_make_point(f"p{i}") for i in range(src_pts)]
+        with (
+            patch("rag.migrate_fgp_to_vrs._make_client") as mock_client,
+            patch("rag.migrate_fgp_to_vrs._scroll_all", return_value=fake_points) as _scroll,
+            patch("rag.migrate_fgp_to_vrs._upsert_batched", return_value=src_pts) as _upsert,
+            patch("rag.migrate_fgp_to_vrs._verify", return_value=True) as _verify,
+        ):
+            source_mock = MagicMock()
+            target_mock = MagicMock()
+            mock_client.side_effect = [source_mock, target_mock]
+            source_mock.get_collection.return_value = _make_collection_info(src_pts)
+            target_mock.get_collection.return_value = _make_collection_info(tgt_pts)
+
+            rc = m.run(dry_run=dry_run, batch_size=64, force=force)
+            return rc, _scroll, _upsert, _verify
+
+    def test_dry_run_returns_0_no_writes(self):
+        rc, scroll, upsert, verify = self._patched_run(dry_run=True)
+        assert rc == 0
+        scroll.assert_not_called()
+        upsert.assert_not_called()
+
+    def test_empty_target_proceeds(self):
+        rc, scroll, upsert, _ = self._patched_run(tgt_pts=0)
+        assert rc == 0
+        scroll.assert_called_once()
+        upsert.assert_called_once()
+
+    def test_non_empty_target_without_force_returns_1(self):
+        rc, scroll, upsert, _ = self._patched_run(tgt_pts=50, force=False)
+        assert rc == 1
+        scroll.assert_not_called()
+        upsert.assert_not_called()
+
+    def test_non_empty_target_with_force_proceeds(self):
+        rc, scroll, upsert, _ = self._patched_run(tgt_pts=50, force=True)
+        assert rc == 0
+        scroll.assert_called_once()
+        upsert.assert_called_once()
+
+    def test_verification_fail_returns_2(self):
+        fake_points = [_make_point(f"p{i}") for i in range(168)]
+        with (
+            patch("rag.migrate_fgp_to_vrs._make_client") as mock_client,
+            patch("rag.migrate_fgp_to_vrs._scroll_all", return_value=fake_points),
+            patch("rag.migrate_fgp_to_vrs._upsert_batched", return_value=168),
+            patch("rag.migrate_fgp_to_vrs._verify", return_value=False),
+        ):
+            src = MagicMock(); tgt = MagicMock()
+            mock_client.side_effect = [src, tgt]
+            src.get_collection.return_value = _make_collection_info(168)
+            tgt.get_collection.return_value = _make_collection_info(0)
+            rc = m.run(dry_run=False, batch_size=64, force=False)
+        assert rc == 2
+
+
+# ---------------------------------------------------------------------------
+# _verify — count parity and vector spot-check
+# ---------------------------------------------------------------------------
+
+class TestVerify:
+    def _make_clients(self, src_vecs: dict[str, list[float]],
+                      tgt_vecs: dict[str, list[float]]):
+        source = MagicMock()
+        target = MagicMock()
+
+        sample_pts = [_make_point(pid, vec) for pid, vec in src_vecs.items()]
+        source.scroll.return_value = (sample_pts, None)
+
+        tgt_pts = [_make_point(pid, vec) for pid, vec in tgt_vecs.items()]
+        target.retrieve.return_value = tgt_pts
+        return source, target
+
+    def test_all_match_returns_true(self):
+        vecs = {f"p{i}": [float(i)] * 768 for i in range(5)}
+        source, target = self._make_clients(vecs, vecs)
+        assert m._verify(source, target, src_count=5, tgt_count=5) is True
+
+    def test_count_mismatch_returns_false(self):
+        vecs = {f"p{i}": [0.1] * 768 for i in range(5)}
+        source, target = self._make_clients(vecs, vecs)
+        assert m._verify(source, target, src_count=5, tgt_count=4) is False
+
+    def test_vector_mismatch_returns_false(self):
+        src_vecs = {"p0": [1.0] * 768}
+        tgt_vecs = {"p0": [2.0] * 768}  # different vector
+        source, target = self._make_clients(src_vecs, tgt_vecs)
+        assert m._verify(source, target, src_count=1, tgt_count=1) is False
+
+    def test_missing_point_on_target_returns_false(self):
+        src_vecs = {"p0": [1.0] * 768}
+        source, target = self._make_clients(src_vecs, {})  # target has no points
+        assert m._verify(source, target, src_count=1, tgt_count=1) is False
+
+    def test_identical_vectors_byte_exact(self):
+        """Verify the comparison is strict equality, not approximate."""
+        vec = [0.123456789] * 768
+        src_vecs = {"p0": vec}
+        tgt_vecs = {"p0": vec[:]}  # same values, different list object
+        source, target = self._make_clients(src_vecs, tgt_vecs)
+        assert m._verify(source, target, src_count=1, tgt_count=1) is True


### PR DESCRIPTION
## Summary

Full snapshot copy of 168 points from spark-2 `fgp_knowledge` → spark-4 `fgp_vrs_knowledge`. Source is read-only throughout. spark-2 remains the active read path until Part 3.

## Migration stats

| | |
|---|---|
| Start | 09:57:13 EDT |
| End | 09:57:15 EDT |
| Elapsed | 1.2s |
| Points migrated | 168 |
| Errors | 0 |
| Count check | 168 == 168 ✅ PASS |
| Vector check | 10/10 byte-identical ✅ PASS |

## Tool: `src/rag/migrate_fgp_to_vrs.py`

- Scroll source (3 × 64-point batches) + upsert target (wait=true)
- Preserves point IDs, vectors, all payload fields
- Safety: dimension mismatch detection, empty source abort, non-empty target blocked without `--force`
- CLI: `--dry-run`, `--batch-size N`, `--force`

**Dry-run output:**
```
pre_check PASS: source=168 points  target=0 points  dim=768  dist=Cosine
[DRY RUN] Would migrate 168 points from fgp_knowledge → fgp_vrs_knowledge. No writes performed.
```

## Safety

- spark-2 `fgp_knowledge` — read-only, unchanged ✅
- No changes to `vectorizer.py`, `knowledge_retriever.py`, `ai_router.py` ✅
- spark-4 `fgp_vrs_knowledge` is a static snapshot — new VRS writes still flow to spark-2 until Part 3 ✅
- Migration is idempotent (`--force` + upsert) — safe to re-run ✅

## Tests

**19 new tests, 89 total passing**
- Schema checks: dim mismatch, distance mismatch, empty source
- Safety: non-empty target blocks without `--force`; `--force` proceeds
- Dry-run: zero writes
- Verification fail → exit code 2
- Scroll pagination, vector byte-equality

⚠️ **Stop before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)