### PR TITLE
feat(judge): Path C — per-task latency budgets + expanded _JUDGE_MAP (v5 decision #11)

### DIFF
--- a/docs/IRON_DOME_ARCHITECTURE.md
+++ b/docs/IRON_DOME_ARCHITECTURE.md
@@ -293,6 +293,17 @@ and update `_MODULE_TO_TASK` in a separate architectural decision.
 Highest-volume task type, lowest-risk errors, fastest iteration.
 Proves the judge architecture end-to-end before replicating.
 
+**Path C update (2026-04-19):** Per-task latency budgets + expanded _JUDGE_MAP.
+- `_JUDGE_TIMEOUTS` dict: legal tasks 1000ms, VRS 200ms, code/market 300–500ms.
+  Falls back to `JUDGE_TIMEOUT_MS` env var (default 200ms) for unknown task types.
+- `_JUDGE_MAP` expanded to 15 entries across all task types (all `is_active=False`).
+  Legal judges (legal_reasoning, brief_drafting, legal_citations, contract_analysis)
+  assigned `qwen2.5:32b` on spark-1 (Path C). VRS + code + vision judges assigned
+  `qwen2.5:7b` on their respective nodes.
+- `is_active=False` on all entries: placeholder routing only. No judge fires until
+  training data accumulates and a model is explicitly promoted.
+- `JUDGE_ENABLED=false` (default) unchanged — zero runtime overhead.
+
 ### Phase 4e.4 through 4e.10 — remaining judges
 One per primary task type, sequenced by data volume and strategic
 value. Legal reasoning judge ships early despite lower volume because
@@ -432,6 +443,13 @@ First working end-to-end loop (Phases 4e.1-4e.3 + 4a): **2-3 weeks**.
 
 10. First judge is vrs_concierge_judge. Highest volume, lowest risk
     per error, fastest iteration to prove architecture.
+
+11. Legal judge uses qwen2.5:32b base with 1000ms inline latency budget
+    (Path C). VRS judges use qwen2.5:7b with 200ms budget. Per-task
+    latency budgets via _JUDGE_TIMEOUTS dict. Rationale: legal stakes per
+    query justify extra latency; low volume makes it UX-tolerable. All
+    judges start is_active=False until training data accumulates and a
+    model is explicitly promoted.
 
 ## Risks live after v5
 

--- a/fortress-guest-platform/backend/services/judge_runtime.py
+++ b/fortress-guest-platform/backend/services/judge_runtime.py
@@ -2,9 +2,20 @@
 judge_runtime.py — Phase 4e.3 judge tier runtime (Ollama-LoRA served).
 
 Evaluates sovereign responses inline via task-type specialized judge models.
-<200ms p95 hard budget. Failure modes never block the response path.
+Per-task latency budgets (Path C, v5 decision #11). Failure modes never
+block the response path.
 
 JUDGE_ENABLED=false (default) → zero overhead, judge skipped entirely.
+
+Per-task timeout budgets (_JUDGE_TIMEOUTS):
+  Legal tasks  (high stakes, low volume)  → 1000 ms
+  VRS tasks    (low stakes, high volume)  → 200 ms
+  Code/market  (medium)                   → 300–500 ms
+  Unknown task_type                       → JUDGE_TIMEOUT_MS env (default 200 ms)
+
+_JUDGE_MAP is_active flag:
+  False (default) → no judge trained yet → confident / no_judge_for_task_type
+  True            → judge deployed, will call Ollama inline
 
 Failure handling:
   timeout        → uncertain  (response may be fine, judge was slow)
@@ -26,24 +37,59 @@ from pydantic import BaseModel
 log = logging.getLogger("judge_runtime")
 
 JUDGE_ENABLED    = os.getenv("JUDGE_ENABLED",    "false").lower() == "true"
-JUDGE_TIMEOUT_MS = int(os.getenv("JUDGE_TIMEOUT_MS", "200"))
+JUDGE_TIMEOUT_MS = int(os.getenv("JUDGE_TIMEOUT_MS", "200"))  # fallback for unknown task types
 
-# task_type → (ollama_model_name, ollama_host_ip)
-# Populated as judges are trained and deployed.
-_JUDGE_MAP: dict[str, tuple[str, str]] = {
-    # VRS judges on spark-4 (192.168.0.106)
-    "vrs_concierge":    ("vrs_concierge_judge",  "192.168.0.106"),
-    "vrs_ota_response": ("vrs_ota_judge",         "192.168.0.106"),
-    "pricing_math":     ("pricing_math_judge",    "192.168.0.106"),
-    "market_research":  ("market_research_judge", "192.168.0.106"),
-    # Legal judges on spark-1 (192.168.0.104)
-    "legal_reasoning":  ("legal_reasoning_judge", "192.168.0.104"),
-    "brief_drafting":   ("brief_drafting_judge",  "192.168.0.104"),
-    # Code judge on spark-2 (192.168.0.100)
-    "code_generation":  ("code_generation_judge", "192.168.0.100"),
-    # Vision judge on spark-3 (192.168.0.105)
-    "vision_damage":    ("vision_analysis_judge", "192.168.0.105"),
-    "vision_photo":     ("vision_analysis_judge", "192.168.0.105"),
+# Per-task latency budgets (ms). Legal tasks justify higher latency due to high stakes
+# per query and low volume. VRS tasks need sub-200ms to stay off the hot path.
+# Unknown task types fall back to JUDGE_TIMEOUT_MS (env default 200ms).
+# v5 Decision #11 / Path C.
+_JUDGE_TIMEOUTS: dict[str, int] = {
+    # Legal (spark-1, qwen2.5:32b) — high stakes, low volume
+    "legal_reasoning":   1000,
+    "brief_drafting":    1000,
+    "legal_citations":   1000,
+    "contract_analysis": 1000,
+    # VRS (spark-4, qwen2.5:7b) — low stakes, high volume
+    "vrs_concierge":     200,
+    "vrs_ota_response":  200,
+    # Business intelligence
+    "pricing_math":      300,
+    "real_time":         300,
+    "market_research":   500,
+    "acquisitions_analysis": 500,
+    # Code (spark-2, qwen2.5:7b)
+    "code_generation":   500,
+    "code_refactoring":  500,
+    "code_debugging":    500,
+    # Vision (spark-3, qwen2.5:7b)
+    "vision_photo":      500,
+    "vision_damage":     500,
+}
+
+# task_type → judge routing config.
+# is_active=False: placeholder — no judge trained yet. Returns confident/no_judge_for_task_type.
+# is_active=True:  judge deployed on target_node, will be called inline.
+# All entries start is_active=False until training data accumulates and a judge is deployed.
+_JUDGE_MAP: dict[str, dict] = {
+    # VRS judges — spark-4 (192.168.0.106), qwen2.5:7b base
+    "vrs_concierge":    {"judge_model": "vrs_concierge_judge",    "target_node": "192.168.0.106", "base_model": "qwen2.5:7b",  "is_active": False},
+    "vrs_ota_response": {"judge_model": "vrs_ota_judge",          "target_node": "192.168.0.106", "base_model": "qwen2.5:7b",  "is_active": False},
+    "pricing_math":     {"judge_model": "pricing_math_judge",     "target_node": "192.168.0.106", "base_model": "qwen2.5:7b",  "is_active": False},
+    "market_research":  {"judge_model": "market_research_judge",  "target_node": "192.168.0.106", "base_model": "qwen2.5:7b",  "is_active": False},
+    "real_time":        {"judge_model": "real_time_judge",        "target_node": "192.168.0.106", "base_model": "qwen2.5:7b",  "is_active": False},
+    # Legal judges — spark-1 (192.168.0.104), qwen2.5:32b base (Path C)
+    "legal_reasoning":   {"judge_model": "legal_reasoning_judge",   "target_node": "192.168.0.104", "base_model": "qwen2.5:32b", "is_active": False},
+    "brief_drafting":    {"judge_model": "brief_drafting_judge",    "target_node": "192.168.0.104", "base_model": "qwen2.5:32b", "is_active": False},
+    "legal_citations":   {"judge_model": "legal_citations_judge",   "target_node": "192.168.0.104", "base_model": "qwen2.5:32b", "is_active": False},
+    "contract_analysis": {"judge_model": "contract_analysis_judge", "target_node": "192.168.0.104", "base_model": "qwen2.5:32b", "is_active": False},
+    "acquisitions_analysis": {"judge_model": "acquisitions_analysis_judge", "target_node": "192.168.0.104", "base_model": "qwen2.5:32b", "is_active": False},
+    # Code judges — spark-2 (192.168.0.100), qwen2.5:7b base
+    "code_generation":  {"judge_model": "code_generation_judge",  "target_node": "192.168.0.100", "base_model": "qwen2.5:7b",  "is_active": False},
+    "code_refactoring": {"judge_model": "code_refactoring_judge", "target_node": "192.168.0.100", "base_model": "qwen2.5:7b",  "is_active": False},
+    "code_debugging":   {"judge_model": "code_debugging_judge",   "target_node": "192.168.0.100", "base_model": "qwen2.5:7b",  "is_active": False},
+    # Vision judges — spark-3 (192.168.0.105), qwen2.5:7b base
+    "vision_damage":    {"judge_model": "vision_analysis_judge",  "target_node": "192.168.0.105", "base_model": "qwen2.5:7b",  "is_active": False},
+    "vision_photo":     {"judge_model": "vision_analysis_judge",  "target_node": "192.168.0.105", "base_model": "qwen2.5:7b",  "is_active": False},
 }
 
 _USER_PROMPT = (
@@ -110,7 +156,8 @@ async def judge_response(
 ) -> JudgeDecision:
     """
     Evaluate sovereign response via specialized judge.
-    Hard timeout: JUDGE_TIMEOUT_MS (default 200ms). Never raises.
+    Timeout is per-task from _JUDGE_TIMEOUTS (falls back to JUDGE_TIMEOUT_MS).
+    Never raises.
     """
     t0 = time.perf_counter()
 
@@ -121,7 +168,7 @@ async def judge_response(
         )
 
     judge_info = _JUDGE_MAP.get(task_type)
-    if judge_info is None:
+    if judge_info is None or not judge_info.get("is_active", False):
         return JudgeDecision(
             decision="confident",
             reasoning=f"no_judge_for_task_type={task_type}",
@@ -129,9 +176,13 @@ async def judge_response(
             latency_ms=int((time.perf_counter() - t0) * 1000),
         )
 
-    model_name, host_ip = judge_info
-    ollama_url  = f"http://{host_ip}:11434"
-    timeout_s   = JUDGE_TIMEOUT_MS / 1000.0
+    model_name = judge_info["judge_model"]
+    host_ip    = judge_info["target_node"]
+    ollama_url = f"http://{host_ip}:11434"
+    timeout_ms = _JUDGE_TIMEOUTS.get(task_type, JUDGE_TIMEOUT_MS)
+    timeout_s  = timeout_ms / 1000.0
+    log.debug("judge_timeout_selected task=%s timeout_ms=%d model=%s",
+              task_type, timeout_ms, model_name)
 
     try:
         async with httpx.AsyncClient(timeout=timeout_s) as client:
@@ -157,10 +208,10 @@ async def judge_response(
     except httpx.TimeoutException:
         latency_ms = int((time.perf_counter() - t0) * 1000)
         log.warning("judge_timeout task=%s model=%s timeout=%dms",
-                    task_type, model_name, JUDGE_TIMEOUT_MS)
+                    task_type, model_name, timeout_ms)
         return JudgeDecision(
             decision="uncertain",
-            reasoning=f"judge_timeout_{JUDGE_TIMEOUT_MS}ms",
+            reasoning=f"judge_timeout_{timeout_ms}ms",
             judge_model=model_name, latency_ms=latency_ms,
         )
     except (httpx.ConnectError, httpx.NetworkError):

--- a/fortress-guest-platform/backend/tests/test_judge_runtime.py
+++ b/fortress-guest-platform/backend/tests/test_judge_runtime.py
@@ -1,4 +1,4 @@
-"""Tests for Phase 4e.3 judge runtime."""
+"""Tests for Phase 4e.3 judge runtime — including Path C per-task latency budgets."""
 import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -9,6 +9,18 @@ import pytest
 def _rt():
     from backend.services import judge_runtime as rt
     return rt
+
+
+# A minimal active judge entry used by tests that exercise the full HTTP path.
+# All real judges have is_active=False until trained; tests that need to reach
+# the Ollama call must inject is_active=True via patch.dict.
+def _active_vrs_entry():
+    return {
+        "judge_model": "vrs_concierge_judge",
+        "target_node": "192.168.0.106",
+        "base_model":  "qwen2.5:7b",
+        "is_active":   True,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -86,6 +98,7 @@ class TestJudgeFailureModes:
         import httpx as _httpx
         rt = _rt()
         with patch.object(rt, "JUDGE_ENABLED", True), \
+             patch.dict(rt._JUDGE_MAP, {"vrs_concierge": _active_vrs_entry()}), \
              patch("httpx.AsyncClient") as mock_client:
             mock_client.return_value.__aenter__ = AsyncMock(
                 side_effect=_httpx.TimeoutException("timeout"))
@@ -98,6 +111,7 @@ class TestJudgeFailureModes:
         import httpx as _httpx
         rt = _rt()
         with patch.object(rt, "JUDGE_ENABLED", True), \
+             patch.dict(rt._JUDGE_MAP, {"vrs_concierge": _active_vrs_entry()}), \
              patch("httpx.AsyncClient") as mock_client:
             mock_client.return_value.__aenter__ = AsyncMock(
                 side_effect=_httpx.ConnectError("refused"))
@@ -112,6 +126,7 @@ class TestJudgeFailureModes:
         mock_resp.raise_for_status = MagicMock()
         mock_resp.json.return_value = {"message": {"content": "garbled output xyz"}}
         with patch.object(rt, "JUDGE_ENABLED", True), \
+             patch.dict(rt._JUDGE_MAP, {"vrs_concierge": _active_vrs_entry()}), \
              patch("httpx.AsyncClient") as mock_client:
             mock_client.return_value.__aenter__ = AsyncMock(return_value=MagicMock(
                 post=AsyncMock(return_value=mock_resp)))
@@ -122,6 +137,7 @@ class TestJudgeFailureModes:
     def test_generic_exception_returns_uncertain(self):
         rt = _rt()
         with patch.object(rt, "JUDGE_ENABLED", True), \
+             patch.dict(rt._JUDGE_MAP, {"vrs_concierge": _active_vrs_entry()}), \
              patch("httpx.AsyncClient") as mock_client:
             mock_client.return_value.__aenter__ = AsyncMock(
                 side_effect=RuntimeError("unexpected"))
@@ -132,8 +148,8 @@ class TestJudgeFailureModes:
     def test_judge_never_raises(self):
         rt = _rt()
         with patch.object(rt, "JUDGE_ENABLED", True), \
+             patch.dict(rt._JUDGE_MAP, {"vrs_concierge": _active_vrs_entry()}), \
              patch("httpx.AsyncClient", side_effect=Exception("catastrophic")):
-            # Should not raise
             result = self._run(rt.judge_response("vrs_concierge", "test", "response"))
         assert result.decision in ("confident", "uncertain", "escalate")
 
@@ -144,6 +160,7 @@ class TestJudgeFailureModes:
         mock_resp.json.return_value = {
             "message": {"content": '{"decision": "confident", "reasoning": "good response"}'}}
         with patch.object(rt, "JUDGE_ENABLED", True), \
+             patch.dict(rt._JUDGE_MAP, {"vrs_concierge": _active_vrs_entry()}), \
              patch("httpx.AsyncClient") as mock_client:
             mock_session = MagicMock()
             mock_session.post = AsyncMock(return_value=mock_resp)
@@ -152,3 +169,108 @@ class TestJudgeFailureModes:
             result = self._run(rt.judge_response("vrs_concierge", "when checkout?", "11am"))
         assert result.decision == "confident"
         assert result.judge_model == "vrs_concierge_judge"
+
+
+# ---------------------------------------------------------------------------
+# Path C — per-task timeout budgets and is_active placeholder behavior
+# ---------------------------------------------------------------------------
+
+class TestPerTaskTimeouts:
+    def test_legal_reasoning_uses_1000ms(self):
+        rt = _rt()
+        assert rt._JUDGE_TIMEOUTS["legal_reasoning"] == 1000
+
+    def test_vrs_concierge_uses_200ms(self):
+        rt = _rt()
+        assert rt._JUDGE_TIMEOUTS["vrs_concierge"] == 200
+
+    def test_brief_drafting_uses_1000ms(self):
+        rt = _rt()
+        assert rt._JUDGE_TIMEOUTS["brief_drafting"] == 1000
+
+    def test_pricing_math_uses_300ms(self):
+        rt = _rt()
+        assert rt._JUDGE_TIMEOUTS["pricing_math"] == 300
+
+    def test_unknown_task_type_uses_default_env(self):
+        """Task types absent from _JUDGE_TIMEOUTS fall back to JUDGE_TIMEOUT_MS."""
+        rt = _rt()
+        default = rt.JUDGE_TIMEOUT_MS  # 200 from env default
+        assert rt._JUDGE_TIMEOUTS.get("completely_unknown_type", default) == default
+
+    def test_timeout_is_used_for_active_judge_call(self):
+        """Verify the selected timeout is passed to httpx, not the global default."""
+        import httpx as _httpx
+        rt = _rt()
+        active_legal = {
+            "judge_model": "legal_reasoning_judge",
+            "target_node": "192.168.0.104",
+            "base_model":  "qwen2.5:32b",
+            "is_active":   True,
+        }
+        captured_timeouts = []
+
+        class CapturingClient:
+            def __init__(self, timeout, **kwargs):
+                captured_timeouts.append(timeout)
+            async def __aenter__(self):
+                raise _httpx.ConnectError("unreachable — just checking timeout")
+            async def __aexit__(self, *a):
+                return False
+
+        with patch.object(rt, "JUDGE_ENABLED", True), \
+             patch.dict(rt._JUDGE_MAP, {"legal_reasoning": active_legal}), \
+             patch("httpx.AsyncClient", CapturingClient):
+            asyncio.get_event_loop().run_until_complete(
+                rt.judge_response("legal_reasoning", "q", "a"))
+
+        assert captured_timeouts == [1.0], f"Expected 1.0s (1000ms), got {captured_timeouts}"
+
+
+class TestPlaceholderJudges:
+    def _run(self, coro):
+        return asyncio.get_event_loop().run_until_complete(coro)
+
+    def test_is_active_false_returns_confident_without_http(self):
+        """All placeholder judges return confident without making a network call."""
+        rt = _rt()
+        with patch.object(rt, "JUDGE_ENABLED", True), \
+             patch("httpx.AsyncClient") as mock_client:
+            result = self._run(rt.judge_response("vrs_concierge", "test", "resp"))
+        assert result.decision == "confident"
+        assert "no_judge_for_task_type" in result.reasoning
+        mock_client.assert_not_called()
+
+    def test_all_placeholder_task_types_return_confident(self):
+        """Every entry in _JUDGE_MAP with is_active=False returns confident."""
+        rt = _rt()
+        with patch.object(rt, "JUDGE_ENABLED", True):
+            for task_type, info in rt._JUDGE_MAP.items():
+                if not info.get("is_active", False):
+                    result = self._run(rt.judge_response(task_type, "q", "a"))
+                    assert result.decision == "confident", \
+                        f"{task_type}: expected confident for is_active=False, got {result.decision}"
+
+    def test_all_judge_map_entries_have_required_fields(self):
+        """Every _JUDGE_MAP entry has the required schema fields."""
+        rt = _rt()
+        required = {"judge_model", "target_node", "base_model", "is_active"}
+        for task_type, info in rt._JUDGE_MAP.items():
+            missing = required - set(info.keys())
+            assert not missing, f"{task_type} missing fields: {missing}"
+
+    def test_legal_judges_use_32b_base(self):
+        """Legal domain judges use qwen2.5:32b (Path C decision)."""
+        rt = _rt()
+        legal_tasks = {"legal_reasoning", "brief_drafting", "legal_citations", "contract_analysis"}
+        for task_type in legal_tasks:
+            assert task_type in rt._JUDGE_MAP, f"{task_type} not in _JUDGE_MAP"
+            assert rt._JUDGE_MAP[task_type]["base_model"] == "qwen2.5:32b", \
+                f"{task_type} should use qwen2.5:32b, got {rt._JUDGE_MAP[task_type]['base_model']}"
+
+    def test_vrs_judges_use_7b_base(self):
+        """VRS judges use qwen2.5:7b (same as production inference model)."""
+        rt = _rt()
+        vrs_tasks = {"vrs_concierge", "vrs_ota_response"}
+        for task_type in vrs_tasks:
+            assert rt._JUDGE_MAP[task_type]["base_model"] == "qwen2.5:7b"


### PR DESCRIPTION
## Summary

Architecture scaffolding for the full judge tier. **No judges fire** — `JUDGE_ENABLED` and `JUDGE_TRAINING_ENABLED` remain `false`. This PR commits the routing map and latency contracts so the first `is_active=True` flip is a one-line change when training data arrives.

## Changes

### `_JUDGE_TIMEOUTS` (new)
Per-task latency budgets (v5 Decision #11 / Path C):
| Domain | Budget | Rationale |
|---|---|---|
| Legal (32B) | 1000ms | High stakes per query, low volume — UX-tolerable |
| VRS (7B) | 200ms | High volume, must stay off hot path |
| Code / Market | 300–500ms | Medium |
| Unknown fallback | `JUDGE_TIMEOUT_MS` env (200ms) | Graceful default |

### `_JUDGE_MAP` expanded (9 → 15 entries, all `is_active=False`)
| Domain | Node | Base model |
|---|---|---|
| legal_reasoning, brief_drafting, legal_citations, contract_analysis, acquisitions_analysis | spark-1 (192.168.0.104) | **qwen2.5:32b** (Path C) |
| vrs_concierge, vrs_ota_response, pricing_math, market_research, real_time | spark-4 (192.168.0.106) | qwen2.5:7b |
| code_generation, code_refactoring, code_debugging | spark-2 (192.168.0.100) | qwen2.5:7b |
| vision_damage, vision_photo | spark-3 (192.168.0.105) | qwen2.5:7b |

### `judge_response()` updates
- `is_active=False` → returns `confident/no_judge_for_task_type` immediately, no HTTP
- Timeout read from `_JUDGE_TIMEOUTS[task_type]` (not global constant)
- Model/host read from dict fields (was tuple)
- Logs selected timeout at DEBUG

## Tests — 26/26 passing (11 new)
- Legal=1000ms, VRS=200ms, unknown→env default
- Timeout value verified reaching httpx (not just asserted on dict)
- `is_active=False` → no HTTP call on any of the 15 entries
- All 15 entries have required schema fields
- Legal judges confirmed on `qwen2.5:32b`, VRS on `qwen2.5:7b`
- Existing HTTP-path tests updated to explicitly opt in via `patch.dict(is_active=True)`

## Safety
- `JUDGE_ENABLED=false` preserved ✅
- No `ai_router` changes ✅
- No `privilege_filter` changes ✅
- No training pipeline changes ✅

⚠️ **Stop before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)