### PR TITLE
fix: CI port mismatch + backfill script env auto-loading

### DIFF
--- a/.github/workflows/fortress-ci.yml
+++ b/.github/workflows/fortress-ci.yml
@@ -48,6 +48,7 @@ jobs:
       NEXT_PUBLIC_APP_URL: http://127.0.0.1:3000
       NEXT_TELEMETRY_DISABLED: "1"
       CI: "true"
+      PORT: "8100"
       BOOTSTRAP_ADMIN_PASSWORD: FortressPrime2026!
       BOOTSTRAP_ADMIN_CONFIRM_PASSWORD: FortressPrime2026!
     steps:

--- a/fortress-guest-platform/backend/tests/test_backfill_env.py
+++ b/fortress-guest-platform/backend/tests/test_backfill_env.py
@@ -1,0 +1,49 @@
+"""Tests for backfill_label_historical.py env auto-loading."""
+import os
+from pathlib import Path
+
+_ENV_FILES = [".env", ".env.dgx", ".env.security"]
+
+
+class TestBackfillEnvLoading:
+    def test_loads_env_without_presourcing(self, tmp_path: Path) -> None:
+        """dotenv block in backfill script loads vars from .env without shell set -a."""
+        fgp_dir = tmp_path / "fortress-guest-platform"
+        fgp_dir.mkdir()
+        (fgp_dir / ".env").write_text("BACKFILL_TEST_SENTINEL=loaded_by_dotenv\n")
+
+        from dotenv import load_dotenv
+
+        for env_file in _ENV_FILES:
+            env_path = fgp_dir / env_file
+            if env_path.exists():
+                load_dotenv(env_path, override=False)
+
+        assert os.environ.get("BACKFILL_TEST_SENTINEL") == "loaded_by_dotenv"
+        os.environ.pop("BACKFILL_TEST_SENTINEL", None)
+
+    def test_missing_env_files_are_skipped(self, tmp_path: Path) -> None:
+        """Missing .env files are silently skipped — no FileNotFoundError."""
+        fgp_dir = tmp_path / "fortress-guest-platform"
+        fgp_dir.mkdir()
+
+        from dotenv import load_dotenv
+
+        for env_file in _ENV_FILES:
+            env_path = fgp_dir / env_file
+            if env_path.exists():
+                load_dotenv(env_path, override=False)
+        # reaching here without exception is the assertion
+
+    def test_explicit_process_env_wins_over_dotenv(self, tmp_path: Path) -> None:
+        """override=False means a pre-set process env var is not overwritten."""
+        fgp_dir = tmp_path / "fortress-guest-platform"
+        fgp_dir.mkdir()
+        (fgp_dir / ".env").write_text("BACKFILL_OVERRIDE_TEST=from_file\n")
+
+        os.environ["BACKFILL_OVERRIDE_TEST"] = "from_process"
+        from dotenv import load_dotenv
+        load_dotenv(fgp_dir / ".env", override=False)
+
+        assert os.environ["BACKFILL_OVERRIDE_TEST"] == "from_process"
+        os.environ.pop("BACKFILL_OVERRIDE_TEST", None)

--- a/fortress-guest-platform/backend/tests/test_run_port.py
+++ b/fortress-guest-platform/backend/tests/test_run_port.py
@@ -1,0 +1,45 @@
+"""Tests for run.py PORT env var behaviour."""
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+_RUN_PY = Path(__file__).resolve().parents[2] / "run.py"
+
+
+def _load_run(extra_env: dict[str, str]) -> tuple[Any, MagicMock]:
+    """Import run.py in a clean module slot with the given env vars set."""
+    mod_name = f"_fgp_run_{os.getpid()}"
+    spec = importlib.util.spec_from_file_location(mod_name, _RUN_PY)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    uvicorn_mock = MagicMock()
+    with patch.dict(os.environ, extra_env, clear=False), \
+         patch.dict(sys.modules, {"uvicorn": uvicorn_mock}):
+        spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod, uvicorn_mock
+
+
+class TestRunPort:
+    def test_default_port_is_8000(self, monkeypatch: Any) -> None:
+        monkeypatch.delenv("PORT", raising=False)
+        mod, uvicorn_mock = _load_run({})
+        mod._serve()
+        _, kwargs = uvicorn_mock.run.call_args
+        assert kwargs["port"] == 8000
+
+    def test_port_read_from_env(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("PORT", "8100")
+        mod, uvicorn_mock = _load_run({"PORT": "8100"})
+        mod._serve()
+        _, kwargs = uvicorn_mock.run.call_args
+        assert kwargs["port"] == 8100
+
+    def test_port_is_integer(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("PORT", "9000")
+        mod, uvicorn_mock = _load_run({"PORT": "9000"})
+        mod._serve()
+        _, kwargs = uvicorn_mock.run.call_args
+        assert isinstance(kwargs["port"], int)

--- a/fortress-guest-platform/run.py
+++ b/fortress-guest-platform/run.py
@@ -71,10 +71,15 @@ _load_env_file(PROJECT_ROOT / ".env.security")
 
 import uvicorn
 
-if __name__ == "__main__":
+
+def _serve() -> None:
     uvicorn.run(
         "backend.main:app",
         host="0.0.0.0",
-        port=8000,
+        port=int(os.getenv("PORT", "8000")),
         log_level="info",
     )
+
+
+if __name__ == "__main__":
+    _serve()

--- a/src/backfill_label_historical.py
+++ b/src/backfill_label_historical.py
@@ -24,6 +24,15 @@ from typing import Any
 
 import psycopg2
 from psycopg2.extras import RealDictCursor
+from dotenv import load_dotenv
+
+# Load env files before backend imports — DB_URI is resolved at labeling_pipeline import time.
+# override=False so an explicitly set process env always wins.
+_repo_root = Path(__file__).resolve().parent.parent
+for _env_file in [".env", ".env.dgx", ".env.security"]:
+    _env_path = _repo_root / "fortress-guest-platform" / _env_file
+    if _env_path.exists():
+        load_dotenv(_env_path, override=False)
 
 # Import shared labeling primitives
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "fortress-guest-platform"))


### PR DESCRIPTION
## Summary

- **run.py** now reads `PORT` env var (default `8000`); no more hardcoded `8000` while CI probes `:8100`
- **CI workflow** adds `PORT: "8100"` to the job env so `nohup python run.py` binds on the correct port
- **backfill_label_historical.py** loads `.env` / `.env.dgx` / `.env.security` via `python-dotenv` before the backend import block resolves `DB_URI`, so the script runs standalone without `set -a source .env`

## Test plan

- [ ] `test_run_port.py` — default 8000, reads 8100 from env, value is int (3 tests)
- [ ] `test_backfill_env.py` — loads without pre-sourcing, skips missing files, process env wins over file (3 tests)
- [ ] All 6 new tests pass locally (`pytest` green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)