### PR TITLE
feat(rag): Phase 5a Part 4 — read cutover scaffold (Option A restart-to-flip)

### DIFF
--- a/docs/IRON_DOME_ARCHITECTURE.md
+++ b/docs/IRON_DOME_ARCHITECTURE.md
@@ -361,18 +361,29 @@ matter-level redaction). Ships after legal_reasoning_judge is mature.
 - Reads still target spark-2 fgp_knowledge. No retrieval code changed.
 - Metrics (in-process): `qdrant_vrs_dual_write_{success,failure,skipped}_total`.
 
-**Part 4 — Read cutover (NEXT)**: flip `QDRANT_URL` → spark-4 and
-`QDRANT_COLLECTION_NAME` → `fgp_vrs_knowledge` once write parity is confirmed
-stable over 24–48h of dual-write operation.
+**Part 4 — Read cutover SCAFFOLDED (2026-04-19)**
+- Feature flag `READ_FROM_VRS_STORE` (bool, default `false`) added to `backend/core/config.py`.
+- Resolver `resolve_read_endpoint()` in `qdrant_dual_writer.py` returns `(url, collection)`:
+  - `false` → spark-2 `fgp_knowledge` (unchanged behaviour on merge)
+  - `true`  → spark-4 `fgp_vrs_knowledge`
+- Single read site wired: `knowledge_retriever.py:_qdrant_search()`.
+  All callers (`agentic_orchestrator.py`, `dgx_tools.py`) inherit the flag via `semantic_search()`.
+- Startup log emitted on every restart: `qdrant_read_endpoint url=... collection=... flag=...`
+- Parity gate extended: `src/rag/verify_dual_write_parity.py --compare-search QUERY`
+  runs the same query on both endpoints and reports top-5 agreement (≥95% required).
+- Option A rollback: flip flag back to `false`, restart — zero code changes needed.
 
-**Part 5 — Write sunset**: stop dual-writing to spark-2 `fgp_knowledge`,
-decommission as VRS Qdrant.
+Promotion workflow (when ready to cut over):
+  1. `python3 -m src.rag.verify_dual_write_parity --compare-search "what does Fallen Timber Lodge look like"` — confirm ≥95% agreement
+  2. Set `READ_FROM_VRS_STORE=true` in `.env`
+  3. `sudo systemctl restart fortress-backend`
+  4. Monitor concierge response quality for 24h (watch `qdrant_semantic_search_hit` log lines)
+  5. If issues: flip back to `false`, restart, investigate
 
-**Part 3 — Read cutover (LATER)**: after spark-4 data matches spark-2 (168 points +
-ongoing delta), flip `QDRANT_URL` → spark-4 and `QDRANT_COLLECTION_NAME` → `fgp_vrs_knowledge`.
-Remove dual-write code.
+**Part 5 — Write sunset (LATER)**: confirm Part 4 stable ≥24h, then stop dual-writing to
+spark-2 `fgp_knowledge` and decommission spark-2 as VRS Qdrant.
 
-Recommendation: Option A (dual-write) — not Option B (hard cutover) because
+Recommendation: Option A (restart-to-flip) — not hard config swap — because
 `_qdrant_search` is called on every guest concierge interaction (zero downtime tolerance).
 See `docs/RAG_INGESTION_AUDIT.md` for full write/read site table and rationale.
 

--- a/fortress-guest-platform/.env.example
+++ b/fortress-guest-platform/.env.example
@@ -34,6 +34,14 @@ QDRANT_HTTP_URL=http://127.0.0.1:6333
 # Phase 5a Part 3 — VRS secondary Qdrant on spark-4 (dual-write)
 QDRANT_VRS_URL=http://192.168.0.106:6333
 ENABLE_QDRANT_VRS_DUAL_WRITE=true
+# Phase 5a Part 4 — Read cutover (Option A: restart to flip)
+# Promotion workflow:
+#   1. python3 -m src.rag.verify_dual_write_parity --compare-search  (confirm >=95% agreement)
+#   2. Set READ_FROM_VRS_STORE=true below
+#   3. sudo systemctl restart fortress-backend
+#   4. Monitor concierge response quality for 24h
+#   5. If issues: flip back to false, restart, investigate
+READ_FROM_VRS_STORE=false
 KAFKA_BROKER_URL=127.0.0.1:19092
 REDIS_URL=redis://127.0.0.1:6379/0
 ARQ_REDIS_URL=redis://127.0.0.1:6379/1

--- a/fortress-guest-platform/backend/core/config.py
+++ b/fortress-guest-platform/backend/core/config.py
@@ -574,6 +574,11 @@ class Settings(BaseSettings):
     # Qdrant — VRS secondary (spark-4, Phase 5a Part 3 dual-write)
     qdrant_vrs_url: str = Field(default="http://192.168.0.106:6333")
     enable_qdrant_vrs_dual_write: bool = Field(default=True)
+    # Phase 5a Part 4 — read cutover (Option A: restart to flip)
+    # False  → reads target spark-2 fgp_knowledge (default, safe)
+    # True   → reads target spark-4 fgp_vrs_knowledge
+    # Run src/rag/verify_dual_write_parity.py --compare-search before flipping.
+    read_from_vrs_store: bool = Field(default=False)
 
     # Redis
     redis_url: str = Field(default="redis://localhost:6379/0")

--- a/fortress-guest-platform/backend/main.py
+++ b/fortress-guest-platform/backend/main.py
@@ -412,6 +412,8 @@ async def lifespan(app: FastAPI):
             qdrant_ready = await ensure_collection()
             if qdrant_ready:
                 logger.info("qdrant_fgp_knowledge_ready")
+                from backend.services.qdrant_dual_writer import log_read_endpoint_at_startup
+                log_read_endpoint_at_startup()
                 from backend.core.database import AsyncSessionLocal
                 from backend.services.async_jobs import enqueue_async_job
 

--- a/fortress-guest-platform/backend/services/knowledge_retriever.py
+++ b/fortress-guest-platform/backend/services/knowledge_retriever.py
@@ -21,8 +21,9 @@ from sqlalchemy import select, and_, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.core.config import settings
-from backend.core.qdrant import COLLECTION_NAME, VECTOR_DIM
+from backend.core.qdrant import VECTOR_DIM
 from backend.models.knowledge import KnowledgeBaseEntry
+from backend.services.qdrant_dual_writer import resolve_read_endpoint
 
 logger = structlog.get_logger()
 
@@ -55,12 +56,16 @@ async def _qdrant_search(
     top_k: int = DEFAULT_TOP_K,
     property_id: Optional[UUID] = None,
 ) -> List[Dict]:
-    """Execute a similarity search against the fgp_knowledge Qdrant collection.
+    """Execute a similarity search against the active fgp knowledge collection.
+
+    Target collection is resolved via READ_FROM_VRS_STORE flag:
+      False (default) → spark-2 fgp_knowledge
+      True            → spark-4 fgp_vrs_knowledge
 
     When *property_id* is supplied the search is scoped to points that either
     belong to that property or have no property_id (global entries).
     """
-    qdrant_url = settings.qdrant_url.rstrip("/")
+    qdrant_url, collection_name = resolve_read_endpoint()
     headers = {"api-key": settings.qdrant_api_key} if settings.qdrant_api_key else {}
 
     body: Dict = {
@@ -80,7 +85,7 @@ async def _qdrant_search(
 
     async with httpx.AsyncClient(timeout=15) as client:
         resp = await client.post(
-            f"{qdrant_url}/collections/{COLLECTION_NAME}/points/search",
+            f"{qdrant_url}/collections/{collection_name}/points/search",
             json=body,
             headers=headers,
         )

--- a/fortress-guest-platform/backend/services/qdrant_dual_writer.py
+++ b/fortress-guest-platform/backend/services/qdrant_dual_writer.py
@@ -112,6 +112,30 @@ async def _write_secondary(points: list[dict[str, Any]], collection: str) -> Non
 # Public API
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Read endpoint resolver (Phase 5a Part 4)
+# ---------------------------------------------------------------------------
+
+def resolve_read_endpoint() -> tuple[str, str]:
+    """Return (qdrant_url, collection_name) for fgp_knowledge reads.
+
+    flag=False (default) → spark-2 fgp_knowledge  (no production change)
+    flag=True            → spark-4 fgp_vrs_knowledge  (post-cutover)
+    """
+    if settings.read_from_vrs_store:
+        return (settings.qdrant_vrs_url.rstrip("/"), _VRS_COLLECTION)
+    return (settings.qdrant_url.rstrip("/"), COLLECTION_NAME)
+
+
+def log_read_endpoint_at_startup() -> None:
+    """Emit a single INFO log so the active read target is visible on every restart."""
+    url, collection = resolve_read_endpoint()
+    log.info(
+        "qdrant_read_endpoint url=%s collection=%s flag=%s",
+        url, collection, settings.read_from_vrs_store,
+    )
+
+
 # Keeps fire-and-forget tasks alive until the event loop can run them.
 _pending: set[asyncio.Task] = set()
 

--- a/fortress-guest-platform/backend/tests/test_read_cutover.py
+++ b/fortress-guest-platform/backend/tests/test_read_cutover.py
@@ -1,0 +1,152 @@
+"""Tests for Phase 5a Part 4 — fgp_knowledge read endpoint resolver."""
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _rt():
+    from backend.services import qdrant_dual_writer as dw
+    return dw
+
+
+def _kr():
+    from backend.services import knowledge_retriever as kr
+    return kr
+
+
+# ---------------------------------------------------------------------------
+# resolve_read_endpoint
+# ---------------------------------------------------------------------------
+
+class TestResolveReadEndpoint:
+    def test_default_flag_false_returns_spark2(self) -> None:
+        dw = _rt()
+        with patch.object(dw.settings, "read_from_vrs_store", False), \
+             patch.object(dw.settings, "qdrant_url", "http://192.168.0.100:6333"), \
+             patch.object(dw.settings, "qdrant_vrs_url", "http://192.168.0.106:6333"):
+            url, collection = dw.resolve_read_endpoint()
+        assert url == "http://192.168.0.100:6333"
+        assert collection == "fgp_knowledge"
+
+    def test_flag_true_returns_spark4(self) -> None:
+        dw = _rt()
+        with patch.object(dw.settings, "read_from_vrs_store", True), \
+             patch.object(dw.settings, "qdrant_url", "http://192.168.0.100:6333"), \
+             patch.object(dw.settings, "qdrant_vrs_url", "http://192.168.0.106:6333"):
+            url, collection = dw.resolve_read_endpoint()
+        assert url == "http://192.168.0.106:6333"
+        assert collection == "fgp_vrs_knowledge"
+
+    def test_trailing_slash_stripped(self) -> None:
+        dw = _rt()
+        with patch.object(dw.settings, "read_from_vrs_store", False), \
+             patch.object(dw.settings, "qdrant_url", "http://192.168.0.100:6333/"), \
+             patch.object(dw.settings, "qdrant_vrs_url", "http://192.168.0.106:6333/"):
+            url, _ = dw.resolve_read_endpoint()
+        assert not url.endswith("/")
+
+    def test_vrs_trailing_slash_stripped(self) -> None:
+        dw = _rt()
+        with patch.object(dw.settings, "read_from_vrs_store", True), \
+             patch.object(dw.settings, "qdrant_url", "http://192.168.0.100:6333/"), \
+             patch.object(dw.settings, "qdrant_vrs_url", "http://192.168.0.106:6333/"):
+            url, _ = dw.resolve_read_endpoint()
+        assert not url.endswith("/")
+
+    def test_returns_tuple_of_two_strings(self) -> None:
+        dw = _rt()
+        result = dw.resolve_read_endpoint()
+        assert isinstance(result, tuple) and len(result) == 2
+        assert all(isinstance(v, str) for v in result)
+
+
+# ---------------------------------------------------------------------------
+# knowledge_retriever uses resolver
+# ---------------------------------------------------------------------------
+
+class TestKnowledgeRetrieverUsesResolver:
+    def _run(self, coro: Any) -> Any:
+        return asyncio.get_event_loop().run_until_complete(coro)
+
+    def test_flag_false_search_hits_spark2_url(self) -> None:
+        kr = _kr()
+        dw = _rt()
+        captured: list[str] = []
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "result": [{"score": 0.9, "payload": {"text": "lodge info"}}]
+        }
+
+        with patch.object(dw.settings, "read_from_vrs_store", False), \
+             patch.object(dw.settings, "qdrant_url", "http://192.168.0.100:6333"), \
+             patch.object(dw.settings, "qdrant_vrs_url", "http://192.168.0.106:6333"), \
+             patch("httpx.AsyncClient") as mock_client:
+            mock_session = MagicMock()
+
+            def capture_post(url: str, **_kwargs: Any) -> Any:
+                captured.append(url)
+                fut: asyncio.Future = asyncio.get_event_loop().create_future()
+                fut.set_result(mock_resp)
+                return fut
+
+            mock_session.post = capture_post
+            mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            self._run(kr._qdrant_search([0.1] * 768))
+
+        assert captured, "no HTTP call captured"
+        assert "192.168.0.100" in captured[0]
+        assert "fgp_knowledge" in captured[0]
+
+    def test_flag_true_search_hits_spark4_url(self) -> None:
+        kr = _kr()
+        dw = _rt()
+        captured: list[str] = []
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "result": [{"score": 0.88, "payload": {"text": "vrs lodge info"}}]
+        }
+
+        with patch.object(dw.settings, "read_from_vrs_store", True), \
+             patch.object(dw.settings, "qdrant_url", "http://192.168.0.100:6333"), \
+             patch.object(dw.settings, "qdrant_vrs_url", "http://192.168.0.106:6333"), \
+             patch("httpx.AsyncClient") as mock_client:
+            mock_session = MagicMock()
+
+            def capture_post(url: str, **_kwargs: Any) -> Any:
+                captured.append(url)
+                fut: asyncio.Future = asyncio.get_event_loop().create_future()
+                fut.set_result(mock_resp)
+                return fut
+
+            mock_session.post = capture_post
+            mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            self._run(kr._qdrant_search([0.1] * 768))
+
+        assert captured, "no HTTP call captured"
+        assert "192.168.0.106" in captured[0]
+        assert "fgp_vrs_knowledge" in captured[0]
+
+
+# ---------------------------------------------------------------------------
+# Parity: equivalent results (skipped when live Qdrants not available)
+# ---------------------------------------------------------------------------
+
+class TestSearchEquivalentResults:
+    def test_compare_search_skip_if_no_live_qdrant(self) -> None:
+        """Verify compare_search returns 1 (FAIL) when both endpoints are unreachable
+        rather than raising — no live Qdrant required in CI."""
+        import sys  # noqa: E401
+        sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parents[3]))
+        from src.rag.verify_dual_write_parity import compare_search
+
+        # With no live Qdrant the embed call will fail → returns 1, not raises
+        result = compare_search("what does Fallen Timber Lodge look like")
+        assert result in (0, 1), "compare_search must return int exit code"

--- a/src/rag/verify_dual_write_parity.py
+++ b/src/rag/verify_dual_write_parity.py
@@ -5,11 +5,15 @@ verify_dual_write_parity.py — Phase 5a operational parity check.
 Compares fgp_knowledge (spark-2) against fgp_vrs_knowledge (spark-4):
   - Point count parity
   - Optional vector spot-check on a random sample
+  - Optional search comparison (--compare-search) for pre-cutover gate
 
 Usage:
-  python3 -m src.rag.verify_dual_write_parity [--sample N]
+  python3 -m src.rag.verify_dual_write_parity [--sample N] [--compare-search QUERY]
 
-  --sample N   Spot-check N random vectors byte-for-byte (default: 0 = skip)
+  --sample N             Spot-check N random vectors byte-for-byte (default: 0 = skip)
+  --compare-search QUERY Run the same search against both endpoints and compare top-5
+                         results. Reports hit-rate agreement. Run before flipping
+                         READ_FROM_VRS_STORE=true.
 """
 from __future__ import annotations
 
@@ -104,9 +108,136 @@ def check_parity(sample_n: int) -> int:
     return 0 if ok else 1
 
 
+EMBED_URL   = "http://192.168.0.100/api/embeddings"
+EMBED_MODEL = "nomic-embed-text"
+EMBED_DIM   = 768
+
+
+def _embed(query: str) -> list[float]:
+    """Embed a query string via the local NIM endpoint (sync)."""
+    import urllib.request, json as _json  # noqa: E401
+    payload = _json.dumps({"model": EMBED_MODEL, "prompt": query[:8000]}).encode()
+    req = urllib.request.Request(
+        EMBED_URL,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        data = _json.loads(resp.read())
+    vec = data.get("embedding", [])
+    if len(vec) != EMBED_DIM:
+        raise ValueError(f"Expected {EMBED_DIM}-dim vector, got {len(vec)}")
+    return vec
+
+
+def _qdrant_search(url: str, collection: str, vec: list[float], top_k: int = 5) -> list[dict]:
+    """Run a top-k search against a Qdrant collection (sync, no SDK)."""
+    import urllib.request, json as _json  # noqa: E401
+    body = _json.dumps({
+        "vector": vec,
+        "limit": top_k,
+        "with_payload": True,
+        "with_vector": False,
+    }).encode()
+    req = urllib.request.Request(
+        f"{url}/collections/{collection}/points/search",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return _json.loads(resp.read()).get("result", [])
+
+
+def compare_search(query: str, top_k: int = 5) -> int:
+    """Run the same query on both endpoints and report agreement.
+
+    Agreement is measured as the fraction of spark-4's top-k results whose
+    record_id appears anywhere in spark-2's top-k results.  ≥95% required
+    before flipping READ_FROM_VRS_STORE=true.
+
+    Returns 0 (PASS) or 1 (FAIL / agreement below threshold).
+    """
+    log.info("compare_search: query=%r top_k=%d", query[:80], top_k)
+
+    try:
+        vec = _embed(query)
+        log.info("embedding_ok dim=%d", len(vec))
+    except Exception as exc:
+        log.error("embedding_failed: %s", exc)
+        return 1
+
+    try:
+        src_hits = _qdrant_search(SOURCE_URL, SOURCE_COLLECTION, vec, top_k)
+        log.info("source_hits=%d from %s/%s", len(src_hits), SOURCE_URL, SOURCE_COLLECTION)
+    except Exception as exc:
+        log.error("source_search_failed: %s", exc)
+        return 1
+
+    try:
+        tgt_hits = _qdrant_search(TARGET_URL, TARGET_COLLECTION, vec, top_k)
+        log.info("target_hits=%d from %s/%s", len(tgt_hits), TARGET_URL, TARGET_COLLECTION)
+    except Exception as exc:
+        log.error("target_search_failed: %s", exc)
+        return 1
+
+    if not src_hits:
+        log.warning("source returned 0 results — no agreement to measure")
+        return 1
+
+    # Report top results from each side
+    for rank, hit in enumerate(src_hits[:top_k], 1):
+        payload = hit.get("payload", {})
+        log.info(
+            "source rank=%d score=%.4f record_id=%s text_preview=%r",
+            rank, hit.get("score", 0), payload.get("record_id", "")[:12],
+            (payload.get("text") or "")[:80],
+        )
+    for rank, hit in enumerate(tgt_hits[:top_k], 1):
+        payload = hit.get("payload", {})
+        log.info(
+            "target rank=%d score=%.4f record_id=%s text_preview=%r",
+            rank, hit.get("score", 0), payload.get("record_id", "")[:12],
+            (payload.get("text") or "")[:80],
+        )
+
+    # Agreement: fraction of target top-k whose record_id is in source top-k
+    src_ids = {
+        hit.get("payload", {}).get("record_id", "") for hit in src_hits[:top_k]
+    }
+    matches = sum(
+        1 for h in tgt_hits[:top_k]
+        if h.get("payload", {}).get("record_id", "") in src_ids
+    )
+    agreement = matches / max(len(tgt_hits), 1)
+    log.info(
+        "search_agreement: matches=%d/%d agreement=%.1f%%",
+        matches, len(tgt_hits[:top_k]), agreement * 100,
+    )
+
+    threshold = 0.95
+    if agreement >= threshold:
+        log.info("compare_search_result: PASS (>=%.0f%% agreement)", threshold * 100)
+        return 0
+    else:
+        log.warning(
+            "compare_search_result: FAIL (%.1f%% < %.0f%% required)",
+            agreement * 100, threshold * 100,
+        )
+        return 1
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="VRS Qdrant parity check")
     parser.add_argument("--sample", type=int, default=0, metavar="N",
                         help="Spot-check N random vectors (default: 0 = count only)")
+    parser.add_argument("--compare-search", metavar="QUERY", default=None,
+                        help="Run same query on both endpoints and report top-5 agreement. "
+                             "Use before flipping READ_FROM_VRS_STORE=true.")
     args = parser.parse_args()
-    sys.exit(check_parity(args.sample))
+
+    if args.compare_search:
+        sys.exit(compare_search(args.compare_search))
+    else:
+        sys.exit(check_parity(args.sample))


### PR DESCRIPTION
## Summary

- **Zero production impact on merge** — `READ_FROM_VRS_STORE` defaults to `false`; all reads continue targeting spark-2 `fgp_knowledge` unchanged
- `resolve_read_endpoint()` in `qdrant_dual_writer.py` returns `(url, collection)` based on the flag — single resolver, single read site
- `knowledge_retriever._qdrant_search()` is the only `fgp_knowledge` read site; wired to use resolver; `agentic_orchestrator` and `dgx_tools` inherit automatically via `semantic_search()`
- Startup log emitted on every restart showing which endpoint is active
- `verify_dual_write_parity.py --compare-search QUERY` pre-cutover gate — reports top-5 result agreement between spark-2 and spark-4 (≥95% required before flip)
- Promotion workflow documented in `.env.example` and `IRON_DOME_ARCHITECTURE.md`

## Read-site audit

| Site | Collection | In scope |
|------|-----------|----------|
| `knowledge_retriever._qdrant_search()` | `fgp_knowledge` | ✓ wired |
| `intelligence._search_single_collection()` | `fortress_knowledge`, `email_embeddings`, `legal_library` | ✗ different collections |
| `elevenlabs_tools`, `s2s_voice_stream` | `guest_golden_responses` | ✗ different collection |

## Test plan

- [ ] `test_read_cutover.py` — 8 tests: resolver default/flag/slash-strip, retriever routes to correct URL, parity script exits cleanly with no live Qdrant
- [ ] All 8 pass locally (`pytest` green)
- [ ] Parity baseline query requires live DGX cluster (NIM unreachable from dev host — expected)

## Rollback

Flip `READ_FROM_VRS_STORE=false` in `.env`, `sudo systemctl restart fortress-backend` — no code change, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)