### PR TITLE
feat(ops): dual-write parity monitor — hourly soak check for Phase 5a Part 4

### DIFF
--- a/deploy/systemd/fortress-parity-monitor.service
+++ b/deploy/systemd/fortress-parity-monitor.service
@@ -1,0 +1,29 @@
+[Unit]
+Description=Fortress Prime — Qdrant dual-write parity monitor (Phase 5a Part 4 soak)
+Documentation=file:///home/admin/Fortress-Prime/src/rag/verify_dual_write_parity.py
+After=network-online.target
+
+[Service]
+Type=oneshot
+User=admin
+Group=admin
+WorkingDirectory=/home/admin/Fortress-Prime/fortress-guest-platform
+
+ExecStart=/bin/bash -c '\
+  set -a; \
+  source /home/admin/Fortress-Prime/fortress-guest-platform/.env 2>/dev/null; \
+  source /home/admin/Fortress-Prime/fortress-guest-platform/.env.dgx 2>/dev/null; \
+  source /home/admin/Fortress-Prime/.env.security 2>/dev/null; \
+  set +a; \
+  exec /home/admin/Fortress-Prime/fortress-guest-platform/.uv-venv/bin/python \
+    -m src.rag.verify_dual_write_parity --monitor'
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=fortress-parity-monitor
+
+# Allow writing alarm files — alarm dir is on NAS, no special permission needed
+# Log writes to /var/log/fortress-parity.log (falls back to ~/fortress-parity.log)
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/fortress-parity-monitor.timer
+++ b/deploy/systemd/fortress-parity-monitor.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run Fortress Prime Qdrant parity monitor every 60 minutes
+Documentation=file:///home/admin/Fortress-Prime/src/rag/verify_dual_write_parity.py
+
+[Timer]
+# First fire 5 minutes after boot, then every 60 minutes
+OnBootSec=5min
+OnUnitActiveSec=60min
+AccuracySec=1min
+
+[Install]
+WantedBy=timers.target

--- a/fortress-guest-platform/backend/tests/test_parity_monitor.py
+++ b/fortress-guest-platform/backend/tests/test_parity_monitor.py
@@ -1,0 +1,210 @@
+"""Tests for verify_dual_write_parity --monitor mode."""
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+from src.rag.verify_dual_write_parity import (  # type: ignore[import]
+    _parity_log_append,
+    _write_alarm,
+    run_monitor,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mock_client(count: int = 168) -> MagicMock:
+    client = MagicMock()
+    collection_info = MagicMock()
+    collection_info.points_count = count
+    client.get_collection.return_value = collection_info
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Log append + rotation
+# ---------------------------------------------------------------------------
+
+class TestParityLogAppend:
+    def test_writes_line(self, tmp_path: Path) -> None:
+        log_file = tmp_path / "parity.log"
+        with patch("src.rag.verify_dual_write_parity.PARITY_LOG", log_file):
+            _parity_log_append('{"status":"pass"}')
+        assert log_file.exists()
+        assert '{"status":"pass"}' in log_file.read_text()
+
+    def test_rotation_keeps_last_n_lines(self, tmp_path: Path) -> None:
+        log_file = tmp_path / "parity.log"
+        # Write 5 lines with max=3
+        with patch("src.rag.verify_dual_write_parity.PARITY_LOG", log_file), \
+             patch("src.rag.verify_dual_write_parity.PARITY_LOG_MAX_LINES", 3):
+            for i in range(5):
+                _parity_log_append(f"line-{i}")
+        lines = [l for l in log_file.read_text().splitlines() if l]
+        assert len(lines) == 3
+        assert lines[-1] == "line-4"
+        assert "line-0" not in lines
+        assert "line-1" not in lines
+
+    def test_fallback_on_permission_error(self, tmp_path: Path) -> None:
+        fallback = tmp_path / "fallback.log"
+        with patch("src.rag.verify_dual_write_parity.PARITY_LOG", Path("/proc/nonexistent/nope.log")), \
+             patch("src.rag.verify_dual_write_parity._PARITY_LOG_FALLBACK", fallback):
+            _parity_log_append('{"status":"pass"}')
+        assert fallback.exists()
+
+
+# ---------------------------------------------------------------------------
+# Alarm file
+# ---------------------------------------------------------------------------
+
+class TestWriteAlarm:
+    def test_writes_alarm_file_on_hard_fail(self, tmp_path: Path) -> None:
+        alarm_dir = tmp_path / "parity-alarm"
+        with patch("src.rag.verify_dual_write_parity.PARITY_ALARM_DIR", alarm_dir):
+            _write_alarm("2026-04-19T12:00:00Z", "count_mismatch", {"src": 168, "tgt": 150})
+        alarm_files = list(alarm_dir.glob("alarm-*.error"))
+        assert len(alarm_files) == 1
+        content = json.loads(alarm_files[0].read_text())
+        assert content["reason"] == "count_mismatch"
+        assert "timestamp" in content
+
+    def test_alarm_file_not_written_on_success(self, tmp_path: Path) -> None:
+        alarm_dir = tmp_path / "parity-alarm"
+        # Don't call _write_alarm — verify it's not called during a PASS run
+        with patch("src.rag.verify_dual_write_parity.PARITY_ALARM_DIR", alarm_dir), \
+             patch("src.rag.verify_dual_write_parity._client") as mock_client_fn, \
+             patch("src.rag.verify_dual_write_parity._search_agreement", return_value=(1.0, "pass")), \
+             patch("src.rag.verify_dual_write_parity._parity_log_append"):
+            mock_client_fn.return_value = _mock_client(168)
+            rc = run_monitor()
+        assert rc == 0
+        assert not alarm_dir.exists() or list(alarm_dir.glob("alarm-*.error")) == []
+
+    def test_alarm_file_not_written_on_soft_fail(self, tmp_path: Path) -> None:
+        alarm_dir = tmp_path / "parity-alarm"
+        with patch("src.rag.verify_dual_write_parity.PARITY_ALARM_DIR", alarm_dir), \
+             patch("src.rag.verify_dual_write_parity._client") as mock_client_fn, \
+             patch("src.rag.verify_dual_write_parity._search_agreement", return_value=(0.92, "soft_fail")), \
+             patch("src.rag.verify_dual_write_parity._parity_log_append"):
+            mock_client_fn.return_value = _mock_client(168)
+            rc = run_monitor()
+        assert rc == 1
+        assert not alarm_dir.exists() or list(alarm_dir.glob("alarm-*.error")) == []
+
+
+# ---------------------------------------------------------------------------
+# Soft vs hard fail classification
+# ---------------------------------------------------------------------------
+
+class TestFailClassification:
+    def test_pass_on_full_agreement(self, tmp_path: Path) -> None:
+        alarm_dir = tmp_path / "alarms"
+        with patch("src.rag.verify_dual_write_parity.PARITY_ALARM_DIR", alarm_dir), \
+             patch("src.rag.verify_dual_write_parity._client") as mcf, \
+             patch("src.rag.verify_dual_write_parity._search_agreement", return_value=(1.0, "pass")), \
+             patch("src.rag.verify_dual_write_parity._parity_log_append"):
+            mcf.return_value = _mock_client(168)
+            assert run_monitor() == 0
+
+    def test_soft_fail_on_90_to_95_agreement(self, tmp_path: Path) -> None:
+        alarm_dir = tmp_path / "alarms"
+        with patch("src.rag.verify_dual_write_parity.PARITY_ALARM_DIR", alarm_dir), \
+             patch("src.rag.verify_dual_write_parity._client") as mcf, \
+             patch("src.rag.verify_dual_write_parity._search_agreement", return_value=(0.92, "soft_fail")), \
+             patch("src.rag.verify_dual_write_parity._parity_log_append"):
+            mcf.return_value = _mock_client(168)
+            assert run_monitor() == 1
+
+    def test_hard_fail_on_count_mismatch(self, tmp_path: Path) -> None:
+        alarm_dir = tmp_path / "alarms"
+        with patch("src.rag.verify_dual_write_parity.PARITY_ALARM_DIR", alarm_dir), \
+             patch("src.rag.verify_dual_write_parity._client") as mcf, \
+             patch("src.rag.verify_dual_write_parity._search_agreement", return_value=(1.0, "pass")), \
+             patch("src.rag.verify_dual_write_parity._parity_log_append"):
+            # Return different counts for source vs target
+            src_client = _mock_client(168)
+            tgt_client = _mock_client(150)
+            mcf.side_effect = [src_client, tgt_client]
+            rc = run_monitor()
+        assert rc == 2
+        assert list(alarm_dir.glob("alarm-*.error"))
+
+    def test_hard_fail_on_search_below_90(self, tmp_path: Path) -> None:
+        alarm_dir = tmp_path / "alarms"
+        with patch("src.rag.verify_dual_write_parity.PARITY_ALARM_DIR", alarm_dir), \
+             patch("src.rag.verify_dual_write_parity._client") as mcf, \
+             patch("src.rag.verify_dual_write_parity._search_agreement", return_value=(0.80, "hard_fail")), \
+             patch("src.rag.verify_dual_write_parity._parity_log_append"):
+            mcf.return_value = _mock_client(168)
+            rc = run_monitor()
+        assert rc == 2
+        assert list(alarm_dir.glob("alarm-*.error"))
+
+    def test_hard_fail_on_connection_error(self, tmp_path: Path) -> None:
+        alarm_dir = tmp_path / "alarms"
+        with patch("src.rag.verify_dual_write_parity.PARITY_ALARM_DIR", alarm_dir), \
+             patch("src.rag.verify_dual_write_parity._client", side_effect=ConnectionError("refused")), \
+             patch("src.rag.verify_dual_write_parity._parity_log_append"):
+            rc = run_monitor()
+        assert rc == 2
+        assert list(alarm_dir.glob("alarm-*.error"))
+
+
+# ---------------------------------------------------------------------------
+# JSON output format
+# ---------------------------------------------------------------------------
+
+class TestMonitorJsonOutput:
+    def test_json_line_contains_required_fields(self, tmp_path: Path) -> None:
+        log_file = tmp_path / "parity.log"
+        alarm_dir = tmp_path / "alarms"
+        with patch("src.rag.verify_dual_write_parity.PARITY_LOG", log_file), \
+             patch("src.rag.verify_dual_write_parity.PARITY_ALARM_DIR", alarm_dir), \
+             patch("src.rag.verify_dual_write_parity._client") as mcf, \
+             patch("src.rag.verify_dual_write_parity._search_agreement", return_value=(1.0, "pass")):
+            mcf.return_value = _mock_client(168)
+            run_monitor()
+        lines = [l for l in log_file.read_text().splitlines() if l]
+        assert lines
+        entry = json.loads(lines[-1])
+        assert "timestamp" in entry
+        assert "overall_status" in entry
+        assert "count_parity_pct" in entry
+        assert "src_count" in entry
+        assert "tgt_count" in entry
+        assert "count_match" in entry
+        assert "search_parity" in entry
+        assert isinstance(entry["search_parity"], dict)
+
+
+# ---------------------------------------------------------------------------
+# drift_alarm integration
+# ---------------------------------------------------------------------------
+
+class TestDriftAlarmIntegration:
+    def test_check_parity_alarms_empty_dir(self, tmp_path: Path) -> None:
+        import tools.drift_alarm as da  # type: ignore[import]
+        (tmp_path / "parity-alarm").mkdir()
+        with patch.object(da, "PARITY_ALARM_DIR", tmp_path / "parity-alarm"):
+            result = da.check_parity_alarms()
+        assert result == []
+
+    def test_check_parity_alarms_finds_error_files(self, tmp_path: Path) -> None:
+        import tools.drift_alarm as da  # type: ignore[import]
+        alarm_dir = tmp_path / "parity-alarm"
+        alarm_dir.mkdir()
+        (alarm_dir / "alarm-20260419T120000Z.error").write_text("{}")
+        (alarm_dir / "alarm-20260419T130000Z.error").write_text("{}")
+        with patch.object(da, "PARITY_ALARM_DIR", alarm_dir):
+            result = da.check_parity_alarms()
+        assert len(result) == 2
+
+    def test_check_parity_alarms_missing_dir(self, tmp_path: Path) -> None:
+        import tools.drift_alarm as da  # type: ignore[import]
+        with patch.object(da, "PARITY_ALARM_DIR", tmp_path / "nonexistent"):
+            result = da.check_parity_alarms()
+        assert result == []

--- a/src/rag/verify_dual_write_parity.py
+++ b/src/rag/verify_dual_write_parity.py
@@ -6,21 +6,37 @@ Compares fgp_knowledge (spark-2) against fgp_vrs_knowledge (spark-4):
   - Point count parity
   - Optional vector spot-check on a random sample
   - Optional search comparison (--compare-search) for pre-cutover gate
+  - --monitor mode: hourly soak monitoring with structured JSON output
 
 Usage:
   python3 -m src.rag.verify_dual_write_parity [--sample N] [--compare-search QUERY]
+  python3 -m src.rag.verify_dual_write_parity --monitor
 
   --sample N             Spot-check N random vectors byte-for-byte (default: 0 = skip)
   --compare-search QUERY Run the same search against both endpoints and compare top-5
                          results. Reports hit-rate agreement. Run before flipping
                          READ_FROM_VRS_STORE=true.
+  --monitor              Non-interactive soak mode. Runs a fixed set of queries,
+                         writes a JSON result line to PARITY_LOG, writes an alarm
+                         file to PARITY_ALARM_DIR on hard fail.
+                         Exit codes: 0=PASS, 1=SOFT_FAIL (90-95% or rank swaps),
+                         2=HARD_FAIL (<90%, count mismatch, or connection error).
+
+Exit codes in --monitor mode:
+  0  PASS      — count match + all search agreements ≥95%
+  1  SOFT_FAIL — all connections ok, parity 90-95% (rank-swap noise)
+  2  HARD_FAIL — count mismatch, connection error, or parity <90%
 """
 from __future__ import annotations
 
 import argparse
+import json
 import logging
+import os
 import random
 import sys
+from datetime import datetime, timezone
+from pathlib import Path
 
 logging.basicConfig(
     level=logging.INFO,
@@ -108,9 +124,25 @@ def check_parity(sample_n: int) -> int:
     return 0 if ok else 1
 
 
-EMBED_URL   = "http://192.168.0.100/api/embeddings"
+# Ollama embedding endpoint (nomic-embed-text, 768-dim).
+# Port 80 Nginx proxy is unavailable from this host; use Ollama directly at :11434.
+EMBED_URL   = os.getenv("PARITY_EMBED_URL", "http://192.168.0.100:11434/api/embeddings")
 EMBED_MODEL = "nomic-embed-text"
 EMBED_DIM   = 768
+
+# Monitor mode config
+PARITY_LOG       = Path(os.getenv("PARITY_LOG",       "/var/log/fortress-parity.log"))
+_PARITY_LOG_FALLBACK = Path.home() / "fortress-parity.log"
+PARITY_ALARM_DIR = Path(os.getenv("PARITY_ALARM_DIR", "/mnt/fortress_nas/parity-alarm"))
+PARITY_LOG_MAX_LINES = int(os.getenv("PARITY_LOG_MAX_LINES", "200"))
+
+_MONITOR_QUERIES: list[str] = [
+    "Fallen Timber Lodge",
+    "pricing weekend stay",
+    "deck exterior materials",
+    "booking policy",
+    "amenities WiFi",
+]
 
 
 def _embed(query: str) -> list[float]:
@@ -228,6 +260,151 @@ def compare_search(query: str, top_k: int = 5) -> int:
         return 1
 
 
+def _parity_log_append(line: str) -> None:
+    """Append a line to the parity log, with size-based rotation (keep last N lines)."""
+    target = PARITY_LOG
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        # Read existing, keep last N-1 lines, append new
+        existing: list[str] = []
+        if target.exists():
+            existing = target.read_text(encoding="utf-8").splitlines()
+        existing = existing[-(PARITY_LOG_MAX_LINES - 1):]
+        existing.append(line)
+        target.write_text("\n".join(existing) + "\n", encoding="utf-8")
+    except OSError:
+        try:
+            _PARITY_LOG_FALLBACK.parent.mkdir(parents=True, exist_ok=True)
+            with open(_PARITY_LOG_FALLBACK, "a", encoding="utf-8") as fh:
+                fh.write(line + "\n")
+        except OSError:
+            log.warning("parity_log_write_failed cannot write to %s or %s", PARITY_LOG, _PARITY_LOG_FALLBACK)
+
+
+def _write_alarm(ts: str, reason: str, detail: dict) -> None:
+    """Write an alarm file to PARITY_ALARM_DIR for pickup by drift_alarm."""
+    try:
+        PARITY_ALARM_DIR.mkdir(parents=True, exist_ok=True)
+        safe_ts = ts.replace(":", "").replace("-", "")
+        alarm_path = PARITY_ALARM_DIR / f"alarm-{safe_ts}.error"
+        payload = json.dumps({"timestamp": ts, "reason": reason, **detail}, indent=2)
+        alarm_path.write_text(payload + "\n", encoding="utf-8")
+        log.error("parity_alarm_written path=%s", alarm_path)
+    except OSError as exc:
+        log.error("parity_alarm_write_failed error=%s", exc)
+
+
+def _search_agreement(query: str, top_k: int = 5) -> tuple[float, str]:
+    """Return (agreement_fraction, status_label) for a single query.
+
+    status_label: 'pass' | 'soft_fail' | 'hard_fail' | 'error'
+    """
+    try:
+        vec = _embed(query)
+    except Exception as exc:
+        log.error("embed_failed query=%r error=%s", query[:50], exc)
+        return 0.0, "error"
+
+    try:
+        src_hits = _qdrant_search(SOURCE_URL, SOURCE_COLLECTION, vec, top_k)
+        tgt_hits = _qdrant_search(TARGET_URL, TARGET_COLLECTION, vec, top_k)
+    except Exception as exc:
+        log.error("search_failed query=%r error=%s", query[:50], exc)
+        return 0.0, "error"
+
+    if not src_hits or not tgt_hits:
+        return 0.0, "hard_fail"
+
+    src_ids = {h.get("payload", {}).get("record_id", "") for h in src_hits[:top_k]}
+    matches = sum(1 for h in tgt_hits[:top_k] if h.get("payload", {}).get("record_id", "") in src_ids)
+    agreement = matches / max(len(tgt_hits[:top_k]), 1)
+
+    if agreement >= 0.95:
+        status = "pass"
+    elif agreement >= 0.90:
+        status = "soft_fail"
+    else:
+        status = "hard_fail"
+
+    return agreement, status
+
+
+def run_monitor() -> int:
+    """Non-interactive soak mode. Returns 0/1/2 exit code."""
+    ts = datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    log.info("monitor_start ts=%s queries=%d", ts, len(_MONITOR_QUERIES))
+
+    # --- Count parity ---
+    try:
+        source = _client(SOURCE_URL)
+        target = _client(TARGET_URL)
+        src_count = _count(source, SOURCE_COLLECTION)
+        tgt_count = _count(target, TARGET_COLLECTION)
+        count_match = src_count == tgt_count
+        count_parity_pct = (tgt_count / src_count * 100) if src_count else 0.0
+    except Exception as exc:
+        log.error("count_check_failed error=%s", exc)
+        result = {
+            "timestamp": ts, "overall_status": "hard_fail",
+            "reason": "connection_error", "error": str(exc)[:200],
+        }
+        _parity_log_append(json.dumps(result))
+        _write_alarm(ts, "connection_error", {"error": str(exc)[:200]})
+        return 2
+
+    log.info("count_check src=%d tgt=%d parity=%.1f%%", src_count, tgt_count, count_parity_pct)
+
+    if not count_match:
+        log.error("COUNT MISMATCH src=%d tgt=%d delta=%d", src_count, tgt_count, src_count - tgt_count)
+
+    # --- Search parity ---
+    per_query: dict[str, dict] = {}
+    for q in _MONITOR_QUERIES:
+        agreement, status = _search_agreement(q)
+        per_query[q] = {"agreement": round(agreement, 4), "status": status}
+        log.info("query_result query=%r agreement=%.1f%% status=%s", q[:50], agreement * 100, status)
+
+    # --- Overall status ---
+    statuses = [v["status"] for v in per_query.values()]
+    has_error    = "error"     in statuses
+    has_hard     = "hard_fail" in statuses
+    has_soft     = "soft_fail" in statuses
+
+    if not count_match or has_error or has_hard:
+        overall = "hard_fail"
+        exit_code = 2
+    elif has_soft:
+        overall = "soft_fail"
+        exit_code = 1
+    else:
+        overall = "pass"
+        exit_code = 0
+
+    result = {
+        "timestamp":         ts,
+        "overall_status":    overall,
+        "count_parity_pct":  round(count_parity_pct, 1),
+        "src_count":         src_count,
+        "tgt_count":         tgt_count,
+        "count_match":       count_match,
+        "search_parity":     per_query,
+    }
+    log.info("monitor_result overall=%s exit=%d", overall, exit_code)
+    _parity_log_append(json.dumps(result))
+
+    if exit_code == 2:
+        _write_alarm(ts, overall, {
+            "count_match": count_match,
+            "src_count": src_count,
+            "tgt_count": tgt_count,
+            "failed_queries": {q: v for q, v in per_query.items() if v["status"] != "pass"},
+        })
+    elif exit_code == 1:
+        log.warning("SOFT_FAIL soft queries=%s", [q for q, v in per_query.items() if v["status"] == "soft_fail"])
+
+    return exit_code
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="VRS Qdrant parity check")
     parser.add_argument("--sample", type=int, default=0, metavar="N",
@@ -235,9 +412,14 @@ if __name__ == "__main__":
     parser.add_argument("--compare-search", metavar="QUERY", default=None,
                         help="Run same query on both endpoints and report top-5 agreement. "
                              "Use before flipping READ_FROM_VRS_STORE=true.")
+    parser.add_argument("--monitor", action="store_true",
+                        help="Hourly soak mode: runs fixed query set, writes JSON to PARITY_LOG, "
+                             "alarm file on hard fail. Exit 0=pass, 1=soft_fail, 2=hard_fail.")
     args = parser.parse_args()
 
-    if args.compare_search:
+    if args.monitor:
+        sys.exit(run_monitor())
+    elif args.compare_search:
         sys.exit(compare_search(args.compare_search))
     else:
         sys.exit(check_parity(args.sample))

--- a/tools/drift_alarm.py
+++ b/tools/drift_alarm.py
@@ -63,6 +63,7 @@ ALERT_MD          = Path(os.getenv("ALERT_MD",
 UNTRACKED_WARN    = int(os.getenv("UNTRACKED_WARN",        "10"))
 UNTRACKED_ALERT   = int(os.getenv("UNTRACKED_ALERT",       "50"))
 STALE_HOURS       = int(os.getenv("MODIFIED_STALE_HOURS",  "48"))
+PARITY_ALARM_DIR  = Path(os.getenv("PARITY_ALARM_DIR",    "/mnt/fortress_nas/parity-alarm"))
 
 _DRIFT_LOG_FALLBACK         = Path.home() / "fortress-drift.log"
 _DRIFT_LOG_WARNED_SENTINEL  = Path.home() / ".fortress_drift_perm_warned"
@@ -156,6 +157,16 @@ def check_secrets() -> list[str]:
     return hits
 
 
+def check_parity_alarms() -> list[Path]:
+    """Return list of unacknowledged parity alarm files in PARITY_ALARM_DIR."""
+    try:
+        if not PARITY_ALARM_DIR.exists():
+            return []
+        return sorted(PARITY_ALARM_DIR.glob("alarm-*.error"))
+    except OSError:
+        return []
+
+
 def check_modified() -> tuple[int, list[str]]:
     """Return (count, stale_files) where stale = modified >STALE_HOURS ago."""
     result = subprocess.run(
@@ -241,19 +252,27 @@ def run(dry_run: bool, why: bool = False) -> int:
     untracked_count, untracked_level = check_untracked()
     secret_hits                       = check_secrets()
     modified_count, stale_files       = check_modified()
+    parity_alarm_files                = check_parity_alarms()
+
+    if parity_alarm_files:
+        log.warning(
+            "parity_alarm_detected count=%d files=%s",
+            len(parity_alarm_files),
+            [f.name for f in parity_alarm_files[:5]],
+        )
 
     # --- Determine overall level ---
     level = ""
     if secret_hits or untracked_level == "ALERT":
         level = "ALERT"
-    elif untracked_level == "WARN" or stale_files:
+    elif untracked_level == "WARN" or stale_files or parity_alarm_files:
         level = "WARN"
 
     # --- Log summary ---
     summary = (
         f"[{level or 'OK'}] untracked={untracked_count} "
         f"secrets={len(secret_hits)} modified={modified_count} "
-        f"stale={len(stale_files)}"
+        f"stale={len(stale_files)} parity_alarms={len(parity_alarm_files)}"
     )
     _append_log(summary)
     log.info(summary)
@@ -291,6 +310,17 @@ def run(dry_run: bool, why: bool = False) -> int:
     ]
     for s in stale_files[:20]:
         lines.append(f"  - {s}")
+
+    lines += [
+        f"",
+        f"## Check 5: Qdrant dual-write parity alarms",
+        f"Count: {len(parity_alarm_files)}",
+        f"Dir: {PARITY_ALARM_DIR}",
+    ]
+    for f in parity_alarm_files[:5]:
+        lines.append(f"  - {f.name}")
+    if len(parity_alarm_files) > 5:
+        lines.append(f"  ... and {len(parity_alarm_files)-5} more")
 
     report = "\n".join(lines) + "\n"
     log.warning("Drift detected — level=%s", level)


### PR DESCRIPTION
## Summary

- Hourly `systemd` timer runs `verify_dual_write_parity --monitor` as a oneshot service
- Structured JSON per run logged to `/var/log/fortress-parity.log` (200-line rolling, fallback `~/fortress-parity.log`)
- Hard-fail writes `alarm-<ts>.error` to `/mnt/fortress_nas/parity-alarm/` — picked up by drift alarm on next 6h run
- `drift_alarm.py` gains Check 5: parity alarm count in summary line, alarm files listed in drift report
- Fixes `EMBED_URL` in parity script to use Ollama `:11434` directly (Nginx port-80 proxy gap documented)

## Fail classification

| Exit | Label | Condition |
|------|-------|-----------|
| 0 | `pass` | count match + all 5 queries ≥95% agreement |
| 1 | `soft_fail` | 90–95% agreement (rank-swap noise) — log WARNING, no alarm |
| 2 | `hard_fail` | count mismatch, <90%, connection error — alarm file written |

## Test plan

- [ ] `test_parity_monitor.py` — 15 tests: log write/rotation/fallback, alarm write on hard fail, alarm NOT written on pass/soft, fail classification (pass/soft/hard/count-mismatch/connection-error), JSON schema, drift_alarm integration
- [ ] All 15 pass locally

## Manual run (post-merge)

```bash
sudo systemctl daemon-reload
sudo systemctl enable --now fortress-parity-monitor.timer
sudo systemctl start fortress-parity-monitor.service
journalctl -u fortress-parity-monitor -f
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)