### PR TITLE
fix(ops): parity monitor WorkingDirectory — repo root, not fortress-guest-platform

### DIFF
--- a/deploy/systemd/fortress-parity-monitor.service
+++ b/deploy/systemd/fortress-parity-monitor.service
@@ -7,7 +7,7 @@ After=network-online.target
 Type=oneshot
 User=admin
 Group=admin
-WorkingDirectory=/home/admin/Fortress-Prime/fortress-guest-platform
+WorkingDirectory=/home/admin/Fortress-Prime
 
 ExecStart=/bin/bash -c '\
   set -a; \


### PR DESCRIPTION
## Fix

Single-line: `WorkingDirectory=/home/admin/Fortress-Prime/fortress-guest-platform` → `WorkingDirectory=/home/admin/Fortress-Prime`

`src/rag/` lives at repo root, not inside `fortress-guest-platform`. With the wrong WorkingDirectory, `python -m src.rag.verify_dual_write_parity` errors with `ModuleNotFoundError: No module named 'src.rag'`.

Already applied to the installed service file (`/etc/systemd/system/`). First manual run confirmed passing after fix:
- All 5 queries 100% agreement
- Result JSON written to `~/fortress-parity.log`
- Timer armed, next fire in 58min

🤖 Generated with [Claude Code](https://claude.com/claude-code)