### PR TITLE
fix(ci): add missing alembic upgrade head — crog_acquisition schema errors on every run since PR #75

### DIFF
--- a/.github/workflows/fortress-ci.yml
+++ b/.github/workflows/fortress-ci.yml
@@ -121,6 +121,12 @@ jobs:
             GRANT USAGE, SELECT ON SEQUENCES TO fortress_api;
           SQL
 
+      - name: Run Alembic migrations
+        working-directory: fortress-guest-platform
+        run: |
+          source "$GITHUB_WORKSPACE/.venv/bin/activate"
+          alembic -c backend/alembic.ini upgrade head
+
       - name: Build Next.js storefront
         working-directory: fortress-guest-platform
         run: npx turbo run build --filter=@fortress/storefront

--- a/.github/workflows/playwright-sovereign-gate.yml
+++ b/.github/workflows/playwright-sovereign-gate.yml
@@ -121,6 +121,12 @@ jobs:
             GRANT USAGE, SELECT ON SEQUENCES TO fortress_api;
           SQL
 
+      - name: Run Alembic migrations
+        working-directory: fortress-guest-platform
+        run: |
+          source "$GITHUB_WORKSPACE/.venv/bin/activate"
+          alembic -c backend/alembic.ini upgrade head
+
       - name: Install Playwright Chromium
         working-directory: fortress-guest-platform/apps/storefront
         run: npx playwright install --with-deps chromium


### PR DESCRIPTION
## Problem

Every CI run since PR #75 has failed with:

```
asyncpg.exceptions.InvalidSchemaNameError: schema "crog_acquisition" does not exist
```

**Root cause:** Neither `fortress-ci.yml` nor `playwright-sovereign-gate.yml` ran `alembic upgrade head`. The ephemeral `fortress_shadow` CI database received only role DDL (`CREATE ROLE fortress_admin/fortress_api`) — no schemas, no tables. `seed_master_admin.py` then fails on first ORM access.

This was diagnosed by comparing the CI step sequence against production: production has `crog_acquisition` because migrations have been applied; CI never applies them.

## Fix

Add one step in each workflow, after "Provision sovereign CI database roles", before the seed step:

```yaml
- name: Run Alembic migrations
  working-directory: fortress-guest-platform
  run: |
    source "$GITHUB_WORKSPACE/.venv/bin/activate"
    alembic -c backend/alembic.ini upgrade head
```

**URL routing verified:** `alembic/env.py` overrides the ini URL with `settings.alembic_database_url` (sync driver), which reads `POSTGRES_ADMIN_URI` from the job env → `postgresql://fortress_admin:fortress_admin@127.0.0.1:5432/fortress_shadow`. Correct database, correct driver.

## Affected workflows

- `fortress-ci.yml` (e2e-gate job)
- `playwright-sovereign-gate.yml` (playwright-e2e job)

Both share the same missing step. No other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)