### PR TITLE
fix(ci): add alembic to root requirements.txt — alembic binary missing from CI venv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ pgvector
 python-dotenv
 requests
 sqlalchemy
+alembic
 psutil
 arq
 redis


### PR DESCRIPTION
## What happened

PR #85 added `alembic upgrade head` to the CI workflow, but the step immediately failed with **exit code 127** (command not found).

**Root cause:** The CI `.venv` is built from `$GITHUB_WORKSPACE/requirements.txt` (the root file). That file had `sqlalchemy` but not `alembic`. The `alembic` CLI binary therefore didn't exist in the activated venv's `PATH`.

The production `.uv-venv` already has alembic installed (it was working locally). The root `requirements.txt` just never got the entry.

## Fix

One line: add `alembic` to `requirements.txt`, immediately after `sqlalchemy` since they're used together.

## Why only `requirements.txt` and not the workflow

The cleanest fix is to add the dependency where it belongs — alembic is a core runtime dependency of the backend, not a CI-only tool. The workflow step is correct; the dependency list was incomplete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)