### PR TITLE
fix(ci): add PYTHONPATH to alembic step — ModuleNotFoundError: No module named 'backend'

### DIFF
--- a/.github/workflows/fortress-ci.yml
+++ b/.github/workflows/fortress-ci.yml
@@ -123,6 +123,8 @@ jobs:
 
       - name: Run Alembic migrations
         working-directory: fortress-guest-platform
+        env:
+          PYTHONPATH: "${{ github.workspace }}/fortress-guest-platform"
         run: |
           source "$GITHUB_WORKSPACE/.venv/bin/activate"
           alembic -c backend/alembic.ini upgrade head

--- a/.github/workflows/playwright-sovereign-gate.yml
+++ b/.github/workflows/playwright-sovereign-gate.yml
@@ -123,6 +123,8 @@ jobs:
 
       - name: Run Alembic migrations
         working-directory: fortress-guest-platform
+        env:
+          PYTHONPATH: "${{ github.workspace }}/fortress-guest-platform"
         run: |
           source "$GITHUB_WORKSPACE/.venv/bin/activate"
           alembic -c backend/alembic.ini upgrade head


### PR DESCRIPTION
## Third iteration of CI alembic fix

**Previous failure (PR #86 run):** `ModuleNotFoundError: No module named 'backend'`

**Root cause:** `alembic/env.py` does `from backend.core.config import settings`. Running `alembic` as a CLI tool does not add the `working-directory` to `sys.path` — unlike `python -m alembic` which would. The `backend` package lives in `fortress-guest-platform/backend/`, so `fortress-guest-platform` must be in `PYTHONPATH`.

**Fix:** Add `env: PYTHONPATH: "${{ github.workspace }}/fortress-guest-platform"` to the migration step in both workflows. This is the same directory that the seed step implicitly gets via its `working-directory: fortress-guest-platform` + Python's CWD-to-sys.path behaviour.

## CI fix history
| PR | Fix | Error cleared | New error |
|----|-----|---------------|-----------|
| #85 | Add `alembic upgrade head` step | `crog_acquisition` schema missing | `exit code 127` (alembic not found) |
| #86 | Add `alembic` to `requirements.txt` | alembic binary found | `ModuleNotFoundError: No module named 'backend'` |
| **#87** | **Add `PYTHONPATH` to migration step** | **`backend` import resolves** | *expected: migrations run* |

🤖 Generated with [Claude Code](https://claude.com/claude-code)