### PR TITLE
fix(ci): alembic upgrade head → heads (multiple migration branch tips)

### DIFF
--- a/.github/workflows/fortress-ci.yml
+++ b/.github/workflows/fortress-ci.yml
@@ -127,7 +127,7 @@ jobs:
           PYTHONPATH: "${{ github.workspace }}/fortress-guest-platform"
         run: |
           source "$GITHUB_WORKSPACE/.venv/bin/activate"
-          alembic -c backend/alembic.ini upgrade head
+          alembic -c backend/alembic.ini upgrade heads
 
       - name: Build Next.js storefront
         working-directory: fortress-guest-platform

--- a/.github/workflows/playwright-sovereign-gate.yml
+++ b/.github/workflows/playwright-sovereign-gate.yml
@@ -127,7 +127,7 @@ jobs:
           PYTHONPATH: "${{ github.workspace }}/fortress-guest-platform"
         run: |
           source "$GITHUB_WORKSPACE/.venv/bin/activate"
-          alembic -c backend/alembic.ini upgrade head
+          alembic -c backend/alembic.ini upgrade heads
 
       - name: Install Playwright Chromium
         working-directory: fortress-guest-platform/apps/storefront


### PR DESCRIPTION
## Change

```diff
-alembic -c backend/alembic.ini upgrade head
+alembic -c backend/alembic.ini upgrade heads
```

Both `fortress-ci.yml` and `playwright-sovereign-gate.yml`.

## Why

The migration graph has two branch tips (`c255801e28a0` and `i23a1_add_payment_credit_codes`). Alembic refuses `upgrade head` (singular) when multiple heads exist:

```
ERROR Multiple head revisions are present for given argument 'head';
please specify a specific target revision, '<branchname>@head' to narrow
to a specific head, or 'heads' for all heads
```

`upgrade heads` (plural) advances all branch tips simultaneously.

## Verified

- Local simulation (clean venv + `fortress_shadow_test`) ran 8 pending migrations cleanly with `upgrade heads`, exit 0
- 75 backend unit tests pass in the CI venv
- Backend starts healthy, seed script passes, storefront serves on :3000

🤖 Generated with [Claude Code](https://claude.com/claude-code)