### PR TITLE
fix(ci): add PORT=8100 to playwright-sovereign-gate.yml — missed in PR #79

### DIFF
--- a/.github/workflows/playwright-sovereign-gate.yml
+++ b/.github/workflows/playwright-sovereign-gate.yml
@@ -49,6 +49,7 @@ jobs:
       NEXT_PUBLIC_APP_URL: http://127.0.0.1:3000
       NEXT_TELEMETRY_DISABLED: "1"
       CI: "true"
+      PORT: "8100"
       BOOTSTRAP_ADMIN_PASSWORD: FortressPrime2026!
       BOOTSTRAP_ADMIN_CONFIRM_PASSWORD: FortressPrime2026!
     steps:


### PR DESCRIPTION
## Change

One line: `PORT: "8100"` added to the job-level `env:` block of `playwright-sovereign-gate.yml`.

## Why

PR #79 added `PORT: "8100"` to `fortress-ci.yml` so `run.py` binds on `:8100` (the port the health-check polls). The same fix was not applied to `playwright-sovereign-gate.yml`. As a result, `run.py` defaulted to port `8000`, the `Wait for backend readiness` step polling `:8100` always timed out, and the workflow never reached the Playwright step.

Diagnosed from the PR #91 CI run: `Fortress CI` (has `PORT`) went green; `Playwright Sovereign Gate` (missing `PORT`) failed at backend readiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)