### PR TITLE
fix: SFTConfig max_seq_length → max_length for TRL 1.1.0

### DIFF
--- a/src/nightly_finetune.py
+++ b/src/nightly_finetune.py
@@ -467,7 +467,7 @@ def run_qlora_training(records: list[dict], adapter_out: Path) -> None:
         save_total_limit=2,
         optim="paged_adamw_8bit",
         gradient_checkpointing=True,
-        max_seq_length=MAX_SEQ_LEN,
+        max_length=MAX_SEQ_LEN,
         dataset_text_field="text",
         packing=True,
         report_to="none",


### PR DESCRIPTION
Fixes `AttributeError` in `src/nightly_finetune.py:466` — TRL 1.1.0 API change. Without this, tonight's 02:01 training would crash again.

## What broke
`SFTConfig.__init__()` no longer accepts `max_seq_length` as of TRL 1.1.0. Last night's run loaded the model (40M LoRA params, 4-bit NF4, ~4min), then hit the error at training init before a single step executed.

## Fix
```python
- max_seq_length=MAX_SEQ_LEN,
+ max_length=MAX_SEQ_LEN,
```

## Validation
- TRL version confirmed: `1.1.0` in `.uv-venv`
- `SFTConfig` param list checked interactively: `max_length` ✓, `max_seq_length` absent
- Training corpus: 36 examples currently (DB auth also restored this morning — labeling will accumulate tonight)

## Risk
None — single param rename, no logic change.