### PR TITLE
fix: scrub hardcoded fortress_admin credential from CI schema test

### DIFF
--- a/fortress-guest-platform/backend/tests/test_ci_schema_bootstrap.py
+++ b/fortress-guest-platform/backend/tests/test_ci_schema_bootstrap.py
@@ -147,16 +147,16 @@ class TestStalenessCheck:
 class TestSchemaLoadsIntoDB:
     def test_schema_sql_loads_cleanly(self) -> None:
         """Load schema.sql into a fresh fortress_shadow_test DB and verify key tables."""
+        import os
         import psycopg2
 
-        # Use existing fortress_shadow_test — it was dropped/recreated earlier in session
-        # This test is run separately and manages its own connection
+        db_url = os.getenv("TEST_DATABASE_URL")
+        if not db_url:
+            pytest.skip("TEST_DATABASE_URL not set — skipping integration test")
+        db_url = db_url.replace("+asyncpg", "")  # psycopg2 doesn't use driver prefixes
+
         try:
-            conn = psycopg2.connect(
-                host="127.0.0.1", port=5432,
-                dbname="fortress_shadow_test",
-                user="fortress_admin", password="fortress_admin",
-            )
+            conn = psycopg2.connect(db_url)
             conn.autocommit = True
             cur = conn.cursor()
             cur.execute("""

--- a/tools/drift_alarm.py
+++ b/tools/drift_alarm.py
@@ -79,7 +79,7 @@ SECRET_PATTERN = re.compile(
     r"sk-fortress-[a-zA-Z0-9]{20}"
     r"|nvapi-[a-zA-Z0-9]{20}"
     r"|" + re.escape(_MINER_BOT_PASS_PREFIX + _MINER_BOT_PASS_SUFFIX)
-    + r"|password\s*=\s*['\"][a-zA-Z0-9]{6,}"
+    + r"|(?i:password|passwd)\s*=\s*['\"][a-zA-Z0-9]{6,}"
 )
 
 EXCLUDE_DIRS = [".git", "node_modules", ".venv", "venv", "__pycache__",


### PR DESCRIPTION
Clears the drift alarm secret hit that has fired every run since PR #90 shipped.

## What

**`test_ci_schema_bootstrap.py:158`** — replaced hardcoded psycopg2 `user="fortress_admin", password="fortress_admin"` with `TEST_DATABASE_URL` env var (the established test-isolation pattern already used by conftest.py).

- Skips cleanly when `TEST_DATABASE_URL` is unset (standard CI without DB)
- Passes when set — verified locally against live `fortress_shadow_test`

**`tools/drift_alarm.py:82`** — extended the password pattern from `password\s*=\s*['"]...` to `(?i:password|passwd)\s*=\s*['"]...` so `PASSWORD=`, `PASSWD=`, `Password=` variants are caught in future.

## Verification

```
pytest backend/tests/test_ci_schema_bootstrap.py   → 16 passed, 1 skipped ✓
pytest ...::TestSchemaLoadsIntoDB (with TEST_DATABASE_URL set)  → 1 passed ✓
drift_alarm.py --dry-run  → test_ci_schema_bootstrap.py no longer in hits ✓
```

## What this does NOT touch

The 6 remaining drift alarm hits (`fleet_commander.py`, `seed_master_admin.py`, `smoke_test_seo.py`, `e2e/helpers/auth.ts` ×2, `docs/OPERATIONS.md`) are pre-existing and out of scope.

## Risk

None — test-only file + alarm tooling. No production code changed.