### PR TITLE
fix: scrub 6 hardcoded credentials to env vars (rotation required)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,11 @@ DB_PASS=REPLACE_ME_WITH_REAL_PASSWORD
 # Google Gemini API Key (Required for Email Mining Rig)
 GOOGLE_API_KEY=your_google_api_key_here
 
+# ---------------------------------------------------------------------------
+# Credentials required by src/ scripts — set via vault before running
+# ---------------------------------------------------------------------------
+ANALYST_WRITER_PASSWORD=<set-via-vault>  # fleet_commander.py — analyst_writer postgres role
+
 # Optional: Database connection overrides for Docker
 # DB_HOST=postgres  # Use service name in Docker Compose
 # DB_NAME=fortress_db

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,5 +1,21 @@
 # Fortress Prime Operations Runbook
 
+## CREDENTIAL ROTATION NOTICE 2026-04-20
+
+The following credentials were previously hardcoded in source and were scrubbed in PR #98.
+**Both must be rotated before running any script that uses them.**
+
+- **`analyst_writer` postgres role password** — used by `src/fleet_commander.py`.
+  Set new password via `sudo -u postgres psql -c "ALTER ROLE analyst_writer PASSWORD '...';"`,
+  then update `ANALYST_WRITER_PASSWORD` in `.env` and vault.
+
+- **Fortress staff login password** (`cabin.rentals.of.georgia@gmail.com`) — used by
+  `seed_master_admin.py`, `smoke_test_seo.py`, and E2E Playwright helpers.
+  Rotate via the staff login UI or `backend/scripts/reset_staff_password.py`,
+  then update `FORTRESS_SMOKE_PASSWORD` and `ADMIN_SEED_PASSWORD` in `.env` and vault.
+
+All three env vars are now required at runtime — scripts fail fast with a clear error if unset.
+
 This runbook captures the verified recovery steps for the Fortress Prime async runtime after the auth and Hunter incident.
 
 ## Canonical Worker Topology
@@ -66,7 +82,7 @@ Run the full auth, BFF, and Hunter smoke suite:
 ```bash
 cd /home/admin/Fortress-Prime
 FORTRESS_SMOKE_EMAIL='cabin.rentals.of.georgia@gmail.com' \
-FORTRESS_SMOKE_PASSWORD='FortressPrime2026!' \
+FORTRESS_SMOKE_PASSWORD='<your-password-here>' \
 ./scripts/fortress_auth_pipeline_smoke.sh
 ```
 

--- a/fortress-guest-platform/.env.example
+++ b/fortress-guest-platform/.env.example
@@ -147,3 +147,10 @@ JUDGE_ENABLED=false             # Set true to enable inline judge evaluation
 JUDGE_TIMEOUT_MS=200            # Hard timeout per judge call (milliseconds)
 JUDGE_TRAINING_ENABLED=false    # Set true to enable weekly training timer
 JUDGE_MIN_EXAMPLES=50           # Minimum labeled examples required for training
+
+# ---------------------------------------------------------------------------
+# Credentials required by scripts/ and E2E helpers — set via vault
+# ---------------------------------------------------------------------------
+ADMIN_SEED_PASSWORD=<set-via-vault>      # seed_master_admin.py — staff admin account password
+FORTRESS_SMOKE_PASSWORD=<set-via-vault>  # smoke_test_seo.py + E2E Playwright helpers
+E2E_LOGIN_EMAIL=<set-via-vault>          # E2E Playwright helpers — staff login email

--- a/fortress-guest-platform/apps/command-center/e2e/helpers/auth.ts
+++ b/fortress-guest-platform/apps/command-center/e2e/helpers/auth.ts
@@ -1,11 +1,17 @@
 import { expect, type Page } from "@playwright/test";
 
-const DEFAULT_E2E_EMAIL = "cabin.rentals.of.georgia@gmail.com";
-const DEFAULT_E2E_PASSWORD = "FortressPrime2026!";
-
 export async function loginAsE2EStaff(page: Page, baseURL: string | undefined): Promise<void> {
   if (!baseURL) {
     throw new Error("Playwright baseURL is required for E2E staff login.");
+  }
+
+  const email = process.env.E2E_LOGIN_EMAIL;
+  const password = process.env.FORTRESS_SMOKE_PASSWORD ?? process.env.E2E_LOGIN_PASSWORD;
+  if (!email || !password) {
+    throw new Error(
+      "E2E_LOGIN_EMAIL and FORTRESS_SMOKE_PASSWORD (or E2E_LOGIN_PASSWORD) must be set. " +
+      "See docs/OPERATIONS.md.",
+    );
   }
 
   page.on("console", (msg) => console.log(`[PLAYWRIGHT BROWSER]: ${msg.text()}`));
@@ -17,9 +23,6 @@ export async function loginAsE2EStaff(page: Page, baseURL: string | undefined): 
       );
     }
   });
-
-  const email = process.env.E2E_LOGIN_EMAIL || DEFAULT_E2E_EMAIL;
-  const password = process.env.E2E_LOGIN_PASSWORD || DEFAULT_E2E_PASSWORD;
 
   const loginResponse = await page.request.post(`${baseURL}/api/auth/login`, {
     data: { email, password },

--- a/fortress-guest-platform/apps/storefront/e2e/helpers/auth.ts
+++ b/fortress-guest-platform/apps/storefront/e2e/helpers/auth.ts
@@ -1,11 +1,17 @@
 import { expect, type Page } from "@playwright/test";
 
-const DEFAULT_E2E_EMAIL = "cabin.rentals.of.georgia@gmail.com";
-const DEFAULT_E2E_PASSWORD = "FortressPrime2026!";
-
 export async function loginAsE2EStaff(page: Page, baseURL: string | undefined): Promise<void> {
   if (!baseURL) {
     throw new Error("Playwright baseURL is required for E2E staff login.");
+  }
+
+  const email = process.env.E2E_LOGIN_EMAIL;
+  const password = process.env.FORTRESS_SMOKE_PASSWORD ?? process.env.E2E_LOGIN_PASSWORD;
+  if (!email || !password) {
+    throw new Error(
+      "E2E_LOGIN_EMAIL and FORTRESS_SMOKE_PASSWORD (or E2E_LOGIN_PASSWORD) must be set. " +
+      "See docs/OPERATIONS.md.",
+    );
   }
 
   page.on("console", (msg) => console.log(`[PLAYWRIGHT BROWSER]: ${msg.text()}`));
@@ -17,9 +23,6 @@ export async function loginAsE2EStaff(page: Page, baseURL: string | undefined): 
       );
     }
   });
-
-  const email = process.env.E2E_LOGIN_EMAIL || DEFAULT_E2E_EMAIL;
-  const password = process.env.E2E_LOGIN_PASSWORD || DEFAULT_E2E_PASSWORD;
 
   await page.goto(`${baseURL}/login`, { waitUntil: "domcontentloaded" });
 

--- a/fortress-guest-platform/backend/scripts/seed_master_admin.py
+++ b/fortress-guest-platform/backend/scripts/seed_master_admin.py
@@ -52,7 +52,12 @@ from backend.models.staff import StaffRole, StaffUser
 
 
 ADMIN_EMAIL = "cabin.rentals.of.georgia@gmail.com"
-ADMIN_PASSWORD = "FortressPrime2026!"
+ADMIN_PASSWORD = os.getenv("ADMIN_SEED_PASSWORD")
+if not ADMIN_PASSWORD:
+    raise SystemExit(
+        "ADMIN_SEED_PASSWORD env var is required to run the seed script.\n"
+        "Set it in .env or export from the vault before running. See docs/OPERATIONS.md."
+    )
 ADMIN_FIRST_NAME = "Gary"
 ADMIN_LAST_NAME = "Knight"
 CI_FIXTURE_PROPERTY_ID = UUID("11111111-1111-1111-1111-111111111111")

--- a/fortress-guest-platform/backend/scripts/smoke_test_seo.py
+++ b/fortress-guest-platform/backend/scripts/smoke_test_seo.py
@@ -38,8 +38,13 @@ from backend.core.config import settings
 API_BASE = os.getenv("SEO_SMOKE_API_BASE", "http://127.0.0.1:8100").rstrip("/")
 HTTP_TIMEOUT = httpx.Timeout(connect=10, read=60, write=30, pool=30)
 SMOKE_PREFIX = "[seo-smoke]"
-DEFAULT_E2E_EMAIL = "cabin.rentals.of.georgia@gmail.com"
-DEFAULT_E2E_PASSWORD = "FortressPrime2026!"
+DEFAULT_E2E_EMAIL = os.getenv("E2E_LOGIN_EMAIL", "cabin.rentals.of.georgia@gmail.com")
+DEFAULT_E2E_PASSWORD = os.getenv("FORTRESS_SMOKE_PASSWORD") or os.getenv("E2E_LOGIN_PASSWORD")
+if not DEFAULT_E2E_PASSWORD:
+    sys.exit(
+        "FORTRESS_SMOKE_PASSWORD (or E2E_LOGIN_PASSWORD) env var required to run smoke tests.\n"
+        "See docs/OPERATIONS.md."
+    )
 DEPLOY_POLL_ATTEMPTS = 20
 DEPLOY_POLL_INTERVAL_SECONDS = 0.5
 

--- a/src/fleet_commander.py
+++ b/src/fleet_commander.py
@@ -27,7 +27,12 @@ DB_PORT = int(os.getenv("DB_PORT", "5432"))
 
 # Use analyst_writer user for data ingestion
 DB_USER = "analyst_writer"
-DB_PASSWORD = "6652201a"
+DB_PASSWORD = os.getenv("ANALYST_WRITER_PASSWORD")
+if not DB_PASSWORD:
+    raise SystemExit(
+        "ANALYST_WRITER_PASSWORD env var is required to run fleet_commander.\n"
+        "Set it in .env or export it from the vault. See docs/OPERATIONS.md."
+    )
 
 DATABASE_URL = f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
 engine = create_engine(DATABASE_URL, pool_pre_ping=True)


### PR DESCRIPTION
## ⚠️ ROTATION REQUIRED AFTER MERGE

Two production credentials were hardcoded in source. **Both must be rotated before running any script that uses them.** Full steps in `docs/OPERATIONS.md` → *CREDENTIAL ROTATION NOTICE 2026-04-20*.

| Credential | Affected files | Rotation action |
|------------|----------------|-----------------|
| `analyst_writer` postgres password | `src/fleet_commander.py` | `ALTER ROLE analyst_writer PASSWORD '...'`, update `ANALYST_WRITER_PASSWORD` in `.env` + vault |
| Staff login password (`cabin.rentals.of.georgia@gmail.com`) | `seed_master_admin.py`, `smoke_test_seo.py`, both `e2e/helpers/auth.ts` | Rotate via staff login UI or reset script, update `FORTRESS_SMOKE_PASSWORD` + `ADMIN_SEED_PASSWORD` in `.env` + vault |

---

## Changes (8 files, +66/-17)

- **`src/fleet_commander.py`** — `DB_PASSWORD` reads `ANALYST_WRITER_PASSWORD`; fail-fast with clear error if unset
- **`backend/scripts/seed_master_admin.py`** — `ADMIN_PASSWORD` reads `ADMIN_SEED_PASSWORD`; fail-fast if unset
- **`backend/scripts/smoke_test_seo.py`** — reads `FORTRESS_SMOKE_PASSWORD` (or `E2E_LOGIN_PASSWORD`); `sys.exit` with message if neither set
- **`apps/storefront/e2e/helpers/auth.ts`** — hardcoded constant removed; reads `E2E_LOGIN_EMAIL` + `FORTRESS_SMOKE_PASSWORD`; throws if unset
- **`apps/command-center/e2e/helpers/auth.ts`** — same; also fixes pre-existing bug where `email`/`password` were referenced before being defined
- **`docs/OPERATIONS.md`** — literal password replaced with `<your-password-here>`; rotation notice added at top of file
- **`.env.example`** — `ANALYST_WRITER_PASSWORD=<set-via-vault>` added
- **`fortress-guest-platform/.env.example`** — `ADMIN_SEED_PASSWORD`, `FORTRESS_SMOKE_PASSWORD`, `E2E_LOGIN_EMAIL` added

## Drift alarm after this PR
- 6 hits cleared → 0 (the 1 remaining hit is `test_ci_schema_bootstrap.py:158`, addressed separately in PR #97)

## Risk
Scripts and E2E tests will fail fast with a clear message if the env vars are not set. No behaviour change when vars are present.