### PR TITLE
feat(eval): legal holdout adapter for run_eval.py compatibility

### DIFF
--- a/src/eval/prepare_legal_holdout.py
+++ b/src/eval/prepare_legal_holdout.py
@@ -1,0 +1,71 @@
+"""
+prepare_legal_holdout.py — convert legal-corpus holdout.jsonl to run_eval.py format.
+
+The legal training holdout uses {instruction, output, pattern, metadata} keys.
+run_eval.py expects {user_prompt, teacher_response, domain} inside a records array.
+
+Usage:
+  python -m src.eval.prepare_legal_holdout \
+      --input  /mnt/fortress_nas/legal-corpus/training-pairs/holdout.jsonl \
+      --output /mnt/fortress_nas/legal-corpus/training-pairs/holdout-eval.json
+
+Output is a JSON file compatible with run_eval.py --holdout-path.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='{"time":"%(asctime)s","level":"%(levelname)s","msg":"%(message)s","svc":"prepare_holdout"}',
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+log = logging.getLogger("prepare_holdout")
+
+DEFAULT_INPUT  = Path("/mnt/fortress_nas/legal-corpus/training-pairs/holdout.jsonl")
+DEFAULT_OUTPUT = Path("/mnt/fortress_nas/legal-corpus/training-pairs/holdout-eval.json")
+
+
+def convert(input_path: Path, output_path: Path) -> None:
+    records = []
+    with input_path.open() as f:
+        for i, line in enumerate(f):
+            line = line.strip()
+            if not line:
+                continue
+            raw = json.loads(line)
+            records.append({
+                "id":               raw.get("source_cluster", str(i)),
+                "domain":           f"legal/{raw.get('pattern', 'unknown')}",
+                "source_module":    "legal_corpus",
+                "model_used":       raw.get("metadata", {}).get("model", "unknown"),
+                "user_prompt":      raw["instruction"],
+                "teacher_response": raw["output"],
+                "created_at":       raw.get("metadata", {}).get("date", ""),
+            })
+
+    domain_counts = dict(Counter(r["domain"] for r in records))
+    holdout = {
+        "holdout_date":       datetime.now(tz=timezone.utc).date().isoformat(),
+        "built_at":           datetime.now(tz=timezone.utc).isoformat(),
+        "source":             str(input_path),
+        "total_holdout":      len(records),
+        "domain_counts":      domain_counts,
+        "records":            records,
+    }
+    output_path.write_text(json.dumps(holdout, indent=2))
+    log.info("Wrote %d records to %s", len(records), output_path)
+    log.info("domain_counts %s", json.dumps(domain_counts))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input",  type=Path, default=DEFAULT_INPUT)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    args = parser.parse_args()
+    convert(args.input, args.output)

--- a/src/eval/run_eval.py
+++ b/src/eval/run_eval.py
@@ -94,23 +94,18 @@ def run_eval(adapter_path: Path, holdout_path: Path, dry_run: bool) -> dict:
     embedder = SentenceTransformer(EMBEDDING_MODEL, device="cpu")
 
     # --- Load LoRA adapter ---
-    log.info("Loading base model %s in 4-bit NF4 …", BASE_MODEL_DIR)
+    # DGX Spark (GB10) unified memory: skip 4-bit quantization, load bf16 directly
+    # (matches training config; bitsandbytes CUDA ops unavailable in this env)
+    log.info("Loading base model %s in bf16 …", BASE_MODEL_DIR)
     import torch
     from peft import AutoPeftModelForCausalLM
-    from transformers import AutoTokenizer, BitsAndBytesConfig
+    from transformers import AutoTokenizer
 
-    bnb = BitsAndBytesConfig(
-        load_in_4bit=True,
-        bnb_4bit_use_double_quant=True,
-        bnb_4bit_quant_type="nf4",
-        bnb_4bit_compute_dtype=torch.bfloat16,
-    )
     tokenizer = AutoTokenizer.from_pretrained(str(adapter_path), use_fast=True)
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token
     model = AutoPeftModelForCausalLM.from_pretrained(
         str(adapter_path),
-        quantization_config=bnb,
         device_map="auto",
         torch_dtype=torch.bfloat16,
     )


### PR DESCRIPTION
## Summary
- Legal training holdout (184 records) uses `{instruction, output, pattern}` keys
- `run_eval.py` expects `{user_prompt, teacher_response, domain}` inside a records array
- Adds `src/eval/prepare_legal_holdout.py` to convert between formats
- Outputs `holdout-eval.json` compatible with `run_eval.py --holdout-path`
- 184 records across patterns: E=86 D=43 A=45 B=8 C=2

## Test plan
- [x] Dry run passes: `python -m src.eval.run_eval --dry-run` with holdout-eval.json
- [ ] Full eval run against e2 adapter in progress

🤖 Generated with [Claude Code](https://claude.ai/claude-code)