### PR TITLE
feat(email-pipeline): parallel email channel — tables, service, concierge, HITL API

### DIFF
--- a/docs/EMAIL_PIPELINE_FOLLOWUPS.md
+++ b/docs/EMAIL_PIPELINE_FOLLOWUPS.md
@@ -1,0 +1,43 @@
+# Email Pipeline — Known Issues & Follow-Ups
+
+Status as of 2026-04-20, PR feat/email-pipeline-parallel (commit 46245ce4b)
+
+## Working
+- IMAP → email_messages persistence (idempotent on imap_uid)
+- 9-seat cold-inquiry concierge deliberation
+- HITL API surface: /api/email/outbound-drafts CRUD
+- SMTP dispatch path (send_quote) wired but not yet end-to-end tested with a real approve
+
+## Known issue: generic draft text for NEUTRAL consensus
+When 7+ of 9 seats return `NEUTRAL` signal, the HYDRA 120B composer
+(`_compose_draft_reply`) falls back to a safe "we're on it" template. The council
+*does* understand the content (recommended actions in `ai_meta.recommendations`
+are correct and specific), but the draft surface is generic.
+
+**Impact:** human reviewer will edit every cold inquiry draft. Defeats the
+HITL-to-autonomous glide path.
+
+**Fix options (pick one later, not tonight):**
+1. Replace composer: use Anthropic (Seat 9 or dedicated) for the final draft
+   composition step on cold inquiries — frontier-class writing quality.
+2. Enrich the composer prompt with the consensus recommendations (currently
+   in meta but not fed back into draft prompt).
+3. Add a cold-inquiry-specific template with variable substitution pulled from
+   the council output (dates, party size, amenity requests).
+
+## Known gap: SMTP approve→send path not yet E2E tested
+`execute_approval_and_dispatch` exists. Never fired against a real draft.
+Next session: approve a draft via `/api/email/outbound-drafts/{id}/approve`,
+verify SMTP dispatch, verify reply lands in the test inbox.
+
+## reservations_draft_queue deprecation
+Old path still creates rows. Plan to drop the table and delete the code path
+in a follow-up PR once the new pipeline has ≥48h of production runtime without
+issue.
+
+## Post-nightly-run health checks
+- Verify cron `ingest_reservations_imap` picks up the new code path on its
+  next 10-min tick (should succeed — subprocess call to backend venv is already
+  wired).
+- Watch `/mnt/fortress_nas/fortress_data/ai_brain/logs/reservations_imap/cron.log`
+  over next 2-3 cron cycles.

--- a/fortress-guest-platform/backend/alembic/versions/l7e8f1a2b3c4_create_email_pipeline_tables.py
+++ b/fortress-guest-platform/backend/alembic/versions/l7e8f1a2b3c4_create_email_pipeline_tables.py
@@ -1,0 +1,179 @@
+"""Create email pipeline tables: email_inquirers and email_messages.
+
+Parallel email-channel tables that mirror the SMS guests/messages architecture.
+Email inquirers may not yet have a phone-bearing Guest row; the existing SMS
+tables are untouched.
+
+Revision ID: l7e8f1a2b3c4
+Revises: c255801e28a0, i23a1_add_payment_credit_codes
+Create Date: 2026-04-20
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "l7e8f1a2b3c4"
+down_revision = ("c255801e28a0", "i23a1_add_payment_credit_codes")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "email_inquirers",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("email", sa.String(255), nullable=False),
+        sa.Column("display_name", sa.String(255)),
+        sa.Column("first_name", sa.String(100)),
+        sa.Column("last_name", sa.String(100)),
+        sa.Column("guest_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("inferred_party_size", sa.Integer()),
+        sa.Column("inferred_dates_text", sa.Text()),
+        sa.Column(
+            "opt_in_email",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column(
+            "first_seen_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column(
+            "last_seen_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column(
+            "inquiry_count",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.UniqueConstraint("email", name="uq_email_inquirers_email"),
+        sa.ForeignKeyConstraint(["guest_id"], ["guests.id"], ondelete="SET NULL"),
+    )
+    op.create_index("idx_email_inquirers_guest_id", "email_inquirers", ["guest_id"])
+
+    op.create_table(
+        "email_messages",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("inquirer_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("guest_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("reservation_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("in_reply_to_message_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("direction", sa.String(20), nullable=False),
+        sa.Column("email_from", sa.String(255), nullable=False),
+        sa.Column("email_to", sa.String(255), nullable=False),
+        sa.Column("email_cc", sa.Text()),
+        sa.Column("subject", sa.Text()),
+        sa.Column("body_text", sa.Text(), nullable=False),
+        sa.Column("body_excerpt", sa.Text()),
+        sa.Column("imap_uid", sa.BigInteger()),
+        sa.Column("imap_message_id", sa.Text()),
+        sa.Column("received_at", sa.TIMESTAMP(timezone=True)),
+        sa.Column("intent", sa.String(50)),
+        sa.Column("sentiment", sa.String(20)),
+        sa.Column("category", sa.String(50)),
+        sa.Column("ai_draft", sa.Text()),
+        sa.Column("ai_confidence", sa.Numeric(4, 3)),
+        sa.Column("ai_meta", postgresql.JSONB()),
+        sa.Column(
+            "approval_status",
+            sa.String(30),
+            nullable=False,
+            server_default=sa.text("'pending_approval'"),
+        ),
+        sa.Column(
+            "requires_human_review",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column("human_reviewed_at", sa.TIMESTAMP(timezone=True)),
+        sa.Column("human_reviewed_by", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("human_edited_body", sa.Text()),
+        sa.Column("sent_at", sa.TIMESTAMP(timezone=True)),
+        sa.Column("smtp_message_id", sa.Text()),
+        sa.Column("error_code", sa.String(50)),
+        sa.Column("error_message", sa.Text()),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column("extra_data", postgresql.JSONB()),
+        sa.CheckConstraint(
+            "direction IN ('inbound', 'outbound')",
+            name="ck_email_messages_direction",
+        ),
+        sa.CheckConstraint(
+            "approval_status IN ('pending_approval', 'approved', 'rejected', "
+            "'sent', 'send_failed', 'no_draft_needed')",
+            name="ck_email_messages_approval_status",
+        ),
+        sa.ForeignKeyConstraint(
+            ["inquirer_id"], ["email_inquirers.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["guest_id"], ["guests.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(
+            ["reservation_id"], ["reservations.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(
+            ["human_reviewed_by"], ["staff_users.id"], ondelete="SET NULL"
+        ),
+    )
+    # Self-referential FK must be added after table exists
+    op.create_foreign_key(
+        "fk_email_messages_reply_to",
+        "email_messages",
+        "email_messages",
+        ["in_reply_to_message_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    # Partial unique on imap_uid (only when set)
+    op.execute(sa.text(
+        "CREATE UNIQUE INDEX idx_email_messages_imap_uid "
+        "ON email_messages (imap_uid) WHERE imap_uid IS NOT NULL"
+    ))
+    op.execute(sa.text(
+        "CREATE INDEX idx_email_messages_inquirer "
+        "ON email_messages (inquirer_id, received_at DESC)"
+    ))
+    op.execute(sa.text(
+        "CREATE INDEX idx_email_messages_status "
+        "ON email_messages (approval_status, received_at DESC)"
+    ))
+    op.create_index(
+        "idx_email_messages_thread", "email_messages", ["in_reply_to_message_id"]
+    )
+
+    # Grant runtime user access to new tables
+    op.execute(sa.text("GRANT SELECT, INSERT, UPDATE ON email_inquirers TO fortress_api"))
+    op.execute(sa.text("GRANT SELECT, INSERT, UPDATE ON email_messages TO fortress_api"))
+
+
+def downgrade() -> None:
+    op.execute(sa.text("REVOKE ALL ON email_messages FROM fortress_api"))
+    op.execute(sa.text("REVOKE ALL ON email_inquirers FROM fortress_api"))
+    op.drop_table("email_messages")
+    op.drop_table("email_inquirers")

--- a/fortress-guest-platform/backend/api/email_outbound_drafts.py
+++ b/fortress-guest-platform/backend/api/email_outbound_drafts.py
@@ -1,0 +1,90 @@
+"""
+Email HITL outbound-draft review API.
+
+Mirrors backend/api/outbound_drafts.py for the email channel.
+Prefix: /api/email/outbound-drafts
+"""
+from uuid import UUID
+from typing import cast
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.core.database import get_db
+from backend.core.security import get_current_user
+from backend.models.staff import StaffUser
+from backend.schemas.email_review import (
+    EmailMessageReviewContext,
+    ReviewActionResponse,
+)
+from backend.services.email_message_service import EmailMessageService
+
+router = APIRouter(
+    prefix="/api/email/outbound-drafts",
+    tags=["HITL Email Review"],
+)
+
+
+@router.get("", response_model=list[EmailMessageReviewContext])
+async def get_email_outbound_drafts(
+    db: AsyncSession = Depends(get_db),
+    _current_user: StaffUser = Depends(get_current_user),
+):
+    """Returns all email drafts pending human approval."""
+    service = EmailMessageService(db)
+    return await service.get_pending_drafts()
+
+
+@router.get("/{message_id}", response_model=EmailMessageReviewContext)
+async def get_email_draft_detail(
+    message_id: UUID,
+    db: AsyncSession = Depends(get_db),
+    _current_user: StaffUser = Depends(get_current_user),
+):
+    """Returns a single email draft with full review context."""
+    service = EmailMessageService(db)
+    ctx = await service.get_draft_context_by_id(message_id)
+    if not ctx or ctx.get("approval_status") != "pending_approval":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Draft not found or not pending review",
+        )
+    return ctx
+
+
+@router.post("/{message_id}/approve", response_model=ReviewActionResponse)
+async def approve_email_draft(
+    message_id: UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user: StaffUser = Depends(get_current_user),
+):
+    """Marks draft approved and dispatches via SMTP."""
+    service = EmailMessageService(db)
+    try:
+        return await service.execute_approval_and_dispatch(
+            message_id, cast(UUID, current_user.id)
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+
+
+@router.post("/{message_id}/reject", response_model=ReviewActionResponse)
+async def reject_email_draft(
+    message_id: UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user: StaffUser = Depends(get_current_user),
+):
+    """Terminal rejection. Records reviewer metadata."""
+    service = EmailMessageService(db)
+    try:
+        return await service.execute_rejection(
+            message_id, cast(UUID, current_user.id)
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e

--- a/fortress-guest-platform/backend/main.py
+++ b/fortress-guest-platform/backend/main.py
@@ -31,6 +31,7 @@ from backend.api import integrations as integrations_api
 from backend.api import booking, housekeeping, channels, agent
 from backend.api import portal as portal_api
 from backend.api import review_queue, email_bridge, damage_claims
+from backend.api import email_outbound_drafts as email_outbound_drafts_api
 from backend.api import tenants as tenants_api
 from backend.api import owner_portal
 from backend.api import paperclip_bridge as paperclip_bridge_api
@@ -557,6 +558,7 @@ app.include_router(paperclip_bridge_api.router, prefix="/api/paperclip", tags=["
 app.include_router(portal_api.router, prefix="/api/portal", tags=["Portal"])
 app.include_router(review_queue.router, prefix="/api/review-queue", tags=["Review Queue"])
 app.include_router(email_bridge.router, prefix="/api/email-bridge", tags=["Email Bridge"])
+app.include_router(email_outbound_drafts_api.router)
 app.include_router(damage_claims.router, prefix="/api/damage-claims", tags=["Damage Claims"])
 app.include_router(tenants_api.router, prefix="/api/tenants", tags=["Tenants"])
 app.include_router(owner_portal.router, prefix="/api/owner", tags=["Owner Portal"])

--- a/fortress-guest-platform/backend/models/__init__.py
+++ b/fortress-guest-platform/backend/models/__init__.py
@@ -6,6 +6,8 @@ from backend.models.guest import Guest
 from backend.models.property import Property
 from backend.models.reservation import Reservation
 from backend.models.message import Message, MessageTemplate, ScheduledMessage
+from backend.models.email_inquirer import EmailInquirer
+from backend.models.email_message import EmailMessage
 from backend.models.workorder import WorkOrder
 from backend.models.guestbook import GuestbookGuide, Extra, ExtraOrder
 from backend.models.analytics import AnalyticsEvent
@@ -106,10 +108,13 @@ __all__ = [
     "Guest",
     "Property",
     "Reservation",
-    # Communication
+    # Communication — SMS
     "Message",
     "MessageTemplate",
     "ScheduledMessage",
+    # Communication — Email
+    "EmailInquirer",
+    "EmailMessage",
     # Operations
     "WorkOrder",
     # "HousekeepingTask",

--- a/fortress-guest-platform/backend/models/email_inquirer.py
+++ b/fortress-guest-platform/backend/models/email_inquirer.py
@@ -1,0 +1,60 @@
+"""
+EmailInquirer — email-channel contact analog of Guest.
+
+Tracks people who contact us via email but may not yet have a phone-bearing
+Guest row. When an inquirer books and provides a phone number they are linked
+via guest_id.
+"""
+from datetime import datetime
+from uuid import uuid4
+
+from sqlalchemy import Boolean, Column, ForeignKey, Integer, String, Text, TIMESTAMP
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+
+from backend.core.database import Base
+
+
+class EmailInquirer(Base):
+    __tablename__ = "email_inquirers"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    email = Column(String(255), nullable=False, unique=True, index=True)
+    display_name = Column(String(255))
+    first_name = Column(String(100))
+    last_name = Column(String(100))
+
+    # Forward linkage: set when this inquirer becomes a real guest
+    guest_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("guests.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    inferred_party_size = Column(Integer)
+    inferred_dates_text = Column(Text)
+
+    opt_in_email = Column(Boolean, nullable=False, default=True)
+
+    first_seen_at = Column(TIMESTAMP(timezone=True), nullable=False, default=datetime.utcnow)
+    last_seen_at = Column(TIMESTAMP(timezone=True), nullable=False, default=datetime.utcnow)
+    inquiry_count = Column(Integer, nullable=False, default=1)
+
+    # Relationships
+    guest = relationship("Guest", foreign_keys=[guest_id])
+    messages = relationship(
+        "EmailMessage",
+        back_populates="inquirer",
+        cascade="all, delete-orphan",
+        order_by="EmailMessage.received_at.desc()",
+    )
+
+    @property
+    def full_name(self) -> str:
+        if self.first_name or self.last_name:
+            return f"{self.first_name or ''} {self.last_name or ''}".strip()
+        return self.display_name or self.email
+
+    def __repr__(self) -> str:
+        return f"<EmailInquirer {self.email}>"

--- a/fortress-guest-platform/backend/models/email_message.py
+++ b/fortress-guest-platform/backend/models/email_message.py
@@ -1,0 +1,126 @@
+"""
+EmailMessage — email-channel communication row, analog of Message (SMS).
+
+direction='inbound'  — from inquirer, captured by the IMAP watcher
+direction='outbound' — reply drafted by AI, approved by staff, sent via SMTP
+"""
+from datetime import datetime
+from uuid import uuid4
+
+from sqlalchemy import (
+    BigInteger, Boolean, CheckConstraint, Column, ForeignKey,
+    Numeric, String, Text, TIMESTAMP,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import relationship
+
+from backend.core.database import Base
+
+
+class EmailMessage(Base):
+    __tablename__ = "email_messages"
+
+    __table_args__ = (
+        CheckConstraint(
+            "direction IN ('inbound', 'outbound')",
+            name="ck_email_messages_direction",
+        ),
+        CheckConstraint(
+            "approval_status IN ('pending_approval', 'approved', 'rejected', "
+            "'sent', 'send_failed', 'no_draft_needed')",
+            name="ck_email_messages_approval_status",
+        ),
+    )
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+
+    # Linkages
+    inquirer_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("email_inquirers.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    guest_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("guests.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    reservation_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("reservations.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    in_reply_to_message_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("email_messages.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    # Email envelope
+    direction = Column(String(20), nullable=False, index=True)
+    email_from = Column(String(255), nullable=False)
+    email_to = Column(String(255), nullable=False)
+    email_cc = Column(Text)
+    subject = Column(Text)
+    body_text = Column(Text, nullable=False)
+    body_excerpt = Column(Text)
+
+    # IMAP source identity (inbound only)
+    imap_uid = Column(BigInteger, index=True)
+    imap_message_id = Column(Text)
+    received_at = Column(TIMESTAMP(timezone=True), index=True)
+
+    # AI / concierge
+    intent = Column(String(50), index=True)
+    sentiment = Column(String(20))
+    category = Column(String(50))
+    ai_draft = Column(Text)
+    ai_confidence = Column(Numeric(4, 3))
+    ai_meta = Column(JSONB)
+
+    # HITL workflow
+    approval_status = Column(String(30), nullable=False, default="pending_approval", index=True)
+    requires_human_review = Column(Boolean, nullable=False, default=True)
+    human_reviewed_at = Column(TIMESTAMP(timezone=True))
+    human_reviewed_by = Column(
+        UUID(as_uuid=True),
+        ForeignKey("staff_users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    human_edited_body = Column(Text)
+
+    # Send / delivery
+    sent_at = Column(TIMESTAMP(timezone=True))
+    smtp_message_id = Column(Text)
+    error_code = Column(String(50))
+    error_message = Column(Text)
+
+    # Audit
+    created_at = Column(TIMESTAMP(timezone=True), nullable=False, default=datetime.utcnow, index=True)
+    extra_data = Column(JSONB)
+
+    # Relationships
+    inquirer = relationship("EmailInquirer", back_populates="messages")
+    guest = relationship("Guest", foreign_keys=[guest_id])
+    reservation = relationship("Reservation", foreign_keys=[reservation_id])
+    reviewer = relationship("StaffUser", foreign_keys=[human_reviewed_by])
+    # Self-referential: message this is a reply to
+    parent_message = relationship(
+        "EmailMessage",
+        foreign_keys=[in_reply_to_message_id],
+        remote_side="EmailMessage.id",
+        back_populates="replies",
+    )
+    # Self-referential: replies sent in response to this message
+    replies = relationship(
+        "EmailMessage",
+        foreign_keys="EmailMessage.in_reply_to_message_id",
+        back_populates="parent_message",
+    )
+
+    def __repr__(self) -> str:
+        return f"<EmailMessage {self.direction} from={self.email_from} status={self.approval_status}>"

--- a/fortress-guest-platform/backend/schemas/email_review.py
+++ b/fortress-guest-platform/backend/schemas/email_review.py
@@ -1,0 +1,44 @@
+"""
+Pydantic schemas for the email HITL review API.
+
+Mirrors backend/schemas/message_review.py for the email channel.
+"""
+from datetime import datetime
+from typing import Literal, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class EmailMessageReviewContext(BaseModel):
+    message_id: UUID
+    inquirer_id: UUID
+    inquirer_email: str
+    inquirer_name: Optional[str] = None
+    guest_id: Optional[UUID] = None
+    reservation_id: Optional[UUID] = None
+    subject: Optional[str] = None
+    body_text: str
+    ai_draft: Optional[str] = None
+    ai_confidence: Optional[float] = None
+    intent: Optional[str] = None
+    sentiment: Optional[str] = None
+    received_at: Optional[datetime] = None
+    created_at: datetime
+    approval_status: Literal[
+        "pending_approval", "approved", "rejected",
+        "sent", "send_failed", "no_draft_needed",
+    ]
+
+    class Config:
+        from_attributes = True
+
+
+class ReviewActionResponse(BaseModel):
+    message_id: UUID
+    status: str
+    action_timestamp: datetime
+    reviewer_id: UUID
+    smtp_message_id: Optional[str] = Field(
+        None, description="SMTP message-ID header if approved and sent"
+    )

--- a/fortress-guest-platform/backend/scripts/seed_master_admin.py
+++ b/fortress-guest-platform/backend/scripts/seed_master_admin.py
@@ -52,7 +52,7 @@ from backend.models.staff import StaffRole, StaffUser
 
 
 ADMIN_EMAIL = "cabin.rentals.of.georgia@gmail.com"
-ADMIN_PASSWORD = os.getenv("ADMIN_SEED_PASSWORD")
+ADMIN_PASSWORD = os.getenv("ADMIN_SEED_PASSWORD") or os.getenv("BOOTSTRAP_ADMIN_PASSWORD")
 if not ADMIN_PASSWORD:
     raise SystemExit(
         "ADMIN_SEED_PASSWORD env var is required to run the seed script.\n"

--- a/fortress-guest-platform/backend/services/email_concierge_engine.py
+++ b/fortress-guest-platform/backend/services/email_concierge_engine.py
@@ -1,0 +1,281 @@
+"""
+Email concierge engine — thin wrapper around crog_concierge_engine.
+
+For cold email inquiries (no guest linkage), runs the 9-seat council with
+an email-specific case brief.  When the inquirer is already linked to a Guest,
+delegates directly to run_guest_triage().
+
+Returns: {draft_text, confidence, meta, intent, sentiment, category}
+"""
+from __future__ import annotations
+
+import json
+import logging
+import uuid as _uuid
+from datetime import datetime
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.models.email_inquirer import EmailInquirer
+from backend.models.email_message import EmailMessage
+
+# Reuse from the existing engine — no code duplication
+from backend.services.crog_concierge_engine import (
+    ConciergePersona,
+    _compose_draft_reply,
+    _persist_operational_deliberation_log,
+    analyze_with_concierge_persona,
+    compute_concierge_consensus,
+    _heuristic_escalation,
+    _make_error_opinion,
+    PERSONA_TIMEOUT_SECONDS,
+    run_guest_triage,
+)
+
+import asyncio
+
+logger = logging.getLogger("email_concierge_engine")
+
+
+async def run_email_triage(
+    db: AsyncSession,
+    *,
+    email_message_id: UUID,
+) -> Dict[str, Any]:
+    """
+    Email-channel analog of run_guest_triage.
+
+    1. Load EmailMessage + EmailInquirer.
+    2. If inquirer.guest_id is set → delegate to run_guest_triage with
+       email body as inbound_message.
+    3. Otherwise → run the 9-seat council with an email-shaped case brief,
+       skipping property context (no reservation available).
+    4. Persist audit row to core.deliberation_logs.
+    5. Return {draft_text, confidence, meta, intent, sentiment, category}.
+    """
+    from sqlalchemy import select
+    from sqlalchemy.orm import selectinload
+
+    result = await db.execute(
+        select(EmailMessage)
+        .options(selectinload(EmailMessage.inquirer))
+        .where(EmailMessage.id == email_message_id)
+    )
+    msg: Optional[EmailMessage] = result.scalar_one_or_none()
+    if msg is None:
+        raise ValueError(f"EmailMessage not found: {email_message_id}")
+
+    inquirer: Optional[EmailInquirer] = msg.inquirer
+    focal_message = (msg.body_text or "").strip()
+
+    # ── Path A: inquirer already linked to a guest → reuse full SMS triage ──
+    if inquirer and inquirer.guest_id:
+        try:
+            triage = await run_guest_triage(
+                db,
+                guest_id=inquirer.guest_id,
+                inbound_message=focal_message,
+                trigger_type="EMAIL_CONCIERGE_TRIAGE",
+            )
+            draft_text = triage.get("draft_reply", {}).get("text", "")
+            consensus = triage.get("council", {})
+            return {
+                "draft_text": _adapt_draft_for_email(draft_text),
+                "confidence": consensus.get("consensus_conviction"),
+                "meta": {
+                    "path": "guest_triage_delegate",
+                    "session_id": triage.get("session_id"),
+                    "consensus_signal": consensus.get("consensus_signal"),
+                    "triage": triage.get("triage"),
+                },
+                "intent": triage.get("triage", {}).get("primary_issue"),
+                "sentiment": None,
+                "category": None,
+            }
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "email_triage_guest_delegate_failed guest_id=%s err=%s",
+                str(inquirer.guest_id), str(exc)[:200],
+            )
+            # Fall through to cold-inquiry path
+
+    # ── Path B: cold inquiry — no guest linkage ──────────────────────────────
+    session_id = f"email-concierge-{_uuid.uuid4()}"
+    personas = ConciergePersona.load_all()
+    if not personas:
+        logger.warning("email_concierge_no_personas — using fast fallback")
+        return _fast_fallback(focal_message)
+
+    case_brief = _build_email_case_brief(
+        focal_message=focal_message,
+        inquirer=inquirer,
+        subject=msg.subject or "",
+        received_at=msg.received_at,
+    )
+
+    opinions = []
+
+    async def _one(persona: ConciergePersona) -> None:
+        try:
+            op = await asyncio.wait_for(
+                analyze_with_concierge_persona(persona, case_brief),
+                timeout=float(PERSONA_TIMEOUT_SECONDS),
+            )
+        except asyncio.TimeoutError:
+            op = _make_error_opinion(
+                persona, f"timeout after {PERSONA_TIMEOUT_SECONDS}s",
+                float(PERSONA_TIMEOUT_SECONDS),
+            )
+        except Exception as exc:  # noqa: BLE001
+            op = _make_error_opinion(persona, f"{type(exc).__name__}: {str(exc)[:200]}", 0.0)
+        opinions.append(op)
+
+    await asyncio.gather(*[_one(p) for p in personas])
+    opinions.sort(key=lambda o: o.seat)
+
+    consensus = compute_concierge_consensus(opinions)
+    if consensus.get("error"):
+        return _fast_fallback(focal_message)
+
+    draft_text = await _compose_draft_reply(
+        case_brief=case_brief,
+        consensus=consensus,
+        focal_message=focal_message,
+    )
+    draft_text = _adapt_draft_for_email(draft_text)
+
+    escalation_level, escalation_rationale = _heuristic_escalation(
+        focal_message,
+        str(consensus.get("consensus_signal", "NEUTRAL")),
+        False,
+    )
+
+    # Infer simple intent/sentiment from consensus
+    intent = (consensus.get("top_operational_arguments") or [None])[0]
+    if intent:
+        intent = intent[:50]
+
+    meta = {
+        "path": "cold_inquiry_9seat",
+        "session_id": session_id,
+        "consensus_signal": consensus.get("consensus_signal"),
+        "consensus_conviction": consensus.get("consensus_conviction"),
+        "escalation_level": escalation_level,
+        "escalation_rationale": escalation_rationale,
+        "signal_breakdown": consensus.get("signal_breakdown"),
+        "top_recommended_actions": consensus.get("top_recommended_actions", [])[:5],
+    }
+
+    # Persist deliberation audit log (best-effort, never blocks the result)
+    try:
+        await _persist_operational_deliberation_log(
+            db,
+            verdict_type="email_concierge_triage",
+            session_id=session_id,
+            guest_id=None,
+            reservation_id=None,
+            property_id=None,
+            message_id=email_message_id,
+            payload={
+                "session_id": session_id,
+                "consensus": consensus,
+                "opinions": [o.to_dict() for o in opinions],
+                "draft_text": draft_text,
+            },
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("email_triage_deliberation_persist_failed err=%s", str(exc)[:200])
+
+    return {
+        "draft_text": draft_text,
+        "confidence": consensus.get("consensus_conviction"),
+        "meta": meta,
+        "intent": intent,
+        "sentiment": None,
+        "category": "email_inquiry",
+    }
+
+
+def _build_email_case_brief(
+    *,
+    focal_message: str,
+    inquirer: Optional[EmailInquirer],
+    subject: str,
+    received_at: Optional[datetime],
+) -> str:
+    lines = [
+        "=== EMAIL TRIAGE — COLD INQUIRY CASE BRIEF ===",
+        "",
+        f"EMAIL_SUBJECT: {subject[:255]}",
+        f"RECEIVED_AT: {received_at.isoformat() if received_at else 'unknown'}",
+        "",
+        f"FOCAL_MESSAGE:\n{focal_message[:8000]}",
+        "",
+    ]
+    if inquirer:
+        lines += [
+            "INQUIRER:",
+            json.dumps(
+                {
+                    "email": inquirer.email,
+                    "display_name": inquirer.display_name,
+                    "first_name": inquirer.first_name,
+                    "last_name": inquirer.last_name,
+                    "inquiry_count": inquirer.inquiry_count,
+                    "first_seen_at": inquirer.first_seen_at.isoformat() if inquirer.first_seen_at else None,
+                    "inferred_party_size": inquirer.inferred_party_size,
+                    "inferred_dates_text": inquirer.inferred_dates_text,
+                },
+                default=str,
+                indent=2,
+            ),
+        ]
+    else:
+        lines.append("INQUIRER: unknown cold contact")
+    lines += [
+        "",
+        "CONTEXT: This is a cold email inquiry — no reservation or guest record linked yet.",
+        "Draft a warm, professional response. Do NOT promise specific availability, pricing,",
+        "or access codes — those require staff verification. Invite the guest to share",
+        "their dates and party size so a quote can be prepared.",
+    ]
+    return "\n".join(lines)
+
+
+def _adapt_draft_for_email(sms_draft: str) -> str:
+    """Expand terse SMS drafts to a warmer email-appropriate tone."""
+    if not sms_draft:
+        return (
+            "Thank you for reaching out to Cabin Rentals of Georgia! We'd love to help "
+            "you plan your stay. Please share your preferred dates and party size and we'll "
+            "get back to you with availability and pricing.\n\n"
+            "Warm regards,\nThe CROG Concierge Team"
+        )
+    # If the draft already looks like a multi-sentence email, return as-is
+    if len(sms_draft) > 200 or "\n" in sms_draft:
+        return sms_draft
+    # Otherwise wrap the SMS message in a basic email greeting/closing
+    return (
+        f"Thank you for contacting Cabin Rentals of Georgia!\n\n"
+        f"{sms_draft}\n\n"
+        f"Warm regards,\nThe CROG Concierge Team"
+    )
+
+
+def _fast_fallback(_focal_message: str) -> Dict[str, Any]:
+    """Used when personas are unavailable or upstream fails."""
+    return {
+        "draft_text": (
+            "Thank you for reaching out to Cabin Rentals of Georgia! We'd love to help "
+            "you plan your perfect mountain getaway. Please share your preferred dates, "
+            "party size, and any questions so we can put together the perfect options for you.\n\n"
+            "Warm regards,\nThe CROG Concierge Team"
+        ),
+        "confidence": 0.5,
+        "meta": {"path": "fast_fallback"},
+        "intent": "general_inquiry",
+        "sentiment": None,
+        "category": "email_inquiry",
+    }

--- a/fortress-guest-platform/backend/services/email_message_service.py
+++ b/fortress-guest-platform/backend/services/email_message_service.py
@@ -1,0 +1,315 @@
+"""
+EmailMessageService — inbound persistence, AI draft generation, and HITL dispatch
+for the email channel.
+
+Mirrors the architectural pattern of MessageService (SMS) but for email.
+All state is persisted into email_inquirers / email_messages tables.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+import sqlalchemy.exc
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from backend.models.email_inquirer import EmailInquirer
+from backend.models.email_message import EmailMessage
+from backend.services.smtp_dispatcher import SMTPDispatcher
+
+logger = logging.getLogger("email_message_service")
+
+
+class EmailMessageService:
+    def __init__(self, db: AsyncSession) -> None:
+        self.db = db
+
+    # ─── Inbound ────────────────────────────────────────────────────────────
+
+    async def receive_email(
+        self,
+        *,
+        email_from: str,
+        email_to: str,
+        subject: str,
+        body_text: str,
+        imap_uid: int,
+        message_id: str,
+        received_at: datetime,
+        cc: Optional[str] = None,
+    ) -> EmailMessage:
+        """
+        Idempotent on imap_uid.  Creates EmailInquirer if new, persists
+        inbound EmailMessage.  Returns the existing row on duplicate imap_uid.
+        """
+        # Idempotency: if we've seen this imap_uid before, return the existing row
+        existing = await self.db.execute(
+            select(EmailMessage).where(EmailMessage.imap_uid == imap_uid)
+        )
+        row = existing.scalar_one_or_none()
+        if row is not None:
+            logger.info("email_receive_duplicate_skipped imap_uid=%s", imap_uid)
+            return row
+
+        inquirer = await self._find_or_create_inquirer(email_from, display_name=None)
+
+        excerpt = (body_text or "")[:500]
+        msg = EmailMessage(
+            inquirer_id=inquirer.id,
+            direction="inbound",
+            email_from=email_from,
+            email_to=email_to,
+            email_cc=cc,
+            subject=subject,
+            body_text=body_text,
+            body_excerpt=excerpt,
+            imap_uid=imap_uid,
+            imap_message_id=message_id,
+            received_at=received_at,
+            approval_status="pending_approval",
+            requires_human_review=True,
+        )
+        self.db.add(msg)
+
+        # Keep inquirer freshness up to date
+        inquirer.last_seen_at = datetime.now(tz=timezone.utc)
+        inquirer.inquiry_count = (inquirer.inquiry_count or 0) + 1
+
+        try:
+            await self.db.commit()
+            await self.db.refresh(msg)
+        except sqlalchemy.exc.IntegrityError:
+            # Race condition: another worker inserted the same imap_uid first
+            await self.db.rollback()
+            result = await self.db.execute(
+                select(EmailMessage).where(EmailMessage.imap_uid == imap_uid)
+            )
+            return result.scalar_one()
+
+        logger.info(
+            "email_received message_id=%s imap_uid=%s from=%s",
+            str(msg.id), imap_uid, email_from,
+        )
+        return msg
+
+    # ─── AI draft ───────────────────────────────────────────────────────────
+
+    async def generate_draft_for_inbound(self, message_id: UUID) -> EmailMessage:
+        """
+        Calls email_concierge_engine.run_email_triage() and persists the
+        resulting draft back into the EmailMessage row.
+        """
+        # Import here to avoid a circular dependency at module load time
+        from backend.services.email_concierge_engine import run_email_triage
+
+        msg = await self.db.get(EmailMessage, message_id)
+        if msg is None:
+            raise ValueError(f"EmailMessage not found: {message_id}")
+
+        try:
+            result = await run_email_triage(self.db, email_message_id=message_id)
+            msg.ai_draft = result.get("draft_text") or ""
+            msg.ai_confidence = result.get("confidence")
+            msg.ai_meta = result.get("meta")
+            msg.intent = result.get("intent")
+            msg.sentiment = result.get("sentiment")
+            msg.category = result.get("category")
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "email_draft_generation_failed message_id=%s err=%s",
+                str(message_id), str(exc)[:300],
+            )
+            msg.ai_draft = ""
+            msg.ai_meta = {"error": str(exc)[:500]}
+
+        await self.db.commit()
+        await self.db.refresh(msg)
+        return msg
+
+    # ─── HITL workflow ──────────────────────────────────────────────────────
+
+    async def get_pending_drafts(self) -> List[Dict[str, Any]]:
+        """Returns all email messages with approval_status='pending_approval'."""
+        result = await self.db.execute(
+            select(EmailMessage)
+            .options(selectinload(EmailMessage.inquirer))
+            .where(EmailMessage.approval_status == "pending_approval")
+            .where(EmailMessage.direction == "inbound")
+            .order_by(EmailMessage.received_at.desc())
+            .limit(100)
+        )
+        messages = result.scalars().all()
+        return [self._to_review_context(m) for m in messages]
+
+    async def get_draft_context_by_id(self, message_id: UUID) -> Optional[Dict[str, Any]]:
+        result = await self.db.execute(
+            select(EmailMessage)
+            .options(selectinload(EmailMessage.inquirer))
+            .where(EmailMessage.id == message_id)
+        )
+        msg = result.scalar_one_or_none()
+        if msg is None:
+            return None
+        return self._to_review_context(msg)
+
+    async def execute_approval_and_dispatch(
+        self, message_id: UUID, reviewer_id: UUID
+    ) -> Dict[str, Any]:
+        """
+        Marks approved, sends via SMTP using the ai_draft (or human_edited_body
+        if the reviewer edited), records sent_at + smtp_message_id.
+        """
+        msg = await self._load_with_inquirer(message_id)
+        if msg is None:
+            raise ValueError(f"EmailMessage not found: {message_id}")
+        if msg.approval_status not in ("pending_approval",):
+            raise ValueError(
+                f"Cannot approve: current status is '{msg.approval_status}'"
+            )
+
+        body_to_send = msg.human_edited_body or msg.ai_draft or ""
+        if not body_to_send:
+            raise ValueError("No draft body available to send")
+
+        now = datetime.now(tz=timezone.utc)
+        msg.approval_status = "approved"
+        msg.human_reviewed_at = now
+        msg.human_reviewed_by = reviewer_id
+        await self.db.commit()
+
+        # Dispatch via SMTP
+        dispatcher = SMTPDispatcher()
+        subject = msg.subject or "Re: Your inquiry — Cabin Rentals of Georgia"
+        smtp_result = await dispatcher.send_quote(
+            to_email=msg.email_from,
+            subject=subject,
+            text_content=body_to_send,
+        )
+
+        if smtp_result.get("success"):
+            msg.approval_status = "sent"
+            msg.sent_at = datetime.now(tz=timezone.utc)
+            msg.smtp_message_id = smtp_result.get("smtp_message_id")
+        else:
+            msg.approval_status = "send_failed"
+            msg.error_code = "smtp_failed"
+            msg.error_message = str(smtp_result.get("error", ""))[:500]
+
+        await self.db.commit()
+        await self.db.refresh(msg)
+
+        logger.info(
+            "email_approval_dispatched message_id=%s status=%s",
+            str(message_id), msg.approval_status,
+        )
+        return {
+            "message_id": message_id,
+            "status": msg.approval_status,
+            "action_timestamp": now,
+            "reviewer_id": reviewer_id,
+            "smtp_message_id": msg.smtp_message_id,
+        }
+
+    async def execute_rejection(
+        self, message_id: UUID, reviewer_id: UUID
+    ) -> Dict[str, Any]:
+        msg = await self._load_with_inquirer(message_id)
+        if msg is None:
+            raise ValueError(f"EmailMessage not found: {message_id}")
+        if msg.approval_status not in ("pending_approval",):
+            raise ValueError(
+                f"Cannot reject: current status is '{msg.approval_status}'"
+            )
+
+        now = datetime.now(tz=timezone.utc)
+        msg.approval_status = "rejected"
+        msg.human_reviewed_at = now
+        msg.human_reviewed_by = reviewer_id
+        await self.db.commit()
+
+        logger.info("email_rejected message_id=%s", str(message_id))
+        return {
+            "message_id": message_id,
+            "status": "rejected",
+            "action_timestamp": now,
+            "reviewer_id": reviewer_id,
+            "smtp_message_id": None,
+        }
+
+    # ─── Inquirer helpers ───────────────────────────────────────────────────
+
+    async def _find_or_create_inquirer(
+        self, email: str, display_name: Optional[str]
+    ) -> EmailInquirer:
+        result = await self.db.execute(
+            select(EmailInquirer).where(EmailInquirer.email == email.lower().strip())
+        )
+        inquirer = result.scalar_one_or_none()
+        if inquirer is not None:
+            return inquirer
+
+        inquirer = EmailInquirer(
+            email=email.lower().strip(),
+            display_name=display_name,
+        )
+        self.db.add(inquirer)
+        try:
+            await self.db.flush()  # get id without full commit
+        except sqlalchemy.exc.IntegrityError:
+            await self.db.rollback()
+            result = await self.db.execute(
+                select(EmailInquirer).where(EmailInquirer.email == email.lower().strip())
+            )
+            inquirer = result.scalar_one()
+        return inquirer
+
+    async def link_inquirer_to_guest(
+        self, inquirer_id: UUID, guest_id: UUID
+    ) -> None:
+        """Called when an email inquirer becomes a real guest (books, provides phone, etc.)."""
+        inquirer = await self.db.get(EmailInquirer, inquirer_id)
+        if inquirer is None:
+            raise ValueError(f"EmailInquirer not found: {inquirer_id}")
+        inquirer.guest_id = guest_id
+        # Back-fill guest_id on all existing messages
+        result = await self.db.execute(
+            select(EmailMessage).where(EmailMessage.inquirer_id == inquirer_id)
+        )
+        for msg in result.scalars().all():
+            if msg.guest_id is None:
+                msg.guest_id = guest_id
+        await self.db.commit()
+
+    # ─── Internal helpers ───────────────────────────────────────────────────
+
+    async def _load_with_inquirer(self, message_id: UUID) -> Optional[EmailMessage]:
+        result = await self.db.execute(
+            select(EmailMessage)
+            .options(selectinload(EmailMessage.inquirer))
+            .where(EmailMessage.id == message_id)
+        )
+        return result.scalar_one_or_none()
+
+    def _to_review_context(self, msg: EmailMessage) -> Dict[str, Any]:
+        inquirer = msg.inquirer
+        return {
+            "message_id": msg.id,
+            "inquirer_id": msg.inquirer_id,
+            "inquirer_email": inquirer.email if inquirer else str(msg.email_from),
+            "inquirer_name": inquirer.full_name if inquirer else None,
+            "guest_id": msg.guest_id,
+            "reservation_id": msg.reservation_id,
+            "subject": msg.subject,
+            "body_text": msg.body_text,
+            "ai_draft": msg.ai_draft,
+            "ai_confidence": float(msg.ai_confidence) if msg.ai_confidence is not None else None,
+            "intent": msg.intent,
+            "sentiment": msg.sentiment,
+            "received_at": msg.received_at,
+            "created_at": msg.created_at,
+            "approval_status": msg.approval_status,
+        }

--- a/fortress-guest-platform/backend/tests/test_email_message_service.py
+++ b/fortress-guest-platform/backend/tests/test_email_message_service.py
@@ -1,0 +1,247 @@
+"""
+Tests for EmailMessageService — inbound persistence and HITL workflow.
+
+Parallel to (nonexistent) test_message_service.py for SMS.
+Set TEST_DATABASE_URL to run against an isolated database; without it the tests
+run against fortress_shadow (the dev DB) with a warning from conftest.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.models.email_inquirer import EmailInquirer
+from backend.models.email_message import EmailMessage
+from backend.services.email_message_service import EmailMessageService
+
+
+# ── shared DB session fixture ─────────────────────────────────────────────────
+
+@pytest_asyncio.fixture
+async def db_session() -> AsyncSession:
+    """
+    Yield an async DB session backed by a savepoint so service commits land
+    on the savepoint (not the outer transaction), allowing full rollback after
+    each test.
+    """
+    from backend.core.database import async_session_factory
+    async with async_session_factory() as session:
+        await session.begin()
+        nested = await session.begin_nested()
+        yield session
+        try:
+            await nested.rollback()
+        except Exception:
+            pass
+        try:
+            await session.rollback()
+        except Exception:
+            pass
+
+
+# ── fixtures ─────────────────────────────────────────────────────────────────
+
+@pytest_asyncio.fixture
+async def reviewer(db_session) -> UUID:
+    """Create a minimal StaffUser and return its UUID for reviewer fields."""
+    from backend.models.staff import StaffUser
+    user = StaffUser(
+        email=f"reviewer-{uuid4()}@crog.internal",
+        password_hash="hashed",
+        first_name="Test",
+        last_name="Reviewer",
+        role="admin",
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user.id
+
+
+@pytest.fixture
+def fake_imap_uid() -> int:
+    import random
+    return random.randint(100_000, 999_999)
+
+
+@pytest.fixture
+def fake_email_payload(fake_imap_uid):
+    return {
+        "email_from": "guest@example.com",
+        "email_to": "reservations@cabin-rentals-of-georgia.com",
+        "subject": "Weekend availability inquiry",
+        "body_text": "Hi! Do you have any cabins available for Memorial Day weekend?",
+        "imap_uid": fake_imap_uid,
+        "message_id": f"<msg-{uuid4()}@example.com>",
+        "received_at": datetime.now(tz=timezone.utc),
+    }
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+async def _make_svc(db: AsyncSession) -> EmailMessageService:
+    return EmailMessageService(db)
+
+
+# ── tests ─────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_receive_email_creates_inquirer_and_message(db_session, fake_email_payload):
+    """receive_email creates a new EmailInquirer and EmailMessage row."""
+    svc = await _make_svc(db_session)
+    msg = await svc.receive_email(**fake_email_payload)
+
+    assert isinstance(msg.id, UUID)
+    assert msg.direction == "inbound"
+    assert msg.email_from == fake_email_payload["email_from"]
+    assert msg.imap_uid == fake_email_payload["imap_uid"]
+    assert msg.approval_status == "pending_approval"
+    assert msg.requires_human_review is True
+    assert msg.inquirer_id is not None
+
+
+@pytest.mark.asyncio
+async def test_receive_email_idempotent(db_session, fake_email_payload):
+    """Calling receive_email twice with the same imap_uid returns the same row."""
+    svc = await _make_svc(db_session)
+    msg1 = await svc.receive_email(**fake_email_payload)
+    msg2 = await svc.receive_email(**fake_email_payload)
+
+    assert msg1.id == msg2.id
+
+
+@pytest.mark.asyncio
+async def test_find_or_create_inquirer_deduplicates(db_session):
+    """_find_or_create_inquirer returns the same inquirer for the same email."""
+    svc = await _make_svc(db_session)
+    email = f"testguest-{uuid4()}@example.com"
+    i1 = await svc._find_or_create_inquirer(email, display_name=None)
+    i2 = await svc._find_or_create_inquirer(email, display_name=None)
+    assert i1.id == i2.id
+
+
+@pytest.mark.asyncio
+async def test_get_pending_drafts_empty(db_session):
+    """get_pending_drafts returns an empty list when no drafts exist."""
+    svc = await _make_svc(db_session)
+    drafts = await svc.get_pending_drafts()
+    assert isinstance(drafts, list)
+
+
+@pytest.mark.asyncio
+async def test_get_pending_drafts_shows_pending_approval(db_session, fake_email_payload):
+    """A newly ingested email appears in get_pending_drafts."""
+    svc = await _make_svc(db_session)
+    msg = await svc.receive_email(**fake_email_payload)
+
+    drafts = await svc.get_pending_drafts()
+    msg_ids = [str(d["message_id"]) for d in drafts]
+    assert str(msg.id) in msg_ids
+
+
+@pytest.mark.asyncio
+async def test_execute_rejection(db_session, fake_email_payload, reviewer):
+    """execute_rejection marks the message rejected with reviewer metadata."""
+    svc = await _make_svc(db_session)
+    msg = await svc.receive_email(**fake_email_payload)
+
+    reviewer_id = reviewer
+    result = await svc.execute_rejection(msg.id, reviewer_id)
+
+    assert result["status"] == "rejected"
+    assert result["reviewer_id"] == reviewer_id
+    assert result["smtp_message_id"] is None
+
+    # Verify DB state
+    refreshed = await db_session.get(EmailMessage, msg.id)
+    assert refreshed.approval_status == "rejected"
+    assert refreshed.human_reviewed_by == reviewer_id
+
+
+@pytest.mark.asyncio
+async def test_execute_rejection_wrong_status_raises(db_session, fake_email_payload, reviewer):
+    """Cannot reject a message that's already been rejected."""
+    svc = await _make_svc(db_session)
+    msg = await svc.receive_email(**fake_email_payload)
+    reviewer_id = reviewer
+
+    await svc.execute_rejection(msg.id, reviewer_id)
+
+    with pytest.raises(ValueError, match="Cannot reject"):
+        await svc.execute_rejection(msg.id, reviewer_id)
+
+
+@pytest.mark.asyncio
+async def test_execute_approval_sends_via_smtp(db_session, fake_email_payload, reviewer):
+    """execute_approval_and_dispatch calls SMTPDispatcher and marks sent."""
+    svc = await _make_svc(db_session)
+    msg = await svc.receive_email(**fake_email_payload)
+
+    # Manually set ai_draft so there's something to send
+    msg.ai_draft = "Thank you for your inquiry! We'll get back to you shortly."
+    await db_session.flush()
+
+    reviewer_id = reviewer
+
+    smtp_mock = AsyncMock(return_value={"success": True, "smtp_message_id": "mock-smtp-id"})
+    with patch(
+        "backend.services.email_message_service.SMTPDispatcher.send_quote",
+        smtp_mock,
+    ):
+        result = await svc.execute_approval_and_dispatch(msg.id, reviewer_id)
+
+    assert result["status"] == "sent"
+    assert result["smtp_message_id"] == "mock-smtp-id"
+
+    refreshed = await db_session.get(EmailMessage, msg.id)
+    assert refreshed.approval_status == "sent"
+    assert refreshed.sent_at is not None
+
+
+@pytest.mark.asyncio
+async def test_execute_approval_smtp_failure_marks_send_failed(db_session, fake_email_payload, reviewer):
+    """If SMTP fails, approval_status becomes send_failed (no exception raised)."""
+    svc = await _make_svc(db_session)
+    msg = await svc.receive_email(**fake_email_payload)
+    msg.ai_draft = "Draft reply text."
+    await db_session.flush()
+
+    reviewer_id = reviewer
+    smtp_mock = AsyncMock(return_value={"success": False, "error": "smtp_not_configured"})
+    with patch(
+        "backend.services.email_message_service.SMTPDispatcher.send_quote",
+        smtp_mock,
+    ):
+        result = await svc.execute_approval_and_dispatch(msg.id, reviewer_id)
+
+    assert result["status"] == "send_failed"
+
+    refreshed = await db_session.get(EmailMessage, msg.id)
+    assert refreshed.approval_status == "send_failed"
+    assert refreshed.error_code == "smtp_failed"
+
+
+@pytest.mark.asyncio
+async def test_link_inquirer_to_guest(db_session, fake_email_payload):
+    """link_inquirer_to_guest back-fills guest_id on all linked messages."""
+    svc = await _make_svc(db_session)
+    msg = await svc.receive_email(**fake_email_payload)
+
+    # Simulate a guest being created
+    from backend.models.guest import Guest
+    fake_guest = Guest(phone_number=f"+1555{uuid4().int % 10_000_000:07d}")
+    db_session.add(fake_guest)
+    await db_session.flush()
+    await db_session.refresh(fake_guest)
+
+    await svc.link_inquirer_to_guest(msg.inquirer_id, fake_guest.id)
+
+    refreshed_msg = await db_session.get(EmailMessage, msg.id)
+    assert refreshed_msg.guest_id == fake_guest.id
+
+    refreshed_inquirer = await db_session.get(EmailInquirer, msg.inquirer_id)
+    assert refreshed_inquirer.guest_id == fake_guest.id

--- a/fortress-guest-platform/ci/schema.meta.json
+++ b/fortress-guest-platform/ci/schema.meta.json
@@ -3,7 +3,7 @@
     "l7e8f1a2b3c4"
   ],
   "alembic_versions_tree": "e53b917bfdb37708e2121735c2cae392488a203f",
-  "generated_at": "2026-04-21T02:37:18Z",
+  "generated_at": "2026-04-21T02:49:45Z",
   "source_db": "fortress_shadow",
-  "source_commit": "edf57063dbe203822f6cdcdc2587ba591fa3b069"
+  "source_commit": "3446e105817985d0c870aad9a782c12f06a5d862"
 }

--- a/fortress-guest-platform/ci/schema.meta.json
+++ b/fortress-guest-platform/ci/schema.meta.json
@@ -1,10 +1,9 @@
 {
   "alembic_revisions": [
-    "c255801e28a0",
-    "i23a1_add_payment_credit_codes"
+    "l7e8f1a2b3c4"
   ],
-  "alembic_versions_tree": "9aaa17e5ccbac6bc1019fdf65f703097102522c9",
-  "generated_at": "2026-04-19T21:49:06Z",
+  "alembic_versions_tree": "e53b917bfdb37708e2121735c2cae392488a203f",
+  "generated_at": "2026-04-21T02:37:18Z",
   "source_db": "fortress_shadow",
-  "source_commit": "c5484163a57de913df52635687916f443ad926a0"
+  "source_commit": "edf57063dbe203822f6cdcdc2587ba591fa3b069"
 }

--- a/fortress-guest-platform/ci/schema.sql
+++ b/fortress-guest-platform/ci/schema.sql
@@ -1,8 +1,8 @@
 -- CI schema snapshot for fortress-guest-platform
--- Generated: 2026-04-19T21:49:06Z
+-- Generated: 2026-04-21T02:49:45Z
 -- Source:    fortress_shadow
--- Commit:    c5484163a57de913df52635687916f443ad926a0
--- Alembic:   c255801e28a0,i23a1_add_payment_credit_codes
+-- Commit:    3446e105817985d0c870aad9a782c12f06a5d862
+-- Alembic:   l7e8f1a2b3c4
 -- NOTE: geometry/vector types replaced with text for CI compatibility.
 --       postgis/vector extensions omitted (postgres:16 has pgcrypto/uuid-ossp).
 
@@ -18,7 +18,7 @@ SET ROLE TO fortress_admin;
 -- PostgreSQL database dump
 --
 
-\restrict k7Ka2M4FW6sHX2WgZamqxwyS9uO30uOfRImi1Ak5PVdpcHfBt87YnaLdvzS8Kno
+\restrict FdO3Ro8PL5WgXQeaZzwcBMCxYm7tASohFPK6iWWOA4tAqKqVEW35qN3uEPfbMbp
 
 -- Dumped from database version 16.13 (Ubuntu 16.13-0ubuntu0.24.04.1)
 -- Dumped by pg_dump version 16.13 (Ubuntu 16.13-0ubuntu0.24.04.1)
@@ -1357,6 +1357,68 @@ CREATE TABLE public.distillation_queue (
     error text,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: email_inquirers; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.email_inquirers (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    email character varying(255) NOT NULL,
+    display_name character varying(255),
+    first_name character varying(100),
+    last_name character varying(100),
+    guest_id uuid,
+    inferred_party_size integer,
+    inferred_dates_text text,
+    opt_in_email boolean DEFAULT true NOT NULL,
+    first_seen_at timestamp with time zone DEFAULT now() NOT NULL,
+    last_seen_at timestamp with time zone DEFAULT now() NOT NULL,
+    inquiry_count integer DEFAULT 1 NOT NULL
+);
+
+
+--
+-- Name: email_messages; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.email_messages (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    inquirer_id uuid NOT NULL,
+    guest_id uuid,
+    reservation_id uuid,
+    in_reply_to_message_id uuid,
+    direction character varying(20) NOT NULL,
+    email_from character varying(255) NOT NULL,
+    email_to character varying(255) NOT NULL,
+    email_cc text,
+    subject text,
+    body_text text NOT NULL,
+    body_excerpt text,
+    imap_uid bigint,
+    imap_message_id text,
+    received_at timestamp with time zone,
+    intent character varying(50),
+    sentiment character varying(20),
+    category character varying(50),
+    ai_draft text,
+    ai_confidence numeric(4,3),
+    ai_meta jsonb,
+    approval_status character varying(30) DEFAULT 'pending_approval'::character varying NOT NULL,
+    requires_human_review boolean DEFAULT true NOT NULL,
+    human_reviewed_at timestamp with time zone,
+    human_reviewed_by uuid,
+    human_edited_body text,
+    sent_at timestamp with time zone,
+    smtp_message_id text,
+    error_code character varying(50),
+    error_message text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    extra_data jsonb,
+    CONSTRAINT ck_email_messages_approval_status CHECK (((approval_status)::text = ANY ((ARRAY['pending_approval'::character varying, 'approved'::character varying, 'rejected'::character varying, 'sent'::character varying, 'send_failed'::character varying, 'no_draft_needed'::character varying])::text[]))),
+    CONSTRAINT ck_email_messages_direction CHECK (((direction)::text = ANY ((ARRAY['inbound'::character varying, 'outbound'::character varying])::text[])))
 );
 
 
@@ -4601,6 +4663,22 @@ ALTER TABLE ONLY public.distillation_queue
 
 
 --
+-- Name: email_inquirers email_inquirers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_inquirers
+    ADD CONSTRAINT email_inquirers_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: email_messages email_messages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_messages
+    ADD CONSTRAINT email_messages_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: email_templates email_templates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -5382,6 +5460,14 @@ ALTER TABLE ONLY public.channel_mappings
 
 ALTER TABLE ONLY public.competitor_listings
     ADD CONSTRAINT uq_competitor_listings_dedupe_hash UNIQUE (dedupe_hash);
+
+
+--
+-- Name: email_inquirers uq_email_inquirers_email; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_inquirers
+    ADD CONSTRAINT uq_email_inquirers_email UNIQUE (email);
 
 
 --
@@ -6208,6 +6294,41 @@ CREATE INDEX idx_cl_qc_queue ON public.capture_labels USING btree (created_at DE
 --
 
 CREATE INDEX idx_cl_task_type ON public.capture_labels USING btree (task_type);
+
+
+--
+-- Name: idx_email_inquirers_guest_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_email_inquirers_guest_id ON public.email_inquirers USING btree (guest_id);
+
+
+--
+-- Name: idx_email_messages_imap_uid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_email_messages_imap_uid ON public.email_messages USING btree (imap_uid) WHERE (imap_uid IS NOT NULL);
+
+
+--
+-- Name: idx_email_messages_inquirer; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_email_messages_inquirer ON public.email_messages USING btree (inquirer_id, received_at DESC);
+
+
+--
+-- Name: idx_email_messages_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_email_messages_status ON public.email_messages USING btree (approval_status, received_at DESC);
+
+
+--
+-- Name: idx_email_messages_thread; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_email_messages_thread ON public.email_messages USING btree (in_reply_to_message_id);
 
 
 --
@@ -9251,6 +9372,46 @@ ALTER TABLE ONLY public.distillation_queue
 
 
 --
+-- Name: email_inquirers email_inquirers_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_inquirers
+    ADD CONSTRAINT email_inquirers_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE SET NULL;
+
+
+--
+-- Name: email_messages email_messages_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_messages
+    ADD CONSTRAINT email_messages_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE SET NULL;
+
+
+--
+-- Name: email_messages email_messages_human_reviewed_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_messages
+    ADD CONSTRAINT email_messages_human_reviewed_by_fkey FOREIGN KEY (human_reviewed_by) REFERENCES public.staff_users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: email_messages email_messages_inquirer_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_messages
+    ADD CONSTRAINT email_messages_inquirer_id_fkey FOREIGN KEY (inquirer_id) REFERENCES public.email_inquirers(id) ON DELETE CASCADE;
+
+
+--
+-- Name: email_messages email_messages_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_messages
+    ADD CONSTRAINT email_messages_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE SET NULL;
+
+
+--
 -- Name: extra_orders extra_orders_extra_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9264,6 +9425,14 @@ ALTER TABLE ONLY public.extra_orders
 
 ALTER TABLE ONLY public.extra_orders
     ADD CONSTRAINT extra_orders_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE CASCADE;
+
+
+--
+-- Name: email_messages fk_email_messages_reply_to; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_messages
+    ADD CONSTRAINT fk_email_messages_reply_to FOREIGN KEY (in_reply_to_message_id) REFERENCES public.email_messages(id) ON DELETE SET NULL;
 
 
 --
@@ -9950,4 +10119,4 @@ ALTER TABLE ONLY public.yield_simulations
 -- PostgreSQL database dump complete
 --
 
-\unrestrict k7Ka2M4FW6sHX2WgZamqxwyS9uO30uOfRImi1Ak5PVdpcHfBt87YnaLdvzS8Kno
+\unrestrict FdO3Ro8PL5WgXQeaZzwcBMCxYm7tASohFPK6iWWOA4tAqKqVEW35qN3uEPfbMbp

--- a/src/ingest_reservations_imap.py
+++ b/src/ingest_reservations_imap.py
@@ -344,13 +344,13 @@ def ingest_to_email_pipeline(fe: FetchedEmail, skip_ai: bool) -> Optional[str]:
 
     runner = (
         "import asyncio, json, sys\n"
-        "from backend.core.database import async_session\n"
+        "from backend.core.database import async_session_factory\n"
         "from backend.services.email_message_service import EmailMessageService\n"
         "from datetime import datetime, timezone\n"
         "from uuid import UUID\n"
         "p = json.loads(sys.stdin.read())\n"
         "async def _run():\n"
-        "    async with async_session() as db:\n"
+        "    async with async_session_factory() as db:\n"
         "        svc = EmailMessageService(db)\n"
         "        msg = await svc.receive_email(\n"
         "            email_from=p['email_from'],\n"

--- a/src/ingest_reservations_imap.py
+++ b/src/ingest_reservations_imap.py
@@ -4,30 +4,33 @@ ingest_reservations_imap.py — Reservations mailbox IMAP watcher
 
 Pattern: poll-based (NOT IDLE). Invoked by cron every 10 minutes.
 Source:  reservations@cabin-rentals-of-georgia.com on mail.cabin-rentals-of-georgia.com (cPanel)
-Sink:    Postgres table fortress_db.reservations_draft_queue
+Sink:    email_messages table via EmailMessageService (backend/services/email_message_service.py)
 
 On startup:
   - First run of the day (or empty queue): scan last 24h for UNSEEN messages
   - Subsequent runs: scan only UNSEEN messages since last run's max UID
-Idempotency: imap_uid UNIQUE constraint in Postgres — re-inserts are no-ops
+Idempotency: imap_uid UNIQUE constraint on email_messages — re-inserts are no-ops
 
 Environment variables (required):
   RESERVATIONS_IMAP_HOST    e.g. "mail.cabin-rentals-of-georgia.com"
   RESERVATIONS_IMAP_PORT    e.g. "993"
   RESERVATIONS_IMAP_USER    e.g. "reservations@cabin-rentals-of-georgia.com"
   RESERVATIONS_IMAP_PASS    cPanel mailbox password
-  DB_HOST, DB_NAME, DB_USER, DB_PASS (existing fortress_db credentials)
 
 Environment variables (optional):
   RESERVATIONS_IMAP_FOLDER  default "INBOX"
   RESERVATIONS_LOOKBACK_HOURS  default 24 (first run per day)
   RESERVATIONS_MAX_PER_RUN  default 50 (cap per invocation)
+  AI_ROUTER_BACKEND_DIR     path to fortress-guest-platform root
 
 Usage:
   python3 -m src.ingest_reservations_imap                    # production poll
   python3 -m src.ingest_reservations_imap --dry-run          # fetch + classify, don't write to DB
-  python3 -m src.ingest_reservations_imap --no-ai            # ingest only, skip reply generation
+  python3 -m src.ingest_reservations_imap --no-ai            # ingest only, skip draft generation
   python3 -m src.ingest_reservations_imap --since-hours 48   # override lookback
+
+DEPRECATED (still present, not removed yet): reservations_draft_queue write path.
+Drop in follow-up PR after email pipeline is proven in production for >=48 hours.
 """
 from __future__ import annotations
 
@@ -66,6 +69,26 @@ IMAP_FOLDER = os.getenv("RESERVATIONS_IMAP_FOLDER", "INBOX")
 LOOKBACK_HOURS = int(os.getenv("RESERVATIONS_LOOKBACK_HOURS", "24"))
 MAX_PER_RUN = int(os.getenv("RESERVATIONS_MAX_PER_RUN", "50"))
 
+# v5 ai_router integration
+AI_ROUTER_TASK_TYPE = os.getenv("RESERVATIONS_TASK_TYPE", "vrs_concierge")
+AI_ROUTER_SOURCE_MODULE = "reservations_imap_watcher"
+AI_ROUTER_MAX_TOKENS = int(os.getenv("RESERVATIONS_AI_MAX_TOKENS", "800"))
+AI_ROUTER_TEMPERATURE = float(os.getenv("RESERVATIONS_AI_TEMPERATURE", "0.4"))
+AI_ROUTER_SYSTEM_PROMPT = os.getenv(
+    "RESERVATIONS_AI_SYSTEM_PROMPT",
+    "You are the concierge for Cabin Rentals of Georgia. "
+    "Draft a warm, professional, accurate reply to this guest email. "
+    "If the guest asks something that requires checking availability, pricing, "
+    "or specific cabin details you don't have, say you'll confirm and follow up "
+    "rather than guessing. Sign as the Cabin Rentals of Georgia team."
+)
+AI_ROUTER_BACKEND_DIR = os.path.expanduser(
+    os.getenv("AI_ROUTER_BACKEND_DIR", "~/Fortress-Prime/fortress-guest-platform")
+)
+AI_ROUTER_TIMEOUT_S = int(os.getenv("RESERVATIONS_AI_TIMEOUT_S", "120"))
+
+# DEPRECATED: fortress_db / miner_bot credentials used by the old reservations_draft_queue path.
+# Keep until email pipeline is verified in production (>= 48h). Then remove.
 DB_HOST = os.getenv("DB_HOST", "localhost")
 DB_NAME = os.getenv("DB_NAME", "fortress_db")
 DB_USER = os.getenv("DB_USER", "miner_bot")
@@ -290,51 +313,197 @@ def insert_draft(conn, fe: FetchedEmail, ai_draft: Optional[str],
 
 
 # -----------------------------------------------------------------------------
-# AI draft generation (wraps guest_reply_engine if available)
+# Email pipeline — ingest via EmailMessageService
 # -----------------------------------------------------------------------------
 
-def generate_draft(fe: FetchedEmail, skip_ai: bool) -> tuple[Optional[str], Optional[float], Optional[dict]]:
+def ingest_to_email_pipeline(fe: FetchedEmail, skip_ai: bool) -> Optional[str]:
     """
-    Attempt to generate an AI draft using guest_reply_engine.
-    Returns (draft_text, confidence, meta_dict) — any can be None on failure.
-    Failures are logged but non-fatal: email still gets queued with no draft.
+    Persist the email into email_messages via EmailMessageService (subprocess).
+
+    Returns the EmailMessage UUID string on success, None on failure.
+    Every failure mode logs an error but never drops the email silently —
+    the caller should log a warning so ops can retry.
+    """
+    import subprocess
+
+    venv_py = os.path.join(AI_ROUTER_BACKEND_DIR, ".uv-venv/bin/python3")
+    if not os.path.exists(venv_py):
+        log.error("email_pipeline_unavailable: backend venv missing at %s", venv_py)
+        return None
+
+    payload = {
+        "email_from": fe.sender,
+        "email_to": fe.recipient,
+        "subject": fe.subject,
+        "body_text": fe.body_text,
+        "imap_uid": fe.imap_uid,
+        "message_id": fe.message_id,
+        "received_at": fe.received_at.isoformat(),
+        "skip_ai": skip_ai,
+    }
+
+    runner = (
+        "import asyncio, json, sys\n"
+        "from backend.core.database import async_session\n"
+        "from backend.services.email_message_service import EmailMessageService\n"
+        "from datetime import datetime, timezone\n"
+        "from uuid import UUID\n"
+        "p = json.loads(sys.stdin.read())\n"
+        "async def _run():\n"
+        "    async with async_session() as db:\n"
+        "        svc = EmailMessageService(db)\n"
+        "        msg = await svc.receive_email(\n"
+        "            email_from=p['email_from'],\n"
+        "            email_to=p['email_to'],\n"
+        "            subject=p['subject'],\n"
+        "            body_text=p['body_text'],\n"
+        "            imap_uid=int(p['imap_uid']),\n"
+        "            message_id=p['message_id'],\n"
+        "            received_at=datetime.fromisoformat(p['received_at']),\n"
+        "        )\n"
+        "        if not p['skip_ai']:\n"
+        "            msg = await svc.generate_draft_for_inbound(msg.id)\n"
+        "        print(json.dumps({'message_id': str(msg.id), 'status': msg.approval_status}))\n"
+        "asyncio.run(_run())\n"
+    )
+
+    try:
+        proc = subprocess.run(
+            [venv_py, "-c", runner],
+            input=json.dumps(payload),
+            cwd=AI_ROUTER_BACKEND_DIR,
+            capture_output=True,
+            text=True,
+            timeout=AI_ROUTER_TIMEOUT_S,
+        )
+        if proc.returncode != 0:
+            log.error(
+                "email_pipeline_subprocess_failed uid=%s returncode=%s stderr=%s",
+                fe.imap_uid, proc.returncode, (proc.stderr or "")[-1000:],
+            )
+            return None
+        out_lines = [ln for ln in (proc.stdout or "").splitlines() if ln.strip()]
+        if not out_lines:
+            log.error(
+                "email_pipeline_no_output uid=%s stderr=%s",
+                fe.imap_uid, (proc.stderr or "")[-500:],
+            )
+            return None
+        result = json.loads(out_lines[-1])
+        return result.get("message_id")
+    except subprocess.TimeoutExpired:
+        log.error("email_pipeline_timeout uid=%s timeout_s=%s", fe.imap_uid, AI_ROUTER_TIMEOUT_S)
+        return None
+    except Exception as exc:
+        log.exception("email_pipeline_exception uid=%s err=%s", fe.imap_uid, exc)
+        return None
+
+
+# -----------------------------------------------------------------------------
+# AI draft generation (wraps guest_reply_engine if available)
+# DEPRECATED: replaced by EmailMessageService.generate_draft_for_inbound.
+# Keep until reservations_draft_queue path is fully retired.
+# -----------------------------------------------------------------------------
+
+def generate_draft(fe: FetchedEmail, skip_ai: bool) -> tuple:
+    """
+    Call ai_router (v5) to generate a draft reply.
+
+    Returns (draft_text, confidence, meta_dict). Failure is non-fatal: email
+    still gets queued with no draft. Routes through
+    backend.services.ai_router.execute_resilient_inference, which handles
+    sovereign->godhead escalation, judging, and v5 capture.
+
+    We invoke ai_router via subprocess in the backend's venv because:
+      1. backend.* modules are not on this script's PYTHONPATH
+      2. ai_router is async; subprocess avoids importing asyncio here
+      3. Subprocess gives clean isolation per-email
+    Cost: ~100-300ms fork overhead per email. Acceptable for cron cadence.
     """
     if skip_ai:
         return (None, None, {"ai_skipped": True})
-    try:
-        from src.guest_reply_engine import process_email  # type: ignore
-    except Exception as e:
-        log.warning(f"guest_reply_engine unavailable ({e}) — queuing without draft")
-        return (None, None, {"ai_unavailable": str(e)})
+
+    import subprocess
+
+    venv_py = os.path.join(AI_ROUTER_BACKEND_DIR, ".uv-venv/bin/python3")
+    if not os.path.exists(venv_py):
+        return (None, None, {"ai_unavailable": "backend venv missing", "expected": venv_py})
+
+    prompt = (
+        "From: " + (fe.sender_name or "") + " <" + fe.sender + ">\n"
+        "Subject: " + fe.subject + "\n\n"
+        + fe.body_text
+    )
+
+    payload = {
+        "prompt": prompt,
+        "task_type": AI_ROUTER_TASK_TYPE,
+        "system_message": AI_ROUTER_SYSTEM_PROMPT,
+        "max_tokens": AI_ROUTER_MAX_TOKENS,
+        "temperature": AI_ROUTER_TEMPERATURE,
+        "source_module": AI_ROUTER_SOURCE_MODULE,
+    }
+
+    # Inline runner script. Reads payload from stdin (avoids shell-quoting hell),
+    # awaits ai_router, prints single-line JSON result on stdout.
+    runner = (
+        "import asyncio, json, sys\n"
+        "from backend.services.ai_router import execute_resilient_inference\n"
+        "p = json.loads(sys.stdin.read())\n"
+        "r = asyncio.run(execute_resilient_inference(\n"
+        "    prompt=p['prompt'],\n"
+        "    task_type=p['task_type'],\n"
+        "    system_message=p['system_message'],\n"
+        "    max_tokens=p['max_tokens'],\n"
+        "    temperature=p['temperature'],\n"
+        "    source_module=p['source_module'],\n"
+        "))\n"
+        "print(json.dumps({\n"
+        "    'text': getattr(r, 'text', None),\n"
+        "    'source': getattr(r, 'source', None),\n"
+        "    'breaker_state': getattr(r, 'breaker_state', None),\n"
+        "    'latency_ms': getattr(r, 'latency_ms', None),\n"
+        "}))\n"
+    )
 
     try:
-        # guest_reply_engine.process_email signature varies by version;
-        # we pass a dict payload and catch whatever shape comes back.
-        payload = {
-            "sender": fe.sender,
-            "sender_name": fe.sender_name,
-            "subject": fe.subject,
-            "body": fe.body_text,
-            "received_at": fe.received_at.isoformat(),
-            "mailbox": "reservations",
-        }
-        result = process_email(payload)  # type: ignore
-        # Normalize result shape
-        if result is None:
-            return (None, None, {"ai_returned_none": True})
-        if isinstance(result, str):
-            return (result, None, None)
-        # Assume object/dict with attributes
-        draft = getattr(result, "reply_text", None) or (result.get("reply_text") if isinstance(result, dict) else None)
-        conf = getattr(result, "confidence", None) or (result.get("confidence") if isinstance(result, dict) else None)
+        proc = subprocess.run(
+            [venv_py, "-c", runner],
+            input=json.dumps(payload),
+            cwd=AI_ROUTER_BACKEND_DIR,
+            capture_output=True,
+            text=True,
+            timeout=AI_ROUTER_TIMEOUT_S,
+        )
+        if proc.returncode != 0:
+            return (None, None, {
+                "ai_subprocess_failed": True,
+                "returncode": proc.returncode,
+                "stderr_tail": (proc.stderr or "")[-2000:],
+            })
+        # ai_router may print log lines; the JSON is on the LAST non-empty stdout line.
+        out_lines = [ln for ln in (proc.stdout or "").splitlines() if ln.strip()]
+        if not out_lines:
+            return (None, None, {"ai_no_output": True, "stderr_tail": (proc.stderr or "")[-1000:]})
+        try:
+            result = json.loads(out_lines[-1])
+        except json.JSONDecodeError as je:
+            return (None, None, {
+                "ai_parse_error": str(je),
+                "stdout_tail": (proc.stdout or "")[-1000:],
+            })
         meta = {
-            "tone": getattr(result, "tone", None) or (result.get("tone") if isinstance(result, dict) else None),
-            "topic": getattr(result, "topic", None) or (result.get("topic") if isinstance(result, dict) else None),
-            "needs_human": getattr(result, "needs_human", None) or (result.get("needs_human") if isinstance(result, dict) else None),
+            "task_type": AI_ROUTER_TASK_TYPE,
+            "ai_source": result.get("source"),
+            "breaker_state": result.get("breaker_state"),
+            "latency_ms": result.get("latency_ms"),
+            "via": "ai_router_v5",
         }
-        return (draft, float(conf) if conf is not None else None, meta)
+        return (result.get("text"), None, meta)
+    except subprocess.TimeoutExpired:
+        return (None, None, {"ai_timeout": True, "timeout_s": AI_ROUTER_TIMEOUT_S})
     except Exception as e:
-        log.exception(f"guest_reply_engine.process_email raised: {e}")
+        log.exception("ai_router subprocess failed: %s", e)
         return (None, None, {"ai_exception": str(e)})
 
 
@@ -359,28 +528,38 @@ def run(since_hours: int, dry_run: bool, skip_ai: bool) -> int:
             return 0
         uids = uids[-MAX_PER_RUN:]  # cap to most recent MAX_PER_RUN
 
-        # DB
-        conn_db = None if dry_run else get_db_connection()
-        if conn_db:
-            ensure_table(conn_db)
+        # DEPRECATED: reservations_draft_queue DB connection — kept for safety, no longer written to.
+        # Remove after email pipeline is proven in production for >=48h.
+        conn_db = None
 
         processed = 0
         for uid in uids:
-            if conn_db and already_queued(conn_db, uid):
-                log.info(f"UID {uid} already queued, skipping")
-                continue
             fe = fetch_by_uid(conn_imap, uid)
             if not fe:
                 continue
             log.info(f"UID {uid} from={fe.sender} subject={fe.subject[:80]!r}")
-            draft, conf, meta = generate_draft(fe, skip_ai=skip_ai)
+
             if dry_run:
-                log.info(f"  DRY-RUN: would insert (draft_len={len(draft) if draft else 0}, conf={conf})")
+                log.info(f"  DRY-RUN: would ingest uid={uid} into email_messages")
+                processed += 1
+                continue
+
+            message_uuid = ingest_to_email_pipeline(fe, skip_ai=skip_ai)
+            if message_uuid:
+                log.info(
+                    "  ingested uid=%s message_id=%s skip_ai=%s",
+                    uid, message_uuid, skip_ai,
+                )
             else:
-                insert_draft(conn_db, fe, draft, conf, meta)
-                log.info(f"  inserted UID {uid} status={'pending' if draft else 'pending_no_draft'}")
+                log.error(
+                    "  FAILED to ingest uid=%s — email NOT lost (IMAP still unread), "
+                    "will retry on next cron run",
+                    uid,
+                )
             processed += 1
 
+        # DEPRECATED: conn_db (reservations_draft_queue) no longer used.
+        # Remove after email pipeline is proven in production for >=48h.
         if conn_db:
             conn_db.close()
         log.info(f"Run complete. processed={processed}")


### PR DESCRIPTION
## Summary

- **Alembic migration** (`l7e8f1a2b3c4`) — creates `email_inquirers` and `email_messages` tables in `fortress_shadow`; merges the two divergent Alembic heads; adds `fortress_api` GRANTs
- **Models** — `EmailInquirer` (analog of `Guest`) and `EmailMessage` (analog of `Message`), both registered in `models/__init__.py`; self-referential thread FK with `remote_side`
- **`EmailMessageService`** — idempotent `receive_email`, AI draft generation, full HITL workflow (approve/reject/dispatch), `link_inquirer_to_guest`
- **`email_concierge_engine`** — 9-seat MoE council for cold inquiries; delegates to `run_guest_triage` when inquirer is already linked to a guest; reuses all existing concierge machinery without duplication
- **`/api/email/outbound-drafts`** API — 4 endpoints mirroring the SMS outbound-drafts API; registered in `main.py`
- **`ingest_reservations_imap.py`** — main loop swapped to new `ingest_to_email_pipeline()` subprocess; `reservations_draft_queue` path marked deprecated (not yet dropped)
- **10 pytest tests** — idempotency, rejection, approval+SMTP, link_to_guest; all passing

## SMS pipeline unchanged
The existing `messages`, `guests`, `outbound_drafts.py`, and `MessageService` are untouched.

## Test plan
- [ ] `pytest backend/tests/test_email_message_service.py` — 10/10 passing
- [ ] `curl http://localhost:8000/api/email/outbound-drafts` returns `[]` (FastAPI running)
- [ ] Send test email to `reservations@cabin-rentals-of-georgia.com`, verify row in `email_messages` within 10 min
- [ ] `ai_draft` populated after watcher run with `--no-ai` off
- [ ] Approve via `POST /api/email/outbound-drafts/{id}/approve`, verify SMTP send + `approval_status=sent`
- [ ] Reject via `POST /api/email/outbound-drafts/{id}/reject`, verify `approval_status=rejected`

## Pending (follow-up PRs per brief §12.11)
- PR B: production `fortress_prod` migration (this PR targets `fortress_shadow`)
- PR C: `reservations_draft_queue` table drop (after >=48h production proven)

🤖 Generated with [Claude Code](https://claude.com/claude-code)