### PR TITLE
fix(model-registry): exclude embed models from Phase 3 chat probe

### DIFF
--- a/fortress-guest-platform/backend/services/model_registry.py
+++ b/fortress-guest-platform/backend/services/model_registry.py
@@ -215,9 +215,15 @@ class ModelRegistry:
             # Phase 3: inference liveness (only when a configured model is warm)
             with self._lock:
                 configured = set(ep.models)
-            warm_configured = configured & warm_models
-            if warm_configured:
-                probe_model = next(iter(warm_configured))
+            # Embed models (nomic-embed-text etc.) return 400 on /api/chat.
+            # Only probe chat-capable models.
+            _EMBED_SKIP = ("embed", "nomic", "mxbai", "all-minilm")
+            warm_chat = {
+                m for m in (configured & warm_models)
+                if not any(p in m.lower() for p in _EMBED_SKIP)
+            }
+            if warm_chat:
+                probe_model = next(iter(warm_chat))
                 try:
                     with httpx.Client(timeout=_PROBE_TIMEOUT) as client:
                         inf_resp = client.post(


### PR DESCRIPTION
## Fix

`nomic-embed-text` and similar embed-only models return HTTP 400 on `POST /api/chat` — they don't support chat inference. The Phase 3 probe (added in #105) was picking the first warm model from `/api/ps`, which is almost always `nomic-embed-text` (it stays resident in VRAM). This caused healthy nodes (spark-2, spark-1) to be marked unhealthy after first probe cycle for the wrong reason.

**Change:** Before selecting the chat probe model, filter out names matching `embed / nomic / mxbai / all-minilm`. Cold-node skip logic is unchanged — if no warm chat model is found, Phase 3 is skipped and the node stays healthy.

## Observed before this fix (journald)
```
probe inference_check failed node=spark-2 model=nomic-embed-text:latest failures=1 error=Client error '400 Bad Request'
probe inference_check failed node=spark-1 model=nomic-embed-text:latest failures=1 error=Client error '400 Bad Request'
```

## Depends on
- #105 (three-phase probe implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)