### PR TITLE
feat(iron-dome-v6): dedicated vrs_fast tier — spark-4 primary for VRS only

### DIFF
--- a/fortress-guest-platform/backend/services/ai_router.py
+++ b/fortress-guest-platform/backend/services/ai_router.py
@@ -210,6 +210,10 @@ class InferenceResult:
 
 _DEEP_TASK_TYPES = {"legal", "reasoning", "analysis"}
 
+# Task types that use the dedicated vrs_fast tier (spark-4 primary, Iron Dome v6).
+# All other fast tasks continue to use the 'fast' tier (spark-2/spark-1).
+_VRS_FAST_TASK_TYPES = {"vrs_concierge"}
+
 def _preferred_ollama_model(task_type: str) -> str:
     if task_type in _DEEP_TASK_TYPES:
         return settings.ollama_deep_model
@@ -220,6 +224,8 @@ def _tier_for_task(task_type: str) -> str:
     """Map task_type to model registry tier name."""
     if task_type in _DEEP_TASK_TYPES:
         return "deep"
+    if task_type in _VRS_FAST_TASK_TYPES:
+        return "vrs_fast"
     return "fast"
 
 

--- a/fortress-guest-platform/backend/services/model_registry.py
+++ b/fortress-guest-platform/backend/services/model_registry.py
@@ -89,9 +89,10 @@ class EndpointState:
 # Registry
 # ---------------------------------------------------------------------------
 
-_PROBE_INTERVAL   = 30   # seconds
-_PROBE_TIMEOUT    = 3    # seconds
-_FAILURE_THRESHOLD = 3   # consecutive failures → unhealthy
+_PROBE_INTERVAL        = 30  # seconds
+_PROBE_TIMEOUT         = 3   # seconds — /api/tags and /api/ps (lightweight reads)
+_INFERENCE_PROBE_TIMEOUT = 8  # seconds — /api/chat Phase 3 (1-token, allows 32b models)
+_FAILURE_THRESHOLD     = 3   # consecutive failures → unhealthy
 
 class ModelRegistry:
     def __init__(self) -> None:
@@ -212,14 +213,19 @@ class ModelRegistry:
                 ps_resp.raise_for_status()
                 warm_models = {m["name"] for m in ps_resp.json().get("models", [])}
 
-            # Phase 3: inference liveness (only when a configured model is warm)
+            # Phase 3: inference liveness — only chat-capable warm models.
+            # Embed models (nomic-embed-text etc.) return HTTP 400 on /api/chat.
+            _EMBED_SKIP = ("embed", "nomic", "mxbai", "all-minilm")
             with self._lock:
                 configured = set(ep.models)
-            warm_configured = configured & warm_models
-            if warm_configured:
-                probe_model = next(iter(warm_configured))
+            warm_chat = {
+                m for m in (configured & warm_models)
+                if not any(p in m.lower() for p in _EMBED_SKIP)
+            }
+            if warm_chat:
+                probe_model = next(iter(warm_chat))
                 try:
-                    with httpx.Client(timeout=_PROBE_TIMEOUT) as client:
+                    with httpx.Client(timeout=_INFERENCE_PROBE_TIMEOUT) as client:
                         inf_resp = client.post(
                             f"{base}/api/chat",
                             json={

--- a/fortress-guest-platform/backend/tests/test_model_registry.py
+++ b/fortress-guest-platform/backend/tests/test_model_registry.py
@@ -200,3 +200,62 @@ class TestLoadFromAtlas:
         r = ModelRegistry()
         r.load_from_atlas(p)
         assert r._loaded is False
+
+
+# ---------------------------------------------------------------------------
+# Iron Dome v6 — vrs_fast tier routing
+# ---------------------------------------------------------------------------
+
+class TestVrsFastTier:
+    """Registry must route vrs_fast tier to spark-4 first, generic fast to spark-2."""
+
+    def _make_v6_registry(self) -> ModelRegistry:
+        spark2 = _make_ep("spark-2", ["qwen2.5:7b"], latency=50.0)
+        spark4 = _make_ep("spark-4", ["qwen2.5:7b"], latency=28.0)
+        return _make_registry(
+            spark2, spark4,
+            tier_routing={
+                "fast":     ["spark-2"],
+                "vrs_fast": ["spark-4", "spark-2"],
+            },
+        )
+
+    def test_vrs_fast_tier_picks_spark4_first(self):
+        r = self._make_v6_registry()
+        url = r.get_endpoint_for_model("qwen2.5:7b", tier="vrs_fast")
+        assert "192.168.0.104" in url  # spark-4 mock URL ends in node_id[-1]="4"
+
+    def test_fast_tier_picks_spark2_not_spark4(self):
+        r = self._make_v6_registry()
+        url = r.get_endpoint_for_model("qwen2.5:7b", tier="fast")
+        assert "192.168.0.102" in url  # spark-2 mock URL ends in "2"
+
+    def test_vrs_fast_falls_back_to_spark2_when_spark4_unhealthy(self):
+        spark2 = _make_ep("spark-2", ["qwen2.5:7b"], latency=50.0)
+        spark4 = _make_ep("spark-4", ["qwen2.5:7b"], healthy=False)
+        r = _make_registry(
+            spark2, spark4,
+            tier_routing={"vrs_fast": ["spark-4", "spark-2"]},
+        )
+        url = r.get_endpoint_for_model("qwen2.5:7b", tier="vrs_fast")
+        assert "192.168.0.102" in url  # falls back to spark-2
+
+
+class TestTierForTask:
+    """_tier_for_task must map vrs_concierge to vrs_fast, everything else to fast or deep."""
+
+    def test_vrs_concierge_maps_to_vrs_fast(self):
+        from backend.services.ai_router import _tier_for_task
+        assert _tier_for_task("vrs_concierge") == "vrs_fast"
+
+    def test_generic_maps_to_fast(self):
+        from backend.services.ai_router import _tier_for_task
+        assert _tier_for_task("generic") == "fast"
+
+    def test_legal_maps_to_deep(self):
+        from backend.services.ai_router import _tier_for_task
+        assert _tier_for_task("legal") == "deep"
+
+    def test_unknown_maps_to_fast(self):
+        from backend.services.ai_router import _tier_for_task
+        assert _tier_for_task("code_generation") == "fast"

--- a/fortress_atlas.yaml
+++ b/fortress_atlas.yaml
@@ -479,9 +479,10 @@ fortress_prime:
 
     # Tier routing policy: which tiers prefer which nodes (in order)
     tier_routing:
-      fast:   ["spark-4", "spark-2", "spark-1"]  # Iron Dome v5: spark-4 primary (dedicated VRS); spark-2/spark-1 overflow
-      mid:    ["spark-1", "spark-4"]           # active-active
-      deep:   ["spark-1", "spark-4"]           # active-active
-      vision: ["spark-3", "spark-1"]           # spark-3 primary; spark-1 overflow
-      embed:  ["spark-2", "spark-1", "spark-4", "spark-3"]  # any node
+      fast:     ["spark-2", "spark-1"]                    # generic fast tasks — spark-2 primary
+      vrs_fast: ["spark-4", "spark-2", "spark-1"]         # Iron Dome v6: VRS concierge dedicated lane — spark-4 primary
+      mid:      ["spark-1", "spark-4"]                    # active-active
+      deep:     ["spark-1", "spark-4"]                    # active-active
+      vision:   ["spark-3", "spark-1"]                    # spark-3 primary; spark-1 overflow
+      embed:    ["spark-2", "spark-1", "spark-4", "spark-3"]  # any node
 


### PR DESCRIPTION
## Problem with PR #105

PR #105 set `tier_routing.fast = ["spark-4", "spark-2", "spark-1"]`, making spark-4 primary for ALL fast-tier tasks including generic traffic. `vrs_concierge` and `generic` both routed to spark-4 — too aggressive.

## Fix: new `vrs_fast` tier

**`fortress_atlas.yaml`**
- `fast` reverted to `["spark-2", "spark-1"]` — generic traffic stays on spark-2/spark-1 as before
- New `vrs_fast: ["spark-4", "spark-2", "spark-1"]` — VRS dedicated lane, spark-4 primary

**`backend/services/ai_router.py`**
- `_VRS_FAST_TASK_TYPES = {"vrs_concierge"}` (one dict, surgical)
- `_tier_for_task`: `vrs_concierge → "vrs_fast"`, all other tasks unchanged

**`backend/services/model_registry.py`**
- Atlas `tier_routing` is a plain dict — `vrs_fast` works without registry changes
- Embeds-exclusion fix for Phase 3 chat probe (nomic-embed-text returns 400 on /api/chat)
- `_INFERENCE_PROBE_TIMEOUT = 8s` — separate from 3s catalog timeout, allows 32b models to respond

## Live verification (3 inferences, post-restart)

| task_type | tier | source | node |
|---|---|---|---|
| `vrs_concierge` | vrs_fast | `ollama` | `192.168.0.106` (spark-4) ✅ |
| `generic` | fast | `ollama` | `192.168.0.104` (spark-1) ✅ NOT spark-4 |
| `legal` | deep | `fallback` | deepseek-r1:70b unavailable — pre-existing, not a routing regression |

## Tests
25/25 passing. New: `TestVrsFastTier` (3 cases) + `TestTierForTask` (4 cases).

## Depends on / supersedes
- Builds on #105 (atlas + 3-phase probe)
- Includes all probe fixes (embed exclusion, inference timeout) — makes PR #106 (`fix/probe-embed-model-exclusion`) redundant; that branch can be closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)