### PR TITLE
fix(eval): reapply bf16 load for DGX Spark — 4-bit NF4 fails on GB10

### DIFF
--- a/src/eval/run_eval.py
+++ b/src/eval/run_eval.py
@@ -94,23 +94,17 @@ def run_eval(adapter_path: Path, holdout_path: Path, dry_run: bool) -> dict:
     embedder = SentenceTransformer(EMBEDDING_MODEL, device="cpu")
 
     # --- Load LoRA adapter ---
-    log.info("Loading base model %s in 4-bit NF4 …", BASE_MODEL_DIR)
+    # DGX Spark (GB10) unified memory: load bf16 directly — 4-bit NF4 conversion fails on this arch
+    log.info("Loading base model %s in bf16 …", BASE_MODEL_DIR)
     import torch
     from peft import AutoPeftModelForCausalLM
-    from transformers import AutoTokenizer, BitsAndBytesConfig
+    from transformers import AutoTokenizer
 
-    bnb = BitsAndBytesConfig(
-        load_in_4bit=True,
-        bnb_4bit_use_double_quant=True,
-        bnb_4bit_quant_type="nf4",
-        bnb_4bit_compute_dtype=torch.bfloat16,
-    )
     tokenizer = AutoTokenizer.from_pretrained(str(adapter_path), use_fast=True)
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token
     model = AutoPeftModelForCausalLM.from_pretrained(
         str(adapter_path),
-        quantization_config=bnb,
         device_map="auto",
         torch_dtype=torch.bfloat16,
     )


### PR DESCRIPTION
## Summary
- 4-bit NF4 weight conversion via BitsAndBytesConfig fails during `_finalize_model_loading` on DGX Spark GB10 architecture
- Reapplies the bf16 direct load that was previously confirmed working for e2 eval
- Matches the training configuration (bf16, no quantization needed on unified memory)

## Test plan
- [x] e3 eval launched successfully with bf16 — weights loading confirmed at 08:50

🤖 Generated with [Claude Code](https://claude.ai/claude-code)