### PR TITLE
feat(retriever): SentMailRetriever — two-collection exemplar search for composer

### DIFF
--- a/fortress-guest-platform/backend/services/sent_mail_retriever.py
+++ b/fortress-guest-platform/backend/services/sent_mail_retriever.py
@@ -1,0 +1,250 @@
+"""
+SentMailRetriever — retrieves past Taylor sent-mail exemplars for composer injection.
+====================================================================================
+Clones the structure of knowledge_retriever.py. Queries two collections in
+parallel and merges results:
+
+  1. fgp_sent_mail       — tarball corpus (2022–2026, Taylor's guest replies)
+  2. guest_golden_responses — curated exemplars (Gary-starred, quality_score=5)
+
+Recency boost: final_score = cosine_score * (1 + RECENCY_COEFF * max(0, 1 - age/RECENCY_WINDOW_YEARS))
+  Coefficient defaults to 0.15 over a 4-year window.
+  Set RECENCY_COEFF = 0 to disable (corpus is already temporally tight at 2022+).
+
+Timeout: 3s hard cap — this is on the critical path of draft generation.
+Failure mode: returns [] on any Qdrant error; caller degrades to council-only composition.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import List, Optional
+
+import httpx
+import structlog
+
+from backend.core.config import settings
+
+logger = structlog.get_logger(service="sent_mail_retriever")
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+QDRANT_URL = "http://127.0.0.1:6333"
+
+COLLECTION_SENT_MAIL = "fgp_sent_mail"
+COLLECTION_GOLDEN = "guest_golden_responses"
+
+EMBED_MODEL = "nomic-embed-text"
+VECTOR_DIM = 768
+EMBED_TIMEOUT = 3.0  # fail-fast: retriever budget is tight
+QDRANT_TIMEOUT = 3.0
+
+# Recency boost — set to 0 to disable
+RECENCY_COEFF = 0.15
+RECENCY_WINDOW_SECONDS = 4.0 * 365.25 * 86400  # 4 years
+
+
+# ---------------------------------------------------------------------------
+# Dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SentMailExemplar:
+    subject: str
+    body: str
+    score: float
+    sent_at: Optional[str]
+    detected_topic: str
+    source: str
+
+
+# ---------------------------------------------------------------------------
+# Embed
+# ---------------------------------------------------------------------------
+
+async def _embed(text: str) -> Optional[List[float]]:
+    """Embed text via nomic-embed-text. Returns None on any failure."""
+    # Try configured embed_base_url (spark-2) first; if unreachable the
+    # 3s timeout fires and we fall back to spark-4.
+    endpoints = [
+        f"{settings.embed_base_url.rstrip('/')}/api/embeddings",
+        "http://192.168.0.106:11434/api/embeddings",  # spark-4 fallback
+    ]
+    for url in endpoints:
+        try:
+            async with httpx.AsyncClient(timeout=EMBED_TIMEOUT) as client:
+                resp = await client.post(
+                    url,
+                    json={"model": EMBED_MODEL, "prompt": text[:8000]},
+                )
+                resp.raise_for_status()
+                vec = resp.json().get("embedding", [])
+                if len(vec) == VECTOR_DIM:
+                    return vec
+        except Exception as exc:
+            logger.debug("embed_endpoint_failed", url=url, error=str(exc)[:80])
+    logger.warning("sent_mail_retriever.embed_all_failed", text_len=len(text))
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Qdrant search helpers
+# ---------------------------------------------------------------------------
+
+async def _search_collection(
+    collection: str,
+    vector: List[float],
+    limit: int,
+) -> List[dict]:
+    """Single-collection similarity search. Returns raw Qdrant result list."""
+    try:
+        async with httpx.AsyncClient(timeout=QDRANT_TIMEOUT) as client:
+            resp = await client.post(
+                f"{QDRANT_URL}/collections/{collection}/points/search",
+                json={
+                    "vector": vector,
+                    "limit": limit,
+                    "with_payload": True,
+                    "with_vector": False,
+                },
+            )
+            resp.raise_for_status()
+            return resp.json().get("result", [])
+    except Exception as exc:
+        logger.warning(
+            "sent_mail_retriever.collection_search_failed",
+            collection=collection,
+            error=str(exc)[:120],
+        )
+        return []
+
+
+def _recency_boost(sent_at_epoch: Optional[int]) -> float:
+    """Compute the recency multiplier for a point."""
+    if not sent_at_epoch or RECENCY_COEFF == 0:
+        return 1.0
+    now = time.time()
+    age_seconds = max(0.0, now - sent_at_epoch)
+    weight = max(0.0, 1.0 - age_seconds / RECENCY_WINDOW_SECONDS)
+    return 1.0 + RECENCY_COEFF * weight
+
+
+def _point_to_exemplar(pt: dict, source_tag: str) -> Optional[SentMailExemplar]:
+    """Convert a raw Qdrant point to a SentMailExemplar."""
+    payload = pt.get("payload", {})
+    score = float(pt.get("score", 0.0))
+
+    if source_tag == COLLECTION_SENT_MAIL:
+        body = payload.get("body", "").strip()
+        subject = payload.get("subject", "")
+        sent_at = payload.get("sent_at")
+        sent_at_epoch = payload.get("sent_at_epoch")
+        topic = payload.get("detected_topic", "other")
+        source = payload.get("source", "fgp_sent_mail")
+    else:
+        # guest_golden_responses schema: ai_output, topic, cabin
+        body = payload.get("ai_output", "").strip()
+        topic_raw = payload.get("topic", "other")
+        cabin = payload.get("cabin", "")
+        subject = f"Guest reply — {cabin}" if cabin else "Guest reply"
+        sent_at = None
+        sent_at_epoch = None
+        topic = topic_raw
+        source = "guest_golden_responses"
+
+    if not body:
+        return None
+
+    boosted_score = score * _recency_boost(sent_at_epoch)
+
+    return SentMailExemplar(
+        subject=subject,
+        body=body,
+        score=boosted_score,
+        sent_at=sent_at,
+        detected_topic=topic,
+        source=source,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+class SentMailRetriever:
+    """Retrieves past sent-mail exemplars for few-shot composer injection."""
+
+    def __init__(self) -> None:
+        pass
+
+    async def find_similar_replies(
+        self,
+        inquiry_body: str,
+        k: int = 3,
+        min_score: float = 0.65,
+    ) -> List[SentMailExemplar]:
+        """
+        Embed inquiry_body, query fgp_sent_mail and guest_golden_responses in
+        parallel, merge, apply recency boost, filter by min_score, return top-k.
+
+        Returns [] if inquiry_body is empty, Qdrant is unreachable, or no
+        results exceed min_score.  Never raises — caller degrades gracefully.
+        """
+        if not inquiry_body or not inquiry_body.strip():
+            return []
+
+        try:
+            vector = await _embed(inquiry_body.strip())
+            if vector is None:
+                return []
+
+            # Query both collections concurrently; isolate failures per collection
+            raw = await asyncio.gather(
+                _search_collection(COLLECTION_SENT_MAIL, vector, k * 2),
+                _search_collection(COLLECTION_GOLDEN, vector, k),
+                return_exceptions=True,
+            )
+            sent_results: List[dict] = raw[0] if not isinstance(raw[0], BaseException) else []
+            golden_results: List[dict] = raw[1] if not isinstance(raw[1], BaseException) else []
+            if isinstance(raw[0], BaseException):
+                logger.warning("sent_mail_search_error", error=str(raw[0])[:120])
+            if isinstance(raw[1], BaseException):
+                logger.warning("golden_search_error", error=str(raw[1])[:120])
+
+            # Convert and merge
+            candidates: List[SentMailExemplar] = []
+            seen_bodies: set[str] = set()
+
+            for pt in sent_results:
+                ex = _point_to_exemplar(pt, COLLECTION_SENT_MAIL)
+                if ex and ex.body not in seen_bodies:
+                    candidates.append(ex)
+                    seen_bodies.add(ex.body)
+
+            for pt in golden_results:
+                ex = _point_to_exemplar(pt, COLLECTION_GOLDEN)
+                if ex and ex.body not in seen_bodies:
+                    candidates.append(ex)
+                    seen_bodies.add(ex.body)
+
+            # Filter by min_score, sort by boosted score, return top-k
+            filtered = [c for c in candidates if c.score >= min_score]
+            filtered.sort(key=lambda x: x.score, reverse=True)
+            top = filtered[:k]
+
+            logger.info(
+                "sent_mail_retriever.results",
+                candidates=len(candidates),
+                above_threshold=len(filtered),
+                returned=len(top),
+                top_score=round(top[0].score, 4) if top else 0,
+                top_topics=[e.detected_topic for e in top],
+            )
+            return top
+
+        except Exception as exc:
+            logger.warning("sent_mail_retriever.find_failed", error=str(exc)[:200])
+            return []

--- a/fortress-guest-platform/backend/tests/test_sent_mail_retriever.py
+++ b/fortress-guest-platform/backend/tests/test_sent_mail_retriever.py
@@ -1,0 +1,264 @@
+"""
+Tests for SentMailRetriever.
+
+Covers:
+  - Recency boost math (pure unit test, no network)
+  - Two-collection merge with dedup
+  - Qdrant timeout → empty list, no exception
+  - Min-score filter
+  - Empty / whitespace query → empty list
+"""
+from __future__ import annotations
+
+import time
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from backend.services.sent_mail_retriever import (
+    SentMailRetriever,
+    SentMailExemplar,
+    _recency_boost,
+    _point_to_exemplar,
+    RECENCY_COEFF,
+    RECENCY_WINDOW_SECONDS,
+    COLLECTION_SENT_MAIL,
+    COLLECTION_GOLDEN,
+)
+
+
+# ---------------------------------------------------------------------------
+# Recency boost math
+# ---------------------------------------------------------------------------
+
+class TestRecencyBoost:
+    def test_zero_age_returns_max_boost(self):
+        # A message sent right now should get the full coefficient boost
+        now_epoch = int(time.time())
+        multiplier = _recency_boost(now_epoch)
+        assert multiplier == pytest.approx(1.0 + RECENCY_COEFF, abs=0.01)
+
+    def test_full_window_age_returns_no_boost(self):
+        # A message sent exactly RECENCY_WINDOW_SECONDS ago gets no boost
+        old_epoch = int(time.time() - RECENCY_WINDOW_SECONDS)
+        multiplier = _recency_boost(old_epoch)
+        assert multiplier == pytest.approx(1.0, abs=0.02)
+
+    def test_older_than_window_clamped_at_no_boost(self):
+        # Messages older than the window never go below 1.0
+        very_old_epoch = int(time.time() - RECENCY_WINDOW_SECONDS * 2)
+        assert _recency_boost(very_old_epoch) == pytest.approx(1.0, abs=0.01)
+
+    def test_none_epoch_returns_no_boost(self):
+        assert _recency_boost(None) == 1.0
+
+    def test_midpoint_roughly_half_boost(self):
+        # Halfway through the window → ~half the coefficient
+        mid_epoch = int(time.time() - RECENCY_WINDOW_SECONDS / 2)
+        mult = _recency_boost(mid_epoch)
+        expected = 1.0 + RECENCY_COEFF * 0.5
+        assert mult == pytest.approx(expected, abs=0.02)
+
+
+# ---------------------------------------------------------------------------
+# Point conversion helpers
+# ---------------------------------------------------------------------------
+
+class TestPointToExemplar:
+    def _sent_pt(self, body="Hello guest", score=0.75, topic="availability",
+                 sent_at_epoch=None):
+        return {
+            "score": score,
+            "payload": {
+                "body": body,
+                "subject": "Re: cabin inquiry",
+                "detected_topic": topic,
+                "sent_at": "2024-06-01T10:00:00+00:00",
+                "sent_at_epoch": sent_at_epoch or int(time.time()),
+                "source": "taylor_sent_tarball_2022_2026",
+            },
+        }
+
+    def _golden_pt(self, ai_output="Hi there!", score=0.80, topic="pricing"):
+        return {
+            "score": score,
+            "payload": {
+                "ai_output": ai_output,
+                "topic": topic,
+                "cabin": "Cohutta Sunset",
+                "quality_score": 5,
+            },
+        }
+
+    def test_sent_mail_point_converts(self):
+        ex = _point_to_exemplar(self._sent_pt(), COLLECTION_SENT_MAIL)
+        assert ex is not None
+        assert ex.body == "Hello guest"
+        assert ex.detected_topic == "availability"
+        assert ex.source == "taylor_sent_tarball_2022_2026"
+
+    def test_golden_point_converts(self):
+        ex = _point_to_exemplar(self._golden_pt(), COLLECTION_GOLDEN)
+        assert ex is not None
+        assert ex.body == "Hi there!"
+        assert ex.detected_topic == "pricing"
+        assert ex.source == "guest_golden_responses"
+        assert "Cohutta Sunset" in ex.subject
+
+    def test_empty_body_returns_none(self):
+        pt = {"score": 0.9, "payload": {"body": "", "ai_output": ""}}
+        assert _point_to_exemplar(pt, COLLECTION_SENT_MAIL) is None
+        assert _point_to_exemplar(pt, COLLECTION_GOLDEN) is None
+
+    def test_recency_boosted_score_applied(self):
+        now_epoch = int(time.time())
+        pt = self._sent_pt(score=0.80, sent_at_epoch=now_epoch)
+        ex = _point_to_exemplar(pt, COLLECTION_SENT_MAIL)
+        assert ex is not None
+        assert ex.score > 0.80  # boost applied
+
+
+# ---------------------------------------------------------------------------
+# SentMailRetriever integration (mocked Qdrant + embed)
+# ---------------------------------------------------------------------------
+
+def _make_qdrant_pt(body, score, topic="availability", collection=COLLECTION_SENT_MAIL,
+                    sent_at_epoch=None):
+    if collection == COLLECTION_SENT_MAIL:
+        payload = {
+            "body": body,
+            "subject": "Re: inquiry",
+            "detected_topic": topic,
+            "sent_at": "2024-01-01T00:00:00+00:00",
+            "sent_at_epoch": sent_at_epoch or int(time.time() - 86400 * 100),
+            "source": "taylor_sent_tarball_2022_2026",
+        }
+    else:
+        payload = {"ai_output": body, "topic": topic, "cabin": "Test Cabin"}
+    return {"score": score, "payload": payload}
+
+
+class TestSentMailRetriever:
+    @pytest.mark.asyncio
+    async def test_empty_query_returns_empty(self):
+        retriever = SentMailRetriever()
+        assert await retriever.find_similar_replies("") == []
+        assert await retriever.find_similar_replies("   ") == []
+
+    @pytest.mark.asyncio
+    async def test_embed_failure_returns_empty(self):
+        retriever = SentMailRetriever()
+        with patch(
+            "backend.services.sent_mail_retriever._embed",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            result = await retriever.find_similar_replies("Looking for a cabin")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_qdrant_timeout_returns_empty_no_exception(self):
+        retriever = SentMailRetriever()
+        fake_vector = [0.1] * 768
+        with patch(
+            "backend.services.sent_mail_retriever._embed",
+            new_callable=AsyncMock,
+            return_value=fake_vector,
+        ), patch(
+            "backend.services.sent_mail_retriever._search_collection",
+            new_callable=AsyncMock,
+            side_effect=Exception("connection timeout"),
+        ):
+            result = await retriever.find_similar_replies("test inquiry")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_min_score_filter_applied(self):
+        retriever = SentMailRetriever()
+        fake_vector = [0.1] * 768
+        # One result below threshold, one above
+        low_pt = _make_qdrant_pt("Low score reply", score=0.50)
+        high_pt = _make_qdrant_pt("High score reply", score=0.90)
+
+        async def _mock_search(collection, vector, limit):
+            if collection == COLLECTION_SENT_MAIL:
+                return [high_pt, low_pt]
+            return []
+
+        with patch("backend.services.sent_mail_retriever._embed",
+                   new_callable=AsyncMock, return_value=fake_vector), \
+             patch("backend.services.sent_mail_retriever._search_collection",
+                   side_effect=_mock_search):
+            results = await retriever.find_similar_replies("test", min_score=0.65)
+
+        assert len(results) == 1
+        assert results[0].body == "High score reply"
+
+    @pytest.mark.asyncio
+    async def test_two_collection_merge_and_dedup(self):
+        retriever = SentMailRetriever()
+        fake_vector = [0.1] * 768
+        # Same body in both collections → deduped to one
+        same_body = "Duplicate body text"
+        pt_sent = _make_qdrant_pt(same_body, score=0.80)
+        pt_golden = _make_qdrant_pt(same_body, score=0.85, collection=COLLECTION_GOLDEN)
+        unique_pt = _make_qdrant_pt("Unique reply from sent", score=0.75)
+
+        async def _mock_search(collection, vector, limit):
+            if collection == COLLECTION_SENT_MAIL:
+                return [pt_sent, unique_pt]
+            return [pt_golden]
+
+        with patch("backend.services.sent_mail_retriever._embed",
+                   new_callable=AsyncMock, return_value=fake_vector), \
+             patch("backend.services.sent_mail_retriever._search_collection",
+                   side_effect=_mock_search):
+            results = await retriever.find_similar_replies("test inquiry", k=5, min_score=0.0)
+
+        bodies = [r.body for r in results]
+        # Duplicate deduped — should appear only once
+        assert bodies.count(same_body) == 1
+        assert len(results) == 2
+
+    @pytest.mark.asyncio
+    async def test_results_sorted_by_boosted_score_descending(self):
+        retriever = SentMailRetriever()
+        fake_vector = [0.1] * 768
+        now = int(time.time())
+        recent_pt = _make_qdrant_pt("Recent reply", score=0.70,
+                                     sent_at_epoch=now - 86400 * 30)   # 30 days old
+        old_pt = _make_qdrant_pt("Old reply", score=0.75,
+                                  sent_at_epoch=now - int(RECENCY_WINDOW_SECONDS * 0.9))
+
+        async def _mock_search(collection, vector, limit):
+            if collection == COLLECTION_SENT_MAIL:
+                return [old_pt, recent_pt]
+            return []
+
+        with patch("backend.services.sent_mail_retriever._embed",
+                   new_callable=AsyncMock, return_value=fake_vector), \
+             patch("backend.services.sent_mail_retriever._search_collection",
+                   side_effect=_mock_search):
+            results = await retriever.find_similar_replies("test", k=5, min_score=0.0)
+
+        # Recent gets boosted enough to outrank older despite lower raw score
+        assert len(results) == 2
+        assert results[0].body == "Recent reply"
+
+    @pytest.mark.asyncio
+    async def test_returns_at_most_k_results(self):
+        retriever = SentMailRetriever()
+        fake_vector = [0.1] * 768
+        many_pts = [_make_qdrant_pt(f"Reply {i}", score=0.9 - i * 0.01) for i in range(10)]
+
+        async def _mock_search(collection, vector, limit):
+            if collection == COLLECTION_SENT_MAIL:
+                return many_pts[:limit]
+            return []
+
+        with patch("backend.services.sent_mail_retriever._embed",
+                   new_callable=AsyncMock, return_value=fake_vector), \
+             patch("backend.services.sent_mail_retriever._search_collection",
+                   side_effect=_mock_search):
+            results = await retriever.find_similar_replies("test", k=3, min_score=0.0)
+
+        assert len(results) <= 3


### PR DESCRIPTION
## Summary

Part 2 of the draft-quality-fix. Adds `backend/services/sent_mail_retriever.py` cloned from the `knowledge_retriever.py` pattern. Queries both exemplar collections in parallel, merges, deduplicates, applies recency boost, and returns top-k above a confidence threshold — all within a 3s budget.

Depends on: #111 (fgp_sent_mail corpus ingestion)

## What it does

1. Embeds the incoming inquiry body via nomic-embed-text (tries spark-2, falls back to spark-4 if busy)
2. Queries `fgp_sent_mail` (600 tarball emails) and `guest_golden_responses` (13 curated) concurrently
3. Merges results, deduplicates by body content
4. Applies recency boost: `score × (1 + 0.15 × max(0, 1 - age / 4yr))`
5. Filters below `min_score` (default 0.65), returns top-k (default 3)
6. Returns `[]` on any failure — caller degrades to council-only composition

## Tests (16/16)
- Recency boost math (5 unit tests, no network)
- Point conversion for both collection schemas
- Empty/whitespace query → `[]`
- Embed failure → `[]`
- Qdrant timeout → `[]`, no exception
- Min-score filter
- Two-collection merge with body deduplication
- Sorted by boosted score descending
- At-most-k cap

## Next
PR 3: `feat/sent-mail-composer-integration` — wire the retriever into `email_concierge_engine._compose_draft_reply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)