### PR TITLE
feat(nim): standalone arm64 probe tool + sentinel daily catalog audit

### DIFF
--- a/tools/nim_arm64_probe.py
+++ b/tools/nim_arm64_probe.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""
+nim_arm64_probe.py — Standalone CLI for NIM ARM64 verification.
+
+Wraps verify_arm64_with_docker() and verify_nas_tar() from scripts/nim_pull_to_nas.
+
+Usage:
+    python3 tools/nim_arm64_probe.py --models nvcr.io/nim/nvidia/nemotron-nano-12b-v2-vl:latest
+    python3 tools/nim_arm64_probe.py --from-file models.txt   # one image_ref per line
+    python3 tools/nim_arm64_probe.py --json                   # machine-readable output
+    python3 tools/nim_arm64_probe.py --verify-nas /mnt/fortress_nas/nim-cache/nim/llama-nemotron-embed-1b-v2/latest/image.tar
+
+Output (human-readable):
+    MODEL                                                    MANIFEST  ELF     VERDICT
+    nvcr.io/nim/nvidia/nemotron-nano-12b-v2-vl:latest       PASS      PASS    PASS
+
+Auth:
+    Before any docker calls, /etc/fortress/nim.env is sourced via sudo to perform
+    docker login nvcr.io. This is done once per run, not per image.
+
+Exit codes:
+    0  — all probes PASS
+    1  — one or more probes FAIL or ERROR
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Import verification functions from scripts/nim_pull_to_nas
+# ---------------------------------------------------------------------------
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from scripts.nim_pull_to_nas import verify_arm64_with_docker, verify_nas_tar, VerificationResult
+
+log = logging.getLogger("nim_arm64_probe")
+
+ENV_FILE = Path("/etc/fortress/nim.env")
+
+# Rate-limit between docker-based probes (ms → seconds)
+PROBE_SLEEP_S = 0.5
+
+
+# ---------------------------------------------------------------------------
+# Result wrapper for tabular output
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ProbeRow:
+    image_ref: str
+    manifest: str  # "PASS" | "FAIL" | "N/A" | "ERROR"
+    elf: str        # "PASS" | "FAIL" | "N/A" | "ERROR" | "SKIP"
+    verdict: str    # "PASS" | "MANIFEST_FAIL" | "ELF_FAIL" | "ERROR"
+    evidence: dict
+
+
+def _result_to_row(image_ref: str, res: VerificationResult) -> ProbeRow:
+    manifest_str = "PASS" if res.stage1_manifest_arm64 else "FAIL"
+    if res.verdict == "ERROR" and not res.stage1_manifest_arm64:
+        manifest_str = "ERROR"
+
+    if res.verdict == "MANIFEST_FAIL":
+        elf_str = "N/A"
+    elif res.verdict == "ERROR" and not res.stage2_elf_aarch64:
+        elf_str = "ERROR"
+    else:
+        elf_str = "PASS" if res.stage2_elf_aarch64 else "FAIL"
+
+    return ProbeRow(
+        image_ref=image_ref,
+        manifest=manifest_str,
+        elf=elf_str,
+        verdict=res.verdict,
+        evidence=res.evidence,
+    )
+
+
+# ---------------------------------------------------------------------------
+# docker login — once per run, via sudo heredoc (no credentials in argv/logs)
+# ---------------------------------------------------------------------------
+
+def docker_login_once() -> bool:
+    """
+    Source /etc/fortress/nim.env as root via sudo and run docker login nvcr.io.
+    Credentials are passed via stdin to avoid appearing in argv or logs.
+    Returns True on success, False if login fails or env file missing.
+    """
+    if not ENV_FILE.exists():
+        log.warning("nim.env not found at %s — skipping docker login", ENV_FILE)
+        return False
+
+    # Heredoc script: source the env file as root, then pipe the API key to docker login
+    # NGC uses $oauthtoken as username and the API key as password
+    script = (
+        "set -e\n"
+        f"source {ENV_FILE}\n"
+        'echo "${NGC_API_KEY}" | docker login nvcr.io --username "$oauthtoken" --password-stdin\n'
+    )
+
+    try:
+        result = subprocess.run(
+            ["sudo", "bash", "-s"],
+            input=script,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if result.returncode == 0:
+            log.info("docker login nvcr.io: OK")
+            return True
+        else:
+            log.warning("docker login nvcr.io failed: %s", result.stderr.strip())
+            return False
+    except Exception as exc:
+        log.warning("docker login attempt failed: %s", exc)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Core probe dispatcher
+# ---------------------------------------------------------------------------
+
+def probe_image(image_ref: str) -> ProbeRow:
+    """Run two-stage ARM64 verification via docker for a single image_ref."""
+    log.info("Probing %s ...", image_ref)
+    try:
+        res = verify_arm64_with_docker(image_ref)
+    except Exception as exc:
+        res = VerificationResult(verdict="ERROR", evidence={"exception": str(exc)})
+    return _result_to_row(image_ref, res)
+
+
+def probe_nas_tar(tar_path: Path) -> ProbeRow:
+    """Run verification against a locally-cached NAS tar (no docker required)."""
+    log.info("Verifying NAS tar %s ...", tar_path)
+    try:
+        res = verify_nas_tar(tar_path)
+    except Exception as exc:
+        res = VerificationResult(verdict="ERROR", evidence={"exception": str(exc)})
+    # Use the tar path as the display key
+    return _result_to_row(str(tar_path), res)
+
+
+# ---------------------------------------------------------------------------
+# Output formatters
+# ---------------------------------------------------------------------------
+
+def _pass_fail(val: str) -> str:
+    return val  # keep raw strings; colour could be added later
+
+
+def print_table(rows: list[ProbeRow]) -> None:
+    col_model = max(len(r.image_ref) for r in rows)
+    col_model = max(col_model, len("MODEL"))
+    header = (
+        f"{'MODEL':<{col_model}}  {'MANIFEST':<8}  {'ELF':<6}  VERDICT"
+    )
+    print(header)
+    print("-" * len(header))
+    for row in rows:
+        print(
+            f"{row.image_ref:<{col_model}}  "
+            f"{_pass_fail(row.manifest):<8}  "
+            f"{_pass_fail(row.elf):<6}  "
+            f"{row.verdict}"
+        )
+
+
+def print_json(rows: list[ProbeRow]) -> None:
+    output = []
+    for row in rows:
+        output.append({
+            "image_ref": row.image_ref,
+            "manifest": row.manifest,
+            "elf": row.elf,
+            "verdict": row.verdict,
+            "evidence": row.evidence,
+        })
+    print(json.dumps(output, indent=2))
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(
+        description=(
+            "nim_arm64_probe — Standalone NIM ARM64 verification CLI.\n"
+            "Wraps verify_arm64_with_docker() from scripts/nim_pull_to_nas."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    source = ap.add_mutually_exclusive_group()
+    source.add_argument(
+        "--models",
+        nargs="+",
+        metavar="IMAGE_REF",
+        help="One or more fully-qualified image refs (e.g. nvcr.io/nim/nvidia/foo:latest)",
+    )
+    source.add_argument(
+        "--from-file",
+        metavar="FILE",
+        help="Path to a text file with one image_ref per line (# comments ignored)",
+    )
+    source.add_argument(
+        "--verify-nas",
+        metavar="TAR_PATH",
+        help=(
+            "Verify an already-cached NAS image.tar using verify_nas_tar() "
+            "(no docker pull, suitable for smoke tests)"
+        ),
+    )
+
+    ap.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output results as a JSON array instead of a human-readable table",
+    )
+    ap.add_argument(
+        "--no-login",
+        action="store_true",
+        help="Skip docker login (use if already authenticated)",
+    )
+    ap.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Enable DEBUG logging",
+    )
+    return ap
+
+
+def main() -> None:
+    ap = build_parser()
+    args = ap.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    # --verify-nas is a special path — no docker login needed
+    if args.verify_nas:
+        tar_path = Path(args.verify_nas)
+        if not tar_path.exists():
+            print(f"ERROR: {tar_path} not found", file=sys.stderr)
+            sys.exit(1)
+        row = probe_nas_tar(tar_path)
+        rows = [row]
+        if args.json_output:
+            print_json(rows)
+        else:
+            print_table(rows)
+        sys.exit(0 if row.verdict == "PASS" else 1)
+
+    # Collect image refs
+    image_refs: list[str] = []
+
+    if args.models:
+        image_refs = args.models
+    elif args.from_file:
+        fpath = Path(args.from_file)
+        if not fpath.exists():
+            print(f"ERROR: --from-file path not found: {fpath}", file=sys.stderr)
+            sys.exit(1)
+        for line in fpath.read_text().splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                image_refs.append(line)
+    else:
+        ap.error("One of --models, --from-file, or --verify-nas is required.")
+
+    if not image_refs:
+        print("ERROR: no image refs to probe", file=sys.stderr)
+        sys.exit(1)
+
+    # docker login — once per run
+    if not args.no_login:
+        docker_login_once()
+
+    # Probe each image
+    rows: list[ProbeRow] = []
+    for i, ref in enumerate(image_refs):
+        if i > 0:
+            time.sleep(PROBE_SLEEP_S)
+        row = probe_image(ref)
+        rows.append(row)
+
+    # Output
+    if args.json_output:
+        print_json(rows)
+    else:
+        print_table(rows)
+
+    # Exit code
+    any_fail = any(r.verdict != "PASS" for r in rows)
+    sys.exit(1 if any_fail else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/nvidia_sentinel.py
+++ b/tools/nvidia_sentinel.py
@@ -10,6 +10,7 @@ Monitors:
     2. Ollama Library — Model tag changes (deepseek-r1:70b, qwen2.5:7b)
     3. NVIDIA Driver — L4T / JetPack / DGX Spark driver releases
     4. ARM64 NIM availability — The critical gate for HYDRA NIM migration
+    5. NIM ARM64 Catalog Audit — Daily manifest-level ARM64 probe with mismatch detection
 
 State:
     Stores last-known digests/versions in Postgres (fortress_db.sentinel_state).
@@ -31,11 +32,12 @@ Governing Documents:
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
 import json
 import logging
 import argparse
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -130,7 +132,7 @@ def get_db_connection():
 
 
 def init_state_table():
-    """Create the sentinel_state table if it doesn't exist."""
+    """Create the sentinel_state table and nim_arm64_probe_results if they don't exist."""
     conn = get_db_connection()
     cur = conn.cursor()
     cur.execute("""
@@ -148,6 +150,11 @@ def init_state_table():
     cur.close()
     conn.close()
     logger.info("sentinel_state table ready")
+    # Also initialise the Phase 4 probe table
+    try:
+        init_nim_arm64_probe_table()
+    except Exception as exc:
+        logger.warning("nim_arm64_probe_results init failed (non-fatal): %s", exc)
 
 
 def get_state(key: str) -> Optional[str]:
@@ -480,6 +487,350 @@ def log_alert_to_db(alerts: list):
 
 
 # =============================================================================
+# VI-B. NIM ARM64 CATALOG AUDIT (Phase 4)
+# =============================================================================
+
+# NIM images to watch for ARM64 manifest status each day.
+# Combines the three active targets plus the sentinel's existing NGC_IMAGES list.
+NIM_ARM64_WATCH = [
+    "nvcr.io/nim/nvidia/nemotron-nano-12b-v2-vl:latest",
+    "nvcr.io/nim/nvidia/llama-nemotron-embed-1b-v2:latest",
+    "nvcr.io/nim/nvidia/nvidia-nemotron-nano-9b-v2:latest",   # broken — watch for fix
+    "nvcr.io/nim/nvidia/llama-nemotron-nano-8b-v1:latest",
+    "nvcr.io/nim/deepseek-ai/deepseek-r1-distill-llama-70b:latest",
+]
+
+
+def init_nim_arm64_probe_table():
+    """Create the nim_arm64_probe_results table if it does not yet exist."""
+    conn = get_db_connection()
+    cur = conn.cursor()
+    cur.execute("""
+        CREATE TABLE IF NOT EXISTS nim_arm64_probe_results (
+            id                    SERIAL PRIMARY KEY,
+            probe_date            DATE NOT NULL,
+            image_path            TEXT NOT NULL,
+            tag                   TEXT NOT NULL,
+            stage1_arm64          BOOLEAN,
+            arm64_digest          TEXT,
+            amd64_digest          TEXT,
+            arm64_manifest_bytes  INT,
+            amd64_manifest_bytes  INT,
+            possible_mismatch     BOOLEAN,
+            verdict               TEXT,
+            probe_notes           TEXT,
+            created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            UNIQUE (probe_date, image_path, tag)
+        );
+        CREATE INDEX IF NOT EXISTS idx_nim_arm64_probe_date
+            ON nim_arm64_probe_results(probe_date);
+        CREATE INDEX IF NOT EXISTS idx_nim_arm64_probe_image
+            ON nim_arm64_probe_results(image_path);
+    """)
+    conn.commit()
+    cur.close()
+    conn.close()
+    logger.info("nim_arm64_probe_results table ready")
+
+
+def _get_ngc_auth_header(image_path: str) -> dict:
+    """Return an Authorization header for a given nvcr.io image path, or empty dict."""
+    if not NGC_API_KEY:
+        return {}
+    try:
+        auth_url = (
+            f"https://authn.nvidia.com/token"
+            f"?service=ngc&scope=repository:{image_path}:pull"
+        )
+        resp = requests.get(auth_url, auth=("$oauthtoken", NGC_API_KEY), timeout=15)
+        resp.raise_for_status()
+        token = resp.json().get("token", "")
+        return {"Authorization": f"Bearer {token}"} if token else {}
+    except Exception as exc:
+        logger.warning("NGC auth failed for %s: %s", image_path, exc)
+        return {}
+
+
+def _manifest_inspect_via_docker(image_ref: str) -> Optional[dict]:
+    """
+    Run `docker manifest inspect <image_ref>` and return parsed JSON, or None on error.
+    Uses subprocess — no docker pull, suitable for daily sentinel runs.
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "manifest", "inspect", image_ref],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            logger.warning(
+                "docker manifest inspect failed for %s: %s",
+                image_ref, result.stderr.strip(),
+            )
+            return None
+        return json.loads(result.stdout)
+    except Exception as exc:
+        logger.warning("manifest inspect error for %s: %s", image_ref, exc)
+        return None
+
+
+def _parse_manifest_arm64(
+    image_ref: str,
+) -> tuple[bool, Optional[str], Optional[str], Optional[int], Optional[int]]:
+    """
+    Stage-1 manifest check via docker manifest inspect.
+
+    Returns:
+        (stage1_arm64, arm64_digest, amd64_digest, arm64_manifest_bytes, amd64_manifest_bytes)
+
+    arm64_manifest_bytes / amd64_manifest_bytes are the `size` field reported by the
+    registry for each sub-manifest.  If both values are identical, that is the ARM64
+    mismatch signal (same-byte packaging defect — the broken 9B VRS image case).
+    """
+    index = _manifest_inspect_via_docker(image_ref)
+    if index is None:
+        return False, None, None, None, None
+
+    arm64_digest: Optional[str] = None
+    amd64_digest: Optional[str] = None
+    arm64_size: Optional[int] = None
+    amd64_size: Optional[int] = None
+
+    # Multi-arch image index
+    if "manifests" in index:
+        for m in index["manifests"]:
+            plat = m.get("platform", {})
+            arch = plat.get("architecture", "")
+            os_name = plat.get("os", "")
+            digest = m.get("digest")
+            size = m.get("size")
+            if arch == "arm64" and os_name == "linux":
+                arm64_digest = digest
+                arm64_size = size
+            elif arch in ("amd64", "x86_64") and os_name == "linux":
+                amd64_digest = digest
+                amd64_size = size
+    elif index.get("architecture") == "arm64":
+        # Single-arch manifest already arm64
+        arm64_digest = image_ref
+
+    stage1_arm64 = arm64_digest is not None
+    return stage1_arm64, arm64_digest, amd64_digest, arm64_size, amd64_size
+
+
+def _upsert_nim_arm64_probe_result(
+    probe_date: date,
+    image_path: str,
+    tag: str,
+    stage1_arm64: Optional[bool],
+    arm64_digest: Optional[str],
+    amd64_digest: Optional[str],
+    arm64_manifest_bytes: Optional[int],
+    amd64_manifest_bytes: Optional[int],
+    possible_mismatch: Optional[bool],
+    verdict: str,
+    probe_notes: str,
+) -> None:
+    """Upsert a probe result row into nim_arm64_probe_results."""
+    try:
+        conn = get_db_connection()
+        cur = conn.cursor()
+        cur.execute("""
+            INSERT INTO nim_arm64_probe_results
+                (probe_date, image_path, tag, stage1_arm64, arm64_digest,
+                 amd64_digest, arm64_manifest_bytes, amd64_manifest_bytes,
+                 possible_mismatch, verdict, probe_notes)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (probe_date, image_path, tag) DO UPDATE SET
+                stage1_arm64         = EXCLUDED.stage1_arm64,
+                arm64_digest         = EXCLUDED.arm64_digest,
+                amd64_digest         = EXCLUDED.amd64_digest,
+                arm64_manifest_bytes = EXCLUDED.arm64_manifest_bytes,
+                amd64_manifest_bytes = EXCLUDED.amd64_manifest_bytes,
+                possible_mismatch    = EXCLUDED.possible_mismatch,
+                verdict              = EXCLUDED.verdict,
+                probe_notes          = EXCLUDED.probe_notes,
+                created_at           = NOW()
+        """, (
+            probe_date, image_path, tag, stage1_arm64, arm64_digest,
+            amd64_digest, arm64_manifest_bytes, amd64_manifest_bytes,
+            possible_mismatch, verdict, probe_notes,
+        ))
+        conn.commit()
+        cur.close()
+        conn.close()
+    except Exception as exc:
+        logger.warning("nim_arm64_probe_results write failed for %s: %s", image_path, exc)
+
+
+def _get_yesterday_probe(image_path: str, tag: str) -> Optional[dict]:
+    """Return the probe row from yesterday for the given image, or None."""
+    try:
+        conn = get_db_connection()
+        cur = conn.cursor()
+        cur.execute("""
+            SELECT stage1_arm64, arm64_digest, arm64_manifest_bytes, amd64_manifest_bytes,
+                   possible_mismatch, verdict
+            FROM nim_arm64_probe_results
+            WHERE image_path = %s AND tag = %s
+              AND probe_date = (CURRENT_DATE - INTERVAL '1 day')::DATE
+            LIMIT 1
+        """, (image_path, tag))
+        row = cur.fetchone()
+        cur.close()
+        conn.close()
+        if row is None:
+            return None
+        return {
+            "stage1_arm64": row[0],
+            "arm64_digest": row[1],
+            "arm64_manifest_bytes": row[2],
+            "amd64_manifest_bytes": row[3],
+            "possible_mismatch": row[4],
+            "verdict": row[5],
+        }
+    except Exception as exc:
+        logger.warning("Yesterday probe read failed for %s: %s", image_path, exc)
+        return None
+
+
+def audit_nim_arm64_catalog(check_only: bool = False) -> list:
+    """
+    Phase 4 — NIM ARM64 Catalog Audit.
+
+    For each image in NIM_ARM64_WATCH:
+      1. Run stage-1 manifest check only (no pull, no ELF — too slow for daily cron).
+      2. Compare against yesterday's result in nim_arm64_probe_results.
+      3. Detect three alert categories:
+         - ARM64_NEW: arm64 manifest newly appeared
+         - ARM64_REGRESSION: arm64 manifest previously present, now gone
+         - ARM64_MANIFEST_MISMATCH: arm64 and amd64 sub-manifests have identical
+           byte counts (packaging defect signal — same as the broken 9B VRS image)
+
+    Returns list of alert dicts (same shape as other audit phases).
+    """
+    alerts: list = []
+    today = date.today()
+
+    for image_ref in NIM_ARM64_WATCH:
+        # Split "nvcr.io/<image_path>:<tag>"
+        ref_no_registry = image_ref.replace("nvcr.io/", "", 1)
+        if ":" in ref_no_registry:
+            image_path, tag = ref_no_registry.rsplit(":", 1)
+        else:
+            image_path = ref_no_registry
+            tag = "latest"
+
+        logger.info("  [NIM ARM64] Checking %s:%s ...", image_path, tag)
+
+        stage1, arm64_digest, amd64_digest, arm64_bytes, amd64_bytes = (
+            _parse_manifest_arm64(image_ref)
+        )
+
+        # Determine possible mismatch: both manifests exist and share identical byte count
+        possible_mismatch = (
+            arm64_bytes is not None
+            and amd64_bytes is not None
+            and arm64_bytes == amd64_bytes
+        )
+
+        if not stage1:
+            verdict = "NO_ARM64"
+        elif possible_mismatch:
+            verdict = "ARM64_MANIFEST_MISMATCH"
+        else:
+            verdict = "ARM64_OK"
+
+        notes_parts: list[str] = []
+        if arm64_bytes:
+            notes_parts.append(f"arm64_bytes={arm64_bytes}")
+        if amd64_bytes:
+            notes_parts.append(f"amd64_bytes={amd64_bytes}")
+        probe_notes = "; ".join(notes_parts)
+
+        # Persist today's result
+        if not check_only:
+            _upsert_nim_arm64_probe_result(
+                probe_date=today,
+                image_path=image_path,
+                tag=tag,
+                stage1_arm64=stage1,
+                arm64_digest=arm64_digest,
+                amd64_digest=amd64_digest,
+                arm64_manifest_bytes=arm64_bytes,
+                amd64_manifest_bytes=amd64_bytes,
+                possible_mismatch=possible_mismatch,
+                verdict=verdict,
+                probe_notes=probe_notes,
+            )
+
+        # Compare with yesterday
+        yesterday = _get_yesterday_probe(image_path, tag)
+
+        alert: Optional[dict] = None
+
+        if yesterday is None:
+            # First-run for this image — no delta to report
+            logger.info("    [%s] First probe — %s", image_path, verdict)
+        elif not yesterday.get("stage1_arm64") and stage1:
+            # ARM64_NEW: previously absent, now present
+            alert = {
+                "source": "NIM_ARM64_CATALOG",
+                "name": f"ARM64_NEW: {image_path}:{tag}",
+                "priority": "CRITICAL",
+                "message": (
+                    f"ARM64 manifest newly available for {image_ref}. "
+                    f"arm64_digest={arm64_digest} — new candidate ready for pull."
+                ),
+                "arm64": True,
+                "image": image_path,
+                "alert_class": "ARM64_NEW",
+            }
+        elif yesterday.get("stage1_arm64") and not stage1:
+            # ARM64_REGRESSION: previously present, now gone
+            alert = {
+                "source": "NIM_ARM64_CATALOG",
+                "name": f"ARM64_REGRESSION: {image_path}:{tag}",
+                "priority": "HIGH",
+                "message": (
+                    f"ARM64 manifest REMOVED for {image_ref}. "
+                    f"Yesterday had arm64_digest={yesterday.get('arm64_digest')}. "
+                    f"NVIDIA may have re-packaged — check for regression."
+                ),
+                "arm64": False,
+                "image": image_path,
+                "alert_class": "ARM64_REGRESSION",
+            }
+        elif possible_mismatch and not yesterday.get("possible_mismatch"):
+            # ARM64_MANIFEST_MISMATCH: mismatch newly detected (or not flagged yesterday)
+            alert = {
+                "source": "NIM_ARM64_CATALOG",
+                "name": f"ARM64_MANIFEST_MISMATCH: {image_path}:{tag}",
+                "priority": "HIGH",
+                "message": (
+                    f"ARM64/AMD64 manifest byte counts are IDENTICAL for {image_ref} "
+                    f"({arm64_bytes} bytes each). Likely packaging defect — "
+                    f"manifest claims arm64 but layers may be x86. Do NOT pull."
+                ),
+                "arm64": False,
+                "image": image_path,
+                "alert_class": "ARM64_MANIFEST_MISMATCH",
+            }
+        else:
+            logger.info("    [%s] No change — verdict=%s", image_path, verdict)
+
+        if alert:
+            alerts.append(alert)
+            logger.warning(
+                "  NIM ARM64 ALERT [%s] %s: %s",
+                alert["alert_class"], image_path, alert["message"],
+            )
+
+    return alerts
+
+
+# =============================================================================
 # VII. MAIN AUDIT LOOP
 # =============================================================================
 
@@ -518,6 +869,13 @@ def run_audit(check_only: bool = False) -> list:
     if result:
         alerts.append(result)
         logger.warning(f"  ALERT: {result['name']} — {result['message']}")
+
+    # 4. NIM ARM64 Catalog Audit
+    logger.info("\n[Phase 4] NIM ARM64 Catalog Audit")
+    nim_alerts = audit_nim_arm64_catalog(check_only=check_only)
+    for alert in nim_alerts:
+        alerts.append(alert)
+        logger.warning(f"  ALERT: {alert['name']} — {alert['message']}")
 
     # Summary
     logger.info(f"\n{'=' * 60}")


### PR DESCRIPTION
## Summary

- **Part A** (`tools/nim_arm64_probe.py`): Standalone CLI wrapping `verify_arm64_with_docker()` and `verify_nas_tar()` from `scripts/nim_pull_to_nas`. Supports `--models`, `--from-file`, `--verify-nas`, and `--json` flags. Docker login sourced once per run from `/etc/fortress/nim.env` via `sudo bash -s` heredoc (no credentials in argv or logs). 500ms rate-limit between docker probes. Exit 0 = all PASS, 1 = any FAIL/ERROR.

- **Part B** (`tools/nvidia_sentinel.py`): Adds Phase 4 — NIM ARM64 Catalog Audit to the daily sentinel. `audit_nim_arm64_catalog()` runs manifest-only checks (no pull, no ELF) via `docker manifest inspect` against 5 images in `NIM_ARM64_WATCH`. New Postgres table `nim_arm64_probe_results` stores per-day results. Alerts Gary via existing `send_email_alert()` on three incident classes: `ARM64_NEW`, `ARM64_REGRESSION`, and `ARM64_MANIFEST_MISMATCH` (identical arm64/amd64 byte count — the same packaging defect class as the broken `nvidia-nemotron-nano-9b-v2`). Existing cron schedule (`0 6 * * *`) and Phases 1–3 are untouched.

## Smoke test

```
python3 tools/nim_arm64_probe.py --verify-nas /mnt/fortress_nas/nim-cache/nim/llama-nemotron-embed-1b-v2/latest/image.tar
```

**Result:** `MANIFEST=PASS  ELF=PASS  VERDICT=PASS` — exit code 0.

## Test plan

- [ ] `python3 tools/nim_arm64_probe.py --verify-nas /mnt/fortress_nas/nim-cache/nim/llama-nemotron-embed-1b-v2/latest/image.tar` returns PASS
- [ ] `python3 tools/nim_arm64_probe.py --json --verify-nas ...` returns valid JSON with `"verdict": "PASS"`
- [ ] `python3 tools/nvidia_sentinel.py --init` creates both `sentinel_state` and `nim_arm64_probe_results` tables
- [ ] `python3 tools/nvidia_sentinel.py --check-only` runs all 4 phases without error; Phase 4 logs NIM ARM64 probe output
- [ ] Cron comment `0 6 * * *` unchanged in sentinel file

🤖 Generated with [Claude Code](https://claude.com/claude-code)