### PR TITLE
fix(sentinel): Phase 4 heuristic refinement + Phase 1 auth URL swap (v2, clean)

### DIFF
--- a/scripts/reset_nim_arm64_baseline_post_heuristic_fix.sql
+++ b/scripts/reset_nim_arm64_baseline_post_heuristic_fix.sql
@@ -1,0 +1,94 @@
+-- reset_nim_arm64_baseline_post_heuristic_fix.sql
+--
+-- Removes the stale nim_arm64_probe_results baseline row for
+-- llama-nemotron-embed-1b-v2 written on 2026-04-22 under the old
+-- byte-size heuristic (which incorrectly returned ARM64_MANIFEST_MISMATCH
+-- for a confirmed genuine aarch64 image).
+--
+-- After this script runs, the next cron execution (06:30 daily) will
+-- write a fresh baseline under the corrected shared-layer-ratio heuristic,
+-- which correctly returns ARM64_OK for this image.
+--
+-- See: docs/PHASE_ONE_AND_EMBED_INVESTIGATION_2026-04-22.md
+-- Fixed by: fix/sentinel-heuristic-and-auth (PR to be merged by Gary)
+--
+-- Run as miner_bot against fortress_db:
+--   psql -h 127.0.0.1 -U miner_bot -d fortress_db \
+--     -f scripts/reset_nim_arm64_baseline_post_heuristic_fix.sql
+--
+-- STOP: Gary runs this manually post-merge. Claude does not execute it.
+
+BEGIN;
+
+-- Guard 1: confirm the table exists
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public'
+          AND table_name   = 'nim_arm64_probe_results'
+    ) THEN
+        RAISE EXCEPTION
+            'nim_arm64_probe_results does not exist — wrong database or table not yet created. Aborting.';
+    END IF;
+END;
+$$;
+
+-- Guard 2: confirm exactly one matching row (the stale baseline) exists
+DO $$
+DECLARE
+    n bigint;
+BEGIN
+    SELECT COUNT(*) INTO n
+    FROM nim_arm64_probe_results
+    WHERE image_path = 'nim/nvidia/llama-nemotron-embed-1b-v2'
+      AND probe_date = '2026-04-22';
+
+    IF n = 0 THEN
+        RAISE EXCEPTION
+            'No row found for llama-nemotron-embed-1b-v2 / 2026-04-22 — already deleted or wrong database. Aborting.';
+    END IF;
+
+    RAISE NOTICE 'Found % row(s) to delete for llama-nemotron-embed-1b-v2 / 2026-04-22. Proceeding.', n;
+END;
+$$;
+
+-- Diagnostic: show the row before deletion
+DO $$
+DECLARE
+    r record;
+BEGIN
+    SELECT * INTO r
+    FROM nim_arm64_probe_results
+    WHERE image_path = 'nim/nvidia/llama-nemotron-embed-1b-v2'
+      AND probe_date = '2026-04-22'
+    LIMIT 1;
+    RAISE NOTICE 'Deleting row: probe_date=% image_path=% tag=% verdict=%',
+        r.probe_date, r.image_path, r.tag, r.verdict;
+END;
+$$;
+
+-- The actual delete
+DELETE FROM nim_arm64_probe_results
+WHERE image_path = 'nim/nvidia/llama-nemotron-embed-1b-v2'
+  AND probe_date = '2026-04-22';
+
+-- Confirm
+DO $$
+DECLARE
+    n bigint;
+BEGIN
+    SELECT COUNT(*) INTO n
+    FROM nim_arm64_probe_results
+    WHERE image_path = 'nim/nvidia/llama-nemotron-embed-1b-v2'
+      AND probe_date = '2026-04-22';
+
+    IF n > 0 THEN
+        RAISE EXCEPTION 'DELETE did not remove all rows. % row(s) still present. Check for constraints.', n;
+    END IF;
+
+    RAISE NOTICE 'OK — stale baseline row deleted. Next cron run will establish a corrected baseline.';
+END;
+$$;
+
+COMMIT;

--- a/tests/test_nvidia_sentinel.py
+++ b/tests/test_nvidia_sentinel.py
@@ -1,0 +1,256 @@
+"""
+Unit tests for tools/nvidia_sentinel.py — Phase 4 heuristic and Phase 1 auth.
+
+All HTTP / subprocess calls are mocked.  No live NGC calls in CI.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tools.nvidia_sentinel import (
+    _OCI_EMPTY_BLOB,
+    _shared_substantive_layer_ratio,
+    _parse_manifest_arm64,
+    get_ngc_token,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _layer(digest: str, size: int) -> dict:
+    return {"digest": digest, "size": size}
+
+
+WHITEOUT = _layer(_OCI_EMPTY_BLOB, 32)
+
+# Fake substantive layer digests
+ARM_A = "sha256:" + "a" * 64
+ARM_B = "sha256:" + "b" * 64
+ARM_C = "sha256:" + "c" * 64
+AMD_A = ARM_A          # shared with arm
+AMD_D = "sha256:" + "d" * 64
+AMD_E = "sha256:" + "e" * 64
+
+
+# ---------------------------------------------------------------------------
+# _shared_substantive_layer_ratio
+# ---------------------------------------------------------------------------
+
+def test_ratio_no_shared_layers():
+    arm64 = [_layer(ARM_A, 1000), _layer(ARM_B, 2000)]
+    amd64 = [_layer(AMD_D, 1000), _layer(AMD_E, 2000)]
+    assert _shared_substantive_layer_ratio(arm64, amd64) == 0.0
+
+
+def test_ratio_all_shared_layers():
+    arm64 = [_layer(ARM_A, 1000), _layer(ARM_B, 2000)]
+    amd64 = [_layer(ARM_A, 1000), _layer(ARM_B, 2000)]
+    assert _shared_substantive_layer_ratio(arm64, amd64) == 1.0
+
+
+def test_ratio_exactly_50_percent():
+    arm64 = [_layer(ARM_A, 1000), _layer(ARM_B, 2000)]
+    amd64 = [_layer(ARM_A, 1000), _layer(AMD_D, 2000)]
+    ratio = _shared_substantive_layer_ratio(arm64, amd64)
+    assert ratio == 0.5
+
+
+def test_ratio_60_percent():
+    arm64 = [_layer(ARM_A, 1000), _layer(ARM_B, 2000), _layer(ARM_C, 3000)]
+    amd64 = [_layer(ARM_A, 1000), _layer(ARM_B, 2000), _layer(AMD_D, 3000)]
+    ratio = _shared_substantive_layer_ratio(arm64, amd64)
+    assert abs(ratio - 2 / 3) < 1e-9
+
+
+def test_ratio_whiteout_layers_excluded():
+    # Only shared layers are zero-size whiteout blobs — ratio must be 0.0
+    arm64 = [WHITEOUT, WHITEOUT, _layer(ARM_A, 1000)]
+    amd64 = [WHITEOUT, WHITEOUT, _layer(AMD_D, 1000)]
+    assert _shared_substantive_layer_ratio(arm64, amd64) == 0.0
+
+
+def test_ratio_empty_layer_list_returns_zero():
+    assert _shared_substantive_layer_ratio([], []) == 0.0
+    assert _shared_substantive_layer_ratio([_layer(ARM_A, 1000)], []) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _parse_manifest_arm64 — verdict mapping
+# ---------------------------------------------------------------------------
+
+def _mock_index(arm64_digest: str, amd64_digest: str) -> dict:
+    return {
+        "manifests": [
+            {"platform": {"architecture": "arm64", "os": "linux"}, "digest": arm64_digest, "size": 10000},
+            {"platform": {"architecture": "amd64", "os": "linux"}, "digest": amd64_digest, "size": 10000},
+        ]
+    }
+
+
+def _mock_sub_manifest(layers: list[dict]) -> dict:
+    return {"schemaVersion": 2, "layers": layers}
+
+
+def _make_inspect_side_effect(index_json, arm64_layers, amd64_layers):
+    """
+    Returns a side_effect function for _manifest_inspect_via_docker that:
+    - returns index_json for the base image ref
+    - returns the arm64 sub-manifest for ...@sha256:arm64...
+    - returns the amd64 sub-manifest for ...@sha256:amd64...
+    """
+    call_count = {"n": 0}
+    responses = [
+        index_json,
+        _mock_sub_manifest(arm64_layers),
+        _mock_sub_manifest(amd64_layers),
+    ]
+
+    def side_effect(_image_ref: str):
+        n = call_count["n"]
+        call_count["n"] += 1
+        return responses[n] if n < len(responses) else None
+
+    return side_effect
+
+
+@patch("tools.nvidia_sentinel._manifest_inspect_via_docker")
+def test_parse_manifest_arm64_ok_no_shared(mock_inspect):
+    """Genuine arm64 image — no shared substantive layers → ARM64_OK."""
+    index = _mock_index("sha256:" + "a" * 64, "sha256:" + "b" * 64)
+    mock_inspect.side_effect = _make_inspect_side_effect(
+        index,
+        arm64_layers=[_layer(ARM_A, 5000)],
+        amd64_layers=[_layer(AMD_D, 5000)],
+    )
+    stage1, _, _, _, _, ratio = _parse_manifest_arm64("nvcr.io/nim/nvidia/model:latest")
+    assert stage1 is True
+    assert ratio == 0.0
+    # Caller maps ratio <= 0.5 → ARM64_OK
+
+
+@patch("tools.nvidia_sentinel._manifest_inspect_via_docker")
+def test_parse_manifest_mismatch_all_shared(mock_inspect):
+    """Packaging defect — all substantive layers shared → ratio 1.0 → ARM64_MANIFEST_MISMATCH."""
+    shared_layer = _layer(ARM_A, 5000)
+    index = _mock_index("sha256:" + "a" * 64, "sha256:" + "b" * 64)
+    mock_inspect.side_effect = _make_inspect_side_effect(
+        index,
+        arm64_layers=[shared_layer],
+        amd64_layers=[shared_layer],
+    )
+    stage1, _, _, _, _, ratio = _parse_manifest_arm64("nvcr.io/nim/nvidia/model:latest")
+    assert stage1 is True
+    assert ratio == 1.0
+    assert ratio > 0.5  # caller maps this → ARM64_MANIFEST_MISMATCH
+
+
+@patch("tools.nvidia_sentinel._manifest_inspect_via_docker")
+def test_parse_manifest_50_percent_is_not_mismatch(mock_inspect):
+    """Exactly 50% shared — strict > 0.5 threshold means NOT a mismatch."""
+    index = _mock_index("sha256:" + "a" * 64, "sha256:" + "b" * 64)
+    mock_inspect.side_effect = _make_inspect_side_effect(
+        index,
+        arm64_layers=[_layer(ARM_A, 5000), _layer(ARM_B, 5000)],
+        amd64_layers=[_layer(ARM_A, 5000), _layer(AMD_D, 5000)],
+    )
+    _, _, _, _, _, ratio = _parse_manifest_arm64("nvcr.io/nim/nvidia/model:latest")
+    assert ratio == 0.5
+    assert not (ratio > 0.5)  # strict threshold — 50% is ARM64_OK
+
+
+@patch("tools.nvidia_sentinel._manifest_inspect_via_docker")
+def test_parse_manifest_60_percent_is_mismatch(mock_inspect):
+    """60% shared → ARM64_MANIFEST_MISMATCH."""
+    index = _mock_index("sha256:" + "a" * 64, "sha256:" + "b" * 64)
+    mock_inspect.side_effect = _make_inspect_side_effect(
+        index,
+        arm64_layers=[_layer(ARM_A, 5000), _layer(ARM_B, 5000), _layer(ARM_C, 5000)],
+        amd64_layers=[_layer(ARM_A, 5000), _layer(ARM_B, 5000), _layer(AMD_D, 5000)],
+    )
+    _, _, _, _, _, ratio = _parse_manifest_arm64("nvcr.io/nim/nvidia/model:latest")
+    assert ratio > 0.5
+
+
+@patch("tools.nvidia_sentinel._manifest_inspect_via_docker")
+def test_parse_manifest_whiteout_only_shared_is_ok(mock_inspect):
+    """Only zero-size whiteout blobs shared — substantive layers all unique → ARM64_OK."""
+    index = _mock_index("sha256:" + "a" * 64, "sha256:" + "b" * 64)
+    mock_inspect.side_effect = _make_inspect_side_effect(
+        index,
+        arm64_layers=[WHITEOUT, WHITEOUT, _layer(ARM_A, 5000)],
+        amd64_layers=[WHITEOUT, WHITEOUT, _layer(AMD_D, 5000)],
+    )
+    _, _, _, _, _, ratio = _parse_manifest_arm64("nvcr.io/nim/nvidia/model:latest")
+    assert ratio == 0.0
+
+
+@patch("tools.nvidia_sentinel._manifest_inspect_via_docker")
+def test_parse_manifest_no_arm64_platform(mock_inspect):
+    """No arm64 entry in index → stage1=False, ratio=0.0."""
+    index = {
+        "manifests": [
+            {"platform": {"architecture": "amd64", "os": "linux"}, "digest": "sha256:" + "b" * 64, "size": 9000},
+        ]
+    }
+    mock_inspect.return_value = index
+    stage1, _, _, _, _, ratio = _parse_manifest_arm64("nvcr.io/nim/nvidia/model:latest")
+    assert stage1 is False
+    assert ratio == 0.0
+
+
+@patch("tools.nvidia_sentinel._manifest_inspect_via_docker")
+def test_parse_manifest_access_denied(mock_inspect):
+    """docker manifest inspect fails (access denied) → stage1=False."""
+    mock_inspect.return_value = None
+    stage1, _, _, _, _, ratio = _parse_manifest_arm64("nvcr.io/nim/nvidia/model:latest")
+    assert stage1 is False
+    assert ratio == 0.0
+
+
+# ---------------------------------------------------------------------------
+# get_ngc_token — Phase 1 auth URL (Fix 2)
+# ---------------------------------------------------------------------------
+
+@patch("tools.nvidia_sentinel.requests.get")
+@patch("tools.nvidia_sentinel.NGC_API_KEY", "fake-nvapi-key")
+def test_get_ngc_token_uses_proxy_auth_url(mock_get):
+    """get_ngc_token() must call nvcr.io/proxy_auth, not authn.nvidia.com."""
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"token": "fake-bearer-token"}
+    mock_resp.raise_for_status.return_value = None
+    mock_get.return_value = mock_resp
+
+    token = get_ngc_token("nim/nvidia/qwen2.5-7b-instruct")
+
+    assert token == "fake-bearer-token"
+    called_url = mock_get.call_args[0][0]
+    assert "nvcr.io/proxy_auth" in called_url, f"Expected nvcr.io/proxy_auth, got: {called_url}"
+    assert "authn.nvidia.com" not in called_url, "Must NOT use authn.nvidia.com"
+    assert "repository%3A" in called_url or "repository:" in called_url
+
+
+@patch("tools.nvidia_sentinel.requests.get")
+@patch("tools.nvidia_sentinel.NGC_API_KEY", "fake-nvapi-key")
+def test_get_ngc_token_extracts_token_from_proxy_auth_response(mock_get):
+    """Token is extracted from proxy_auth JSON response."""
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"token": "eyJhbGci.test.token"}
+    mock_resp.raise_for_status.return_value = None
+    mock_get.return_value = mock_resp
+
+    token = get_ngc_token("nim/nvidia/model:latest")
+    assert token == "eyJhbGci.test.token"
+
+
+@patch("tools.nvidia_sentinel.NGC_API_KEY", "")
+def test_get_ngc_token_returns_none_when_key_missing():
+    """Returns None and logs warning when NGC_API_KEY is empty."""
+    token = get_ngc_token("nim/nvidia/model:latest")
+    assert token is None

--- a/tools/nvidia_sentinel.py
+++ b/tools/nvidia_sentinel.py
@@ -200,17 +200,21 @@ def set_state(key: str, value: str, source: str = "unknown",
 # =============================================================================
 
 def get_ngc_token(image: str) -> Optional[str]:
-    """Authenticate with NVIDIA NGC and get a bearer token for a specific image."""
+    """Authenticate with NVIDIA NGC and get a bearer token for a specific image.
+
+    Uses nvcr.io/proxy_auth — compatible with nvapi-* key format.
+    Mirrors scripts/nim_pull_to_nas._get_token() which is the proven-working pattern.
+    """
     if not NGC_API_KEY:
         logger.warning("NGC_API_KEY not set — skipping NGC checks")
         return None
 
     try:
         auth_url = (
-            f"https://authn.nvidia.com/token"
-            f"?service=ngc&scope=repository:{image}:pull"
+            f"https://nvcr.io/proxy_auth?account=%24oauthtoken"
+            f"&scope=repository%3A{image}%3Apull"
         )
-        resp = requests.get(auth_url, auth=("$oauthtoken", NGC_API_KEY), timeout=15)
+        resp = requests.get(auth_url, auth=("$oauthtoken", NGC_API_KEY), timeout=20)
         resp.raise_for_status()
         return resp.json().get("token")
     except Exception as e:
@@ -557,22 +561,60 @@ def _manifest_inspect_via_docker(image_ref: str) -> Optional[dict]:
         return None
 
 
+# Standard OCI empty-layer blob (whiteout marker) — always shared, not a code layer.
+_OCI_EMPTY_BLOB = "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1"
+# Layers at or below this size are structural blobs, not architecture-bearing code.
+_MIN_SUBSTANTIVE_BYTES = 32
+
+
+def _shared_substantive_layer_ratio(
+    arm64_layers: list[dict],
+    amd64_layers: list[dict],
+) -> float:
+    """
+    Fraction of substantive arm64 layer digests that also appear in the amd64 manifest.
+
+    Substantive = not the OCI empty blob and size > _MIN_SUBSTANTIVE_BYTES.
+    Returns 0.0 when either architecture has no substantive layers.
+
+    A ratio > 0.5 indicates that more than half of the architecture-bearing layers
+    are shared between arm64 and amd64 — a strong signal of a packaging defect
+    (genuine arm64 images diverge from amd64 at the OS base layer).
+    """
+    def substantive_digests(layers: list[dict]) -> set[str]:
+        return {
+            la["digest"] for la in layers
+            if la.get("digest") != _OCI_EMPTY_BLOB
+            and la.get("size", 0) > _MIN_SUBSTANTIVE_BYTES
+        }
+
+    arm64_sub = substantive_digests(arm64_layers)
+    amd64_sub = substantive_digests(amd64_layers)
+    denominator = min(len(arm64_sub), len(amd64_sub))
+    if denominator == 0:
+        return 0.0
+    return len(arm64_sub & amd64_sub) / denominator
+
+
 def _parse_manifest_arm64(
     image_ref: str,
-) -> tuple[bool, Optional[str], Optional[str], Optional[int], Optional[int]]:
+) -> tuple[bool, Optional[str], Optional[str], Optional[int], Optional[int], float]:
     """
     Stage-1 manifest check via docker manifest inspect.
 
     Returns:
-        (stage1_arm64, arm64_digest, amd64_digest, arm64_manifest_bytes, amd64_manifest_bytes)
+        (stage1_arm64, arm64_digest, amd64_digest,
+         arm64_manifest_bytes, amd64_manifest_bytes, shared_layer_ratio)
 
-    arm64_manifest_bytes / amd64_manifest_bytes are the `size` field reported by the
-    registry for each sub-manifest.  If both values are identical, that is the ARM64
-    mismatch signal (same-byte packaging defect — the broken 9B VRS image case).
+    shared_layer_ratio is the fraction of substantive (non-whiteout) arm64 layer
+    digests that are identical in the amd64 manifest.  Ratio > 0.5 is the
+    ARM64_MANIFEST_MISMATCH signal (replaces the old byte-size equality heuristic
+    which produced false positives on images with the same layer count but different
+    content — see PR #133 investigation).
     """
     index = _manifest_inspect_via_docker(image_ref)
     if index is None:
-        return False, None, None, None, None
+        return False, None, None, None, None, 0.0
 
     arm64_digest: Optional[str] = None
     amd64_digest: Optional[str] = None
@@ -598,7 +640,20 @@ def _parse_manifest_arm64(
         arm64_digest = image_ref
 
     stage1_arm64 = arm64_digest is not None
-    return stage1_arm64, arm64_digest, amd64_digest, arm64_size, amd64_size
+
+    # Compute shared-layer ratio by fetching each arch's full layer manifest
+    shared_ratio = 0.0
+    if arm64_digest and amd64_digest:
+        base_ref = image_ref.rsplit(":", 1)[0] if ":" in image_ref else image_ref
+        arm64_manifest = _manifest_inspect_via_docker(f"{base_ref}@{arm64_digest}")
+        amd64_manifest = _manifest_inspect_via_docker(f"{base_ref}@{amd64_digest}")
+        if arm64_manifest and amd64_manifest:
+            shared_ratio = _shared_substantive_layer_ratio(
+                arm64_manifest.get("layers", []),
+                amd64_manifest.get("layers", []),
+            )
+
+    return stage1_arm64, arm64_digest, amd64_digest, arm64_size, amd64_size, shared_ratio
 
 
 def _upsert_nim_arm64_probe_result(
@@ -706,16 +761,13 @@ def audit_nim_arm64_catalog(check_only: bool = False) -> list:
 
         logger.info("  [NIM ARM64] Checking %s:%s ...", image_path, tag)
 
-        stage1, arm64_digest, amd64_digest, arm64_bytes, amd64_bytes = (
+        stage1, arm64_digest, amd64_digest, arm64_bytes, amd64_bytes, shared_ratio = (
             _parse_manifest_arm64(image_ref)
         )
 
-        # Determine possible mismatch: both manifests exist and share identical byte count
-        possible_mismatch = (
-            arm64_bytes is not None
-            and amd64_bytes is not None
-            and arm64_bytes == amd64_bytes
-        )
+        # Mismatch: >50% of substantive layers shared between arm64 and amd64.
+        # See PR #133 investigation — byte-size equality was a false positive.
+        possible_mismatch = shared_ratio > 0.5
 
         if not stage1:
             verdict = "NO_ARM64"
@@ -729,6 +781,7 @@ def audit_nim_arm64_catalog(check_only: bool = False) -> list:
             notes_parts.append(f"arm64_bytes={arm64_bytes}")
         if amd64_bytes:
             notes_parts.append(f"amd64_bytes={amd64_bytes}")
+        notes_parts.append(f"shared_layer_ratio={shared_ratio:.2f}")
         probe_notes = "; ".join(notes_parts)
 
         # Persist today's result


### PR DESCRIPTION
Clean re-run of PR #134 with only the intended sentinel + SQL changes. Three contaminating src/ files removed.

References PR #133 investigation.

**Fix 1 — Phase 4 heuristic:** `_shared_substantive_layer_ratio` replaces byte-size arm64 heuristic. Resolves false positive on 1B embed (confirmed aarch64). Ratio > 0.5 of substantive layers shared = packaging defect.

**Fix 2 — Phase 1 auth:** NGC auth URL swap from `authn.nvidia.com` to `nvcr.io/proxy_auth` (nvapi-* key compat). Mirrors proven pattern in `nim_pull_to_nas._get_token()`.

**Post-merge:** Gary runs `scripts/reset_nim_arm64_baseline_post_heuristic_fix.sql` against `fortress_db` to clear the stale 1B embed row. Next 06:30 cron will write a correct `ARM64_OK` baseline.

Supersedes #134 (closed). Contaminated branch preserved at tag `backup/sentinel-pr-134-contaminated-2026-04-22`.