### PR TITLE
feat(legal): bakeoff training infrastructure — seed + per-model LoRA + candidate aliases

### DIFF
--- a/src/judge/base_model_locator.py
+++ b/src/judge/base_model_locator.py
@@ -29,19 +29,28 @@ _MODEL_ALIASES: dict[str, list[str]] = {
     "qwen2.5:7b":      ["Qwen--Qwen2.5-7B-Instruct", "Qwen--Qwen2.5-7B"],
     "qwen2.5:0.5b":    ["Qwen--Qwen2.5-0.5B-Instruct"],
     "qwen2.5:1.5b":    ["Qwen--Qwen2.5-1.5B-Instruct"],
+    "qwen2.5:14b":     ["Qwen--Qwen2.5-14B-Instruct"],
     "qwen2.5:32b":     ["Qwen--Qwen2.5-32B-Instruct"],
     "deepseek-r1:70b": ["deepseek-ai--DeepSeek-R1-Distill-Llama-70B"],
+    "mistral:7b-v0.3": ["mistralai--Mistral-7B-Instruct-v0.3"],
+    "phi3:medium":     ["microsoft--Phi-3-medium-128k-instruct"],
 }
 
 # Maps friendly names → actual directory names on NAS (flat, no HF double-dash format).
 # The NAS direct search uses these before falling back to the generic name transform.
 _NAS_ALIASES: dict[str, list[str]] = {
-    "qwen2.5:7b":               ["Qwen2.5-7B-Instruct"],
-    "Qwen/Qwen2.5-7B-Instruct": ["Qwen2.5-7B-Instruct"],
-    "qwen2.5:0.5b":             ["Qwen2.5-0.5B-Instruct"],
-    "qwen2.5:1.5b":             ["Qwen2.5-1.5B-Instruct"],
-    "qwen2.5:32b":              ["Qwen2.5-32B-Instruct"],
-    "deepseek-r1:70b":          ["DeepSeek-R1-Distill-Llama-70B"],
+    "qwen2.5:7b":                              ["Qwen2.5-7B-Instruct"],
+    "Qwen/Qwen2.5-7B-Instruct":               ["Qwen2.5-7B-Instruct"],
+    "qwen2.5:0.5b":                            ["Qwen2.5-0.5B-Instruct"],
+    "qwen2.5:1.5b":                            ["Qwen2.5-1.5B-Instruct"],
+    "qwen2.5:14b":                             ["bases/Qwen2.5-14B-Instruct"],
+    "Qwen/Qwen2.5-14B-Instruct":              ["bases/Qwen2.5-14B-Instruct"],
+    "qwen2.5:32b":                             ["Qwen2.5-32B-Instruct"],
+    "deepseek-r1:70b":                         ["DeepSeek-R1-Distill-Llama-70B"],
+    "mistral:7b-v0.3":                         ["bases/Mistral-7B-Instruct-v0.3"],
+    "mistralai/Mistral-7B-Instruct-v0.3":     ["bases/Mistral-7B-Instruct-v0.3"],
+    "phi3:medium":                             ["bases/Phi-3-medium-128k-instruct"],
+    "microsoft/Phi-3-medium-128k-instruct":   ["bases/Phi-3-medium-128k-instruct"],
 }
 
 

--- a/src/legal/bakeoff_train.sh
+++ b/src/legal/bakeoff_train.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# bakeoff_train.sh — Train one bake-off candidate adapter with locked hyperparams.
+#
+# Usage:
+#   CANDIDATE=c1_qwen14b bash src/legal/bakeoff_train.sh
+#   CANDIDATE=c2_mistral7b bash src/legal/bakeoff_train.sh
+#   CANDIDATE=c3_phi3medium bash src/legal/bakeoff_train.sh
+#
+# All hyperparams locked; only BASE_MODEL, OUTPUT_DIR, and LORA_TARGET_MODULES differ.
+
+set -euo pipefail
+
+CANDIDATE="${CANDIDATE:?must set CANDIDATE (c0_qwen7b|c1_qwen14b|c2_mistral7b|c3_phi3medium)}"
+PYTHON="/home/admin/Fortress-Prime/fortress-guest-platform/.uv-venv/bin/python3"
+TRAIN_DATA="/mnt/fortress_nas/legal-corpus/training-pairs/train.jsonl"
+VAL_DATA="/mnt/fortress_nas/legal-corpus/training-pairs/val.jsonl"
+BAKEOFF_DIR="/mnt/fortress_nas/models/bakeoff_20260422"
+LOG_DIR="/home/admin/Fortress-Prime/logs"
+DATE=$(date +%Y%m%d)
+
+# ── Locked hyperparams (identical for all candidates) ─────────────────────────
+export LEGAL_LORA_RANK=16
+export LEGAL_LORA_ALPHA=32
+export LEGAL_MAX_SEQ_LEN=4096
+export LEGAL_EPOCHS=3
+export LEGAL_LR=2e-4
+export LEGAL_BATCH_SIZE=1
+export LEGAL_GRAD_ACCUM=8
+export LEGAL_EVAL_STEPS=50
+export LEGAL_SEED=42
+export PYTHONPATH=/home/admin/Fortress-Prime
+
+# ── Per-candidate config ───────────────────────────────────────────────────────
+case "$CANDIDATE" in
+  c0_qwen7b)
+    export LEGAL_BASE_MODEL="qwen2.5:7b"
+    export LEGAL_LORA_TARGET_MODULES="q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj"
+    ;;
+  c1_qwen14b)
+    export LEGAL_BASE_MODEL="qwen2.5:14b"
+    export LEGAL_LORA_TARGET_MODULES="q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj"
+    ;;
+  c2_mistral7b)
+    export LEGAL_BASE_MODEL="mistral:7b-v0.3"
+    export LEGAL_LORA_TARGET_MODULES="q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj"
+    ;;
+  c3_phi3medium)
+    export LEGAL_BASE_MODEL="phi3:medium"
+    export LEGAL_LORA_TARGET_MODULES="qkv_proj,o_proj,gate_up_proj,down_proj"
+    ;;
+  *)
+    echo "Unknown candidate: $CANDIDATE" >&2; exit 1 ;;
+esac
+
+OUTPUT_DIR="${BAKEOFF_DIR}/${CANDIDATE}"
+LOG_FILE="${LOG_DIR}/bakeoff_${CANDIDATE}_${DATE}.log"
+
+mkdir -p "$OUTPUT_DIR"
+echo "[$(date -Iseconds)] Starting bakeoff train: CANDIDATE=$CANDIDATE BASE=$LEGAL_BASE_MODEL" | tee -a "$LOG_FILE"
+
+"$PYTHON" -m src.legal.train_legal_instruct \
+  --train  "$TRAIN_DATA" \
+  --val    "$VAL_DATA" \
+  --output-dir "$OUTPUT_DIR" \
+  2>&1 | tee -a "$LOG_FILE"
+
+echo "[$(date -Iseconds)] DONE: $CANDIDATE" | tee -a "$LOG_FILE"

--- a/src/legal/train_legal_instruct.py
+++ b/src/legal/train_legal_instruct.py
@@ -67,10 +67,17 @@ BATCH_SIZE    = int(os.getenv("LEGAL_BATCH_SIZE",   "1"))
 GRAD_ACCUM    = int(os.getenv("LEGAL_GRAD_ACCUM",   "8"))
 EVAL_STEPS    = int(os.getenv("LEGAL_EVAL_STEPS",   "50"))
 MIN_EXAMPLES  = int(os.getenv("LEGAL_MIN_EXAMPLES", "50"))
+TRAINING_SEED = int(os.getenv("LEGAL_SEED",         "42"))
 NTFY_TOPIC    = os.getenv("NTFY_TOPIC", "")
 
-LORA_TARGET_MODULES = ["q_proj", "k_proj", "v_proj", "o_proj",
-                        "gate_proj", "up_proj", "down_proj"]
+# Default target modules for Qwen/Mistral dense models.
+# Override via LEGAL_LORA_TARGET_MODULES (comma-separated) for other architectures.
+# Phi-3: "qkv_proj,o_proj,gate_up_proj,down_proj"
+_default_modules = ["q_proj", "k_proj", "v_proj", "o_proj",
+                    "gate_proj", "up_proj", "down_proj"]
+_modules_env = os.getenv("LEGAL_LORA_TARGET_MODULES", "")
+LORA_TARGET_MODULES = [m.strip() for m in _modules_env.split(",") if m.strip()] \
+                      if _modules_env else _default_modules
 
 # Prompt template — mirrors the chat template the model was trained on
 _SYSTEM = (
@@ -325,6 +332,7 @@ def train(args: argparse.Namespace) -> int:
             optim="adamw_torch_fused",        # no bitsandbytes needed on unified memory
             max_length=MAX_SEQ_LEN, dataset_text_field="text",
             packing=True, report_to="none",
+            seed=TRAINING_SEED, data_seed=TRAINING_SEED,
         )
         trainer = SFTTrainer(
             model=model, args=sft,


### PR DESCRIPTION
Fortress Legal training infrastructure for comparing multiple base models.

Changes:
- src/judge/base_model_locator.py — adds qwen2.5:14b, mistral:7b-v0.3, phi3:medium as candidate aliases
- src/legal/bakeoff_train.sh — new wrapper script runs training across candidates
- src/legal/train_legal_instruct.py — TRAINING_SEED + LORA_TARGET_MODULES env overrides for reproducibility

This is Fortress Legal domain work, independent of tonight's sentinel + NGC hardening. Original commit authored dc43e6517 (local-only until now).

Gary to review with Legal training context.