### PR TITLE
audit: housekeeping sweep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,5 +101,10 @@ __pycache__/
 # Background process output
 nohup.out
 
-# Backup files
+# Backup files — env files with live credentials must never be tracked
+*.env.bak
+.env.backup
+.env.telemetry_backup
+*.yaml.bak
+*.yml.bak
 *.bak

--- a/fortress-guest-platform/deploy/vllm_http_proxy.py
+++ b/fortress-guest-platform/deploy/vllm_http_proxy.py
@@ -17,6 +17,9 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 BIND_HOST = os.getenv("VLLM_BRIDGE_BIND", "127.0.0.1")
 BIND_PORT = int(os.getenv("VLLM_BRIDGE_PORT", "18001"))
+# AUDIT NOTE (2026-04-22): Container "vllm-70b-captain" does not exist in `docker ps`.
+# fortress-vllm-bridge.service is active but non-functional. Before re-enabling,
+# stand up the target container or update VLLM_BRIDGE_CONTAINER env var.
 CONTAINER_NAME = os.getenv("VLLM_BRIDGE_CONTAINER", "vllm-70b-captain")
 TARGET_BASE_URL = os.getenv("VLLM_BRIDGE_TARGET_URL", "http://127.0.0.1:8000").rstrip("/")
 DOCKER_BIN = os.getenv("DOCKER_BIN", "/usr/bin/docker")


### PR DESCRIPTION
Safe-only changes from 2026-04-22 full-stack audit (55 findings, 69 evidence files).

**.gitignore additions:**
`*.env.bak`, `.env.backup`, `.env.telemetry_backup`, `*.yaml.bak` — prevents future accidental git tracking of backup env files. Two such files (`.env.backup`, `.env.telemetry_backup`) currently sit in the `fortress-guest-platform/` tree with 135 lines each. They are not tracked (confirmed via git log) but the pattern was absent from .gitignore.

**`vllm_http_proxy.py` comment:**
Added audit note that `fortress-vllm-bridge.service` targets container `vllm-70b-captain` which does not exist in `docker ps`. The service appears active/healthy in systemd but is non-functional. Operators should not assume the legal inference bridge is working.

**Not in this PR (needs Gary):** UFW rules, Stripe idempotency fix, trust ledger migration, NIM key rotation, IRON_DOME update, npm audit fix, PostgreSQL tuning.

See full report: `/mnt/fortress_nas/audits/fortress-prime-audit-20260422.md`