### PR TITLE
fix(stripe): idempotency guard on payment_intent.succeeded webhook

### DIFF
--- a/fortress-guest-platform/backend/api/stripe_webhooks.py
+++ b/fortress-guest-platform/backend/api/stripe_webhooks.py
@@ -32,12 +32,13 @@ Dual-journal commit (capex path):
 import stripe
 import structlog
 from fastapi import APIRouter, Depends, Header, HTTPException, Request
-from sqlalchemy import text
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.core.config import settings
 from backend.core.database import get_db
 from backend.integrations.stripe_payments import StripePayments
+from backend.models.reservation_hold import ReservationHold
 from backend.services.booking_hold_service import BookingHoldError, convert_hold_to_reservation
 
 logger = structlog.get_logger()
@@ -81,6 +82,26 @@ async def stripe_webhook(
             meta_hold = metadata.get("hold_id") or metadata.get("reservation_hold_id")
             meta_hold = str(meta_hold).strip() if meta_hold else None
             if payment_intent_id:
+                # ── Idempotency pre-check ────────────────────────────────────────────
+                # If the hold is already converted (status == "converted" +
+                # converted_reservation_id set), this is a Stripe retry of a
+                # successfully settled payment. Return 200 immediately — the same
+                # response Stripe received the first time — so it stops retrying.
+                # Without this guard the handler raises HTTP 409, which Stripe treats
+                # as a transient error and retries indefinitely.
+                _hold_status = await db.scalar(
+                    select(ReservationHold.status).where(
+                        ReservationHold.payment_intent_id == payment_intent_id
+                    )
+                )
+                if _hold_status == "converted":
+                    logger.info(
+                        "direct_booking_already_processed",
+                        payment_intent_id=payment_intent_id,
+                    )
+                    return {"event_type": event_type, "status": "already_processed"}
+                # ────────────────────────────────────────────────────────────────────
+
                 try:
                     reservation = await convert_hold_to_reservation(
                         payment_intent_id,
@@ -88,6 +109,16 @@ async def stripe_webhook(
                         metadata_hold_id=meta_hold,
                     )
                 except BookingHoldError as exc:
+                    # "Hold already finalized" means a race was won by the client-side
+                    # confirm flow or a concurrent webhook delivery. Treat as success so
+                    # Stripe does not retry (HTTP 409 triggers retries).
+                    if "already finalized" in str(exc).lower():
+                        logger.info(
+                            "direct_booking_already_processed",
+                            payment_intent_id=payment_intent_id,
+                            detail=str(exc),
+                        )
+                        return {"event_type": event_type, "status": "already_processed"}
                     logger.warning(
                         "direct_booking_hold_conversion_rejected",
                         payment_intent_id=payment_intent_id,

--- a/fortress-guest-platform/backend/tests/test_stripe_webhook_convergence.py
+++ b/fortress-guest-platform/backend/tests/test_stripe_webhook_convergence.py
@@ -175,3 +175,115 @@ async def test_stripe_webhook_legacy_sync_failure_queues_reconciliation() -> Non
         stripe_payment_intent_id="pi_bridge_fail",
         failure_reason="streamline_unreachable",
     )
+
+
+# ── Idempotency tests (fix: audit finding A-01) ───────────────────────────────
+
+@pytest.mark.asyncio
+async def test_stripe_webhook_duplicate_delivery_returns_200_without_converting() -> None:
+    """
+    Stripe retries a webhook that was already successfully processed.
+    db.scalar pre-check returns "converted" → returns 200 immediately.
+    convert_hold_to_reservation must NOT be called (would attempt double settlement).
+    """
+    app = build_stripe_webhook_test_app()
+    mock_session = AsyncMock()
+
+    # db.scalar returns "converted" — hold was already settled
+    mock_session.scalar.return_value = "converted"
+
+    async def override_get_db():
+        yield mock_session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    with (
+        patch(
+            "backend.api.stripe_webhooks.StripePayments.handle_webhook",
+            new_callable=AsyncMock,
+            return_value={
+                "type": "payment_intent.succeeded",
+                "data": {
+                    "object": {
+                        "id": "pi_already_settled",
+                        "metadata": {"source": "direct_booking_hold"},
+                    }
+                },
+            },
+        ),
+        patch(
+            "backend.api.stripe_webhooks.convert_hold_to_reservation",
+            new_callable=AsyncMock,
+        ) as convert_hold,
+    ):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/api/webhooks/stripe",
+                content=b"{}",
+                headers={"stripe-signature": "sig_test"},
+            )
+
+    app.dependency_overrides.clear()
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "already_processed"
+    convert_hold.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stripe_webhook_already_finalized_error_returns_200_not_409() -> None:
+    """
+    convert_hold_to_reservation raises BookingHoldError("Hold already finalized", 409)
+    because a race was won by the client-side confirm flow or a concurrent webhook.
+    The handler must return HTTP 200 (not 409) so Stripe stops retrying.
+
+    CLAUDE.md invariant: duplicate event is success, not an error.
+    HTTP 409 from the handler causes Stripe retry storms.
+    """
+    from backend.services.booking_hold_service import BookingHoldError
+
+    app = build_stripe_webhook_test_app()
+    mock_session = AsyncMock()
+
+    # db.scalar returns None — hold not found yet (race: convert raises "already finalized")
+    mock_session.scalar.return_value = None
+
+    async def override_get_db():
+        yield mock_session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    with (
+        patch(
+            "backend.api.stripe_webhooks.StripePayments.handle_webhook",
+            new_callable=AsyncMock,
+            return_value={
+                "type": "payment_intent.succeeded",
+                "data": {
+                    "object": {
+                        "id": "pi_race_condition",
+                        "metadata": {"source": "direct_booking_hold"},
+                    }
+                },
+            },
+        ),
+        patch(
+            "backend.api.stripe_webhooks.convert_hold_to_reservation",
+            new_callable=AsyncMock,
+            side_effect=BookingHoldError("Hold already finalized", 409),
+        ),
+    ):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/api/webhooks/stripe",
+                content=b"{}",
+                headers={"stripe-signature": "sig_test"},
+            )
+
+    app.dependency_overrides.clear()
+
+    # Must be 200, not 409 — Stripe treats 4xx as retriable
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "already_processed"


### PR DESCRIPTION
**Closes audit finding A-01 (CRITICAL).**

## Problem

The `direct_booking_hold` settlement path in `stripe_webhooks.py` was the only `payment_intent.succeeded` handler without an explicit idempotency pre-check. Three other handlers in the same file (guest_quote, capex, storefront) all have one.

Two concrete failure modes:

1. **Stripe retry on 409:** When a client-side confirm races with a webhook delivery, `convert_hold_to_reservation` raises `BookingHoldError("Hold already finalized", 409)`. The handler propagated this as HTTP 409. Stripe treats 4xx (except 400/401) as transient and retries — triggering retry storms and repeated attempts at an already-settled booking.

2. **No pre-check guard:** On any Stripe retry, the handler called `convert_hold_to_reservation` unconditionally, relying entirely on the service layer's internal `already_finalized` flag — which is correct but not accessible at the webhook level, and still attempts DB operations and lock acquisition before determining the work is done.

## Fix

1. **Pre-check:** `await db.scalar(select(ReservationHold.status).where(payment_intent_id == ...))` — if `status == "converted"`, return HTTP 200 immediately without touching `convert_hold_to_reservation`.

2. **BookingHoldError "already finalized" → HTTP 200:** Catch this specific error and return 200 so Stripe stops retrying.

Per CLAUDE.md: *"a duplicate event is a success, not an error. Never re-raise IntegrityError from an idempotent trust posting path."*

## Tests

2 new tests in `test_stripe_webhook_convergence.py` (5/5 pass):
- `test_stripe_webhook_duplicate_delivery_returns_200_without_converting` — pre-check fires, `convert_hold_to_reservation` is never called
- `test_stripe_webhook_already_finalized_error_returns_200_not_409` — race condition path returns 200 not 409

No existing tests modified. One pre-existing coroutine warning in the legacy sync test (unrelated).