### PR TITLE
infra: disable fortress-vllm-bridge.service (I-03)

### DIFF
--- a/fortress-guest-platform/deploy/systemd/fortress-vllm-bridge.service
+++ b/fortress-guest-platform/deploy/systemd/fortress-vllm-bridge.service
@@ -1,3 +1,9 @@
+# PHASE 1 (2026-04-23): SERVICE DISABLED — Audit finding I-03.
+# The vLLM bridge proxy (127.0.0.1:18001 → vllm-70b-captain container) became
+# dead code when the vllm-70b-captain container was retired. Unit file is
+# preserved so Phase 3 (real vLLM stand-up) can re-use or replace it directly.
+# To re-activate: remove these 6 header lines and:
+#   sudo systemctl enable --now fortress-vllm-bridge
 [Unit]
 Description=Fortress vLLM Bridge
 Wants=network-online.target docker.service


### PR DESCRIPTION
## Summary
- Stopped + disabled `fortress-vllm-bridge.service` — it was targeting the retired `vllm-70b-captain` container.
- Unit file preserved with a 6-line Phase 1 header so Phase 3 (real vLLM + Qwen 7B + e3.1 adapter on spark-2) can re-use or replace it cleanly.
- Closes audit finding I-03.

## Test plan
- [x] `systemctl is-active fortress-vllm-bridge` → `inactive`
- [x] `systemctl is-enabled fortress-vllm-bridge` → `linked` (no `multi-user.target.wants` entry; will not auto-start on boot)
- [x] No listener on port 18001 (`ss -tlnp | grep :18001` empty)
- [x] Unit + header visible via `systemctl cat fortress-vllm-bridge`
- [x] No systemd unit or repo code references `fortress-vllm-bridge` / `VLLM_BRIDGE` / port `18001` aside from `install_services.sh`

Ref: `/mnt/fortress_nas/audits/fortress-prime-audit-20260422.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)