### PR TITLE
infra: spark-3 Vision NIM env-file + KV tune (I-09, I-01)

### DIFF
--- a/deploy/systemd/fortress-nim-vision-concierge.service
+++ b/deploy/systemd/fortress-nim-vision-concierge.service
@@ -1,0 +1,59 @@
+[Unit]
+Description=Fortress NIM Vision Concierge — nvidia/nemotron-nano-12b-v2-vl on spark-3
+Documentation=file:///home/admin/Fortress-Prime/deploy/systemd/fortress-nim-vision-concierge.service
+After=docker.service network-online.target
+Requires=docker.service
+
+[Service]
+Type=simple
+User=admin
+Group=admin
+Restart=always
+RestartSec=30
+TimeoutStartSec=300
+
+# Phase 1 (2026-04-23) — audit findings I-01, I-09:
+# - I-09: NGC_API_KEY moved off docker -e plaintext arg (was visible in ps -ef)
+#   onto --env-file /etc/fortress/nim.env (root:admin 640; docker CLI reads file directly).
+# - I-01: NIM_KVCACHE_PERCENT pinned to 0.55 to keep spark-3 RAM <=60% of 121 GiB
+#   per IRON_DOME headroom rule. Was previously unset (NIM vLLM default ~0.9).
+#   If RAM still >60% post-restart, tune down to 0.50 and re-verify.
+# No systemd EnvironmentFile needed — docker consumes the file directly.
+
+ExecStartPre=-/usr/bin/docker stop fortress-nim-vision-concierge
+ExecStartPre=-/usr/bin/docker rm fortress-nim-vision-concierge
+
+# Load from NAS if pinned image not in local Docker daemon cache
+# Pinned to arm64 manifest digest sha-33032f00aed9 (pulled 2026-04-21)
+ExecStartPre=/bin/bash -c '\
+  if ! docker image inspect nvcr.io/nim/nvidia/nemotron-nano-12b-v2-vl:sha-33032f00aed9 >/dev/null 2>&1; then \
+    if ! docker image inspect nvcr.io/nim/nvidia/nemotron-nano-12b-v2-vl:latest >/dev/null 2>&1; then \
+      echo "Loading NIM from NAS cache..."; \
+      docker load < /mnt/fortress_nas/nim-cache/nim/nemotron-nano-12b-v2-vl/latest/image.tar; \
+    fi; \
+    docker tag nvcr.io/nim/nvidia/nemotron-nano-12b-v2-vl:latest nvcr.io/nim/nvidia/nemotron-nano-12b-v2-vl:sha-33032f00aed9; \
+  fi'
+
+# Gate via spark-3 VISION_BUSY marker (prevents Financial GPU contention)
+ExecStartPre=/bin/bash -c '\
+  source /mnt/fortress_nas/spark3/vision_guard.sh || exit 1'
+
+ExecStart=/usr/bin/docker run \
+  --name fortress-nim-vision-concierge \
+  --rm \
+  --gpus all \
+  --shm-size=16g \
+  -p 8101:8000 \
+  -v /mnt/fortress_nas/nim-cache/nim/nemotron-nano-12b-v2-vl/nim-weights-cache:/opt/nim/.cache \
+  --env-file /etc/fortress/nim.env \
+  -e NIM_KVCACHE_PERCENT=0.55 \
+  nvcr.io/nim/nvidia/nemotron-nano-12b-v2-vl:sha-33032f00aed9
+
+ExecStop=/usr/bin/docker stop fortress-nim-vision-concierge
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=fortress-nim-vision-concierge
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
Two audit findings resolved in one unit edit on spark-3:

- **I-09 (NGC key leak):** NGC_API_KEY moved off the `-e` plaintext docker arg (visible in `ps -ef` and `systemctl cat`) onto `--env-file /etc/fortress/nim.env` (mode 640 root:admin). The systemd `EnvironmentFile=` directive was dropped since docker now consumes the file directly.
- **I-01 (RAM headroom):** `-e NIM_KVCACHE_PERCENT=0.55` added inline in `docker run`. Was previously unset (the NIM vLLM profile default is ~0.9). spark-3 RAM dropped from 69.4% → 49.5% under load — 10.5 pts below the IRON_DOME 60% ceiling.

Also formalizes the unit in the repo at the path referenced by its `Documentation=` line. Previously the canonical copy lived only on spark-3.

## Test plan
- [x] `systemctl is-active` → `active`
- [x] `/v1/health/ready` → HTTP 200 `{"message":"Service is ready."}` at 345s post-restart
- [x] `/v1/models` → HTTP 200, lists `nvidia/nemotron-nano-12b-v2-vl`
- [x] `ps -ef | grep 'docker.*vision-concierge'` — no `NGC_API_KEY=nvapi-…` in cmdline
- [x] `systemctl cat fortress-nim-vision-concierge` — no `nvapi-…` plaintext
- [x] `docker inspect .Config.Env` — contains `NGC_API_KEY=…` and `NIM_KVCACHE_PERCENT=0.55` (expected: docker propagates `--env-file` vars into container env; access requires docker socket privilege)
- [x] `free -h` — 49.5% used / 121 GiB total
- [x] vision inference (3 calls, 1x1 PNG + "Describe in one word" prompt) — median 0.61s, 0.74x pre-restart baseline

## Notes
- `NIM_KVCACHE_PERCENT` intentionally kept inline in ExecStart (not in the env-file), since it is not a secret and should be diff-visible in `systemctl cat`.
- Audit gave explicit go-ahead to tune lower (0.50) if 0.55 wasn't enough. Current headroom is comfortable; no further tune needed.
- /etc/fortress/nim.env on both spark-2 and spark-3 normalized to mode 640 root:admin for `--env-file` compatibility. /etc/fortress/secrets.env stays at 600 (only read by systemd-as-root via EnvironmentFile).

Ref: `/mnt/fortress_nas/audits/fortress-prime-audit-20260422.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)