### PR TITLE
fix(vectorizer): point embed URL at Ollama :11434, not dead Captain:80 nginx

### DIFF
--- a/fortress-guest-platform/backend/workers/vectorizer.py
+++ b/fortress-guest-platform/backend/workers/vectorizer.py
@@ -9,7 +9,9 @@ Designed to be called:
   - As a post-sync hook from sync_all() in streamline_vrs.py
   - Standalone for backfill:  python -m backend.workers.vectorizer
 
-Embedding model: nomic-embed-text (768-dim) on Nginx LB (Captain:80)
+Embedding model: nomic-embed-text (768-dim) via Ollama on spark-1 (192.168.0.100:11434).
+(Historical: was "Nginx LB (Captain:80)" — the nginx LB is gone; this endpoint now
+ points directly at Ollama's /api/embeddings, which serves the same model + format.)
 """
 
 import hashlib
@@ -27,7 +29,7 @@ from backend.core.qdrant import COLLECTION_NAME, VECTOR_DIM
 
 logger = structlog.get_logger()
 
-EMBED_URL = f"http://192.168.0.100/api/embeddings"
+EMBED_URL = "http://192.168.0.100:11434/api/embeddings"
 EMBED_MODEL = "nomic-embed-text"
 QDRANT_BATCH_SIZE = 50
 MAX_RECORDS_PER_RUN = 500


### PR DESCRIPTION
## Summary

Fix `backend/workers/vectorizer.py` — hard-coded `EMBED_URL` pointed at `http://192.168.0.100/api/embeddings` (port 80, implying an nginx LB that no longer exists). Result: all `vectorize_new_records` jobs completed in ~0.4s with `errors=341, properties=0` — zero actual work done, backlog grew unnoticed.

Change: point directly at Ollama's native embeddings endpoint on the same host:
```
-EMBED_URL = f"http://192.168.0.100/api/embeddings"
+EMBED_URL = "http://192.168.0.100:11434/api/embeddings"
```

Ollama already serves `nomic-embed-text` (the expected 768-dim model) at `/api/embeddings` with the exact same request/response shape the vectorizer uses. Confirmed via manual POST:
```
$ curl -sS -X POST http://192.168.0.100:11434/api/embeddings -d '{"model":"nomic-embed-text","prompt":"hello"}'
{"embedding": [-0.154, -0.030, -3.913, ...]}  # 768-dim vector
```

Also updated the file's header comment (was "Nginx LB (Captain:80)") to reflect the current deployment.

## Context

This was discovered during a P0 investigation into `fortress-event-consumer` journal errors (`embedding_request_failed`). Two separate embedder pipelines were conflated:
- `backend/core/vector_db.py` reads `settings.embed_base_url` → Ollama. That path was temporarily broken when `ollama.service` was stopped for an unrelated brain deployment and has since been restored.
- `backend/workers/vectorizer.py` has its own hard-coded `EMBED_URL` → the dead LB. This PR fixes that second path.

Full diagnostic chain recorded in `/mnt/fortress_nas/audits/failures-log.md`.

## Followups (not in this PR)

- Unify both paths onto `settings.embed_base_url` — eliminate the hard-coded URL.
- Switch from Ollama's single-prompt `/api/embeddings` to the batched form (or OpenAI-compatible `/v1/embeddings` with array input) to drain backlogs faster; current serial loop is throughput-bound.
- 326 DB rows currently in `async_job_runs` status='queued' for `vectorize_new_records` were orphaned (arq jobs expired). They were re-enqueued via a one-off script (`/tmp/replay_vectorize.py`) while this PR was in flight; worker is now draining them at the concurrency limit (~1 per Ollama round-trip, slowed by 500s reindex_property_knowledge jobs holding 7 of the 8 concurrency slots).

## Test plan

- [x] Manual POST to :11434/api/embeddings returns 768-dim vector.
- [x] arq-worker restarted cleanly after code change (no import/auth errors).
- [x] Replay script re-enqueued 326 orphan rows; arq Redis ZSET now has those jobs queued.
- [x] One vectorize_new_records job is in status='running' post-restart (processing through the handler with the fixed URL).

Generated with Claude Code.