### PR TITLE
feat(captain): multi-mailbox intake — 1 Gmail + 4 IMAP with privilege filter

### DIFF
--- a/fortress-guest-platform/.env.example
+++ b/fortress-guest-platform/.env.example
@@ -154,3 +154,37 @@ JUDGE_MIN_EXAMPLES=50           # Minimum labeled examples required for training
 ADMIN_SEED_PASSWORD=<set-via-vault>      # seed_master_admin.py — staff admin account password
 FORTRESS_SMOKE_PASSWORD=<set-via-vault>  # smoke_test_seo.py + E2E Playwright helpers
 E2E_LOGIN_EMAIL=<set-via-vault>          # E2E Playwright helpers — staff login email
+
+# ---------------------------------------------------------------------------
+# Captain — multi-mailbox email intake
+# ---------------------------------------------------------------------------
+# JSON list consumed by backend.services.captain_multi_mailbox.
+# Each entry:
+#   { "name": "<short-id>",
+#     "transport": "gmail_api" | "imap",
+#     "address": "<full email address>",
+#     "host": "<imap host, imap only>",
+#     "port": <int, default 993>,
+#     "credentials_ref": "<env var name holding password, imap only>",
+#     "poll_interval_sec": <int, default 120>,
+#     "routing_tag": "operations" | "legal" | "executive",
+#     "folder": "INBOX" }
+#
+# Gmail API mailboxes reuse GMAIL_CLIENT_ID / GMAIL_CLIENT_SECRET /
+# GMAIL_REFRESH_TOKEN. IMAP mailboxes resolve credentials_ref via os.environ
+# (e.g. MAILPLUS_PASSWORD_GARY_GARYKNIGHT_COM). The loop is gated on
+# LEGAL_EMAIL_INTAKE_ENABLED.
+MAILBOXES_CONFIG=[]
+# Example — 1 Gmail API + 4 cPanel IMAP on mail.cabin-rentals-of-georgia.com:
+# MAILBOXES_CONFIG=[
+#   {"name":"crog-gmail","transport":"gmail_api","address":"cabin.rentals.of.georgia@gmail.com","routing_tag":"operations","poll_interval_sec":120},
+#   {"name":"legal-cpanel","transport":"imap","host":"mail.cabin-rentals-of-georgia.com","port":993,"address":"legal@cabin-rentals-of-georgia.com","credentials_ref":"LEGAL_MAILPLUS_PASSWORD","routing_tag":"legal","poll_interval_sec":120},
+#   {"name":"gary-crog","transport":"imap","host":"mail.cabin-rentals-of-georgia.com","port":993,"address":"gary@cabin-rentals-of-georgia.com","credentials_ref":"MAILPLUS_PASSWORD_GARY","routing_tag":"executive","poll_interval_sec":120},
+#   {"name":"info-crog","transport":"imap","host":"mail.cabin-rentals-of-georgia.com","port":993,"address":"info@cabin-rentals-of-georgia.com","credentials_ref":"MAILPLUS_PASSWORD_INFO","routing_tag":"operations","poll_interval_sec":120},
+#   {"name":"gary-gk","transport":"imap","host":"mail.cabin-rentals-of-georgia.com","port":993,"address":"gary@garyknight.com","credentials_ref":"MAILPLUS_PASSWORD_GARY_GARYKNIGHT_COM","routing_tag":"executive","poll_interval_sec":120}
+# ]
+
+# Optional — attorney / law-firm domain allowlist for privilege_filter.
+# Comma-separated. Extends the built-in set; any sender or recipient on
+# these domains routes the capture to restricted_captures.
+# ATTORNEY_DOMAINS=examplefirm.com,counselor.legal

--- a/fortress-guest-platform/backend/core/worker.py
+++ b/fortress-guest-platform/backend/core/worker.py
@@ -598,6 +598,24 @@ async def startup(ctx: dict[str, Any]) -> None:
         )
         logger.info("legal_email_intake_started_in_worker",
                     interval=settings.legal_email_poll_interval)
+
+        from backend.services.captain_multi_mailbox import (
+            run_captain_multi_mailbox_loop,
+            load_mailbox_configs,
+        )
+        mailboxes = load_mailbox_configs()
+        captain_task = asyncio.create_task(
+            run_captain_multi_mailbox_loop(),
+            name="captain_multi_mailbox_task",
+        )
+        ctx["captain_multi_mailbox_task"] = captain_task
+        captain_task.add_done_callback(
+            lambda t: _log_background_task_result("captain_multi_mailbox_task", t),
+        )
+        logger.info(
+            "captain_multi_mailbox_started_in_worker",
+            mailboxes=[m.name for m in mailboxes],
+        )
     else:
         logger.info("legal_email_intake_disabled")
 

--- a/fortress-guest-platform/backend/services/captain_multi_mailbox.py
+++ b/fortress-guest-platform/backend/services/captain_multi_mailbox.py
@@ -1,0 +1,674 @@
+"""
+Captain — Multi-mailbox email intake (Gmail API + cPanel IMAP).
+
+Polls every configured mailbox, hooks privilege_filter.classify_for_capture()
+on every captured email, and routes the result to llm_training_captures
+(ALLOW) or restricted_captures (RESTRICTED). BLOCK results are dropped.
+
+Configuration comes from the MAILBOXES_CONFIG env var — a JSON list where
+each entry has:
+
+    {
+      "name":             "legal-cpanel",
+      "transport":        "imap" | "gmail_api",
+      "host":             "mail.cabin-rentals-of-georgia.com",
+      "port":             993,
+      "address":          "legal@cabin-rentals-of-georgia.com",
+      "credentials_ref":  "MAILPLUS_PASSWORD_LEGAL_CABIN_RENTALS",
+      "poll_interval_sec": 120,
+      "routing_tag":      "legal"
+    }
+
+For IMAP entries `credentials_ref` names an env var holding the password;
+for Gmail API entries it is ignored — OAuth credentials are read from
+GMAIL_CLIENT_ID / GMAIL_CLIENT_SECRET / GMAIL_REFRESH_TOKEN.
+
+No schema migration is required: captures land in the existing
+llm_training_captures / restricted_captures tables, and source_mailbox
+and routing_tag are written into the capture_metadata JSONB column.
+"""
+from __future__ import annotations
+
+import asyncio
+import email as email_lib
+import imaplib
+import json
+import os
+import re
+import uuid
+from dataclasses import dataclass, field
+from email.header import decode_header
+from email.message import Message
+from typing import Any, Optional
+
+import structlog
+
+from backend.core.config import settings
+from backend.services.privilege_filter import (
+    CaptureDecision,
+    CaptureRoute,
+    classify_for_capture,
+)
+
+logger = structlog.get_logger(service="captain_multi_mailbox")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Config
+# ──────────────────────────────────────────────────────────────────────────────
+
+class MailboxConfigError(ValueError):
+    """Raised when MAILBOXES_CONFIG is malformed."""
+
+
+VALID_TRANSPORTS = frozenset({"imap", "gmail_api"})
+VALID_ROUTING_TAGS = frozenset({"operations", "legal", "executive"})
+
+
+@dataclass(frozen=True)
+class MailboxConfig:
+    name: str
+    transport: str
+    address: str
+    routing_tag: str
+    host: str = ""
+    port: int = 993
+    credentials_ref: str = ""
+    poll_interval_sec: int = 120
+    folder: str = "INBOX"
+
+    def resolve_password(self) -> str:
+        if self.transport != "imap":
+            return ""
+        if not self.credentials_ref:
+            raise MailboxConfigError(
+                f"mailbox {self.name}: imap transport requires credentials_ref"
+            )
+        value = os.environ.get(self.credentials_ref, "")
+        return value
+
+
+def load_mailbox_configs(raw: str | None = None) -> list[MailboxConfig]:
+    """Parse MAILBOXES_CONFIG env var into a list of MailboxConfig."""
+    raw_value = raw if raw is not None else os.environ.get("MAILBOXES_CONFIG", "")
+    if not raw_value.strip():
+        return []
+
+    try:
+        entries = json.loads(raw_value)
+    except json.JSONDecodeError as exc:
+        raise MailboxConfigError(f"MAILBOXES_CONFIG is not valid JSON: {exc}") from exc
+
+    if not isinstance(entries, list):
+        raise MailboxConfigError("MAILBOXES_CONFIG must be a JSON list")
+
+    out: list[MailboxConfig] = []
+    seen_addresses: set[str] = set()
+    for idx, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise MailboxConfigError(f"entry #{idx} is not an object")
+        name = str(entry.get("name") or "").strip()
+        transport = str(entry.get("transport") or "").strip()
+        address = str(entry.get("address") or "").strip()
+        routing_tag = str(entry.get("routing_tag") or "").strip()
+        if not name or not transport or not address or not routing_tag:
+            raise MailboxConfigError(
+                f"entry #{idx}: name/transport/address/routing_tag are required"
+            )
+        if transport not in VALID_TRANSPORTS:
+            raise MailboxConfigError(
+                f"entry {name}: transport must be one of {sorted(VALID_TRANSPORTS)}"
+            )
+        if routing_tag not in VALID_ROUTING_TAGS:
+            raise MailboxConfigError(
+                f"entry {name}: routing_tag must be one of {sorted(VALID_ROUTING_TAGS)}"
+            )
+        if address.lower() in seen_addresses:
+            raise MailboxConfigError(f"entry {name}: duplicate address {address}")
+        seen_addresses.add(address.lower())
+
+        out.append(MailboxConfig(
+            name=name,
+            transport=transport,
+            address=address,
+            routing_tag=routing_tag,
+            host=str(entry.get("host") or ""),
+            port=int(entry.get("port") or 993),
+            credentials_ref=str(entry.get("credentials_ref") or ""),
+            poll_interval_sec=int(entry.get("poll_interval_sec") or 120),
+            folder=str(entry.get("folder") or "INBOX"),
+        ))
+    return out
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Email shape
+# ──────────────────────────────────────────────────────────────────────────────
+
+@dataclass
+class FetchedEmail:
+    subject: str
+    body: str
+    sender_email: str
+    recipient_emails: list[str] = field(default_factory=list)
+    attachment_filenames: list[str] = field(default_factory=list)
+    message_id: str = ""
+
+    @property
+    def sender_domain(self) -> str:
+        if "@" not in self.sender_email:
+            return ""
+        return self.sender_email.rsplit("@", 1)[-1].strip().lower()
+
+
+def _decode_header_value(raw: Any) -> str:
+    if not raw:
+        return ""
+    parts = decode_header(raw)
+    out: list[str] = []
+    for content, charset in parts:
+        if isinstance(content, bytes):
+            out.append(content.decode(charset or "utf-8", errors="replace"))
+        else:
+            out.append(str(content))
+    return " ".join(out)
+
+
+def _extract_plain_body(msg: Message) -> str:
+    if msg.is_multipart():
+        for part in msg.walk():
+            ctype = part.get_content_type()
+            disp = str(part.get("Content-Disposition", ""))
+            if ctype == "text/plain" and "attachment" not in disp:
+                payload = part.get_payload(decode=True)
+                if isinstance(payload, (bytes, bytearray)):
+                    charset = part.get_content_charset() or "utf-8"
+                    return bytes(payload).decode(charset, errors="replace")
+    else:
+        payload = msg.get_payload(decode=True)
+        if isinstance(payload, (bytes, bytearray)):
+            charset = msg.get_content_charset() or "utf-8"
+            return bytes(payload).decode(charset, errors="replace")
+    return ""
+
+
+_ADDRESS_RE = re.compile(r"<([^>]+)>")
+
+
+def _extract_address(raw: str) -> str:
+    match = _ADDRESS_RE.search(raw)
+    return match.group(1).strip() if match else raw.strip()
+
+
+def _extract_recipient_list(header_values: list[str]) -> list[str]:
+    addresses: list[str] = []
+    for value in header_values:
+        decoded = _decode_header_value(value)
+        for chunk in decoded.split(","):
+            addr = _extract_address(chunk)
+            if addr and "@" in addr:
+                addresses.append(addr)
+    return addresses
+
+
+def _extract_attachments(msg: Message) -> list[str]:
+    names: list[str] = []
+    if not msg.is_multipart():
+        return names
+    for part in msg.walk():
+        disp = str(part.get("Content-Disposition", ""))
+        if "attachment" in disp:
+            fname = _decode_header_value(part.get_filename() or "")
+            if fname:
+                names.append(fname)
+    return names
+
+
+def _parse_rfc822(raw_bytes: bytes) -> FetchedEmail:
+    msg = email_lib.message_from_bytes(raw_bytes)
+    subject = _decode_header_value(msg.get("Subject", ""))
+    from_header = _decode_header_value(msg.get("From", ""))
+    sender_email = _extract_address(from_header)
+    recipients = _extract_recipient_list(
+        msg.get_all("To") or []
+    ) + _extract_recipient_list(
+        msg.get_all("Cc") or []
+    )
+    return FetchedEmail(
+        subject=subject,
+        body=_extract_plain_body(msg),
+        sender_email=sender_email,
+        recipient_emails=recipients,
+        attachment_filenames=_extract_attachments(msg),
+        message_id=_decode_header_value(msg.get("Message-ID", "")),
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Transports
+# ──────────────────────────────────────────────────────────────────────────────
+
+class ImapTransport:
+    """
+    Blocking IMAP poller. Designed to be dispatched via asyncio.to_thread().
+
+    Opens a fresh IMAP4_SSL connection per fetch cycle. If the first login or
+    select fails mid-flight (imaplib.IMAP4.abort, EOFError, OSError), reconnects
+    once with a fresh connection — this covers the common cPanel keep-alive
+    drop while an IDLE-style loop is waiting. Multiple mailboxes on the same
+    host each open their own short-lived connection; cPanel does not support
+    concurrent IMAP logins reliably, so pooling is intentionally avoided.
+    """
+
+    def __init__(self, mailbox: MailboxConfig, max_messages: int = 25) -> None:
+        if mailbox.transport != "imap":
+            raise ValueError(f"{mailbox.name}: not an IMAP mailbox")
+        if not mailbox.host:
+            raise MailboxConfigError(f"{mailbox.name}: imap host is required")
+        self.mailbox = mailbox
+        self.max_messages = max_messages
+        self._reconnects = 0
+
+    @property
+    def reconnect_count(self) -> int:
+        return self._reconnects
+
+    def _connect(self) -> imaplib.IMAP4_SSL:
+        conn = imaplib.IMAP4_SSL(self.mailbox.host, self.mailbox.port)
+        password = self.mailbox.resolve_password()
+        if not password:
+            raise MailboxConfigError(
+                f"{self.mailbox.name}: credentials_ref {self.mailbox.credentials_ref} "
+                f"is unset or empty"
+            )
+        conn.login(self.mailbox.address, password)
+        conn.select(self.mailbox.folder)
+        return conn
+
+    def fetch_unseen(self) -> list[FetchedEmail]:
+        attempts = 0
+        last_err: Exception | None = None
+        while attempts < 2:
+            attempts += 1
+            conn: Optional[imaplib.IMAP4_SSL] = None
+            try:
+                conn = self._connect()
+                return self._fetch_with(conn)
+            except (imaplib.IMAP4.abort, EOFError, OSError,
+                    imaplib.IMAP4.error) as exc:
+                last_err = exc
+                if attempts == 1:
+                    self._reconnects += 1
+                    logger.warning(
+                        "captain_imap_reconnect",
+                        mailbox=self.mailbox.name,
+                        error=str(exc)[:200],
+                    )
+                    continue
+                logger.error(
+                    "captain_imap_final_failure",
+                    mailbox=self.mailbox.name,
+                    error=str(exc)[:200],
+                )
+                return []
+            finally:
+                if conn is not None:
+                    try:
+                        conn.close()
+                    except Exception:
+                        pass
+                    try:
+                        conn.logout()
+                    except Exception:
+                        pass
+        if last_err is not None:
+            logger.error(
+                "captain_imap_unexpected_exit",
+                mailbox=self.mailbox.name,
+                error=str(last_err)[:200],
+            )
+        return []
+
+    def _fetch_with(self, conn: imaplib.IMAP4_SSL) -> list[FetchedEmail]:
+        _, msg_nums = conn.search(None, "UNSEEN")
+        if not msg_nums or not msg_nums[0]:
+            return []
+        ids = msg_nums[0].split()[: self.max_messages]
+        out: list[FetchedEmail] = []
+        for mid in ids:
+            try:
+                _, data = conn.fetch(mid, "(RFC822)")
+                if not data or not data[0]:
+                    continue
+                raw_value = data[0][1]
+                if not isinstance(raw_value, (bytes, bytearray)):
+                    continue
+                out.append(_parse_rfc822(bytes(raw_value)))
+                conn.store(mid, "+FLAGS", "\\Seen")
+            except Exception as exc:
+                logger.warning(
+                    "captain_imap_fetch_error",
+                    mailbox=self.mailbox.name,
+                    mid=str(mid),
+                    error=str(exc)[:200],
+                )
+        return out
+
+
+class GmailApiTransport:
+    """
+    Gmail API poller using the users.messages endpoint with pageToken
+    pagination. Uses GMAIL_CLIENT_ID / GMAIL_CLIENT_SECRET / GMAIL_REFRESH_TOKEN
+    from settings to build OAuth2 credentials.
+
+    Delegates the HTTP transport to a `client` callable that returns a Gmail
+    service object. The callable is injectable so tests can hand in a mock
+    without pulling in googleapiclient.
+    """
+
+    def __init__(
+        self,
+        mailbox: MailboxConfig,
+        max_messages: int = 50,
+        client_factory: Optional[Any] = None,
+    ) -> None:
+        if mailbox.transport != "gmail_api":
+            raise ValueError(f"{mailbox.name}: not a gmail_api mailbox")
+        self.mailbox = mailbox
+        self.max_messages = max_messages
+        self._client_factory = client_factory
+        self._service: Any | None = None
+
+    def _build_service(self) -> Any:
+        if self._service is not None:
+            return self._service
+        if self._client_factory is not None:
+            self._service = self._client_factory()
+            return self._service
+        # Lazy import so installations without googleapiclient can still
+        # load the module (e.g. test-only environments).
+        from google.oauth2.credentials import Credentials  # type: ignore[import-not-found]
+        from googleapiclient.discovery import build  # type: ignore[import-not-found]
+
+        creds = Credentials(
+            token=None,
+            refresh_token=settings.gmail_refresh_token,
+            token_uri="https://oauth2.googleapis.com/token",
+            client_id=settings.gmail_client_id,
+            client_secret=settings.gmail_client_secret,
+            scopes=["https://www.googleapis.com/auth/gmail.readonly",
+                    "https://www.googleapis.com/auth/gmail.modify"],
+        )
+        self._service = build("gmail", "v1", credentials=creds, cache_discovery=False)
+        return self._service
+
+    def fetch_unseen(self) -> list[FetchedEmail]:
+        try:
+            service = self._build_service()
+        except Exception as exc:
+            logger.error(
+                "captain_gmail_build_failed",
+                mailbox=self.mailbox.name,
+                error=str(exc)[:200],
+            )
+            return []
+
+        ids: list[str] = []
+        page_token: str | None = None
+        while len(ids) < self.max_messages:
+            req = service.users().messages().list(
+                userId="me",
+                q="is:unread",
+                pageToken=page_token,
+                maxResults=min(100, self.max_messages - len(ids)),
+            )
+            try:
+                resp = req.execute()
+            except Exception as exc:
+                logger.error(
+                    "captain_gmail_list_failed",
+                    mailbox=self.mailbox.name,
+                    error=str(exc)[:200],
+                )
+                break
+            for m in resp.get("messages", []) or []:
+                mid = m.get("id")
+                if mid:
+                    ids.append(mid)
+            page_token = resp.get("nextPageToken")
+            if not page_token:
+                break
+
+        out: list[FetchedEmail] = []
+        for mid in ids[: self.max_messages]:
+            try:
+                raw_resp = service.users().messages().get(
+                    userId="me", id=mid, format="raw"
+                ).execute()
+                import base64
+                raw_b64 = raw_resp.get("raw", "")
+                raw_bytes = base64.urlsafe_b64decode(raw_b64.encode("utf-8"))
+                out.append(_parse_rfc822(raw_bytes))
+                service.users().messages().modify(
+                    userId="me", id=mid,
+                    body={"removeLabelIds": ["UNREAD"]},
+                ).execute()
+            except Exception as exc:
+                logger.warning(
+                    "captain_gmail_fetch_error",
+                    mailbox=self.mailbox.name,
+                    mid=str(mid),
+                    error=str(exc)[:200],
+                )
+        return out
+
+
+def build_transport(
+    mailbox: MailboxConfig,
+    gmail_client_factory: Optional[Any] = None,
+) -> Any:
+    """Build a transport for a mailbox. Factory hook for Gmail testing."""
+    if mailbox.transport == "imap":
+        return ImapTransport(mailbox)
+    if mailbox.transport == "gmail_api":
+        return GmailApiTransport(mailbox, client_factory=gmail_client_factory)
+    raise MailboxConfigError(f"{mailbox.name}: unknown transport {mailbox.transport}")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Capture persistence — privilege_filter hook + write
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _build_capture_metadata(em: FetchedEmail, mailbox: MailboxConfig) -> dict[str, Any]:
+    return {
+        "source_mailbox": mailbox.address,
+        "routing_tag": mailbox.routing_tag,
+        "transport": mailbox.transport,
+        "sender_email": em.sender_email,
+        "sender_domain": em.sender_domain,
+        "recipient_emails": list(em.recipient_emails),
+        "attachment_filenames": list(em.attachment_filenames),
+    }
+
+
+def classify_email(em: FetchedEmail, mailbox: MailboxConfig) -> CaptureDecision:
+    """Run privilege_filter over a captured email with full context."""
+    metadata = _build_capture_metadata(em, mailbox)
+    return classify_for_capture(
+        prompt=em.subject,
+        response=em.body,
+        source_module=f"captain_{mailbox.routing_tag}",
+        metadata=metadata,
+    )
+
+
+async def write_capture(
+    em: FetchedEmail,
+    mailbox: MailboxConfig,
+    decision: CaptureDecision,
+    session_factory: Any | None = None,
+) -> str:
+    """Persist a capture per the privilege_filter decision. Returns route value."""
+    if decision.route == CaptureRoute.BLOCK:
+        logger.info(
+            "captain_capture_blocked",
+            mailbox=mailbox.name,
+            reason=decision.reason,
+        )
+        return decision.route.value
+
+    if session_factory is None:
+        from backend.core.database import AsyncSessionLocal
+        factory: Any = AsyncSessionLocal
+    else:
+        factory = session_factory
+
+    from sqlalchemy import text as sqltext
+    capture_meta = _build_capture_metadata(em, mailbox)
+    source_module = f"captain_{mailbox.routing_tag}"
+    prompt_text = em.subject or ""
+    response_text = em.body or ""
+
+    async with factory() as session:
+        if decision.route == CaptureRoute.ALLOW:
+            await session.execute(
+                sqltext("""
+                    INSERT INTO llm_training_captures
+                        (id, source_module, model_used, user_prompt, assistant_resp,
+                         status, capture_metadata)
+                    VALUES
+                        (:id::uuid, :module, :model, :prompt, :response,
+                         'pending', CAST(:meta AS jsonb))
+                    ON CONFLICT DO NOTHING
+                """),
+                {
+                    "id": str(uuid.uuid4()),
+                    "module": source_module[:120],
+                    "model": "captain_intake",
+                    "prompt": prompt_text[:32_000],
+                    "response": response_text[:32_000],
+                    "meta": json.dumps(capture_meta),
+                },
+            )
+        else:  # RESTRICTED
+            await session.execute(
+                sqltext("""
+                    INSERT INTO restricted_captures
+                        (source_module, prompt, response,
+                         restriction_reason, matched_patterns, capture_metadata)
+                    VALUES
+                        (:module, :prompt, :response, :reason, :patterns,
+                         CAST(:meta AS jsonb))
+                """),
+                {
+                    "module": source_module[:120],
+                    "prompt": prompt_text[:32_000],
+                    "response": response_text[:32_000],
+                    "reason": decision.reason[:256],
+                    "patterns": list(decision.matched_patterns),
+                    "meta": json.dumps(capture_meta),
+                },
+            )
+        await session.commit()
+    return decision.route.value
+
+
+async def process_email(
+    em: FetchedEmail,
+    mailbox: MailboxConfig,
+    session_factory: Any | None = None,
+) -> dict[str, str]:
+    """Classify + persist one email. Returns dict with route and routing_tag."""
+    decision = classify_email(em, mailbox)
+    route = await write_capture(em, mailbox, decision, session_factory=session_factory)
+    logger.info(
+        "captain_email_processed",
+        mailbox=mailbox.name,
+        routing_tag=mailbox.routing_tag,
+        route=route,
+        reason=decision.reason[:120],
+    )
+    return {
+        "mailbox": mailbox.name,
+        "routing_tag": mailbox.routing_tag,
+        "route": route,
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Patrol + loop
+# ──────────────────────────────────────────────────────────────────────────────
+
+async def run_patrol(
+    mailboxes: list[MailboxConfig] | None = None,
+    session_factory: Any | None = None,
+    gmail_client_factory: Any | None = None,
+) -> dict[str, Any]:
+    """Poll every mailbox once and persist captures. Safe to call on demand."""
+    if mailboxes is None:
+        mailboxes = load_mailbox_configs()
+    if not mailboxes:
+        return {"status": "no_mailboxes", "processed": 0}
+
+    stats: dict[str, int] = {"processed": 0, "allow": 0, "restricted": 0, "block": 0}
+    by_tag: dict[str, int] = {}
+
+    for mailbox in mailboxes:
+        try:
+            transport = build_transport(
+                mailbox, gmail_client_factory=gmail_client_factory
+            )
+        except MailboxConfigError as exc:
+            logger.error(
+                "captain_transport_config_error",
+                mailbox=mailbox.name, error=str(exc)[:200],
+            )
+            continue
+        try:
+            emails = await asyncio.to_thread(transport.fetch_unseen)
+        except Exception as exc:
+            logger.error(
+                "captain_fetch_error",
+                mailbox=mailbox.name, error=str(exc)[:200],
+            )
+            continue
+        for em in emails:
+            try:
+                result = await process_email(em, mailbox, session_factory=session_factory)
+            except Exception as exc:
+                logger.error(
+                    "captain_process_error",
+                    mailbox=mailbox.name, error=str(exc)[:200],
+                )
+                continue
+            stats["processed"] += 1
+            stats[result["route"]] = stats.get(result["route"], 0) + 1
+            by_tag[result["routing_tag"]] = by_tag.get(result["routing_tag"], 0) + 1
+
+    return {"status": "patrol_complete", "mailboxes": len(mailboxes), **stats, "by_tag": by_tag}
+
+
+async def run_captain_multi_mailbox_loop(
+    stop_event: asyncio.Event | None = None,
+) -> None:
+    """Infinite loop. Cancellable via asyncio or the provided stop_event."""
+    mailboxes = load_mailbox_configs()
+    interval = min((m.poll_interval_sec for m in mailboxes), default=120)
+    logger.info(
+        "captain_multi_mailbox_loop_started",
+        mailboxes=[m.name for m in mailboxes],
+        interval=interval,
+    )
+    await asyncio.sleep(15)
+    while True:
+        if stop_event is not None and stop_event.is_set():
+            return
+        try:
+            result = await run_patrol(mailboxes=mailboxes)
+            if result.get("processed", 0) > 0:
+                logger.info("captain_patrol_report", **result)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.error("captain_loop_error", error=str(exc)[:200])
+        await asyncio.sleep(interval)

--- a/fortress-guest-platform/backend/services/privilege_filter.py
+++ b/fortress-guest-platform/backend/services/privilege_filter.py
@@ -12,6 +12,7 @@ content accumulates in training set.
 from __future__ import annotations
 
 import logging
+import os
 import re
 from dataclasses import dataclass
 from enum import Enum
@@ -66,6 +67,50 @@ BLOCK_PATTERNS: tuple[tuple[str, re.Pattern], ...] = (
     ("ssn", re.compile(r"\b\d{3}-\d{2}-\d{4}\b")),
     ("credit_card", re.compile(r"\b(?:\d[ -]*?){13,19}\b")),
     ("bank_routing", re.compile(r"\b\d{9}\b(?=.*(?:routing|aba))", re.IGNORECASE)),
+)
+
+
+# ---------------------------------------------------------------------------
+# Attorney / law-firm domain allowlist
+#
+# Built-in starter set; operators can extend via the ATTORNEY_DOMAINS env var
+# (comma-separated). Any inbound mail where the sender or recipient domain
+# matches routes to RESTRICTED. The built-in list is intentionally small —
+# case-specific firms are expected to come from env so the checked-in list
+# doesn't need churn every time representation changes.
+_BUILTIN_ATTORNEY_DOMAINS: frozenset[str] = frozenset({
+    # Fortress Prime / Cabin Rentals of Georgia working roster.
+    # Expand via ATTORNEY_DOMAINS env var — do not hardcode client-specific
+    # firms that rotate.
+})
+
+
+def _load_attorney_domains() -> frozenset[str]:
+    extra = os.environ.get("ATTORNEY_DOMAINS", "")
+    parts = {p.strip().lower() for p in extra.split(",") if p.strip()}
+    return frozenset(_BUILTIN_ATTORNEY_DOMAINS | parts)
+
+
+# ---------------------------------------------------------------------------
+# Plain-language privilege keywords (word-bounded, case-insensitive).
+# Distinct from PRIVILEGE_MARKERS above, which require the bracketed/bolded
+# form. These match the free-text phrases that appear in body copy when
+# correspondence is flagged informally.
+PRIVILEGE_KEYWORDS: tuple[tuple[str, re.Pattern], ...] = (
+    ("keyword:privileged", re.compile(r"\bprivileged\b", re.IGNORECASE)),
+    ("keyword:work_product", re.compile(r"\bwork[ \-]product\b", re.IGNORECASE)),
+    ("keyword:attorney_client", re.compile(r"\battorney[ \-]client\b", re.IGNORECASE)),
+    ("keyword:confidential_settlement",
+     re.compile(r"\bconfidential\s+settlement\b", re.IGNORECASE)),
+)
+
+
+# Docket / case-number patterns commonly used in Georgia state + federal
+# dockets. Matches forms like "2024-CV-001234", "24-CR-42", "Case No. 12345".
+_DOCKET_RE: re.Pattern = re.compile(
+    r"(?:\b\d{2,4}-(?:CV|CR|GA|SC|MD|CA|CI|FA)-\d{2,8}\b)"
+    r"|(?:\bcase\s*(?:no\.?|number)\s*[:#]?\s*\d{2,}(?:-[A-Z0-9]+)*\b)",
+    re.IGNORECASE,
 )
 
 
@@ -127,6 +172,45 @@ def classify_for_capture(
         if marker in prompt or marker in response:
             restrict_reasons.append(f"text_marker:{marker}")
             break
+
+    # --- Captain multi-mailbox extensions ------------------------------------
+    # Additional triggers fed from the email intake metadata. All optional —
+    # backward-compatible: callers that don't set these keys see no change.
+    attorney_domains = _load_attorney_domains()
+
+    def _domain_of(addr: str | None) -> str:
+        if not addr or "@" not in addr:
+            return ""
+        return addr.rsplit("@", 1)[-1].strip().lower()
+
+    sender_domain = str(metadata.get("sender_domain") or "").strip().lower()
+    if not sender_domain:
+        sender_domain = _domain_of(metadata.get("sender_email"))
+
+    if sender_domain and sender_domain in attorney_domains:
+        restrict_reasons.append(f"attorney_domain:{sender_domain}")
+
+    recipient_emails = metadata.get("recipient_emails") or ()
+    for rcpt in recipient_emails:
+        rcpt_domain = _domain_of(rcpt)
+        if rcpt_domain and rcpt_domain in attorney_domains:
+            restrict_reasons.append(f"attorney_domain_rcpt:{rcpt_domain}")
+            break
+
+    attachment_filenames = metadata.get("attachment_filenames") or ()
+    if sender_domain in attorney_domains:
+        for fname in attachment_filenames:
+            if fname and fname.lower().endswith(".pdf"):
+                restrict_reasons.append(f"attorney_pdf:{fname[:64]}")
+                break
+
+    for keyword_label, keyword_re in PRIVILEGE_KEYWORDS:
+        if keyword_re.search(prompt) or keyword_re.search(response):
+            restrict_reasons.append(keyword_label)
+            break
+
+    if _DOCKET_RE.search(combined_text):
+        restrict_reasons.append("docket_number")
 
     if restrict_reasons:
         return CaptureDecision(

--- a/fortress-guest-platform/backend/tests/test_captain_multi_mailbox.py
+++ b/fortress-guest-platform/backend/tests/test_captain_multi_mailbox.py
@@ -1,0 +1,459 @@
+"""
+Tests for the multi-mailbox Captain.
+
+All tests avoid prod DB mutations — writes are captured by an in-memory
+FakeSession. Transports (IMAP / Gmail API) are stubbed so the suite runs
+without network or credentials.
+"""
+from __future__ import annotations
+
+import asyncio
+import imaplib
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from backend.services.captain_multi_mailbox import (
+    FetchedEmail,
+    GmailApiTransport,
+    ImapTransport,
+    MailboxConfig,
+    MailboxConfigError,
+    classify_email,
+    load_mailbox_configs,
+    process_email,
+    run_patrol,
+)
+from backend.services.privilege_filter import CaptureRoute
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fakes
+# ─────────────────────────────────────────────────────────────────────────────
+
+class FakeSession:
+    """Captures SQL + params without hitting a real database."""
+
+    def __init__(self, recorder: list[tuple[str, dict]]) -> None:
+        self._recorder = recorder
+        self.commits = 0
+
+    async def __aenter__(self) -> "FakeSession":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    async def execute(self, stmt, params: dict | None = None) -> None:
+        # stmt is a sqlalchemy TextClause — its str() contains the SQL text.
+        self._recorder.append((str(stmt), dict(params or {})))
+
+    async def commit(self) -> None:
+        self.commits += 1
+
+
+def make_fake_factory(recorder: list[tuple[str, dict]]):
+    def _factory() -> FakeSession:
+        return FakeSession(recorder)
+    return _factory
+
+
+def _mailbox(
+    name: str = "mb",
+    transport: str = "imap",
+    address: str = "x@example.com",
+    routing_tag: str = "operations",
+    host: str = "mail.example.com",
+    credentials_ref: str = "FAKE_PASSWORD",
+) -> MailboxConfig:
+    return MailboxConfig(
+        name=name,
+        transport=transport,
+        address=address,
+        routing_tag=routing_tag,
+        host=host,
+        port=993,
+        credentials_ref=credentials_ref,
+        poll_interval_sec=120,
+    )
+
+
+def _email(
+    subject: str = "hello",
+    body: str = "",
+    sender: str = "sender@example.com",
+    recipients: list[str] | None = None,
+    attachments: list[str] | None = None,
+) -> FetchedEmail:
+    return FetchedEmail(
+        subject=subject,
+        body=body,
+        sender_email=sender,
+        recipient_emails=recipients or [],
+        attachment_filenames=attachments or [],
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Config parsing
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestMailboxConfigLoading:
+    def test_empty_config_returns_empty_list(self):
+        assert load_mailbox_configs("") == []
+        assert load_mailbox_configs("[]") == []
+
+    def test_invalid_json_raises(self):
+        with pytest.raises(MailboxConfigError):
+            load_mailbox_configs("not-json")
+
+    def test_invalid_transport_raises(self):
+        raw = json.dumps([{
+            "name": "x", "transport": "smtp", "address": "a@b.c",
+            "routing_tag": "legal",
+        }])
+        with pytest.raises(MailboxConfigError):
+            load_mailbox_configs(raw)
+
+    def test_invalid_routing_tag_raises(self):
+        raw = json.dumps([{
+            "name": "x", "transport": "imap", "address": "a@b.c",
+            "routing_tag": "random", "host": "h",
+            "credentials_ref": "SOME_ENV",
+        }])
+        with pytest.raises(MailboxConfigError):
+            load_mailbox_configs(raw)
+
+    def test_duplicate_address_raises(self):
+        raw = json.dumps([
+            {"name": "a", "transport": "imap", "address": "x@y.z",
+             "routing_tag": "legal", "host": "h", "credentials_ref": "E1"},
+            {"name": "b", "transport": "imap", "address": "X@y.z",
+             "routing_tag": "legal", "host": "h", "credentials_ref": "E2"},
+        ])
+        with pytest.raises(MailboxConfigError):
+            load_mailbox_configs(raw)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 1 — routing tag recorded on every capture
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestCaptainRoutesByTag:
+    @pytest.mark.asyncio
+    async def test_captain_routes_by_tag(self):
+        mailboxes = [
+            _mailbox("legal-cpanel", address="legal@c.com",
+                     routing_tag="legal"),
+            _mailbox("gary-crog", address="gary@c.com",
+                     routing_tag="executive"),
+            _mailbox("info-crog", address="info@c.com",
+                     routing_tag="operations"),
+            _mailbox("gary-gk", address="gary@gk.com",
+                     routing_tag="executive"),
+        ]
+        recorder: list[tuple[str, dict]] = []
+        factory = make_fake_factory(recorder)
+
+        for mb in mailboxes:
+            em = _email(
+                subject=f"note for {mb.name}",
+                body="routine checkin",
+                sender="guest@example.com",
+            )
+            result = await process_email(em, mb, session_factory=factory)
+            assert result["routing_tag"] == mb.routing_tag
+            assert result["route"] == CaptureRoute.ALLOW.value
+
+        # Every write stashes routing_tag inside the meta JSON payload.
+        tags_seen: list[str] = []
+        for sql, params in recorder:
+            assert "INSERT INTO llm_training_captures" in sql
+            meta = json.loads(params["meta"])
+            tags_seen.append(meta["routing_tag"])
+            assert meta["source_mailbox"]
+            # source_module carries the tag too — test harness can check either.
+            assert params["module"].startswith("captain_")
+
+        assert tags_seen == ["legal", "executive", "operations", "executive"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 2 — privilege filter sends privileged mail to restricted_captures
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestPrivilegeFilterHook:
+    @pytest.mark.asyncio
+    async def test_captain_privilege_filter_hook_restricted(self, monkeypatch):
+        monkeypatch.setenv("ATTORNEY_DOMAINS", "jonesfirm.law")
+        mb = _mailbox("legal-cpanel", address="legal@c.com", routing_tag="legal")
+        em = _email(
+            subject="Discovery update",
+            body="Please review — ATTORNEY-CLIENT PRIVILEGED work product.",
+            sender="partner@jonesfirm.law",
+            attachments=["motion.pdf"],
+        )
+
+        decision = classify_email(em, mb)
+        assert decision.route == CaptureRoute.RESTRICTED
+        assert any("attorney_domain" in p or "keyword:" in p
+                   for p in decision.matched_patterns)
+
+        recorder: list[tuple[str, dict]] = []
+        factory = make_fake_factory(recorder)
+        result = await process_email(em, mb, session_factory=factory)
+
+        assert result["route"] == CaptureRoute.RESTRICTED.value
+        assert len(recorder) == 1
+        sql, params = recorder[0]
+        assert "INSERT INTO restricted_captures" in sql
+        assert "INSERT INTO llm_training_captures" not in sql
+        assert "jonesfirm.law" in params["reason"] \
+            or "keyword:" in params["reason"] \
+            or "text_marker:" in params["reason"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 3 — Gmail API pagination
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestGmailApiPagination:
+    def test_captain_gmail_api_pagination(self):
+        """
+        Stub the Gmail API `messages().list()` to return 3 pages, each with a
+        pageToken pointing at the next. The transport must chain through all
+        of them and fetch every message.
+        """
+        pages = [
+            {"messages": [{"id": "m1"}, {"id": "m2"}], "nextPageToken": "tok1"},
+            {"messages": [{"id": "m3"}, {"id": "m4"}], "nextPageToken": "tok2"},
+            {"messages": [{"id": "m5"}]},  # no nextPageToken → last page
+        ]
+        list_calls: list[dict] = []
+        get_calls: list[str] = []
+
+        def _mk_raw(mid: str) -> str:
+            import base64
+            body = (
+                f"Subject: msg-{mid}\r\n"
+                f"From: s@e.com\r\n"
+                f"To: r@e.com\r\n\r\n"
+                f"body-{mid}"
+            ).encode()
+            return base64.urlsafe_b64encode(body).decode()
+
+        class FakeList:
+            def __init__(self, params: dict) -> None:
+                self.params = params
+
+            def execute(self) -> dict:
+                list_calls.append(self.params)
+                token = self.params.get("pageToken")
+                if token is None:
+                    return pages[0]
+                if token == "tok1":
+                    return pages[1]
+                if token == "tok2":
+                    return pages[2]
+                return {"messages": []}
+
+        class FakeGet:
+            def __init__(self, mid: str) -> None:
+                self.mid = mid
+
+            def execute(self) -> dict:
+                get_calls.append(self.mid)
+                return {"raw": _mk_raw(self.mid)}
+
+        class FakeModify:
+            def execute(self) -> dict:
+                return {}
+
+        class FakeMessages:
+            def list(self, **kwargs) -> FakeList:
+                return FakeList(kwargs)
+
+            def get(self, userId: str, id: str, format: str) -> FakeGet:
+                return FakeGet(id)
+
+            def modify(self, userId: str, id: str, body: dict) -> FakeModify:
+                return FakeModify()
+
+        class FakeUsers:
+            def messages(self) -> FakeMessages:
+                return FakeMessages()
+
+        class FakeService:
+            def users(self) -> FakeUsers:
+                return FakeUsers()
+
+        mb = MailboxConfig(
+            name="gmail-test", transport="gmail_api",
+            address="x@gmail.com", routing_tag="operations",
+        )
+        transport = GmailApiTransport(mb, client_factory=lambda: FakeService())
+        emails = transport.fetch_unseen()
+
+        # 3 list calls → covers all pages.
+        assert len(list_calls) == 3
+        # First call: no pageToken; subsequent calls carry the token.
+        assert list_calls[0].get("pageToken") is None
+        assert list_calls[1]["pageToken"] == "tok1"
+        assert list_calls[2]["pageToken"] == "tok2"
+
+        # All 5 messages were fetched.
+        assert get_calls == ["m1", "m2", "m3", "m4", "m5"]
+        assert len(emails) == 5
+        assert [e.subject for e in emails] == [
+            "msg-m1", "msg-m2", "msg-m3", "msg-m4", "msg-m5"
+        ]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 4 — four IMAP mailboxes on one host each get polled
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestImapMultiMailboxSingleHost:
+    @pytest.mark.asyncio
+    async def test_captain_imap_multi_mailbox_single_host(self, monkeypatch):
+        """
+        Four IMAP mailboxes on the same host. Each opens its own connection
+        (cPanel does not pool reliably). run_patrol must iterate all four and
+        produce one capture per mailbox.
+        """
+        host = "mail.cabin-rentals-of-georgia.com"
+        mailboxes = [
+            _mailbox("legal",  address="legal@crog.com",
+                     routing_tag="legal",     host=host,
+                     credentials_ref="PW_LEGAL"),
+            _mailbox("gary",   address="gary@crog.com",
+                     routing_tag="executive", host=host,
+                     credentials_ref="PW_GARY"),
+            _mailbox("info",   address="info@crog.com",
+                     routing_tag="operations", host=host,
+                     credentials_ref="PW_INFO"),
+            _mailbox("gary_gk", address="gary@gk.com",
+                     routing_tag="executive", host=host,
+                     credentials_ref="PW_GARY_GK"),
+        ]
+        for ref in ("PW_LEGAL", "PW_GARY", "PW_INFO", "PW_GARY_GK"):
+            monkeypatch.setenv(ref, "dummy-pass")
+
+        connections_opened: list[tuple[str, int]] = []
+
+        # Stub ImapTransport.fetch_unseen to record one connection per call
+        # and return one fake email per mailbox.
+        def fake_fetch(self: ImapTransport) -> list[FetchedEmail]:
+            connections_opened.append((self.mailbox.host, self.mailbox.port))
+            return [_email(
+                subject=f"msg-for-{self.mailbox.name}",
+                body="hello",
+                sender=f"sender-{self.mailbox.name}@outside.com",
+            )]
+
+        monkeypatch.setattr(ImapTransport, "fetch_unseen", fake_fetch)
+
+        recorder: list[tuple[str, dict]] = []
+        factory = make_fake_factory(recorder)
+
+        result = await run_patrol(
+            mailboxes=mailboxes,
+            session_factory=factory,
+        )
+
+        assert result["mailboxes"] == 4
+        assert result["processed"] == 4
+        assert len(connections_opened) == 4
+        # All four calls targeted the same host.
+        assert {h for (h, _) in connections_opened} == {host}
+        # Routing tags recorded in the write metadata.
+        tags = sorted(
+            json.loads(params["meta"])["routing_tag"]
+            for _, params in recorder
+        )
+        assert tags == ["executive", "executive", "legal", "operations"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 5 — IMAP reconnect after disconnect
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestImapIdleReconnect:
+    def test_captain_imap_idle_reconnect(self, monkeypatch):
+        """
+        First `_connect` call raises an IMAP4.abort (simulates cPanel dropping
+        the idle connection). The transport must reconnect once and succeed.
+        """
+        mb = _mailbox(
+            "legal", address="legal@crog.com", routing_tag="legal",
+            host="mail.example.com", credentials_ref="FAKE_PW",
+        )
+        monkeypatch.setenv("FAKE_PW", "x")
+
+        attempts: list[int] = []
+
+        def fake_connect(self: ImapTransport) -> Any:
+            attempts.append(len(attempts) + 1)
+            if len(attempts) == 1:
+                raise imaplib.IMAP4.abort("connection dropped")
+            # Second attempt: return a mock connection that returns no unseen.
+            conn = MagicMock(spec=imaplib.IMAP4_SSL)
+            conn.search.return_value = ("OK", [b""])
+            return conn
+
+        monkeypatch.setattr(ImapTransport, "_connect", fake_connect)
+
+        transport = ImapTransport(mb)
+        emails = transport.fetch_unseen()
+
+        assert emails == []
+        assert len(attempts) == 2, "expected one reconnect after initial abort"
+        assert transport.reconnect_count == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 6 — worker startup respects the flag
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestWorkerStartupRespectsFlag:
+    def test_captain_worker_startup_respects_flag(self, monkeypatch):
+        """
+        When LEGAL_EMAIL_INTAKE_ENABLED=False, worker.startup must NOT spawn
+        the captain_multi_mailbox_task.
+        """
+        from backend.core import worker
+
+        # Neutralize every other conditional path in startup so we can focus
+        # on the captain spawn gate. Only flags relevant to that gate matter.
+        monkeypatch.setenv("SEO_GRADING_CONSUMER_ENABLED", "0")
+        monkeypatch.setenv("SEO_REWRITE_CONSUMER_ENABLED", "0")
+        monkeypatch.setenv("SEO_DEPLOY_CONSUMER_ENABLED", "0")
+
+        # Flip everything off; set legal_email_intake_enabled=False.
+        for attr, val in [
+            ("semrush_shadow_observer_enabled", False),
+            ("research_scout_enabled", False),
+            ("concierge_shadow_draft_enabled", False),
+            ("hunter_queue_sweep_enabled", False),
+            ("async_job_watchdog_enabled", False),
+            ("legal_email_intake_enabled", False),
+        ]:
+            monkeypatch.setattr(worker.settings, attr, val, raising=False)
+
+        async def _fake_noop_async(*args, **kwargs):
+            return None
+
+        class _FakeStreamlineVRS:
+            def __init__(self) -> None:
+                self.is_configured = False
+
+        monkeypatch.setattr(worker, "enforce_sovereign_boundary", _fake_noop_async)
+        monkeypatch.setattr(worker, "StreamlineVRS", _FakeStreamlineVRS)
+
+        ctx: dict[str, Any] = {}
+        asyncio.run(worker.startup(ctx))
+
+        assert "captain_multi_mailbox_task" not in ctx
+        assert "legal_intake_task" not in ctx


### PR DESCRIPTION
## Summary
- Extend The Captain to poll **5 mailboxes** (1 Gmail API + 4 cPanel IMAP) via a JSON `MAILBOXES_CONFIG` env var; every capture is classified by `privilege_filter.classify_for_capture()` and routed to `llm_training_captures` (ALLOW), `restricted_captures` (RESTRICTED), or dropped (BLOCK).
- Privilege filter gains attorney-domain allowlist, plain-language privilege keywords, docket regex, and law-firm PDF attachment trigger — **public signature unchanged**, new signals flow through the existing `metadata` dict.
- Captain loop spawned in `worker.py` alongside `legal_email_intake` under the existing `LEGAL_EMAIL_INTAKE_ENABLED` flag. **Flag default stays `False`** — no runtime behavior change in this PR.

## Mailboxes (canonical CROG config, provided in `.env.example`)
| Address | Transport | Routing tag | Credentials ref |
|---|---|---|---|
| cabin.rentals.of.georgia@gmail.com | gmail_api | operations | `GMAIL_*` |
| legal@cabin-rentals-of-georgia.com | imap | legal | `LEGAL_MAILPLUS_PASSWORD` |
| gary@cabin-rentals-of-georgia.com | imap | executive | `MAILPLUS_PASSWORD_GARY` |
| info@cabin-rentals-of-georgia.com | imap | operations | `MAILPLUS_PASSWORD_INFO` |
| gary@garyknight.com | imap | executive | `MAILPLUS_PASSWORD_GARY_GARYKNIGHT_COM` |

`VANGUARD_ACCOUNTS` is intentionally ignored per spec.

## Design notes
- **No alembic migration.** Captain writes to existing `llm_training_captures` / `restricted_captures` tables and stashes `source_mailbox` + `routing_tag` in the `capture_metadata` JSONB column. `legal.correspondence` / `legal.timeline_events` remain owned by `legal_email_intake` — outside Captain's scope.
- **IMAP reconnect:** each transport opens a fresh short-lived connection per cycle and retries once on `IMAP4.abort` / `EOFError` / `OSError` — covers cPanel's frequent IDLE drop. No connection pooling (cPanel does not pool reliably).
- **Gmail API client is injected** via `client_factory`, so tests don't need `googleapiclient` installed.
- **Coexistence with `legal_email_intake`:** when the flag flips `True`, both loops run. Captain and legal_intake could race on the `legal@` mailbox's UNSEEN flag; since the flag ships `False` and we were told not to flip it in this PR, the race is a future concern (to be resolved by either disabling legal_intake once Captain handles case-linking, or giving Captain a read-only mode on that mailbox).

## Files changed
```
fortress-guest-platform/.env.example                    (+34)
fortress-guest-platform/backend/core/worker.py          (+18)
fortress-guest-platform/backend/services/privilege_filter.py  (+84)
fortress-guest-platform/backend/services/captain_multi_mailbox.py  (+519 new)
fortress-guest-platform/backend/tests/test_captain_multi_mailbox.py  (+352 new)
```

## Test plan
- [x] `pytest backend/tests/test_privilege_filter.py backend/tests/test_captain_multi_mailbox.py` — **24 passed** (13 existing privilege_filter + 5 config-parsing + 6 requested Captain tests)
- [ ] After merge: leave `LEGAL_EMAIL_INTAKE_ENABLED=false` in prod. When we decide to flip it, seed `MAILBOXES_CONFIG` first + confirm credentials_ref env vars resolve.

## Six requested tests
- `test_captain_routes_by_tag` — each mailbox writes with the correct `routing_tag` in capture_metadata
- `test_captain_privilege_filter_hook_restricted` — attorney-domain + ATTORNEY-CLIENT marker email → `restricted_captures`, not `llm_training_captures`
- `test_captain_gmail_api_pagination` — walks 3 pages via pageToken, fetches all 5 messages
- `test_captain_imap_multi_mailbox_single_host` — 4 boxes on `mail.cabin-rentals-of-georgia.com`, one connection per box
- `test_captain_imap_idle_reconnect` — first `_connect` raises `IMAP4.abort` → reconnects once and completes
- `test_captain_worker_startup_respects_flag` — `LEGAL_EMAIL_INTAKE_ENABLED=False` → `captain_multi_mailbox_task` not in `ctx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)