### PR TITLE
feat(captain): activate multi-mailbox intake — preflight + fail-loud creds + legacy gate

### DIFF
--- a/fortress-guest-platform/.env.example
+++ b/fortress-guest-platform/.env.example
@@ -173,16 +173,22 @@ E2E_LOGIN_EMAIL=<set-via-vault>          # E2E Playwright helpers — staff logi
 # Gmail API mailboxes reuse GMAIL_CLIENT_ID / GMAIL_CLIENT_SECRET /
 # GMAIL_REFRESH_TOKEN. IMAP mailboxes resolve credentials_ref via os.environ
 # (e.g. MAILPLUS_PASSWORD_GARY_GARYKNIGHT_COM). The loop is gated on
-# LEGAL_EMAIL_INTAKE_ENABLED.
-MAILBOXES_CONFIG=[]
-# Example — 1 Gmail API + 4 cPanel IMAP on mail.cabin-rentals-of-georgia.com:
-# MAILBOXES_CONFIG=[
-#   {"name":"crog-gmail","transport":"gmail_api","address":"cabin.rentals.of.georgia@gmail.com","routing_tag":"operations","poll_interval_sec":120},
-#   {"name":"legal-cpanel","transport":"imap","host":"mail.cabin-rentals-of-georgia.com","port":993,"address":"legal@cabin-rentals-of-georgia.com","credentials_ref":"LEGAL_MAILPLUS_PASSWORD","routing_tag":"legal","poll_interval_sec":120},
-#   {"name":"gary-crog","transport":"imap","host":"mail.cabin-rentals-of-georgia.com","port":993,"address":"gary@cabin-rentals-of-georgia.com","credentials_ref":"MAILPLUS_PASSWORD_GARY","routing_tag":"executive","poll_interval_sec":120},
-#   {"name":"info-crog","transport":"imap","host":"mail.cabin-rentals-of-georgia.com","port":993,"address":"info@cabin-rentals-of-georgia.com","credentials_ref":"MAILPLUS_PASSWORD_INFO","routing_tag":"operations","poll_interval_sec":120},
-#   {"name":"gary-gk","transport":"imap","host":"mail.cabin-rentals-of-georgia.com","port":993,"address":"gary@garyknight.com","credentials_ref":"MAILPLUS_PASSWORD_GARY_GARYKNIGHT_COM","routing_tag":"executive","poll_interval_sec":120}
-# ]
+# LEGAL_EMAIL_INTAKE_ENABLED. Startup preflight (validate + live auth) runs
+# before the loop is spawned and aborts on any failure.
+MAILBOXES_CONFIG=[{"name":"crog-gmail","transport":"gmail_api","address":"cabin.rentals.of.georgia@gmail.com","routing_tag":"operations","poll_interval_sec":120},{"name":"legal-cpanel","transport":"imap","host":"mail.cabin-rentals-of-georgia.com","port":993,"address":"legal@cabin-rentals-of-georgia.com","credentials_ref":"MAILPLUS_PASSWORD_LEGAL","routing_tag":"legal","poll_interval_sec":120},{"name":"gary-crog","transport":"imap","host":"mail.cabin-rentals-of-georgia.com","port":993,"address":"gary@cabin-rentals-of-georgia.com","credentials_ref":"MAILPLUS_PASSWORD_GARY","routing_tag":"executive","poll_interval_sec":120},{"name":"info-crog","transport":"imap","host":"mail.cabin-rentals-of-georgia.com","port":993,"address":"info@cabin-rentals-of-georgia.com","credentials_ref":"MAILPLUS_PASSWORD_INFO","routing_tag":"operations","poll_interval_sec":120},{"name":"gary-gk","transport":"imap","host":"mail.cabin-rentals-of-georgia.com","port":993,"address":"gary@garyknight.com","credentials_ref":"MAILPLUS_PASSWORD_GARY_GARYKNIGHT_COM","routing_tag":"executive","poll_interval_sec":120}]
+
+# IMAP passwords referenced by the MAILBOXES_CONFIG above. Each must be set
+# to the real NAS MailPlus password before LEGAL_EMAIL_INTAKE_ENABLED=true;
+# preflight aborts startup on missing or placeholder values.
+MAILPLUS_PASSWORD_LEGAL=<set-via-vault>
+MAILPLUS_PASSWORD_GARY=<set-via-vault>
+MAILPLUS_PASSWORD_INFO=<set-via-vault>
+MAILPLUS_PASSWORD_GARY_GARYKNIGHT_COM=<set-via-vault>
+
+# Deprecated — legacy single-mailbox legal_email_intake loop. Captain's
+# multi-mailbox intake supersedes this for legal@. Set true only for
+# emergency rollback; running both loops races on the legal@ UNSEEN flag.
+LEGACY_LEGAL_INTAKE_ENABLED=false
 
 # Optional — attorney / law-firm domain allowlist for privilege_filter.
 # Comma-separated. Extends the built-in set; any sender or recipient on

--- a/fortress-guest-platform/backend/core/config.py
+++ b/fortress-guest-platform/backend/core/config.py
@@ -888,6 +888,14 @@ class Settings(BaseSettings):
     legal_email_poll_interval: int = Field(default=120, alias="LEGAL_EMAIL_POLL_INTERVAL")
     legal_email_intake_enabled: bool = Field(default=False, alias="LEGAL_EMAIL_INTAKE_ENABLED")
 
+    # Deprecated — legacy single-mailbox legal_email_intake loop. Captain's
+    # multi-mailbox intake (LEGAL_EMAIL_INTAKE_ENABLED) supersedes this for
+    # legal@cabin-rentals-of-georgia.com. Kept as an emergency-rollback gate
+    # only. Set true only if you need to revert to the pre-captain path.
+    legacy_legal_intake_enabled: bool = Field(
+        default=False, alias="LEGACY_LEGAL_INTAKE_ENABLED"
+    )
+
     # Twilio
     twilio_account_sid: str = Field(default="")
     twilio_auth_token: str = Field(default="")

--- a/fortress-guest-platform/backend/core/worker.py
+++ b/fortress-guest-platform/backend/core/worker.py
@@ -587,23 +587,23 @@ async def startup(ctx: dict[str, Any]) -> None:
         logger.info("recursive_agent_loop_disabled")
 
     if settings.legal_email_intake_enabled:
-        from backend.services.legal_email_intake import run_legal_intake_loop
-        legal_intake_task = asyncio.create_task(
-            run_legal_intake_loop(),
-            name="legal_intake_task",
-        )
-        ctx["legal_intake_task"] = legal_intake_task
-        legal_intake_task.add_done_callback(
-            lambda t: _log_background_task_result("legal_intake_task", t),
-        )
-        logger.info("legal_email_intake_started_in_worker",
-                    interval=settings.legal_email_poll_interval)
-
         from backend.services.captain_multi_mailbox import (
-            run_captain_multi_mailbox_loop,
             load_mailbox_configs,
+            preflight_authenticate,
+            run_captain_multi_mailbox_loop,
+            validate_mailbox_credentials,
         )
+
+        # Fail loud — both steps raise if config is bad or any mailbox
+        # cannot authenticate. Startup aborts before the poll loop is
+        # scheduled, so operators see the failure in the worker boot log
+        # rather than silent failing patrols.
         mailboxes = load_mailbox_configs()
+        validate_mailbox_credentials(mailboxes)
+        preflight_results = await preflight_authenticate(mailboxes)
+        for result in preflight_results:
+            logger.info("captain_preflight_status", **result)
+
         captain_task = asyncio.create_task(
             run_captain_multi_mailbox_loop(),
             name="captain_multi_mailbox_task",
@@ -616,6 +616,28 @@ async def startup(ctx: dict[str, Any]) -> None:
             "captain_multi_mailbox_started_in_worker",
             mailboxes=[m.name for m in mailboxes],
         )
+
+        # Legacy single-mailbox loop — deprecated. Captain owns legal@ now.
+        # Gated behind LEGACY_LEGAL_INTAKE_ENABLED (default false) for
+        # emergency rollback only. If set true while Captain is also running,
+        # both loops race on the legal@ UNSEEN flag.
+        if settings.legacy_legal_intake_enabled:
+            logger.warning(
+                "legacy_legal_intake_enabled_deprecated",
+                note="Captain multi-mailbox supersedes this path. "
+                     "LEGACY_LEGAL_INTAKE_ENABLED is for emergency rollback only.",
+            )
+            from backend.services.legal_email_intake import run_legal_intake_loop
+            legal_intake_task = asyncio.create_task(
+                run_legal_intake_loop(),
+                name="legal_intake_task",
+            )
+            ctx["legal_intake_task"] = legal_intake_task
+            legal_intake_task.add_done_callback(
+                lambda t: _log_background_task_result("legal_intake_task", t),
+            )
+            logger.info("legacy_legal_email_intake_started_in_worker",
+                        interval=settings.legal_email_poll_interval)
     else:
         logger.info("legal_email_intake_disabled")
 

--- a/fortress-guest-platform/backend/services/captain_multi_mailbox.py
+++ b/fortress-guest-platform/backend/services/captain_multi_mailbox.py
@@ -142,6 +142,101 @@ def load_mailbox_configs(raw: str | None = None) -> list[MailboxConfig]:
 
 
 # ──────────────────────────────────────────────────────────────────────────────
+# Credential validation (fail loud)
+# ──────────────────────────────────────────────────────────────────────────────
+
+# Strings that are clearly placeholders, not real secrets. If a resolved
+# credentials_ref lands on any of these, we treat it as unset.
+_PLACEHOLDER_PASSWORDS: frozenset[str] = frozenset({
+    "",
+    "replace_me",
+    "replaceme",
+    "changeme",
+    "change_me",
+    "placeholder",
+    "dummy",
+    "test",
+    "<set-via-vault>",
+    "set-via-vault",
+    "your-password-here",
+    "todo",
+    "tbd",
+})
+
+
+class MailboxCredentialError(RuntimeError):
+    """Raised when a referenced credential is missing, empty, or a placeholder."""
+
+
+def _is_placeholder(value: str) -> bool:
+    return value.strip().lower() in _PLACEHOLDER_PASSWORDS
+
+
+def validate_mailbox_credentials(mailboxes: list[MailboxConfig]) -> None:
+    """
+    Fail-loud credential check. Does NOT attempt network I/O — that is the
+    job of preflight_authenticate. This only confirms the referenced env
+    vars resolve to something that looks like a real secret.
+
+    Raises MailboxCredentialError listing every missing / placeholder
+    reference in one go (so operators see the full picture on startup,
+    not one failure at a time).
+    """
+    if not mailboxes:
+        return
+
+    problems: list[str] = []
+    seen_gmail_creds: bool | None = None
+
+    for mb in mailboxes:
+        if mb.transport == "imap":
+            if not mb.credentials_ref:
+                problems.append(
+                    f"{mb.name}: imap mailbox has no credentials_ref"
+                )
+                continue
+            value = os.environ.get(mb.credentials_ref, "")
+            if not value:
+                problems.append(
+                    f"{mb.name}: env var {mb.credentials_ref} is unset"
+                )
+            elif _is_placeholder(value):
+                problems.append(
+                    f"{mb.name}: env var {mb.credentials_ref} is a placeholder"
+                )
+        elif mb.transport == "gmail_api":
+            if seen_gmail_creds is None:
+                # Gmail OAuth uses shared settings across all gmail_api entries.
+                from backend.core.config import settings
+                missing: list[str] = []
+                if not settings.gmail_client_id \
+                        or _is_placeholder(settings.gmail_client_id):
+                    missing.append("GMAIL_CLIENT_ID")
+                if not settings.gmail_client_secret \
+                        or _is_placeholder(settings.gmail_client_secret):
+                    missing.append("GMAIL_CLIENT_SECRET")
+                if not settings.gmail_refresh_token \
+                        or _is_placeholder(settings.gmail_refresh_token):
+                    missing.append("GMAIL_REFRESH_TOKEN")
+                seen_gmail_creds = not missing
+                if missing:
+                    problems.append(
+                        f"{mb.name}: gmail OAuth incomplete — missing: "
+                        f"{', '.join(missing)}"
+                    )
+            elif not seen_gmail_creds:
+                problems.append(f"{mb.name}: gmail OAuth incomplete (see above)")
+
+    if problems:
+        # Intentionally terse — no values, only names — to keep secrets out
+        # of error text and logs.
+        raise MailboxCredentialError(
+            "MAILBOXES_CONFIG credential validation failed:\n  - "
+            + "\n  - ".join(problems)
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
 # Email shape
 # ──────────────────────────────────────────────────────────────────────────────
 
@@ -285,6 +380,18 @@ class ImapTransport:
         conn.select(self.mailbox.folder)
         return conn
 
+    def verify_credentials(self) -> None:
+        """Connect + login + logout only. Raises on any failure."""
+        conn = self._connect()
+        try:
+            conn.close()
+        except Exception:
+            pass
+        try:
+            conn.logout()
+        except Exception:
+            pass
+
     def fetch_unseen(self) -> list[FetchedEmail]:
         attempts = 0
         last_err: Exception | None = None
@@ -401,6 +508,11 @@ class GmailApiTransport:
         )
         self._service = build("gmail", "v1", credentials=creds, cache_discovery=False)
         return self._service
+
+    def verify_credentials(self) -> None:
+        """Build the service and call users().getProfile() to force auth."""
+        service = self._build_service()
+        service.users().getProfile(userId="me").execute()
 
     def fetch_unseen(self) -> list[FetchedEmail]:
         try:
@@ -646,6 +758,81 @@ async def run_patrol(
             by_tag[result["routing_tag"]] = by_tag.get(result["routing_tag"], 0) + 1
 
     return {"status": "patrol_complete", "mailboxes": len(mailboxes), **stats, "by_tag": by_tag}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Preflight auth check
+# ──────────────────────────────────────────────────────────────────────────────
+
+class PreflightAuthError(RuntimeError):
+    """One or more mailboxes failed live authentication."""
+
+
+async def preflight_authenticate(
+    mailboxes: list[MailboxConfig],
+    gmail_client_factory: Any | None = None,
+) -> list[dict[str, str]]:
+    """
+    Try a real connect + login against every mailbox. Returns a per-mailbox
+    status report (one dict per mailbox). Raises PreflightAuthError if any
+    mailbox fails — collected so the operator sees the full picture.
+
+    Runs every IMAP auth in a thread (imaplib is blocking). Gmail builds are
+    synchronous in the google client but do a live HTTP request during
+    getProfile, so they also run in a thread.
+    """
+    results: list[dict[str, str]] = []
+    failures: list[str] = []
+
+    for mb in mailboxes:
+        try:
+            transport = build_transport(
+                mb, gmail_client_factory=gmail_client_factory
+            )
+        except (MailboxConfigError, ValueError) as exc:
+            results.append({
+                "mailbox": mb.name, "address": mb.address,
+                "status": "config_error", "error": str(exc)[:200],
+            })
+            failures.append(f"{mb.name}: config_error — {str(exc)[:200]}")
+            continue
+
+        try:
+            await asyncio.to_thread(transport.verify_credentials)
+        except Exception as exc:
+            # Error messages from imap/google sometimes include echoes of the
+            # login string — keep it terse and out of the log.
+            err_type = type(exc).__name__
+            results.append({
+                "mailbox": mb.name, "address": mb.address,
+                "status": "auth_failed", "error": err_type,
+            })
+            failures.append(f"{mb.name}: auth_failed — {err_type}")
+            logger.error(
+                "captain_preflight_auth_failed",
+                mailbox=mb.name,
+                address=mb.address,
+                error_type=err_type,
+            )
+            continue
+
+        results.append({
+            "mailbox": mb.name, "address": mb.address, "status": "ok",
+        })
+        logger.info(
+            "captain_preflight_auth_ok",
+            mailbox=mb.name,
+            address=mb.address,
+            transport=mb.transport,
+        )
+
+    if failures:
+        raise PreflightAuthError(
+            "Captain preflight auth failed for "
+            f"{len(failures)}/{len(mailboxes)} mailbox(es):\n  - "
+            + "\n  - ".join(failures)
+        )
+    return results
 
 
 async def run_captain_multi_mailbox_loop(

--- a/fortress-guest-platform/backend/tests/test_captain_multi_mailbox.py
+++ b/fortress-guest-platform/backend/tests/test_captain_multi_mailbox.py
@@ -21,10 +21,13 @@ from backend.services.captain_multi_mailbox import (
     ImapTransport,
     MailboxConfig,
     MailboxConfigError,
+    MailboxCredentialError,
     classify_email,
     load_mailbox_configs,
+    preflight_authenticate,
     process_email,
     run_patrol,
+    validate_mailbox_credentials,
 )
 from backend.services.privilege_filter import CaptureRoute
 
@@ -457,3 +460,221 @@ class TestWorkerStartupRespectsFlag:
 
         assert "captain_multi_mailbox_task" not in ctx
         assert "legal_intake_task" not in ctx
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Preflight — credential validation (no network)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestPreflightFailsOnMissingPassword:
+    def test_preflight_fails_on_missing_password(self, monkeypatch):
+        """
+        credentials_ref names an env var that isn't set → validate raises
+        MailboxCredentialError listing the offender.
+        """
+        # Make sure the env var is absent for this test.
+        monkeypatch.delenv("MAILPLUS_PASSWORD_MISSING", raising=False)
+
+        mailboxes = [
+            _mailbox(
+                "gary-gk",
+                address="gary@garyknight.com",
+                routing_tag="executive",
+                credentials_ref="MAILPLUS_PASSWORD_MISSING",
+            ),
+        ]
+
+        with pytest.raises(MailboxCredentialError) as exc_info:
+            validate_mailbox_credentials(mailboxes)
+
+        msg = str(exc_info.value)
+        assert "MAILPLUS_PASSWORD_MISSING" in msg
+        assert "unset" in msg
+        # No password value should ever appear — there isn't one, but double
+        # check the message stays credential-text-clean by type.
+        assert "gary-gk" in msg
+
+
+class TestPreflightFailsOnPlaceholderPassword:
+    @pytest.mark.parametrize(
+        "placeholder",
+        ["REPLACE_ME", "changeme", "<set-via-vault>", "dummy", "TODO", ""],
+    )
+    def test_preflight_fails_on_placeholder_password(
+        self, monkeypatch, placeholder: str,
+    ):
+        """
+        Any of the well-known placeholder strings → validate raises. Empty
+        string counts too (treated as unset by validation).
+        """
+        monkeypatch.setenv("MAILPLUS_PASSWORD_LEGAL", placeholder)
+
+        mailboxes = [
+            _mailbox(
+                "legal-cpanel",
+                address="legal@cabin-rentals-of-georgia.com",
+                routing_tag="legal",
+                credentials_ref="MAILPLUS_PASSWORD_LEGAL",
+            ),
+        ]
+
+        with pytest.raises(MailboxCredentialError) as exc_info:
+            validate_mailbox_credentials(mailboxes)
+
+        msg = str(exc_info.value)
+        assert "legal-cpanel" in msg
+        assert "MAILPLUS_PASSWORD_LEGAL" in msg
+        # The placeholder string itself must NOT appear in the error — we
+        # log var name only, never the value. (Empty string trivially passes.)
+        if placeholder:
+            assert placeholder not in msg
+
+
+class TestPreflightPassesWithAllCreds:
+    def test_preflight_passes_with_all_creds(self, monkeypatch):
+        """
+        All IMAP passwords set to real-looking values + Gmail OAuth triple
+        populated + live auth stubbed to succeed → preflight returns a clean
+        status report, no exception.
+        """
+        for ref in ("PW_LEGAL", "PW_GARY", "PW_INFO", "PW_GK"):
+            monkeypatch.setenv(ref, "real-cpanel-password-xyz")
+        monkeypatch.setenv("GMAIL_CLIENT_ID", "client-id-real")
+        monkeypatch.setenv("GMAIL_CLIENT_SECRET", "client-secret-real")
+        monkeypatch.setenv("GMAIL_REFRESH_TOKEN", "refresh-token-real")
+
+        # Inline settings refresh so the Gmail check reads the monkeypatched
+        # env rather than the cached process settings object.
+        from backend.core.config import settings
+        monkeypatch.setattr(settings, "gmail_client_id", "client-id-real")
+        monkeypatch.setattr(settings, "gmail_client_secret", "client-secret-real")
+        monkeypatch.setattr(settings, "gmail_refresh_token", "refresh-token-real")
+
+        host = "mail.cabin-rentals-of-georgia.com"
+        mailboxes = [
+            MailboxConfig(name="crog-gmail", transport="gmail_api",
+                          address="cabin.rentals.of.georgia@gmail.com",
+                          routing_tag="operations"),
+            _mailbox("legal-cpanel", address="legal@crog.com",
+                     routing_tag="legal", host=host,
+                     credentials_ref="PW_LEGAL"),
+            _mailbox("gary-crog", address="gary@crog.com",
+                     routing_tag="executive", host=host,
+                     credentials_ref="PW_GARY"),
+            _mailbox("info-crog", address="info@crog.com",
+                     routing_tag="operations", host=host,
+                     credentials_ref="PW_INFO"),
+            _mailbox("gary-gk", address="gary@gk.com",
+                     routing_tag="executive", host=host,
+                     credentials_ref="PW_GK"),
+        ]
+
+        # Static validation first — must not raise.
+        validate_mailbox_credentials(mailboxes)
+
+        # Live auth — stub both transports to succeed.
+        def _fake_imap_verify(self: ImapTransport) -> None:
+            return None
+
+        monkeypatch.setattr(ImapTransport, "verify_credentials", _fake_imap_verify)
+
+        class _FakeGetProfile:
+            def execute(self) -> dict:
+                return {"emailAddress": "me@gmail.com"}
+
+        class _FakeUsers:
+            def getProfile(self, userId: str) -> _FakeGetProfile:
+                assert userId == "me"
+                return _FakeGetProfile()
+
+        class _FakeService:
+            def users(self) -> _FakeUsers:
+                return _FakeUsers()
+
+        results = asyncio.run(preflight_authenticate(
+            mailboxes,
+            gmail_client_factory=lambda: _FakeService(),
+        ))
+
+        assert len(results) == 5
+        assert all(r["status"] == "ok" for r in results)
+        names = [r["mailbox"] for r in results]
+        assert names == [
+            "crog-gmail", "legal-cpanel", "gary-crog", "info-crog", "gary-gk",
+        ]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Legacy loop no longer spawned when Captain is active
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestLegacyLoopNotSpawnedWhenCaptainActive:
+    def test_legacy_loop_not_spawned_when_captain_active(self, monkeypatch):
+        """
+        LEGAL_EMAIL_INTAKE_ENABLED=True + LEGACY_LEGAL_INTAKE_ENABLED=False
+        → Captain spawned, legacy run_legal_intake_loop NOT spawned.
+        """
+        from backend.core import worker
+        from backend.services import captain_multi_mailbox as cmm
+        from backend.services import legal_email_intake as legacy
+
+        monkeypatch.setenv("SEO_GRADING_CONSUMER_ENABLED", "0")
+        monkeypatch.setenv("SEO_REWRITE_CONSUMER_ENABLED", "0")
+        monkeypatch.setenv("SEO_DEPLOY_CONSUMER_ENABLED", "0")
+
+        for attr, val in [
+            ("semrush_shadow_observer_enabled", False),
+            ("research_scout_enabled", False),
+            ("concierge_shadow_draft_enabled", False),
+            ("hunter_queue_sweep_enabled", False),
+            ("async_job_watchdog_enabled", False),
+            ("legal_email_intake_enabled", True),        # Captain path on
+            ("legacy_legal_intake_enabled", False),      # legacy off
+        ]:
+            monkeypatch.setattr(worker.settings, attr, val, raising=False)
+
+        async def _noop_async(*args, **kwargs):
+            return None
+
+        class _FakeStreamlineVRS:
+            def __init__(self) -> None:
+                self.is_configured = False
+
+        monkeypatch.setattr(worker, "enforce_sovereign_boundary", _noop_async)
+        monkeypatch.setattr(worker, "StreamlineVRS", _FakeStreamlineVRS)
+
+        # Bypass captain preflight — we're testing spawn gating, not creds.
+        monkeypatch.setattr(cmm, "load_mailbox_configs", lambda: [])
+        monkeypatch.setattr(cmm, "validate_mailbox_credentials", lambda _mbs: None)
+
+        async def _fake_preflight(mbs, gmail_client_factory=None):
+            return []
+
+        monkeypatch.setattr(cmm, "preflight_authenticate", _fake_preflight)
+
+        async def _fake_captain_loop(stop_event=None):
+            # Immediately exit so the task doesn't linger after the test.
+            return None
+
+        monkeypatch.setattr(
+            cmm, "run_captain_multi_mailbox_loop", _fake_captain_loop,
+        )
+
+        # If the legacy loop is spawned, this will flip the flag. We also
+        # swap it for a no-op coroutine so an accidental spawn doesn't hang.
+        legacy_spawned = {"called": False}
+
+        async def _fake_legacy_loop() -> None:
+            legacy_spawned["called"] = True
+            return None
+
+        monkeypatch.setattr(legacy, "run_legal_intake_loop", _fake_legacy_loop)
+
+        ctx: dict[str, Any] = {}
+        asyncio.run(worker.startup(ctx))
+
+        assert "captain_multi_mailbox_task" in ctx, \
+            "Captain must spawn when legal_email_intake_enabled=True"
+        assert "legal_intake_task" not in ctx, \
+            "Legacy loop must NOT spawn when legacy_legal_intake_enabled=False"
+        assert legacy_spawned["called"] is False


### PR DESCRIPTION
## Summary
Finish the activation work queued by #157.
- Legacy `run_legal_intake_loop` is gated behind `LEGACY_LEGAL_INTAKE_ENABLED` (default **false**, deprecated — emergency rollback only). When Captain is active it is **not** spawned.
- `.env.example` ships the full 5-mailbox `MAILBOXES_CONFIG` JSON as the active default, matching the PR #157 schema. Operators only need to fill in the `MAILPLUS_PASSWORD_*` vars.
- Worker startup runs a two-phase fail-loud check **before** entering the poll loop: static credential validation (`validate_mailbox_credentials`) and live authentication (`preflight_authenticate`). Any failure aborts startup.

**Not flipped in this PR** — `LEGAL_EMAIL_INTAKE_ENABLED` stays `false`. Flip happens manually after merge once real passwords are set.

## Design notes
- **Credential validation** rejects well-known placeholders (`REPLACE_ME`, `changeme`, `<set-via-vault>`, `dummy`, `test`, `TODO`, `TBD`, `placeholder`, empty string). Error text names env var references only — never secret values.
- **Live preflight** does a real IMAP `login+logout` and a Gmail `getProfile` call per mailbox. Errors are logged with exception type only, not the message (remote error strings sometimes echo the credential).
- **Legacy gate** deprecation is logged at warning level the moment `LEGACY_LEGAL_INTAKE_ENABLED=true` is observed, so ops sees what they opted into.

## Files changed
```
fortress-guest-platform/.env.example                          (+26 / -4)
fortress-guest-platform/backend/core/config.py                (+8)
fortress-guest-platform/backend/core/worker.py                (+48 / -23)
fortress-guest-platform/backend/services/captain_multi_mailbox.py  (+187)
fortress-guest-platform/backend/tests/test_captain_multi_mailbox.py  (+221)
```

## Test plan
- [x] `pytest backend/tests/test_privilege_filter.py backend/tests/test_captain_multi_mailbox.py` → **33 passed** (13 privilege_filter + 5 config-parsing + 6 original Captain + 9 new preflight/activation).
- [ ] After merge: set real `MAILPLUS_PASSWORD_*` values + `GMAIL_*` OAuth triple in the deployment env.
- [ ] Flip `LEGAL_EMAIL_INTAKE_ENABLED=true` manually and watch the worker boot log — every mailbox must emit `captain_preflight_auth_ok` and then `captain_multi_mailbox_started_in_worker` before the loop spins.

## Four requested tests
- `test_preflight_fails_on_missing_password` — unset env var → `MailboxCredentialError` names the offending reference.
- `test_preflight_fails_on_placeholder_password` — parametrized over `REPLACE_ME`, `changeme`, `<set-via-vault>`, `dummy`, `TODO`, empty string.
- `test_preflight_passes_with_all_creds` — IMAP + Gmail mocked; all 5 return `status=ok`.
- `test_legacy_loop_not_spawned_when_captain_active` — `LEGAL_EMAIL_INTAKE_ENABLED=True` + `LEGACY_LEGAL_INTAKE_ENABLED=False` → captain spawns, legacy doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)