### PR TITLE
fix(captain): rewrite :bind::type casts as CAST(:bind AS type)

### DIFF
--- a/fortress-guest-platform/backend/services/ai_router.py
+++ b/fortress-guest-platform/backend/services/ai_router.py
@@ -142,7 +142,7 @@ async def _capture_interaction(
                              task_type, judge_decision, judge_reasoning,
                              capture_metadata)
                         VALUES
-                            (:id::uuid, :module, :model, :prompt, :response, 'pending',
+                            (CAST(:id AS uuid), :module, :model, :prompt, :response, 'pending',
                              :endpoint, :store,
                              :esc_from, :sov_attempt,
                              :t_endpoint, :t_model,

--- a/fortress-guest-platform/backend/services/captain_multi_mailbox.py
+++ b/fortress-guest-platform/backend/services/captain_multi_mailbox.py
@@ -649,7 +649,7 @@ async def write_capture(
                         (id, source_module, model_used, user_prompt, assistant_resp,
                          status, capture_metadata)
                     VALUES
-                        (:id::uuid, :module, :model, :prompt, :response,
+                        (CAST(:id AS uuid), :module, :model, :prompt, :response,
                          'pending', CAST(:meta AS jsonb))
                     ON CONFLICT DO NOTHING
                 """),

--- a/fortress-guest-platform/backend/tests/test_captain_multi_mailbox.py
+++ b/fortress-guest-platform/backend/tests/test_captain_multi_mailbox.py
@@ -678,3 +678,80 @@ class TestLegacyLoopNotSpawnedWhenCaptainActive:
         assert "legal_intake_task" not in ctx, \
             "Legacy loop must NOT spawn when legacy_legal_intake_enabled=False"
         assert legacy_spawned["called"] is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Regression — :bind::type pattern is unsafe under SQLAlchemy + asyncpg
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestCaptainAllowInsertUsesCastNotColonColon:
+    """
+    `:name::type` inside a SQLAlchemy text() block collides with asyncpg's
+    param parser — Postgres errors with "syntax error at or near ':'". The
+    workaround is CAST(:name AS type), which is semantically equivalent
+    and parses cleanly. This test scans every SQL-writing module the
+    Captain touches to make sure the pattern doesn't resurface.
+    """
+
+    import re as _re
+    from pathlib import Path as _Path
+
+    # Any bind param followed by :: cast is rejected. Literal casts
+    # like 'foo'::jsonb or column::type are not matched (no leading ':'
+    # before the identifier).
+    _BIND_CAST_RE = _re.compile(r":[A-Za-z_][A-Za-z0-9_]*::[A-Za-z_]")
+
+    # Repo-relative file paths scanned by this regression. Add entries
+    # here when a new module starts writing SQL via text()/sqltext().
+    _SCANNED_FILES = (
+        "fortress-guest-platform/backend/services/captain_multi_mailbox.py",
+        "fortress-guest-platform/backend/services/ai_router.py",
+        "fortress-guest-platform/backend/services/legal_council.py",
+        "fortress-guest-platform/backend/workers/recursive_agent_loop.py",
+    )
+
+    def _repo_root(self) -> "TestCaptainAllowInsertUsesCastNotColonColon._Path":
+        # tests/ -> backend/ -> fortress-guest-platform/ -> <repo root>
+        return self._Path(__file__).resolve().parents[3]
+
+    def test_captain_allow_insert_uses_cast_not_colon_colon(self):
+        """Core fix — captain's ALLOW branch uses CAST(:id AS uuid)."""
+        repo = self._repo_root()
+        src = (
+            repo / "fortress-guest-platform/backend/services/captain_multi_mailbox.py"
+        ).read_text()
+        assert "INSERT INTO llm_training_captures" in src, \
+            "ALLOW-branch INSERT has moved — update this test"
+        # The fix: the bind-param cast is written via CAST(... AS uuid).
+        assert "CAST(:id AS uuid)" in src, \
+            "captain ALLOW INSERT must bind :id via CAST(:id AS uuid)"
+        # The anti-pattern must be absent from THIS file.
+        offenders = self._BIND_CAST_RE.findall(src)
+        assert not offenders, (
+            f"found {len(offenders)} :x::type bind-cast(s) in "
+            f"captain_multi_mailbox.py: {offenders!r}"
+        )
+
+    def test_no_bind_param_colon_colon_cast_in_sql_modules(self):
+        """Preventive scan across every captain-adjacent SQL writer."""
+        repo = self._repo_root()
+        offenders: list[str] = []
+        for rel in self._SCANNED_FILES:
+            path = repo / rel
+            if not path.exists():
+                continue
+            for line_no, line in enumerate(path.read_text().splitlines(), 1):
+                stripped = line.lstrip()
+                # Skip full-line comments; docstrings may legitimately
+                # discuss the forbidden pattern while documenting it.
+                if stripped.startswith("#"):
+                    continue
+                for match in self._BIND_CAST_RE.finditer(line):
+                    offenders.append(
+                        f"{rel}:{line_no}: {match.group()!r} in: {stripped[:120]}"
+                    )
+        assert not offenders, (
+            "found :bind::type SQL casts (unsafe under asyncpg — use "
+            "CAST(:bind AS type) instead):\n  - "
+            + "\n  - ".join(offenders)
+        )

--- a/fortress-guest-platform/backend/workers/recursive_agent_loop.py
+++ b/fortress-guest-platform/backend/workers/recursive_agent_loop.py
@@ -190,7 +190,7 @@ async def _handle_guest_dormant(sig: LoopSignal) -> list[LoopSignal]:
                 # Enqueue for reactivation hunter
                 await db.execute(text("""
                     INSERT INTO agent_queue (guest_id, trigger_source, score, status)
-                    VALUES (:gid::uuid, 'dormancy_signal', :score, 'pending')
+                    VALUES (CAST(:gid AS uuid), 'dormancy_signal', :score, 'pending')
                     ON CONFLICT DO NOTHING
                 """), {
                     "gid":   str(guest_id),
@@ -257,7 +257,7 @@ async def _handle_ota_parity_signal(sig: LoopSignal) -> list[LoopSignal]:
                         (event_type, source, description, metadata, occurred_at)
                     VALUES
                         ('ota_parity_signal', 'competitive_sentinel',
-                         :desc, :meta::jsonb, now())
+                         :desc, CAST(:meta AS jsonb), now())
                     ON CONFLICT DO NOTHING
                 """), {
                     "desc": f"OTA competitor at {competitor_url} priced ${abs(delta):.0f} {'below' if delta<0 else 'above'} sovereign rate",
@@ -379,7 +379,7 @@ async def _handle_intelligence_signal(sig: LoopSignal) -> list[LoopSignal]:
                      dedupe_hash, target_tags, source_urls, discovered_at)
                 VALUES
                     (:cat, :title, :summary, :market, :market,
-                     :conf, :dhash, :tags::jsonb, '[]'::jsonb, now())
+                     :conf, :dhash, CAST(:tags AS jsonb), '[]'::jsonb, now())
                 ON CONFLICT (dedupe_hash) DO NOTHING
             """), {
                 "cat":     category[:64],
@@ -469,7 +469,7 @@ async def _handle_legal_deliberation_complete(sig: LoopSignal) -> list[LoopSigna
                         (event_type, source, description, metadata, occurred_at)
                     VALUES
                         ('legal_clearance', 'recursive_agent_loop',
-                         :desc, :meta::jsonb, now())
+                         :desc, CAST(:meta AS jsonb), now())
                 """), {
                     "desc": f"Legal barrier cleared for property {property_id} — {outcome}",
                     "meta": json.dumps({"case_slug": case_slug, "conviction": avg_conviction}),


### PR DESCRIPTION
## Bug
SQLAlchemy \`text()\` under asyncpg rejects \`:name::type\` shorthand — Postgres raises \`syntax error at or near ':'\` because the driver leaves the \`::\` in a position asyncpg's param substitution can't negotiate. \`CAST(:name AS type)\` is the equivalent form the codebase already uses for \`:meta → jsonb\`.

## Fix
| File | Before | After |
|---|---|---|
| \`captain_multi_mailbox.py:652\` (ALLOW INSERT) | \`:id::uuid\` | \`CAST(:id AS uuid)\` ← **primary fix** |
| \`ai_router.py:145\` (_capture_interaction ALLOW INSERT) | \`:id::uuid\` | \`CAST(:id AS uuid)\` ← silent failure mode, same bug class |
| \`recursive_agent_loop.py:193\` | \`:gid::uuid\` | \`CAST(:gid AS uuid)\` |
| \`recursive_agent_loop.py:260\` | \`:meta::jsonb\` | \`CAST(:meta AS jsonb)\` |
| \`recursive_agent_loop.py:382\` | \`:tags::jsonb\` | \`CAST(:tags AS jsonb)\` |
| \`recursive_agent_loop.py:472\` | \`:meta::jsonb\` | \`CAST(:meta AS jsonb)\` |
| \`legal_council.py\` | scanned, clean — no bind-cast occurrences | — |

Column/literal casts like \`'[]'::jsonb\` left intact — those aren't bind params and don't trip the parser.

## Regression
- \`test_captain_allow_insert_uses_cast_not_colon_colon\` — direct assertion that captain's ALLOW INSERT carries \`CAST(:id AS uuid)\` and contains zero \`:bind::type\` occurrences.
- \`test_no_bind_param_colon_colon_cast_in_sql_modules\` — scans every captain-adjacent SQL writer (4 files) line-by-line, ignores comments, fails with a full offender list if anyone reintroduces the pattern.

## Test plan
- [x] \`pytest backend/tests/test_fortress_load_secrets.py backend/tests/test_captain_multi_mailbox.py backend/tests/test_privilege_filter.py\` → **41 passed** (2 new regression tests + full prior suite green).

## Operator action after merge
\`\`\`bash
cd /home/admin/Fortress-Prime
git pull --ff-only origin main
sudo systemctl restart fortress-arq-worker
sudo journalctl -u fortress-arq-worker -f \\
  | grep -E 'captain_preflight|captain_multi_mailbox|captain_email_processed|syntax error'
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)