### PR TITLE
feat(captain): three-tier junk filter — headers → sender → LLM fail-open

### DIFF
--- a/fortress-guest-platform/.env.example
+++ b/fortress-guest-platform/.env.example
@@ -194,3 +194,43 @@ LEGACY_LEGAL_INTAKE_ENABLED=false
 # Comma-separated. Extends the built-in set; any sender or recipient on
 # these domains routes the capture to restricted_captures.
 # ATTORNEY_DOMAINS=examplefirm.com,counselor.legal
+
+# ---------------------------------------------------------------------------
+# Captain — junk/bulk-mail filter
+# ---------------------------------------------------------------------------
+# When true (default), captain_junk_filter.classify_junk() runs on every
+# inbound email BEFORE the privilege filter. Junked mail is dropped with a
+# captain_email_junked log line — no writes to llm_training_captures or
+# restricted_captures, and privilege_filter is not consulted.
+#
+# Three tiers, short-circuit in order:
+#   1. Headers: List-Unsubscribe, List-Unsubscribe-Post, Precedence: bulk,
+#      X-Campaign-Id / X-Mailchimp-Campaign-Id / X-Mailgun-Tag,
+#      Auto-Submitted. Deterministic, ~0ms.
+#   2. Sender heuristics: noreply/donotreply/do-not-reply local-parts;
+#      newsletter/news/updates/digest/announce local-parts; bounce/
+#      mailer-daemon/postmaster; ESP relay FROM domains (amazonses,
+#      mailgun, sendgrid, postmarkapp, Mailchimp mcsv/rsgsv, etc.).
+#      Deterministic, ~0ms.
+#   3. LLM triage: Ollama qwen2.5:0.5b with 500ms timeout, fails open.
+#      Any timeout/non-200/parse-error returns is_junk=False — a
+#      false negative (junk gets through) is cheaper than dropping
+#      legit mail when the LLM tier is unhealthy.
+#
+# Extend tier-2 sender patterns or tier-1 marketing headers by editing
+# backend/services/captain_junk_filter.py. There is no env-driven list;
+# these are stable enough to live in source. Per-captain bypass for a
+# specific sender is not supported today — a .allow list lives in
+# ATTORNEY_DOMAINS upstream of this filter (privilege_filter short-
+# circuits via RESTRICTED, not ALLOW, so the junk filter still runs).
+#
+# Set false to roll back to the pre-junk-filter behaviour (every email
+# reaches the privilege filter + capture tables) without a code revert.
+CAPTAIN_JUNK_FILTER_ENABLED=true
+
+# Optional LLM tier overrides — useful when the Ollama task-classifier
+# stack moves to a new host or a smaller/faster model is available.
+# If unset, captain_junk_filter reuses OLLAMA_BASE_URL and picks
+# qwen2.5:0.5b as the model.
+# TASK_CLASSIFIER_OLLAMA_URL=http://192.168.0.100:11434
+# TASK_CLASSIFIER_MODEL=qwen2.5:0.5b

--- a/fortress-guest-platform/backend/core/config.py
+++ b/fortress-guest-platform/backend/core/config.py
@@ -896,6 +896,15 @@ class Settings(BaseSettings):
         default=False, alias="LEGACY_LEGAL_INTAKE_ENABLED"
     )
 
+    # Captain junk/bulk-mail filter. When true (default), every inbound
+    # email runs through captain_junk_filter.classify_junk() BEFORE the
+    # privilege filter — junked mail is dropped with a log line, zero DB
+    # writes. Set false to revert to pre-junk-filter behaviour without
+    # editing code.
+    captain_junk_filter_enabled: bool = Field(
+        default=True, alias="CAPTAIN_JUNK_FILTER_ENABLED"
+    )
+
     # Twilio
     twilio_account_sid: str = Field(default="")
     twilio_auth_token: str = Field(default="")

--- a/fortress-guest-platform/backend/services/captain_junk_filter.py
+++ b/fortress-guest-platform/backend/services/captain_junk_filter.py
@@ -1,0 +1,340 @@
+"""
+Captain — junk / bulk-mail filter.
+
+Three-tier classifier run BEFORE the privilege filter in the Captain
+intake pipeline. Keeps newsletters, transactional notifications, and
+marketing blasts out of the training capture flywheel.
+
+Tier 1 — header inspection (deterministic, ~0ms)
+  RFC-standard bulk-mail headers are a reliable signal: List-Unsubscribe,
+  Precedence: bulk|list|junk, Auto-Submitted: auto-generated, and the
+  ESP campaign tags (X-Campaign-Id, X-Mailchimp-Campaign-Id,
+  X-Mailgun-Tag) between them catch the large majority of inbound bulk.
+
+Tier 2 — sender heuristics (deterministic, ~0ms)
+  Structured local-parts (noreply, newsletter, bounce, mailer-daemon)
+  and ESP relay domains in the From address (amazonses, mailgun, sendgrid,
+  postmark) — personal/legal mail never originates from these.
+
+Tier 3 — LLM triage (Ollama, ~500ms, fails OPEN)
+  Only reached for mail that slipped both deterministic tiers. Uses a
+  small fast model (qwen2.5:0.5b on the existing TASK_CLASSIFIER_MODEL
+  / OLLAMA_BASE_URL) with a 500ms timeout. Any failure — timeout, non-
+  200, parse error — returns is_junk=False so legitimate mail is never
+  dropped when the LLM tier is unhealthy.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import structlog
+
+from backend.core.config import settings
+from backend.services.captain_multi_mailbox import FetchedEmail
+
+logger = structlog.get_logger(service="captain_junk_filter")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Public types
+# ──────────────────────────────────────────────────────────────────────────────
+
+VALID_CATEGORIES: frozenset[str] = frozenset({
+    "legal", "business", "marketing", "receipt",
+    "newsletter", "notification", "personal", "unknown",
+})
+
+
+@dataclass(frozen=True)
+class JunkDecision:
+    is_junk: bool
+    category: str
+    reason: str
+    confidence: float
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Tier 1 — headers
+# ──────────────────────────────────────────────────────────────────────────────
+
+# Headers whose mere presence signals bulk/newsletter routing.
+_NEWSLETTER_HEADERS: tuple[str, ...] = (
+    "list-unsubscribe",
+    "list-unsubscribe-post",
+)
+
+# Known campaign/ESP tagging headers. Presence => marketing blast.
+_MARKETING_HEADERS: tuple[str, ...] = (
+    "x-campaign-id",
+    "x-mailchimp-campaign-id",
+    "x-mailgun-tag",
+)
+
+# Precedence values that indicate bulk delivery per RFC 2076.
+_BULK_PRECEDENCE_VALUES: frozenset[str] = frozenset({"bulk", "list", "junk"})
+
+
+def _check_headers(em: FetchedEmail) -> JunkDecision | None:
+    for name in _NEWSLETTER_HEADERS:
+        if em.headers_present(name):
+            return JunkDecision(
+                is_junk=True,
+                category="newsletter",
+                reason=f"header_{name.replace('-', '_')}",
+                confidence=1.0,
+            )
+
+    precedence = em.header("precedence").strip().lower()
+    if precedence in _BULK_PRECEDENCE_VALUES:
+        return JunkDecision(
+            is_junk=True,
+            category="newsletter",
+            reason="header_precedence_bulk",
+            confidence=1.0,
+        )
+
+    for name in _MARKETING_HEADERS:
+        if em.headers_present(name):
+            return JunkDecision(
+                is_junk=True,
+                category="marketing",
+                reason=f"header_{name.replace('-', '_')}",
+                confidence=1.0,
+            )
+
+    auto_submitted = em.header("auto-submitted").strip().lower()
+    if auto_submitted and auto_submitted != "no":
+        # RFC 3834: values include auto-generated, auto-replied.
+        return JunkDecision(
+            is_junk=True,
+            category="notification",
+            reason="header_auto_submitted",
+            confidence=1.0,
+        )
+
+    return None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Tier 2 — sender heuristics
+# ──────────────────────────────────────────────────────────────────────────────
+
+# Match the local-part (left of @). Bounds help avoid catching legitimate
+# addresses that happen to contain the pattern as a substring (e.g.
+# "newsletters-manager@firm.com").
+_NOREPLY_LOCAL_RE = re.compile(
+    r"^(?:no[-_.]?reply|donotreply|do[-_.]?not[-_.]?reply)"
+    r"(?:[-_.+@]|$)",
+    re.IGNORECASE,
+)
+_NEWSLETTER_LOCAL_RE = re.compile(
+    r"^(?:newsletter|news|updates|digest|announce|announcements)"
+    r"(?:[-_.+@]|$)",
+    re.IGNORECASE,
+)
+_BOUNCE_LOCAL_RE = re.compile(
+    r"^(?:bounce(?:s)?|mailer[-_.]?daemon|postmaster)"
+    r"(?:[-_.+@]|$)",
+    re.IGNORECASE,
+)
+
+# ESP relay domains. If the FROM sender sits on one of these it's a
+# marketing/transactional blast — legitimate senders use their own
+# domain even when relaying through these services (via Reply-To).
+_ESP_RELAY_DOMAINS: frozenset[str] = frozenset({
+    "amazonses.com",
+    "mailgun.net",
+    "sendgrid.net",
+    "sendgrid.com",
+    "postmarkapp.com",
+    "mcsv.net",            # Mailchimp
+    "rsgsv.net",           # Mailchimp
+    "mailerlite.com",
+    "constantcontact.com",
+})
+
+
+def _check_sender(em: FetchedEmail) -> JunkDecision | None:
+    sender = em.sender_email or ""
+    if "@" not in sender:
+        return None
+    local, _, domain = sender.partition("@")
+    local = local.strip()
+    domain = domain.strip().lower()
+
+    if _BOUNCE_LOCAL_RE.match(local):
+        return JunkDecision(
+            is_junk=True,
+            category="notification",
+            reason="sender_bounce",
+            confidence=1.0,
+        )
+    if _NOREPLY_LOCAL_RE.match(local):
+        return JunkDecision(
+            is_junk=True,
+            category="notification",
+            reason="sender_noreply",
+            confidence=0.95,
+        )
+    if _NEWSLETTER_LOCAL_RE.match(local):
+        return JunkDecision(
+            is_junk=True,
+            category="newsletter",
+            reason="sender_newsletter_localpart",
+            confidence=0.9,
+        )
+    if domain in _ESP_RELAY_DOMAINS:
+        return JunkDecision(
+            is_junk=True,
+            category="marketing",
+            reason="sender_esp_relay_domain",
+            confidence=0.9,
+        )
+    return None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Tier 3 — LLM triage (fail-open)
+# ──────────────────────────────────────────────────────────────────────────────
+
+_LLM_SYSTEM_PROMPT = """You are a mail triage classifier for Cabin Rentals of Georgia.
+
+Read the email and classify it. Respond ONLY with valid JSON — no markdown, no explanation:
+{
+  "category": "legal|business|marketing|receipt|newsletter|notification|personal|unknown",
+  "is_junk": true|false,
+  "confidence": 0.0-1.0,
+  "reason": "short phrase, e.g. marketing_body_copy, personal_thread_reply"
+}
+
+is_junk=true ONLY for: newsletter, marketing, notification, receipt (low-value bulk).
+is_junk=false for: legal correspondence, business inquiries, personal messages, anything that needs a human.
+When unsure, prefer is_junk=false — a false negative (junk gets through) is cheaper than a false positive (important mail dropped).
+"""
+
+_LLM_TIMEOUT_S = 0.5
+
+
+def _ollama_endpoint() -> str:
+    """Resolve the Ollama base URL. TASK_CLASSIFIER_OLLAMA_URL wins."""
+    override = os.environ.get("TASK_CLASSIFIER_OLLAMA_URL", "").strip()
+    if override:
+        return override.rstrip("/")
+    return (settings.ollama_base_url or "").rstrip("/")
+
+
+def _ollama_model() -> str:
+    override = os.environ.get("TASK_CLASSIFIER_MODEL", "").strip()
+    if override:
+        return override
+    # Smallest fast model available on the task-classifier stack.
+    return "qwen2.5:0.5b"
+
+
+async def _check_llm(em: FetchedEmail) -> JunkDecision:
+    base_url = _ollama_endpoint()
+    if not base_url:
+        return JunkDecision(
+            is_junk=False, category="unknown",
+            reason="llm_unavailable", confidence=0.0,
+        )
+
+    prompt = (
+        f"From: {em.sender_email}\n"
+        f"Subject: {em.subject}\n\n"
+        f"{em.body[:2000]}"
+    )
+    payload = {
+        "model": _ollama_model(),
+        "messages": [
+            {"role": "system", "content": _LLM_SYSTEM_PROMPT},
+            {"role": "user", "content": prompt},
+        ],
+        "stream": False,
+        "options": {"temperature": 0.0, "num_predict": 128},
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=_LLM_TIMEOUT_S) as client:
+            resp = await client.post(f"{base_url}/api/chat", json=payload)
+        if resp.status_code != 200:
+            return JunkDecision(
+                is_junk=False, category="unknown",
+                reason=f"llm_http_{resp.status_code}", confidence=0.0,
+            )
+        content = (resp.json().get("message") or {}).get("content", "").strip()
+    except (httpx.TimeoutException, asyncio.TimeoutError):
+        return JunkDecision(
+            is_junk=False, category="unknown",
+            reason="llm_timeout", confidence=0.0,
+        )
+    except Exception as exc:
+        logger.debug("captain_junk_llm_error", error=str(exc)[:120])
+        return JunkDecision(
+            is_junk=False, category="unknown",
+            reason="llm_error", confidence=0.0,
+        )
+
+    parsed = _parse_llm_json(content)
+    if parsed is None:
+        return JunkDecision(
+            is_junk=False, category="unknown",
+            reason="llm_parse_failed", confidence=0.0,
+        )
+    category = str(parsed.get("category") or "unknown").strip().lower()
+    if category not in VALID_CATEGORIES:
+        category = "unknown"
+    try:
+        confidence = float(parsed.get("confidence") or 0.0)
+    except (TypeError, ValueError):
+        confidence = 0.0
+    confidence = max(0.0, min(1.0, confidence))
+    is_junk = bool(parsed.get("is_junk"))
+    reason_text = str(parsed.get("reason") or "")[:64] or "llm_classified"
+    return JunkDecision(
+        is_junk=is_junk,
+        category=category,
+        reason=f"llm_{reason_text}",
+        confidence=confidence,
+    )
+
+
+def _parse_llm_json(raw: str) -> dict[str, Any] | None:
+    text = raw.strip()
+    if text.startswith("```"):
+        lines = [ln for ln in text.split("\n") if not ln.strip().startswith("```")]
+        text = "\n".join(lines).strip()
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        return None
+    try:
+        loaded = json.loads(text[start:end + 1])
+    except json.JSONDecodeError:
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Public API
+# ──────────────────────────────────────────────────────────────────────────────
+
+async def classify_junk(em: FetchedEmail) -> JunkDecision:
+    """
+    Classify an inbound email. Short-circuits at the first tier that
+    returns a verdict so the ordering (headers → sender → LLM) is
+    observable by tests and operator dashboards.
+    """
+    tier1 = _check_headers(em)
+    if tier1 is not None:
+        return tier1
+    tier2 = _check_sender(em)
+    if tier2 is not None:
+        return tier2
+    return await _check_llm(em)

--- a/fortress-guest-platform/backend/services/captain_multi_mailbox.py
+++ b/fortress-guest-platform/backend/services/captain_multi_mailbox.py
@@ -248,12 +248,28 @@ class FetchedEmail:
     recipient_emails: list[str] = field(default_factory=list)
     attachment_filenames: list[str] = field(default_factory=list)
     message_id: str = ""
+    # Full message headers keyed lowercase, values as lists (one entry per
+    # occurrence). Populated by _parse_rfc822 but default-empty so synthetic
+    # FetchedEmail instances in tests don't have to provide it.
+    headers: dict[str, list[str]] = field(default_factory=dict)
 
     @property
     def sender_domain(self) -> str:
         if "@" not in self.sender_email:
             return ""
         return self.sender_email.rsplit("@", 1)[-1].strip().lower()
+
+    def header(self, name: str) -> str:
+        """First value of a header, case-insensitive. Empty string if absent."""
+        values = self.headers.get(name.lower())
+        return values[0] if values else ""
+
+    def headers_present(self, *names: str) -> bool:
+        """True iff any of the named headers is present (non-empty)."""
+        for n in names:
+            if self.headers.get(n.lower()):
+                return True
+        return False
 
 
 def _decode_header_value(raw: Any) -> str:
@@ -329,6 +345,9 @@ def _parse_rfc822(raw_bytes: bytes) -> FetchedEmail:
     ) + _extract_recipient_list(
         msg.get_all("Cc") or []
     )
+    headers: dict[str, list[str]] = {}
+    for name, value in msg.items():
+        headers.setdefault(name.lower(), []).append(_decode_header_value(value))
     return FetchedEmail(
         subject=subject,
         body=_extract_plain_body(msg),
@@ -336,6 +355,7 @@ def _parse_rfc822(raw_bytes: bytes) -> FetchedEmail:
         recipient_emails=recipients,
         attachment_filenames=_extract_attachments(msg),
         message_id=_decode_header_value(msg.get("Message-ID", "")),
+        headers=headers,
     )
 
 
@@ -690,7 +710,36 @@ async def process_email(
     mailbox: MailboxConfig,
     session_factory: Any | None = None,
 ) -> dict[str, str]:
-    """Classify + persist one email. Returns dict with route and routing_tag."""
+    """
+    Classify + persist one email. Returns a dict with:
+      mailbox       — mailbox.name
+      routing_tag   — mailbox.routing_tag
+      route         — 'allow' | 'restricted' | 'block' | 'junk'
+      junk_category — only present when route == 'junk'
+    """
+    # Junk pass runs first — short-circuit before the privilege filter
+    # so newsletters / bounces / marketing blasts never reach the capture
+    # tables and never cost a classify_for_capture() call.
+    if settings.captain_junk_filter_enabled:
+        from backend.services.captain_junk_filter import classify_junk
+        junk = await classify_junk(em)
+        if junk.is_junk:
+            logger.info(
+                "captain_email_junked",
+                mailbox=mailbox.name,
+                routing_tag=mailbox.routing_tag,
+                junk_category=junk.category,
+                reason=junk.reason[:120],
+                confidence=round(junk.confidence, 3),
+                sender_domain=em.sender_domain,
+            )
+            return {
+                "mailbox": mailbox.name,
+                "routing_tag": mailbox.routing_tag,
+                "route": "junk",
+                "junk_category": junk.category,
+            }
+
     decision = classify_email(em, mailbox)
     route = await write_capture(em, mailbox, decision, session_factory=session_factory)
     logger.info(
@@ -722,8 +771,15 @@ async def run_patrol(
     if not mailboxes:
         return {"status": "no_mailboxes", "processed": 0}
 
-    stats: dict[str, int] = {"processed": 0, "allow": 0, "restricted": 0, "block": 0}
+    stats: dict[str, int] = {
+        "processed": 0,
+        "allow": 0,
+        "restricted": 0,
+        "block": 0,
+        "junk": 0,
+    }
     by_tag: dict[str, int] = {}
+    by_junk_category: dict[str, int] = {}
 
     for mailbox in mailboxes:
         try:
@@ -756,8 +812,17 @@ async def run_patrol(
             stats["processed"] += 1
             stats[result["route"]] = stats.get(result["route"], 0) + 1
             by_tag[result["routing_tag"]] = by_tag.get(result["routing_tag"], 0) + 1
+            if result["route"] == "junk":
+                cat = result.get("junk_category", "unknown")
+                by_junk_category[cat] = by_junk_category.get(cat, 0) + 1
 
-    return {"status": "patrol_complete", "mailboxes": len(mailboxes), **stats, "by_tag": by_tag}
+    return {
+        "status": "patrol_complete",
+        "mailboxes": len(mailboxes),
+        **stats,
+        "by_tag": by_tag,
+        "by_junk_category": by_junk_category,
+    }
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/fortress-guest-platform/backend/tests/test_captain_junk_filter.py
+++ b/fortress-guest-platform/backend/tests/test_captain_junk_filter.py
@@ -1,0 +1,384 @@
+"""
+Tests for the Captain junk filter — three-tier classifier that gates
+access to the privilege filter + capture writes.
+
+All LLM calls are stubbed; no real Ollama / network traffic.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from backend.services import captain_junk_filter as junk_mod
+from backend.services import captain_multi_mailbox as captain_mod
+from backend.services.captain_junk_filter import (
+    JunkDecision,
+    classify_junk,
+)
+from backend.services.captain_multi_mailbox import (
+    FetchedEmail,
+    MailboxConfig,
+    process_email,
+    run_patrol,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fixtures / helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _mailbox(
+    name: str = "legal-cpanel",
+    address: str = "legal@cabin-rentals-of-georgia.com",
+    routing_tag: str = "legal",
+) -> MailboxConfig:
+    return MailboxConfig(
+        name=name,
+        transport="imap",
+        address=address,
+        routing_tag=routing_tag,
+        host="mail.cabin-rentals-of-georgia.com",
+        port=993,
+        credentials_ref="MAILPLUS_PASSWORD_TEST",
+        poll_interval_sec=120,
+    )
+
+
+def _email(
+    subject: str = "hello",
+    body: str = "routine message body",
+    sender: str = "jane@example.com",
+    headers: dict[str, list[str]] | None = None,
+) -> FetchedEmail:
+    return FetchedEmail(
+        subject=subject, body=body, sender_email=sender,
+        headers=headers or {},
+    )
+
+
+def _force_llm_returning(monkeypatch, decision: JunkDecision) -> dict[str, int]:
+    """Replace _check_llm with a fake. Returns a counter of calls."""
+    calls = {"count": 0}
+
+    async def fake(em: FetchedEmail) -> JunkDecision:
+        calls["count"] += 1
+        return decision
+
+    monkeypatch.setattr(junk_mod, "_check_llm", fake)
+    return calls
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. test_junk_header_list_unsubscribe_routes_junk
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestJunkHeaderListUnsubscribeRoutesJunk:
+    def test_junk_header_list_unsubscribe_routes_junk(self, monkeypatch):
+        monkeypatch.setattr(junk_mod, "_check_llm", None)  # must not be called
+        em = _email(
+            sender="analyst@bloomberg.net",
+            headers={"list-unsubscribe": ["<mailto:u@bb.net>"]},
+        )
+        decision = asyncio.run(classify_junk(em))
+        assert decision.is_junk is True
+        assert decision.category == "newsletter"
+        assert decision.reason == "header_list_unsubscribe"
+        assert decision.confidence == 1.0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. test_junk_header_precedence_bulk_routes_junk
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestJunkHeaderPrecedenceBulkRoutesJunk:
+    @pytest.mark.parametrize("value", ["bulk", "list", "junk", "BULK", "  Bulk  "])
+    def test_junk_header_precedence_bulk_routes_junk(self, monkeypatch, value):
+        monkeypatch.setattr(junk_mod, "_check_llm", None)
+        em = _email(headers={"precedence": [value]})
+        decision = asyncio.run(classify_junk(em))
+        assert decision.is_junk is True
+        assert decision.reason == "header_precedence_bulk"
+        assert decision.category == "newsletter"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. test_junk_sender_noreply_routes_junk
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestJunkSenderNoreplyRoutesJunk:
+    @pytest.mark.parametrize("addr", [
+        "noreply@stripe.com",
+        "no-reply@amazonaws.com",
+        "donotreply@airbnb.com",
+        "do-not-reply@somewhere.com",
+        "NoReply@mixedcase.com",
+    ])
+    def test_junk_sender_noreply_routes_junk(self, monkeypatch, addr):
+        monkeypatch.setattr(junk_mod, "_check_llm", None)
+        em = _email(sender=addr)
+        decision = asyncio.run(classify_junk(em))
+        assert decision.is_junk is True
+        assert decision.category == "notification"
+        assert decision.reason == "sender_noreply"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. test_junk_sender_mailchimp_domain_routes_junk
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestJunkSenderMailchimpDomainRoutesJunk:
+    @pytest.mark.parametrize("addr", [
+        "newsletter@mcsv.net",
+        "campaign@rsgsv.net",
+        "sender@sendgrid.net",
+        "foo@amazonses.com",
+        "bar@mailgun.net",
+    ])
+    def test_junk_sender_mailchimp_domain_routes_junk(self, monkeypatch, addr):
+        monkeypatch.setattr(junk_mod, "_check_llm", None)
+        em = _email(sender=addr)
+        decision = asyncio.run(classify_junk(em))
+        assert decision.is_junk is True
+        assert decision.category in {"marketing", "newsletter"}
+        assert decision.reason in {
+            "sender_esp_relay_domain",
+            "sender_newsletter_localpart",
+        }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. test_junk_legal_email_with_no_junk_signals_passes_through
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestJunkLegalEmailWithNoJunkSignalsPassesThrough:
+    def test_junk_legal_email_with_no_junk_signals_passes_through(self, monkeypatch):
+        """
+        Realistic opposing-counsel email: no bulk headers, a personal
+        sender address. Tier-3 LLM says is_junk=False. Must reach the
+        downstream privilege filter (i.e. classify_junk returns is_junk=False).
+        """
+        _force_llm_returning(monkeypatch, JunkDecision(
+            is_junk=False, category="legal",
+            reason="llm_legal_correspondence", confidence=0.92,
+        ))
+        em = _email(
+            subject="RE: Johnson v CROG — Rule 26 disclosures",
+            body="Counsel — see attached the plaintiff's Rule 26 disclosures.",
+            sender="jdoe@opposingfirm.com",
+        )
+        decision = asyncio.run(classify_junk(em))
+        assert decision.is_junk is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 6. test_junk_llm_timeout_fails_open
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestJunkLlmTimeoutFailsOpen:
+    def test_junk_llm_timeout_fails_open(self, monkeypatch):
+        """
+        httpx.TimeoutException during the tier-3 call must NOT raise and
+        must NOT route to junk. Email falls through to the privilege
+        filter as if junk filtering were disabled for this message.
+        """
+        import httpx
+
+        class _FakeClient:
+            def __init__(self, *args, **kwargs): pass
+            async def __aenter__(self): return self
+            async def __aexit__(self, *a): return False
+            async def post(self, *args, **kwargs):
+                raise httpx.TimeoutException("timed out")
+
+        monkeypatch.setattr(junk_mod.httpx, "AsyncClient", _FakeClient)
+        monkeypatch.setenv("TASK_CLASSIFIER_OLLAMA_URL", "http://stub:11434")
+
+        em = _email(
+            subject="quick question",
+            body="Hi Gary — any chance we can chat tomorrow?",
+            sender="normal@person.com",
+        )
+        decision = asyncio.run(classify_junk(em))
+        assert decision.is_junk is False
+        assert decision.category == "unknown"
+        assert decision.reason == "llm_timeout"
+        assert decision.confidence == 0.0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 7. test_junk_ordering_header_before_sender_before_llm
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestJunkOrderingHeaderBeforeSenderBeforeLlm:
+    def test_junk_ordering_header_before_sender_before_llm(self, monkeypatch):
+        """
+        If all three tiers would fire, the header tier must win (=> LLM
+        never called). We plant an exploding LLM stub: any call fails
+        the test.
+        """
+        def _boom_llm(*_args, **_kwargs):
+            raise AssertionError("LLM must not be consulted when headers match")
+
+        monkeypatch.setattr(junk_mod, "_check_llm", _boom_llm)
+
+        # Noreply sender (tier 2 would match) + List-Unsubscribe header
+        # (tier 1 matches) — expect tier-1 verdict.
+        em = _email(
+            sender="noreply@news.bloomberg.net",
+            headers={"list-unsubscribe": ["<mailto:u@bb.net>"]},
+        )
+        decision = asyncio.run(classify_junk(em))
+        assert decision.reason == "header_list_unsubscribe"
+
+    def test_sender_before_llm(self, monkeypatch):
+        """Tier 2 matches, no headers → LLM must not fire."""
+        def _boom_llm(*_args, **_kwargs):
+            raise AssertionError("LLM must not be consulted when sender matches")
+
+        monkeypatch.setattr(junk_mod, "_check_llm", _boom_llm)
+        em = _email(sender="noreply@stripe.com")
+        decision = asyncio.run(classify_junk(em))
+        assert decision.reason == "sender_noreply"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 8. test_patrol_report_includes_junk_counters
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestPatrolReportIncludesJunkCounters:
+    @pytest.mark.asyncio
+    async def test_patrol_report_includes_junk_counters(self, monkeypatch):
+        """
+        Feed 3 emails to a mocked mailbox: 1 newsletter (junk), 1 marketing
+        (junk), 1 legitimate (allow). Patrol report must reflect
+        junk=2, allow=1, and the by_junk_category breakdown.
+        """
+        monkeypatch.setattr(
+            captain_mod.settings, "captain_junk_filter_enabled", True,
+            raising=False,
+        )
+
+        emails_to_deliver = [
+            _email(
+                subject="Bloomberg morning briefing",
+                sender="news@bloomberg.net",
+                headers={"list-unsubscribe": ["<mailto:u@bb.net>"]},
+            ),
+            _email(
+                subject="Big sale this weekend",
+                sender="promo@amazonses.com",
+            ),
+            _email(
+                subject="Re: contract revision",
+                sender="counsel@firm.example",
+                body="Please review the attached contract changes.",
+            ),
+        ]
+
+        def fake_fetch(self) -> list[FetchedEmail]:
+            return list(emails_to_deliver)
+
+        monkeypatch.setattr(
+            captain_mod.ImapTransport, "fetch_unseen", fake_fetch,
+        )
+
+        # The non-junk email reaches write_capture — stub the DB writer.
+        writes: list[str] = []
+
+        async def fake_write(em, mailbox, decision, session_factory=None):
+            writes.append(decision.route.value)
+            return decision.route.value
+
+        monkeypatch.setattr(captain_mod, "write_capture", fake_write)
+
+        result = await run_patrol(mailboxes=[_mailbox()])
+
+        assert result["processed"] == 3
+        assert result["junk"] == 2
+        assert result["allow"] == 1
+        assert result["restricted"] == 0
+        assert result["block"] == 0
+        assert result["by_junk_category"] == {"newsletter": 1, "marketing": 1}
+        assert result["by_tag"] == {"legal": 3}
+        # Only the non-junk email hit the write path.
+        assert writes == ["allow"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 9. test_privilege_filter_not_called_when_email_is_junk
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestPrivilegeFilterNotCalledWhenEmailIsJunk:
+    @pytest.mark.asyncio
+    async def test_privilege_filter_not_called_when_email_is_junk(
+        self, monkeypatch,
+    ):
+        """
+        Efficiency: a junk email must short-circuit before classify_email
+        (which calls privilege_filter.classify_for_capture) is touched.
+        Also asserts write_capture is never reached.
+        """
+        monkeypatch.setattr(
+            captain_mod.settings, "captain_junk_filter_enabled", True,
+            raising=False,
+        )
+
+        classify_spy = MagicMock(side_effect=AssertionError(
+            "classify_email must not be called for junk mail"
+        ))
+        monkeypatch.setattr(captain_mod, "classify_email", classify_spy)
+
+        async def explode_write(*args, **kwargs):
+            raise AssertionError("write_capture must not be called for junk mail")
+        monkeypatch.setattr(captain_mod, "write_capture", explode_write)
+
+        em = _email(
+            sender="newsletter@mailgun.net",  # tier-2 ESP relay domain
+            headers={"list-unsubscribe": ["<https://u.mailgun.net/x>"]},
+        )
+
+        result = await process_email(em, _mailbox())
+        assert result["route"] == "junk"
+        assert result["junk_category"] == "newsletter"
+        classify_spy.assert_not_called()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Bonus — flag-off passthrough (ensures rollback works without revert)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestJunkFilterDisabledSkipsEntirely:
+    @pytest.mark.asyncio
+    async def test_flag_false_bypasses_junk_classifier(self, monkeypatch):
+        monkeypatch.setattr(
+            captain_mod.settings, "captain_junk_filter_enabled", False,
+            raising=False,
+        )
+
+        # If junk classifier were called, this would fire.
+        async def _boom(em):
+            raise AssertionError("classify_junk must not be called when flag is off")
+
+        monkeypatch.setattr(junk_mod, "classify_junk", _boom)
+
+        # The path therefore runs straight to classify_email + write_capture.
+        class _FakeDecision:
+            route = type("_R", (), {"value": "allow"})()
+            reason = "ok"
+            matched_patterns: tuple[str, ...] = ()
+        monkeypatch.setattr(
+            captain_mod, "classify_email", lambda *_: _FakeDecision(),
+        )
+
+        async def fake_write(em, mailbox, decision, session_factory=None):
+            return decision.route.value
+        monkeypatch.setattr(captain_mod, "write_capture", fake_write)
+
+        em = _email(
+            sender="noreply@stripe.com",                  # tier-2 match, ignored
+            headers={"list-unsubscribe": ["<u@x.com>"]},  # tier-1 match, ignored
+        )
+        result = await process_email(em, _mailbox())
+        assert result["route"] == "allow"


### PR DESCRIPTION
## Summary
Keep newsletters, marketing blasts, and transactional notifications out of the training capture flywheel. Runs **before** the privilege filter, so bulk mail never reaches `classify_for_capture()` or any capture table.

## What ships
- `backend/services/captain_junk_filter.py` — new module with `classify_junk(em)` → `JunkDecision(is_junk, category, reason, confidence)`.
- `FetchedEmail.headers` — additive field (default `{}`), populated in `_parse_rfc822` for real IMAP fetches, optional for synthetic test instances. New helpers: `.header(name)` + `.headers_present(*names)`.
- `captain_multi_mailbox.process_email` — junk check runs first when `CAPTAIN_JUNK_FILTER_ENABLED=true` (default). Junk → log `captain_email_junked`, `route="junk"`, no DB write, no privilege_filter call.
- `captain_multi_mailbox.run_patrol` — now emits `junk` counter + `by_junk_category` breakdown alongside `allow/restricted/block`.
- `backend/core/config.py` — `captain_junk_filter_enabled` bool, aliased to `CAPTAIN_JUNK_FILTER_ENABLED`, default `True`.
- `.env.example` — full Captain junk-filter doc block (tier order, extension points, rollback flag, optional `TASK_CLASSIFIER_OLLAMA_URL` / `TASK_CLASSIFIER_MODEL` overrides).

## Tiers

| Tier | Cost | Short-circuits on |
|---|---|---|
| 1 — headers | ~0ms | `List-Unsubscribe`, `List-Unsubscribe-Post`, `Precedence: bulk\|list\|junk`, `X-Campaign-Id`, `X-Mailchimp-Campaign-Id`, `X-Mailgun-Tag`, `Auto-Submitted: *` |
| 2 — sender  | ~0ms | `bounce+/mailer-daemon/postmaster`, `noreply/donotreply/do-not-reply`, `newsletter/news/updates/digest/announce` local-parts, ESP relay FROM domains (amazonses, mailgun, sendgrid, postmark, Mailchimp mcsv/rsgsv, mailerlite, constantcontact) |
| 3 — LLM (qwen2.5:0.5b) | ~500ms | JSON verdict from Ollama. **Fails open** — any timeout / non-200 / parse-error returns `is_junk=False` so legit mail survives an unhealthy LLM tier. |

## Test plan
- [x] `pytest backend/tests/test_captain_junk_filter.py backend/tests/test_captain_multi_mailbox.py backend/tests/test_privilege_filter.py backend/tests/test_fortress_load_secrets.py` → **64 passed**.
- [ ] After merge: operator restarts fortress-arq-worker; verify `captain_patrol_report` now carries `junk=N  by_junk_category={...}` and that `captain_email_junked` lines appear for the obvious bulk senders.

## Nine requested tests (+ 1 bonus rollback test)
1. `test_junk_header_list_unsubscribe_routes_junk`
2. `test_junk_header_precedence_bulk_routes_junk` (×5 case variants)
3. `test_junk_sender_noreply_routes_junk` (×5 address variants)
4. `test_junk_sender_mailchimp_domain_routes_junk` (×5 ESP domains)
5. `test_junk_legal_email_with_no_junk_signals_passes_through`
6. `test_junk_llm_timeout_fails_open`
7. `test_junk_ordering_header_before_sender_before_llm` (+ inline `test_sender_before_llm`)
8. `test_patrol_report_includes_junk_counters`
9. `test_privilege_filter_not_called_when_email_is_junk`
+ `test_flag_false_bypasses_junk_classifier` — confirms rollback via env var only.

## Constraints satisfied
- No DB migration / no new tables.
- No secrets touched.
- `privilege_filter` public API unchanged (`classify_for_capture` signature + return type intact).
- `FetchedEmail.headers` default-empty → every existing synthetic test instance keeps working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)