### PR TITLE
chore(nim): redirect legal inference endpoints to spark-5 (Gate 1 consolidation)

### DIFF
--- a/docs/nim-endpoint-redirect-spark-5-2026-04-24.md
+++ b/docs/nim-endpoint-redirect-spark-5-2026-04-24.md
@@ -1,0 +1,83 @@
+# NIM endpoint redirect — spark-5 (Gate 1 consolidation)
+
+**Date:** 2026-04-24
+**Target:** `http://192.168.0.109:8100` (LAN, spark-5)
+**Supersedes:** `http://192.168.0.104:8000` (spark-2 / `fortress-nim-sovereign`)
+**Done by:** live `.env` edit on spark-1 + worker restart. `.env` is
+gitignored — this doc is the audit artifact.
+
+## What changed
+
+Three runtime env vars in
+`fortress-guest-platform/.env` on spark-1:
+
+| Variable | Before | After |
+|---|---|---|
+| `NIM_SOVEREIGN_URL` | `http://192.168.0.104:8000` | `http://192.168.0.109:8100` |
+| `LEGAL_NIM_ENDPOINT` | `http://192.168.0.104:8000` | `http://192.168.0.109:8100` |
+| `SOVEREIGN_DISTILL_ADAPTER_URL` | (unset → config default `127.0.0.1:8100/v1`, gated off) | `http://192.168.0.109:8100/v1` |
+
+Pre-edit `.env` backup saved to
+`fortress-guest-platform/.env.bak.nim-redirect-20260424_120648`.
+
+## Addressing decision
+
+LAN IP `192.168.0.109` preferred over Tailscale hostname `spark-5` /
+`spark-5.taildd4879.ts.net` / Tailscale IP `100.96.13.99`:
+
+- Median LAN health-probe latency **1.137 ms** vs Tailscale median
+  **1.834 ms** — 1.61× faster.
+- Worst-case (cold): LAN 2.490 ms vs Tailscale 17.051 ms.
+- LAN removes the Tailscale mesh dependency — one fewer failure
+  domain under the legal inference path.
+- Note: there is no LAN hostname for spark-5 in `/etc/hosts` or
+  `~/.ssh/config` today; the IP is written literally.
+
+## Live verification
+
+- `http://192.168.0.109:8100/v1/health/ready` → HTTP 200
+  `"Service is ready."` (2.7 ms).
+- `/v1/models` → lists `nvidia/llama-3.3-nemotron-super-49b-v1.5-fp8`
+  with `max_model_len=32768`.
+- Post-restart probe of `legal_council`'s effective env:
+  `POST /v1/chat/completions` returned HTTP 200 with a valid
+  Nemotron `<think>…` trace in 2.48 s.
+
+## Tests
+
+`backend/tests/test_nim_migration.py` previously hardcoded the
+legacy IP in three `test_default_points_to_spark1` / -`config_default_is_spark1`
+assertions. Those three line-level updates ship in this PR
+(104 → 109). The remaining test assertions, probe fixtures, and the
+"spark-1 IP" *comments* are intentionally untouched — the deeper
+rework (assert against `cfg.nim_sovereign_url` instead of a
+hardcoded IP; correct the naming comments) belongs in the
+hostname-convention cleanup PR.
+
+After edit: **11/11 green** in `test_nim_migration.py`.
+
+## Out of scope
+
+- `fortress-nim-brain.service` on spark-1 has **not** been stopped
+  in this PR. Stopping that service (freeing the GPU for the
+  CourtListener ingest via nomic) is the next operation, now
+  unblocked by the redirect.
+- `backend/core/config.py` still has
+  `nim_sovereign_url: str = Field(default="http://192.168.0.104:8000")`.
+  That default is only surfaced when both `NIM_SOVEREIGN_URL` and
+  `LEGAL_NIM_ENDPOINT` are absent from `.env`. Not corrected here
+  to keep the PR minimal; belongs in the hostname-convention
+  cleanup PR.
+- `ai_router.py:45` default `SOVEREIGN_DISTILL_ADAPTER_URL` stays
+  at `127.0.0.1:8100/v1` in code — gated off by
+  `SOVEREIGN_DISTILL_ADAPTER_PCT=0`. `.env` now supplies the real
+  value; default only matters if the env var is ever removed.
+
+## Rollback
+
+```bash
+cp /home/admin/Fortress-Prime/fortress-guest-platform/.env.bak.nim-redirect-20260424_120648 \
+   /home/admin/Fortress-Prime/fortress-guest-platform/.env
+sudo systemctl restart fortress-arq-worker
+git revert <this merge sha>
+```

--- a/fortress-guest-platform/backend/tests/test_nim_migration.py
+++ b/fortress-guest-platform/backend/tests/test_nim_migration.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 class TestNimSovereignConfig:
     def test_nim_sovereign_url_default_is_spark1(self) -> None:
         from backend.core.config import settings
-        assert "192.168.0.104" in settings.nim_sovereign_url
+        assert "192.168.0.109" in settings.nim_sovereign_url
 
     def test_nim_sovereign_url_env_overridable(self, monkeypatch: Any) -> None:
         monkeypatch.setenv("NIM_SOVEREIGN_URL", "http://10.0.0.1:8000")
@@ -52,7 +52,7 @@ def _fresh_deposition(monkeypatch: Any):
 class TestLegalCouncilEndpoint:
     def test_default_points_to_spark1(self, monkeypatch: Any) -> None:
         lc = _fresh_council(monkeypatch)
-        assert "192.168.0.104" in lc._NIM_ENDPOINT, \
+        assert "192.168.0.109" in lc._NIM_ENDPOINT, \
             f"Expected spark-1 IP in _NIM_ENDPOINT, got: {lc._NIM_ENDPOINT}"
 
     def test_env_override_respected(self, monkeypatch: Any) -> None:
@@ -70,7 +70,7 @@ class TestLegalCouncilEndpoint:
 class TestDepositionEndpoint:
     def test_default_points_to_spark1(self, monkeypatch: Any) -> None:
         de = _fresh_deposition(monkeypatch)
-        assert "192.168.0.104" in de.SOVEREIGN_URL, \
+        assert "192.168.0.109" in de.SOVEREIGN_URL, \
             f"Expected spark-1 IP in SOVEREIGN_URL, got: {de.SOVEREIGN_URL}"
         assert "/v1/chat/completions" in de.SOVEREIGN_URL
 


### PR DESCRIPTION
## Summary
Redirect all legal-inference NIM endpoint env vars from `spark-2:fortress-nim-sovereign` (`192.168.0.104:8000`) to `spark-5:fortress-nim-brain` (`192.168.0.109:8100`) per Gate 1 consolidation. Live `.env` on spark-1 already edited + worker restarted + probe verified. `.env` is gitignored, so this PR carries two artifacts: the test assertions that were hardcoded to the legacy IP, plus an audit doc.

## Latency (median of 5 warm runs)
| Path | Median | Worst |
|---|---|---|
| LAN `192.168.0.109` | **1.137 ms** | 2.490 ms |
| Tailscale `100.96.13.99` | 1.834 ms | 17.051 ms |

LAN picked — 1.61× median speedup, ~10× better cold-case, drops Tailscale mesh dependency.

## `.env` change (keys only, values not shown)
```
NIM_SOVEREIGN_URL             [updated]
LEGAL_NIM_ENDPOINT            [updated]
SOVEREIGN_DISTILL_ADAPTER_URL [added]
```
Backup at `fortress-guest-platform/.env.bak.nim-redirect-20260424_120648`.

## Tests
`backend/tests/test_nim_migration.py` — **11/11 passed** after 3 assert updates (104 → 109). Comments and deeper test design left alone per your step-8 instruction.

## Step-11 live probe
- `POST http://192.168.0.109:8100/v1/chat/completions` through worker's effective env → **HTTP 200**, response content starts with `<think>\nOkay, the user said "Say` (Nemotron's reasoning trace, truncated at `max_tokens=10`), **2.48s**.

## Step-12 re-grep
15 hits on `127.0.0.1:8100` / `localhost:8100` / `spark-1:8100` / `192.168.0.100:8100` — all the same false positives flagged pre-edit: FastAPI/VRS/SEO/Command-Center callers whose port-8100 default is overridden in `.env` (actual FastAPI backend listens on 8000). `ai_router.py:45` `SOVEREIGN_DISTILL_ADAPTER_URL` default stays `127.0.0.1:8100/v1` but is gated off (`SOVEREIGN_DISTILL_ADAPTER_PCT=0`) and the runtime `.env` value now points at spark-5.

## Out of scope
- `fortress-nim-brain.service` on spark-1 is **still running**. This PR unblocks the stop by eliminating `legal_council` / `legal_deposition_engine` dependency on it, but the actual stop (freeing the GPU for nomic so the CourtListener ingest can proceed) is the next operation.
- `config.py` default (`192.168.0.104:8000`) untouched — belongs in hostname-convention cleanup PR.
- Stale "spark-1 IP" comments in `test_nim_migration.py` untouched — same cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)