### PR TITLE
feat(legal-council): retrieve controlling authority from legal_caselaw

### DIFF
--- a/fortress-guest-platform/backend/services/legal_council.py
+++ b/fortress-guest-platform/backend/services/legal_council.py
@@ -71,7 +71,27 @@ PERSONAS_DIR = os.getenv(
     "LEGAL_PERSONAS_DIR",
     "/home/admin/Fortress-Prime/personas/legal",
 )
-LEGAL_ALLOWED_VECTOR_COLLECTIONS = frozenset({"legal_library", "legal_ediscovery"})
+LEGAL_ALLOWED_VECTOR_COLLECTIONS = frozenset({"legal_library", "legal_ediscovery", "legal_caselaw"})
+
+# Precedent retrieval knobs — legal_caselaw holds the controlling-authority corpus
+# (CourtListener opinions). Defaults picked to fit comfortably inside frontier-model
+# context budgets after case brief + evidence chunks.
+CASELAW_COLLECTION = "legal_caselaw"
+CASELAW_TOP_K = int(os.getenv("LEGAL_COUNCIL_CASELAW_TOP_K", "10"))
+CONTEXT_BUDGET_TOKENS = int(os.getenv("LEGAL_COUNCIL_CONTEXT_BUDGET_TOKENS", "12000"))
+# Approximate char-per-token ratio used for budget enforcement on pre-prompt
+# retrieved context only (not the full seat prompt).
+_CHARS_PER_TOKEN = 4
+
+CASELAW_CONTEXT_HEADER = "--- CONTROLLING AUTHORITY (LEGAL CASE LAW) ---"
+EVIDENCE_CONTEXT_HEADER = "--- CASE EVIDENCE (E-DISCOVERY) ---"
+
+CITATION_INSTRUCTION = (
+    "CITATION DISCIPLINE:\n"
+    "When citing case law, cite only from the [CASE LAW: ...] blocks provided in "
+    "context. Do not invent citations. If no case law block is provided for a "
+    "proposition, state the proposition without a citation and note uncertainty."
+)
 
 from backend.core.config import settings as _cfg
 
@@ -718,6 +738,8 @@ YOUR BIASES & FOCUS:
 {chr(10).join(f'- {b}' for b in persona.bias)}
 {chr(10).join(f'- {f}' for f in persona.focus_areas)}
 
+{CITATION_INSTRUCTION}
+
 CRITICAL DIRECTIVE:
 You are an automated analytical engine operating on bare-metal hardware. You MUST output your ENTIRE response as a single, valid JSON object.
 - DO NOT wrap the JSON in markdown formatting (no ```json).
@@ -1127,6 +1149,144 @@ async def freeze_context(
     return vector_ids, context_chunks
 
 
+def _format_caselaw_citation(payload: Dict[str, Any]) -> str:
+    """Render a [CASE LAW: ...] header line from a legal_caselaw point payload."""
+    case_name = payload.get("case_name") or "<unknown case>"
+    court = payload.get("court") or "<unknown court>"
+    date_filed = payload.get("date_filed") or ""
+    citation_raw = payload.get("citation")
+    if isinstance(citation_raw, list):
+        citation = "; ".join(str(c) for c in citation_raw if c) or "no reporter citation"
+    else:
+        citation = str(citation_raw) if citation_raw else "no reporter citation"
+    return f"[CASE LAW: {case_name}, {court} ({date_filed}) — {citation}]"
+
+
+async def freeze_caselaw_context(
+    case_brief: str,
+    top_k: int = CASELAW_TOP_K,
+) -> Tuple[List[str], List[str]]:
+    """
+    Retrieve top-K controlling-authority chunks from legal_caselaw for the
+    deliberation query. Returns (caselaw_point_refs, context_chunks) where
+    each ref is a string of the form "caselaw:{opinion_id}:{chunk_index}"
+    so vault consumers can reconstruct which opinions were used without
+    touching the vault schema.
+
+    Graceful failure mode: on embed or Qdrant error, returns ([], []) and
+    the council proceeds without precedent context rather than crashing.
+    """
+    logger.info("freeze_caselaw_context_start  collection=%s  top_k=%d", CASELAW_COLLECTION, top_k)
+
+    query_vec = await _embed_text(case_brief)
+    if query_vec is None:
+        logger.warning("freeze_caselaw_context_no_embedding — proceeding without precedent")
+        return [], []
+
+    headers = {"api-key": _cfg.qdrant_api_key} if _cfg.qdrant_api_key else {}
+    body: Dict[str, Any] = {
+        "vector": query_vec,
+        "limit": top_k,
+        "with_payload": True,
+        "with_vector": False,
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=15) as client:
+            resp = await client.post(
+                f"{_cfg.qdrant_url.rstrip('/')}/collections/{CASELAW_COLLECTION}/points/search",
+                json=body,
+                headers=headers,
+            )
+            resp.raise_for_status()
+            results = resp.json().get("result", [])
+    except Exception as e:
+        logger.warning("freeze_caselaw_context_qdrant_failed  error=%s", str(e)[:200])
+        return [], []
+
+    refs: List[str] = []
+    chunks: List[str] = []
+    for pt in results:
+        payload = pt.get("payload", {})
+        text = payload.get("text_chunk") or payload.get("text") or ""
+        opinion_id = payload.get("opinion_id")
+        chunk_index = payload.get("chunk_index", 0)
+        if not text or opinion_id is None:
+            continue
+        refs.append(f"caselaw:{opinion_id}:{chunk_index}")
+        header = _format_caselaw_citation(payload)
+        chunks.append(f"{header}\n{text}")
+
+    logger.info(
+        "freeze_caselaw_context_complete  refs=%d  chunks=%d  top_score=%.3f",
+        len(refs), len(chunks),
+        results[0].get("score", 0.0) if results else 0.0,
+    )
+    return refs, chunks
+
+
+def _enforce_context_budget(
+    caselaw_chunks: List[str],
+    evidence_chunks: List[str],
+    budget_tokens: int = CONTEXT_BUDGET_TOKENS,
+) -> Tuple[List[str], List[str]]:
+    """
+    Trim retrieved context so the joined string stays within the char-equivalent
+    of budget_tokens. Caselaw (controlling authority) is preserved first; when
+    the budget is exceeded, evidence chunks are dropped from the tail until
+    the total fits. If caselaw alone already exceeds the budget, caselaw is
+    also trimmed from the tail, keeping at least the top-ranked chunk.
+    """
+    budget_chars = max(1, budget_tokens) * _CHARS_PER_TOKEN
+
+    total = sum(len(c) for c in caselaw_chunks) + sum(len(c) for c in evidence_chunks)
+    if total <= budget_chars:
+        return caselaw_chunks, evidence_chunks
+
+    evidence_kept: List[str] = []
+    running = sum(len(c) for c in caselaw_chunks)
+    for chunk in evidence_chunks:
+        if running + len(chunk) > budget_chars:
+            break
+        evidence_kept.append(chunk)
+        running += len(chunk)
+
+    if running <= budget_chars:
+        return caselaw_chunks, evidence_kept
+
+    caselaw_kept: List[str] = []
+    running = 0
+    for chunk in caselaw_chunks:
+        if caselaw_kept and running + len(chunk) > budget_chars:
+            break
+        caselaw_kept.append(chunk)
+        running += len(chunk)
+    return caselaw_kept, []
+
+
+def assemble_frozen_context(
+    caselaw_chunks: List[str],
+    evidence_chunks: List[str],
+    operator_context: str = "",
+) -> str:
+    """
+    Build the final frozen context string passed to every seat. Order is
+    caselaw → evidence → operator_context; sections with no content are
+    skipped so empty headers never leak into seat prompts.
+    """
+    parts: List[str] = []
+    if caselaw_chunks:
+        parts.append(CASELAW_CONTEXT_HEADER)
+        parts.append("\n\n".join(caselaw_chunks))
+    if evidence_chunks:
+        parts.append(EVIDENCE_CONTEXT_HEADER)
+        parts.append("\n\n".join(evidence_chunks))
+    if operator_context:
+        parts.append("--- OPERATOR CONTEXT ---")
+        parts.append(operator_context)
+    return "\n\n".join(parts)
+
+
 # ═══════════════════════════════════════════════════════════════════════
 # Roster Snapshot Builder (Pillar 4 — Hardware & Model Provenance)
 # ═══════════════════════════════════════════════════════════════════════
@@ -1269,19 +1429,36 @@ async def run_council_deliberation(
             })
         return
 
-    # ── Pillar 2: Context Freezing ────────────────────────────────────
-    vector_ids, context_chunks = await freeze_context(case_brief, top_k=20, case_slug=case_slug or None)
+    # ── Pillar 2: Context Freezing — evidence + controlling authority ──
+    evidence_vector_ids, evidence_chunks_raw = await freeze_context(
+        case_brief, top_k=20, case_slug=case_slug or None,
+    )
+    caselaw_refs, caselaw_chunks_raw = await freeze_caselaw_context(
+        case_brief, top_k=CASELAW_TOP_K,
+    )
 
-    frozen_context = "\n\n".join(context_chunks) if context_chunks else context
-    if context and context_chunks:
-        frozen_context = f"{context}\n\n--- RETRIEVED EVIDENCE ---\n\n{frozen_context}"
+    # Enforce retrieved-context token budget (caselaw-first preservation).
+    caselaw_chunks, evidence_chunks = _enforce_context_budget(
+        caselaw_chunks_raw, evidence_chunks_raw, CONTEXT_BUDGET_TOKENS,
+    )
+
+    frozen_context = assemble_frozen_context(caselaw_chunks, evidence_chunks, context)
+
+    # Vault receives both sets of identifiers so audits can verify citation
+    # grounding. Caselaw refs are prefixed "caselaw:{opinion_id}:{chunk_index}".
+    vector_ids = list(evidence_vector_ids) + list(caselaw_refs)
+    context_chunks = list(caselaw_chunks) + list(evidence_chunks)
 
     if progress_callback:
         await progress_callback({
             "type": "context_frozen",
-            "vector_count": len(vector_ids),
-            "chunk_count": len(context_chunks),
+            "vector_count": len(evidence_vector_ids),
+            "chunk_count": len(evidence_chunks),
             "collection": LEGAL_COLLECTION,
+            "caselaw_ref_count": len(caselaw_refs),
+            "caselaw_chunk_count": len(caselaw_chunks),
+            "caselaw_collection": CASELAW_COLLECTION,
+            "context_budget_tokens": CONTEXT_BUDGET_TOKENS,
         })
 
     # ── Pillar 4: Roster Snapshot ─────────────────────────────────────

--- a/fortress-guest-platform/backend/tests/test_legal_council_caselaw_retrieval.py
+++ b/fortress-guest-platform/backend/tests/test_legal_council_caselaw_retrieval.py
@@ -1,0 +1,400 @@
+"""
+Tests for Legal Council precedent retrieval — ensures the council now pulls
+controlling-authority chunks from the legal_caselaw Qdrant collection in
+addition to the existing legal_ediscovery evidence retrieval, keeps the
+merged context within the configured token budget, stamps seat prompts with
+citation discipline, and threads caselaw opinion ids into the vault payload.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+from backend.services import legal_council as lc
+
+
+# ── Qdrant mock scaffolding ────────────────────────────────────────────
+
+def _caselaw_point(opinion_id: int, chunk_index: int, text: str, case_name: str = "Smith v. Jones") -> Dict[str, Any]:
+    return {
+        "id": f"{opinion_id}-{chunk_index}",
+        "score": 0.9,
+        "payload": {
+            "opinion_id": opinion_id,
+            "cluster_id": opinion_id + 1000,
+            "case_name": case_name,
+            "court": "Court of Appeals of Georgia",
+            "date_filed": "2022-05-10",
+            "citation": ["123 Ga. App. 456"],
+            "chunk_index": chunk_index,
+            "text_chunk": text,
+        },
+    }
+
+
+def _evidence_point(point_id: str, text: str, case_slug: str = "matter-001") -> Dict[str, Any]:
+    return {
+        "id": point_id,
+        "score": 0.8,
+        "payload": {
+            "case_slug": case_slug,
+            "document_id": "doc-abc",
+            "file_name": "Exhibit-A.pdf",
+            "chunk_index": 0,
+            "text": text,
+        },
+    }
+
+
+class _FakeResponse:
+    def __init__(self, payload: Dict[str, Any]):
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> Dict[str, Any]:
+        return self._payload
+
+
+class _FakeAsyncClient:
+    """
+    Minimal drop-in for httpx.AsyncClient.
+    Routes POSTs to /collections/<name>/points/search to the matching stub in
+    a collection -> result-list registry so callers can script responses per
+    Qdrant collection.
+    """
+
+    def __init__(self, registry: Dict[str, List[Dict[str, Any]]], *_, **__):
+        self._registry = registry
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_):
+        return False
+
+    async def post(self, url: str, json: Dict[str, Any] | None = None, headers: Dict[str, str] | None = None) -> _FakeResponse:
+        for name, results in self._registry.items():
+            if f"/collections/{name}/points/search" in url:
+                return _FakeResponse({"result": results})
+        return _FakeResponse({"result": []})
+
+
+@pytest.fixture
+def mock_qdrant(monkeypatch: pytest.MonkeyPatch):
+    """Install a per-test Qdrant stub. Returns a registry the test can populate."""
+    registry: Dict[str, List[Dict[str, Any]]] = {}
+
+    def _factory(*args, **kwargs):
+        return _FakeAsyncClient(registry, *args, **kwargs)
+
+    monkeypatch.setattr(lc.httpx, "AsyncClient", _factory)
+    return registry
+
+
+@pytest.fixture
+def mock_embed(monkeypatch: pytest.MonkeyPatch):
+    """Return a non-None deterministic embedding so freeze paths don't early-exit."""
+
+    async def fake_embed(text: str):
+        return [0.1] * lc._cfg.embed_dim
+
+    monkeypatch.setattr(lc, "_embed_text", fake_embed)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 1. Caselaw block appears in assembled context
+# ═══════════════════════════════════════════════════════════════════════
+
+@pytest.mark.asyncio
+async def test_council_context_includes_caselaw_block(
+    mock_qdrant: Dict[str, List[Dict[str, Any]]],
+    mock_embed,
+) -> None:
+    mock_qdrant["legal_caselaw"] = [
+        _caselaw_point(
+            111, 0,
+            "The insurer owes a duty of good faith in settlement negotiations.",
+            case_name="Acme Ins. v. Doe",
+        ),
+    ]
+    mock_qdrant["legal_ediscovery"] = [
+        _evidence_point("ev-1", "Defendant filed answer on the due date."),
+    ]
+
+    refs, chunks = await lc.freeze_caselaw_context("What duty does the insurer owe?", top_k=5)
+    assert refs == ["caselaw:111:0"]
+    assert chunks, "expected at least one caselaw chunk"
+
+    evidence_ids, evidence_chunks = await lc.freeze_context("case", top_k=5)
+    combined_caselaw, combined_evidence = lc._enforce_context_budget(chunks, evidence_chunks)
+    context = lc.assemble_frozen_context(combined_caselaw, combined_evidence)
+
+    assert lc.CASELAW_CONTEXT_HEADER in context
+    assert lc.EVIDENCE_CONTEXT_HEADER in context
+    assert "[CASE LAW: Acme Ins. v. Doe, Court of Appeals of Georgia (2022-05-10) — 123 Ga. App. 456]" in context
+    assert context.index(lc.CASELAW_CONTEXT_HEADER) < context.index(lc.EVIDENCE_CONTEXT_HEADER), \
+        "caselaw (authority) must precede evidence in the merged context"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 2. Caselaw retrieval respects top_k
+# ═══════════════════════════════════════════════════════════════════════
+
+@pytest.mark.asyncio
+async def test_council_caselaw_retrieval_respects_top_k(
+    mock_qdrant: Dict[str, List[Dict[str, Any]]],
+    mock_embed,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_qdrant["legal_caselaw"] = [
+        _caselaw_point(i, 0, f"Authority chunk {i}.") for i in range(20)
+    ]
+
+    captured_limits: List[int] = []
+    original_post = _FakeAsyncClient.post
+
+    async def capture_post(self, url, json=None, headers=None):  # type: ignore[no-untyped-def]
+        if "legal_caselaw" in url and json:
+            captured_limits.append(int(json.get("limit", -1)))
+        # Respect the limit so the returned payload size matches the request.
+        if "legal_caselaw" in url and json:
+            limit = int(json.get("limit", 0))
+            payload = {"result": mock_qdrant["legal_caselaw"][:limit]}
+            return _FakeResponse(payload)
+        return await original_post(self, url, json=json, headers=headers)
+
+    monkeypatch.setattr(_FakeAsyncClient, "post", capture_post)
+
+    refs, chunks = await lc.freeze_caselaw_context("query", top_k=7)
+    assert captured_limits == [7]
+    assert len(refs) == 7
+    assert len(chunks) == 7
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 3. Context budget is enforced — evidence gets trimmed first
+# ═══════════════════════════════════════════════════════════════════════
+
+def test_council_context_budget_enforced() -> None:
+    big = "x" * 4000  # ~1000 tokens per chunk at 4 chars/token
+    caselaw = [f"[CASE LAW: A v. B, … — …]\n{big}" for _ in range(3)]
+    evidence = [f"[ev-{i}] {big}" for i in range(10)]
+
+    # Budget = 3000 tokens = 12_000 chars. Caselaw alone (3 * ~4025 = 12_075)
+    # already exceeds budget; evidence must be dropped entirely and caselaw
+    # retains at least the top-ranked chunk.
+    kept_caselaw, kept_evidence = lc._enforce_context_budget(caselaw, evidence, budget_tokens=3000)
+    assert kept_evidence == []
+    assert len(kept_caselaw) >= 1
+
+    # Budget = 10_000 tokens = 40_000 chars: all 3 caselaw fit (12k chars),
+    # then evidence fills until we get close to 40k chars.
+    kept_caselaw2, kept_evidence2 = lc._enforce_context_budget(caselaw, evidence, budget_tokens=10_000)
+    assert len(kept_caselaw2) == 3
+    assert 0 < len(kept_evidence2) < 10
+    total = sum(len(c) for c in kept_caselaw2) + sum(len(c) for c in kept_evidence2)
+    assert total <= 10_000 * 4
+
+    # Roomy budget: everything fits.
+    kept_all_caselaw, kept_all_evidence = lc._enforce_context_budget(caselaw, evidence, budget_tokens=100_000)
+    assert kept_all_caselaw == caselaw
+    assert kept_all_evidence == evidence
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 4. Seat system prompt carries the citation-discipline instruction
+# ═══════════════════════════════════════════════════════════════════════
+
+@pytest.mark.asyncio
+async def test_council_seat_prompt_contains_citation_instruction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    persona = lc.LegalPersona(
+        name="The Test Seat",
+        slug="test-seat",
+        seat=1,
+        archetype="test",
+        domain="legal",
+        god_head_domain="legal",
+        worldview="Prefer defensible, grounded analysis.",
+        bias=["Ground claims in authority."],
+        focus_areas=["Citations"],
+        trigger_events=["test event"],
+        godhead_prompt="You are The Test Seat.",
+        vector_collection="legal_library",
+    )
+
+    captured: Dict[str, str] = {}
+
+    async def fake_call_llm(
+        system_prompt: str,
+        user_prompt: str,
+        model: str = "",
+        base_url: str = "",
+        api_key: str = "",
+        temperature: float = 0.3,
+        max_tokens: int = 4096,
+    ) -> tuple[str, str]:
+        captured["system"] = system_prompt
+        captured["user"] = user_prompt
+        return (
+            '{"signal":"NEUTRAL","conviction":0.5,"reasoning":"ok",'
+            '"defense_arguments":[],"risk_factors":[],"recommended_actions":[]}',
+            "fake-model",
+        )
+
+    monkeypatch.setattr(lc, "_call_llm", fake_call_llm)
+
+    await lc.analyze_with_persona(persona, case_brief="Brief", context="op-ctx")
+    assert "CITATION DISCIPLINE" in captured["system"]
+    assert "cite only from the [CASE LAW: ...] blocks" in captured["system"]
+    assert "Do not invent citations" in captured["system"]
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 5. Vaulted deliberation records caselaw opinion ids
+# ═══════════════════════════════════════════════════════════════════════
+
+@pytest.mark.asyncio
+async def test_vaulted_deliberation_records_caselaw_opinion_ids(
+    mock_qdrant: Dict[str, List[Dict[str, Any]]],
+    mock_embed,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    mock_qdrant["legal_caselaw"] = [
+        _caselaw_point(42, 0, "Authority chunk 42."),
+        _caselaw_point(77, 1, "Authority chunk 77."),
+    ]
+    mock_qdrant["legal_ediscovery"] = [
+        _evidence_point("ev-1", "Evidence chunk 1."),
+    ]
+
+    captured_vault_args: Dict[str, Any] = {}
+
+    def fake_vault_deliberation(
+        case_slug: str,
+        case_number,
+        trigger_type: str,
+        vector_ids: list,
+        context_chunks: list,
+        user_prompt: str,
+        roster_snapshot: dict,
+        seat_opinions: list,
+        counsel_results: dict,
+        execution_time_ms: int,
+    ):
+        captured_vault_args["case_slug"] = case_slug
+        captured_vault_args["vector_ids"] = list(vector_ids)
+        captured_vault_args["context_chunks"] = list(context_chunks)
+        return ("event-xyz", "a" * 64)
+
+    monkeypatch.setattr(lc, "vault_deliberation", fake_vault_deliberation)
+
+    monkeypatch.setattr(lc, "_build_roster_snapshot", lambda: {"roster_version": "test", "seats": []})
+
+    # Single-persona roster — keeps the fan-out deterministic.
+    persona = lc.LegalPersona(
+        name="Seat 1",
+        slug="seat-1",
+        seat=1,
+        archetype="test",
+        domain="legal",
+        god_head_domain="legal",
+        worldview="test",
+        bias=["b"],
+        focus_areas=["f"],
+        trigger_events=["e"],
+        godhead_prompt="prompt",
+        vector_collection="legal_library",
+    )
+    monkeypatch.setattr(lc.LegalPersona, "load_all", staticmethod(lambda: [persona]))
+
+    async def fake_analyze(_persona, _brief, _context):
+        return lc.LegalOpinion(
+            persona_name="Seat 1",
+            seat=1,
+            slug="seat-1",
+            event="test event",
+            signal=lc.LegalSignal.NEUTRAL,
+            conviction=0.5,
+            reasoning="ok",
+            defense_arguments=[],
+            risk_factors=[],
+            recommended_actions=[],
+            timestamp="now",
+            model_used="fake",
+            elapsed_seconds=0.1,
+        )
+
+    monkeypatch.setattr(lc, "analyze_with_persona", fake_analyze)
+
+    await lc.run_council_deliberation(
+        session_id="sess-1",
+        case_brief="brief",
+        context="",
+        progress_callback=None,
+        case_slug="matter-001",
+        case_number="CASE-1",
+        trigger_type="TEST",
+    )
+
+    refs = captured_vault_args["vector_ids"]
+    assert any(r.startswith("caselaw:42:") for r in refs)
+    assert any(r.startswith("caselaw:77:") for r in refs)
+    # Evidence UUIDs stay bare (no "caselaw:" prefix).
+    assert any(r == "ev-1" for r in refs)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 6. Regression: legal_ediscovery retrieval behavior unchanged
+# ═══════════════════════════════════════════════════════════════════════
+
+@pytest.mark.asyncio
+async def test_ediscovery_retrieval_unchanged(
+    mock_qdrant: Dict[str, List[Dict[str, Any]]],
+    mock_embed,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    freeze_context must still:
+      - return (vector_ids, chunks) from legal_ediscovery only
+      - apply case_slug filter when the collection is legal_ediscovery
+      - format chunks as "[{source}] {text}"
+    """
+    mock_qdrant["legal_ediscovery"] = [
+        _evidence_point("ev-A", "Alpha chunk", case_slug="matter-001"),
+        _evidence_point("ev-B", "Beta chunk", case_slug="matter-001"),
+    ]
+    mock_qdrant["legal_caselaw"] = [_caselaw_point(9, 0, "should not appear in this result")]
+
+    captured_bodies: List[Dict[str, Any]] = []
+    original_post = _FakeAsyncClient.post
+
+    async def capture_post(self, url, json=None, headers=None):  # type: ignore[no-untyped-def]
+        captured_bodies.append({"url": url, "json": json})
+        return await original_post(self, url, json=json, headers=headers)
+
+    monkeypatch.setattr(_FakeAsyncClient, "post", capture_post)
+
+    vector_ids, chunks = await lc.freeze_context(
+        "brief", top_k=20, case_slug="matter-001",
+    )
+
+    # Only ediscovery was queried by freeze_context.
+    hit_urls = [b["url"] for b in captured_bodies]
+    assert any("legal_ediscovery" in u for u in hit_urls)
+    assert not any("legal_caselaw" in u for u in hit_urls)
+
+    # case_slug filter applied.
+    ediscovery_body = next(b for b in captured_bodies if "legal_ediscovery" in b["url"])
+    filt = ediscovery_body["json"].get("filter", {})
+    assert filt == {"must": [{"key": "case_slug", "match": {"value": "matter-001"}}]}
+
+    # Shape is still (ids, "[file] text" strings).
+    assert vector_ids == ["ev-A", "ev-B"]
+    assert chunks == ["[Exhibit-A.pdf] Alpha chunk", "[Exhibit-A.pdf] Beta chunk"]


### PR DESCRIPTION
## Summary

Legal Council currently freezes only `legal_ediscovery` at deliberation time, so the 9 seats reason about case evidence without the 2,711-chunk Georgia precedent corpus living in Qdrant (`legal_caselaw`). This PR adds a parallel retrieval tier that pulls controlling-authority chunks, merges them with evidence under a token budget, and stamps every seat prompt with citation discipline.

Motivation surfaced by the 2026-04-24 Fortress Legal Connectivity Audit (Wiring Gap §3) and 7IL v. Knight Readiness Audit (Corpus 4): the precedent tier existed in `legal_caselaw` but was never wired into `legal_council.freeze_context()`.

## What changed

`backend/services/legal_council.py`:
- **`freeze_caselaw_context(case_brief, top_k)`** — new retrieval function. Queries `legal_caselaw` with the case-brief embedding, returns `(refs, chunks)`. Each ref is `"caselaw:{opinion_id}:{chunk_index}"`; each chunk is prefixed with `[CASE LAW: {case_name}, {court} ({date_filed}) — {citation}]` so seats cite from real opinions, not paraphrased summaries.
- **`_enforce_context_budget(caselaw, evidence, budget_tokens)`** — trims retrieved context to a char-equivalent token budget. Caselaw (authority) is preserved first; evidence is dropped from the tail when over budget.
- **`assemble_frozen_context(caselaw, evidence, operator_context)`** — merges the three layers under clear section headers (`CONTROLLING AUTHORITY` → `CASE EVIDENCE` → `OPERATOR CONTEXT`), skipping empty sections.
- **`analyze_with_persona`** — system prompt now includes `CITATION_INSTRUCTION`: cite only from provided `[CASE LAW: ...]` blocks, never invent, flag uncertainty when no authority is provided.
- **`run_council_deliberation`** — calls both freeze paths, merges and trims, emits richer `context_frozen` progress events, threads the combined `vector_ids` (evidence UUIDs + `caselaw:`-prefixed refs) into `vault_deliberation` so the immutable ledger records exactly which opinions backed the council's reasoning.
- **`LEGAL_ALLOWED_VECTOR_COLLECTIONS`** now includes `legal_caselaw`.
- New env vars: `LEGAL_COUNCIL_CASELAW_TOP_K` (default `10`), `LEGAL_COUNCIL_CONTEXT_BUDGET_TOKENS` (default `12000`).

`backend/tests/test_legal_council_caselaw_retrieval.py` — 6 new tests:
- `test_council_context_includes_caselaw_block`
- `test_council_caselaw_retrieval_respects_top_k`
- `test_council_context_budget_enforced`
- `test_council_seat_prompt_contains_citation_instruction`
- `test_vaulted_deliberation_records_caselaw_opinion_ids`
- `test_ediscovery_retrieval_unchanged` (regression)

Qdrant HTTP mocked at `httpx.AsyncClient`; LiteLLM mocked at `_call_llm`. No frontier API calls during tests.

## Not touched
- `vault_deliberation` schema (caselaw provenance rides in `vector_ids` with a `caselaw:` prefix rather than adding a column)
- `privilege_filter`, `captain_multi_mailbox`, `nightly_finetune` / distillation exporter
- No DB migrations

## Test plan

- [x] `pytest backend/tests/test_legal_council_caselaw_retrieval.py` — 6/6 pass
- [x] `pytest backend/tests/test_legal_council_retry.py` — 3/3 pass (regression)
- [ ] Post-merge smoke: trigger a live council deliberation against `legal_council.run_council_deliberation` and confirm `context_frozen` progress event includes `caselaw_chunk_count > 0` and vault record contains `caselaw:`-prefixed refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)