### PR TITLE
fix(nightly-finetune): bnb 4-bit CPU-offload + explicit max_memory plan

### DIFF
--- a/src/nightly_finetune.py
+++ b/src/nightly_finetune.py
@@ -63,6 +63,7 @@ import sys
 import time
 from datetime import date, timedelta
 from pathlib import Path
+from typing import Any
 
 from judge.base_model_locator import find_base_model
 
@@ -378,6 +379,77 @@ def load_training_data(rolling_days: int) -> list[dict]:
 # ---------------------------------------------------------------------------
 # Step 3: QLoRA training
 # ---------------------------------------------------------------------------
+# QLoRA helpers — extracted so tests can validate the quantization + memory
+# contracts without requiring a GPU. The 2026-04-24 nightly failed on
+# `ValueError: Some modules are dispatched on the CPU or the disk` because
+# bnb 4-bit refused an implicit CPU-offload device_map; the fix is to (a)
+# set `llm_int8_enable_fp32_cpu_offload=True` on the bnb config, (b) pass an
+# explicit `max_memory` dict with GPU headroom + CPU room so `device_map="auto"`
+# has a valid plan even when the GPU is under pressure.
+# ---------------------------------------------------------------------------
+
+FINETUNE_CPU_OFFLOAD_GB = int(os.getenv("FINETUNE_CPU_OFFLOAD_GB", "64"))
+FINETUNE_GPU_HEADROOM_GB = int(os.getenv("FINETUNE_GPU_HEADROOM_GB", "2"))
+
+
+def build_quantization_kwargs(compute_dtype: Any) -> dict:
+    """
+    Return the kwargs passed to transformers.BitsAndBytesConfig. Exposed so
+    tests can assert the CPU-offload flag is always set without needing to
+    import bitsandbytes / instantiate a real config.
+    """
+    return {
+        "load_in_4bit": True,
+        "bnb_4bit_use_double_quant": True,
+        "bnb_4bit_quant_type": "nf4",
+        "bnb_4bit_compute_dtype": compute_dtype,
+        "llm_int8_enable_fp32_cpu_offload": True,
+    }
+
+
+def build_max_memory_map(
+    free_gpu_bytes: int | None,
+    cpu_ram_gb: int = FINETUNE_CPU_OFFLOAD_GB,
+    gpu_headroom_gb: int = FINETUNE_GPU_HEADROOM_GB,
+) -> dict:
+    """
+    Build the `max_memory` dict for `from_pretrained(device_map="auto", ...)`.
+
+    If `free_gpu_bytes` is None or non-positive, returns a CPU-only map
+    (the loader will place everything on CPU rather than erroring out).
+    Otherwise reserves `gpu_headroom_gb` for cuBLAS/workspace and pins the
+    rest as the GPU budget, with `cpu_ram_gb` as the overflow bucket.
+    """
+    if not free_gpu_bytes or free_gpu_bytes <= 0:
+        return {"cpu": f"{int(cpu_ram_gb)}GiB"}
+    free_gb = free_gpu_bytes / (1024 ** 3)
+    usable_gb = max(0, int(free_gb) - int(gpu_headroom_gb))
+    return {"0": f"{usable_gb}GiB", "cpu": f"{int(cpu_ram_gb)}GiB"}
+
+
+def log_gpu_preflight(torch_module: Any) -> dict:
+    """
+    Log free GPU memory before `from_pretrained`. Returns a state dict used
+    by the caller to decide the `max_memory` map. Never raises — on any
+    torch/CUDA error, falls back to the no-GPU path and the caller will
+    place the model on CPU.
+    """
+    state = {"has_gpu": False, "free_bytes": None, "total_bytes": None}
+    try:
+        if torch_module.cuda.is_available():
+            free, total = torch_module.cuda.mem_get_info()
+            state.update(has_gpu=True, free_bytes=int(free), total_bytes=int(total))
+            log.info(
+                "gpu_preflight  free_gb=%.2f  total_gb=%.2f",
+                free / (1024 ** 3), total / (1024 ** 3),
+            )
+        else:
+            log.warning("gpu_preflight  no_cuda_device — falling back to CPU-only")
+    except Exception as e:
+        log.warning("gpu_preflight  error=%s", str(e)[:200])
+    return state
+
+
 def run_qlora_training(records: list[dict], adapter_out: Path) -> None:
     # Import here — deps may have been freshly installed
     import torch
@@ -406,13 +478,21 @@ def run_qlora_training(records: list[dict], adapter_out: Path) -> None:
         tokenizer.pad_token = tokenizer.eos_token
     tokenizer.padding_side = "right"
 
-    # --- 4-bit NF4 quantization config ---
-    bnb_config = BitsAndBytesConfig(
-        load_in_4bit=True,
-        bnb_4bit_use_double_quant=True,
-        bnb_4bit_quant_type="nf4",
-        bnb_4bit_compute_dtype=torch.bfloat16,
+    # --- Pre-flight GPU inventory ---
+    gpu_state = log_gpu_preflight(torch)
+
+    # --- 4-bit NF4 quantization config (with CPU-offload safety valve) ---
+    bnb_kwargs = build_quantization_kwargs(torch.bfloat16)
+    bnb_config = BitsAndBytesConfig(**bnb_kwargs)
+
+    # --- Explicit max_memory plan so device_map="auto" can dispatch to CPU
+    #     instead of raising when GPU RAM is tight.
+    max_memory = build_max_memory_map(
+        free_gpu_bytes=gpu_state.get("free_bytes"),
+        cpu_ram_gb=FINETUNE_CPU_OFFLOAD_GB,
+        gpu_headroom_gb=FINETUNE_GPU_HEADROOM_GB,
     )
+    log.info("max_memory_plan %s", max_memory)
 
     # --- Load base model ---
     log.info("Loading base model in 4-bit NF4 …")
@@ -420,10 +500,16 @@ def run_qlora_training(records: list[dict], adapter_out: Path) -> None:
         str(BASE_MODEL_DIR),
         quantization_config=bnb_config,
         device_map="auto",
+        max_memory=max_memory,
         trust_remote_code=False,
         torch_dtype=torch.bfloat16,
         attn_implementation="sdpa",
     )
+    try:
+        effective_map = getattr(model, "hf_device_map", None)
+        log.info("effective_device_map %s", str(effective_map)[:500])
+    except Exception:
+        pass
     model = prepare_model_for_kbit_training(model, use_gradient_checkpointing=True)
 
     # --- LoRA config ---

--- a/src/tests/test_nightly_finetune_bnb_device_map.py
+++ b/src/tests/test_nightly_finetune_bnb_device_map.py
@@ -1,0 +1,169 @@
+"""
+Tests for the QLoRA quantization + device_map plumbing in
+src/nightly_finetune.py. The 2026-04-24 nightly failed on bnb 4-bit's
+"Some modules are dispatched on the CPU or the disk" ValueError; the fix
+is to set `llm_int8_enable_fp32_cpu_offload=True` on the bnb config and
+pass an explicit `max_memory` dict to `from_pretrained` so the loader has
+a valid CPU-overflow plan even when GPU RAM is tight.
+
+These tests exercise the pure Python helpers the trainer now calls; no
+GPU is required. An optional GPU smoke test is gated on
+LOCAL_GPU_AVAILABLE=1 and instantiates the config + memory map but does
+NOT load weights.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import types
+
+import pytest
+
+nf = importlib.import_module("nightly_finetune")
+
+
+# ── 1. BnB config always carries the CPU-offload flag ──────────────────
+
+def test_bnb_config_has_cpu_offload_flag() -> None:
+    """llm_int8_enable_fp32_cpu_offload must be True to survive tight GPU
+    plans; bnb 4-bit refuses implicit CPU dispatch without it."""
+    sentinel_dtype = object()  # stand-in for torch.bfloat16
+    kwargs = nf.build_quantization_kwargs(sentinel_dtype)
+
+    assert kwargs["llm_int8_enable_fp32_cpu_offload"] is True
+    assert kwargs["load_in_4bit"] is True
+    assert kwargs["bnb_4bit_quant_type"] == "nf4"
+    assert kwargs["bnb_4bit_use_double_quant"] is True
+    assert kwargs["bnb_4bit_compute_dtype"] is sentinel_dtype
+
+
+# ── 2. max_memory is built correctly for each GPU state ────────────────
+
+def test_device_map_respects_max_memory_gpu_present() -> None:
+    """With a real free_gpu_bytes value, GPU slot reflects (free - headroom)
+    in GiB and CPU overflow bucket is present."""
+    ten_gib = 10 * (1024 ** 3)
+    m = nf.build_max_memory_map(free_gpu_bytes=ten_gib, cpu_ram_gb=64, gpu_headroom_gb=2)
+    assert m == {"0": "8GiB", "cpu": "64GiB"}
+
+
+def test_device_map_respects_max_memory_no_gpu() -> None:
+    """When no GPU is available, map is CPU-only so the loader can still
+    materialize the model rather than raising."""
+    assert nf.build_max_memory_map(free_gpu_bytes=None, cpu_ram_gb=48) == {"cpu": "48GiB"}
+    assert nf.build_max_memory_map(free_gpu_bytes=0, cpu_ram_gb=48) == {"cpu": "48GiB"}
+    assert nf.build_max_memory_map(free_gpu_bytes=-1, cpu_ram_gb=48) == {"cpu": "48GiB"}
+
+
+def test_device_map_headroom_applied() -> None:
+    """Headroom must be deducted from the advertised GPU budget."""
+    twenty_gib = 20 * (1024 ** 3)
+    m_strict = nf.build_max_memory_map(free_gpu_bytes=twenty_gib, cpu_ram_gb=64, gpu_headroom_gb=4)
+    m_loose = nf.build_max_memory_map(free_gpu_bytes=twenty_gib, cpu_ram_gb=64, gpu_headroom_gb=2)
+    assert m_strict["0"] == "16GiB"
+    assert m_loose["0"] == "18GiB"
+
+
+def test_device_map_headroom_never_negative() -> None:
+    """Tiny free GPU (smaller than headroom) → 0 GPU budget, CPU overflow
+    still set. Prevents a negative int from leaking into max_memory."""
+    one_gib = 1 * (1024 ** 3)
+    m = nf.build_max_memory_map(free_gpu_bytes=one_gib, cpu_ram_gb=64, gpu_headroom_gb=2)
+    assert m == {"0": "0GiB", "cpu": "64GiB"}
+
+
+# ── 3. Preflight reads torch.cuda.mem_get_info and logs ────────────────
+
+class _FakeCuda:
+    def __init__(self, available: bool = True, free: int = 42 * (1024 ** 3), total: int = 120 * (1024 ** 3)):
+        self._available = available
+        self._free = free
+        self._total = total
+
+    def is_available(self) -> bool:
+        return self._available
+
+    def mem_get_info(self) -> tuple[int, int]:
+        return (self._free, self._total)
+
+
+def _fake_torch(cuda: _FakeCuda) -> types.SimpleNamespace:
+    return types.SimpleNamespace(cuda=cuda)
+
+
+def test_preflight_logs_gpu_state(caplog: pytest.LogCaptureFixture) -> None:
+    """Happy path: GPU present; returns populated state dict, emits a log
+    line with free + total GiB."""
+    fake = _fake_torch(_FakeCuda(available=True, free=40 * (1024 ** 3), total=120 * (1024 ** 3)))
+    with caplog.at_level(logging.INFO, logger="finetune"):
+        state = nf.log_gpu_preflight(fake)
+
+    assert state["has_gpu"] is True
+    assert state["free_bytes"] == 40 * (1024 ** 3)
+    assert state["total_bytes"] == 120 * (1024 ** 3)
+    assert any("gpu_preflight" in r.getMessage() for r in caplog.records)
+
+
+def test_preflight_no_gpu_falls_back_cleanly(caplog: pytest.LogCaptureFixture) -> None:
+    """No CUDA → state.has_gpu False, free/total None, warning logged. Caller
+    will build a CPU-only max_memory from this."""
+    fake = _fake_torch(_FakeCuda(available=False))
+    with caplog.at_level(logging.WARNING, logger="finetune"):
+        state = nf.log_gpu_preflight(fake)
+
+    assert state == {"has_gpu": False, "free_bytes": None, "total_bytes": None}
+    assert any("no_cuda_device" in r.getMessage() for r in caplog.records)
+
+
+def test_preflight_swallows_torch_errors() -> None:
+    """If mem_get_info or is_available raises, preflight returns the no-GPU
+    state rather than propagating — the trainer must never die in preflight."""
+    class _Exploder:
+        def is_available(self) -> bool:
+            raise RuntimeError("cuda not initialized")
+
+        def mem_get_info(self) -> tuple[int, int]:  # pragma: no cover — not reached
+            raise AssertionError("should not be called")
+
+    fake = _fake_torch(_Exploder())  # type: ignore[arg-type]
+    state = nf.log_gpu_preflight(fake)
+    assert state == {"has_gpu": False, "free_bytes": None, "total_bytes": None}
+
+
+# ── 4. Explicit kwargs override the module-level defaults ──────────────
+
+def test_helper_kwargs_override_module_defaults() -> None:
+    """Callers can override cpu_ram_gb / gpu_headroom_gb without touching
+    env vars; module defaults are used only when kwargs are omitted. This
+    guards against future refactors that drop the parameters in favor of
+    reading env vars mid-function (which would defeat testability)."""
+    twenty_gib = 20 * (1024 ** 3)
+    m = nf.build_max_memory_map(free_gpu_bytes=twenty_gib, cpu_ram_gb=128, gpu_headroom_gb=8)
+    assert m == {"0": "12GiB", "cpu": "128GiB"}
+
+
+# ── 5. Optional GPU smoke (off in CI) ──────────────────────────────────
+
+@pytest.mark.skipif(
+    os.getenv("LOCAL_GPU_AVAILABLE") != "1",
+    reason="GPU smoke test — set LOCAL_GPU_AVAILABLE=1 to run on a host with CUDA",
+)
+def test_local_gpu_smoke_builds_config_without_loading_weights() -> None:
+    """With a real GPU, the config + max_memory map should be constructible
+    without touching the model. This catches torch/bnb/transformers import
+    breakage early, in under a second, without burning the 6h nightly."""
+    import torch
+    from transformers import BitsAndBytesConfig
+
+    state = nf.log_gpu_preflight(torch)
+    assert state["has_gpu"] is True
+    assert state["free_bytes"] is not None and state["free_bytes"] > 0
+
+    kwargs = nf.build_quantization_kwargs(torch.bfloat16)
+    bnb = BitsAndBytesConfig(**kwargs)
+    assert bnb.load_in_4bit is True
+    assert getattr(bnb, "llm_int8_enable_fp32_cpu_offload", None) is True
+
+    mem = nf.build_max_memory_map(free_gpu_bytes=state["free_bytes"])
+    assert "0" in mem and "cpu" in mem


### PR DESCRIPTION
## Summary

`fortress-nightly-finetune.service` failed at **2026-04-24 02:07 EDT** with:

> `ValueError: Some modules are dispatched on the CPU or the disk. Make sure you have enough GPU RAM to fit the quantized model. If you want to dispatch the model on the CPU or the disk while keeping these modules in 32-bit, you need to set \`llm_int8_enable_fp32_cpu_offload=True\` and pass a custom \`device_map\` to \`from_pretrained\`.`

Root cause: `BitsAndBytesConfig` was missing `llm_int8_enable_fp32_cpu_offload`, and the model was loaded with a bare `device_map="auto"`. When bnb saw any module the accelerate planner wanted to push to CPU, it aborted. The GPU is free on spark-1 today (nim-brain stopped 15:07), but the code path needs the safety valve for future contention — in particular, the next time BRAIN is up during the 02:07 window.

**Next scheduled run: Sat 2026-04-25 02:07 EDT.** This must land before then.

## Changes — `src/nightly_finetune.py`

New env-driven knobs (defaults sized so 7B QLoRA fits with BRAIN loaded):

| Var | Default | Role |
|---|---|---|
| `FINETUNE_CPU_OFFLOAD_GB` | `64` | CPU overflow bucket size |
| `FINETUNE_GPU_HEADROOM_GB` | `2` | cuBLAS/workspace reserve pulled off the GPU budget |

Three pure helpers extracted so the quantization + memory contracts are GPU-free testable:

- **`build_quantization_kwargs(compute_dtype)`** — returns the bnb kwargs with **`llm_int8_enable_fp32_cpu_offload=True`** + explicit 4-bit NF4, double-quant, bfloat16 compute dtype.
- **`build_max_memory_map(free_gpu_bytes, cpu_ram_gb, gpu_headroom_gb)`** — builds the `max_memory` dict for `from_pretrained(device_map="auto", ...)`. CPU-only when `free_gpu_bytes` is None/0/negative so a GPU-dead host doesn't explode; GPU budget = `free - headroom` when present; negative budgets clamped to 0.
- **`log_gpu_preflight(torch_module)`** — logs free/total GiB, returns a state dict; never raises (wraps torch.cuda calls in try/except so a broken CUDA init doesn't take down the nightly).

`run_qlora_training` now: (a) calls `log_gpu_preflight`, (b) builds the bnb config via `build_quantization_kwargs` so the CPU-offload flag is guaranteed, (c) passes the explicit `max_memory` dict to `from_pretrained`, (d) logs the effective `hf_device_map` after load so journalctl traces show where each layer landed.

## Tests — `src/tests/test_nightly_finetune_bnb_device_map.py` (10 new)

- `test_bnb_config_has_cpu_offload_flag`
- `test_device_map_respects_max_memory_gpu_present`
- `test_device_map_respects_max_memory_no_gpu`
- `test_device_map_headroom_applied`
- `test_device_map_headroom_never_negative`
- `test_preflight_logs_gpu_state`
- `test_preflight_no_gpu_falls_back_cleanly`
- `test_preflight_swallows_torch_errors`
- `test_helper_kwargs_override_module_defaults`
- `test_local_gpu_smoke_builds_config_without_loading_weights` (skipped unless `LOCAL_GPU_AVAILABLE=1` — instantiates real `BitsAndBytesConfig` + `max_memory` but never touches weights)

Results: **9 passed + 1 skipped** in the new file; **32 passed + 1 skipped** across the three `nightly_finetune` test files (no regression in `test_nightly_finetune_retarget`, `test_nightly_finetune_nim`).

## Out of scope (per brief)
- Exporter (`nightly_distillation_exporter.py`) — untouched
- Training data shape — untouched
- Adapter target path — untouched
- Systemd timer schedule — unchanged
- `SOVEREIGN_DISTILL_ADAPTER_PCT` in `ai_router.py` — Phase 4c, separate PR

## Schedule conflict check
- `fortress-drift-alarm.timer` — next 11:42 EDT
- `fortress-nightly-finetune.timer` — next Sat 02:07 EDT
- No overlap.

## Test plan

- [x] `pytest src/tests/test_nightly_finetune_bnb_device_map.py` — 9 pass, 1 skip (GPU smoke)
- [x] Regression: `pytest src/tests/test_nightly_finetune_retarget.py src/tests/test_nightly_finetune_nim.py` — 23 pass (no regression)
- [ ] Post-merge: Sat 2026-04-25 02:07 EDT nightly run — verify journal shows `gpu_preflight` + `max_memory_plan` + `effective_device_map` log lines, and the job exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)