### PR TITLE
fix(legal-council): COUNCIL_FRONTIER_PROVIDERS_ENABLED gating safeguard

### DIFF
--- a/fortress-guest-platform/.env.example
+++ b/fortress-guest-platform/.env.example
@@ -246,3 +246,12 @@ CAPTAIN_JUNK_FILTER_ENABLED=true
 # fortress-load-secrets loader (PR #159 pattern) and drop it from .env.
 LITELLM_BASE_URL=http://127.0.0.1:8002/v1
 LITELLM_MASTER_KEY=<sync-from-litellm_config.yaml-general_settings.master_key>
+
+# Council degraded-mode safeguard — comma-separated allowlist of frontier
+# providers permitted to fan out in legal_council deliberations. Seats whose
+# provider is not in this list are SKIPPED entirely (no fallback to local
+# Ollama, no contamination of llm_training_captures). Default is "anthropic"
+# — the conservative floor while upstream OpenAI/xAI/DeepSeek/Gemini auth at
+# the gateway is unstable. Set to "all" to re-enable every frontier provider
+# once /etc/fortress/secrets.env is fully populated. Aliases: "google" → "gemini".
+COUNCIL_FRONTIER_PROVIDERS_ENABLED=anthropic

--- a/fortress-guest-platform/backend/services/legal_council.py
+++ b/fortress-guest-platform/backend/services/legal_council.py
@@ -184,6 +184,51 @@ _OLLAMA_CTX_DEFAULT = 8192
 _CLOUD_PROVIDERS = {"ANTHROPIC", "ANTHROPIC_OPUS", "OPENAI", "XAI", "XAI_FLAGSHIP",
                     "DEEPSEEK", "DEEPSEEK_REASONER", "GEMINI"}
 
+# Map SEAT_ROUTING provider strings → logical provider names used by the
+# COUNCIL_FRONTIER_PROVIDERS_ENABLED env var. Any SEAT_ROUTING provider not in
+# this map is treated as a local/sovereign backend (HYDRA, SPARK, SWARM, VLLM)
+# and is always allowed — gating only applies to frontier (cloud) providers.
+_FRONTIER_PROVIDER_NORMALIZATION = {
+    "ANTHROPIC":         "anthropic",
+    "ANTHROPIC_OPUS":    "anthropic",
+    "OPENAI":            "openai",
+    "XAI":               "xai",
+    "XAI_FLAGSHIP":      "xai",
+    "DEEPSEEK":          "deepseek",
+    "DEEPSEEK_REASONER": "deepseek",
+    "GEMINI":            "gemini",
+}
+
+
+def _get_enabled_frontier_providers() -> frozenset[str]:
+    """Read the COUNCIL_FRONTIER_PROVIDERS_ENABLED allowlist.
+
+    Comma-separated logical provider names. Default is ``"anthropic"`` —
+    a degraded-mode floor that matches the current operational state on
+    spark-node-2 where only Anthropic upstream auth is known to work
+    (see docs/runbooks/litellm-key-rotation.md). Special token ``"all"``
+    re-enables every frontier provider (legacy 9-seat behavior).
+    """
+    raw = os.getenv("COUNCIL_FRONTIER_PROVIDERS_ENABLED", "anthropic")
+    parts = {p.strip().lower() for p in raw.split(",") if p.strip()}
+    if "google" in parts:
+        parts = (parts - {"google"}) | {"gemini"}
+    return frozenset(parts)
+
+
+def _seat_frontier_provider_enabled(seat: int, enabled: frozenset[str]) -> bool:
+    """True iff the seat's frontier provider is allowlisted, or if the seat
+    routes to a sovereign/local backend (always allowed — gating is for
+    frontier-auth contamination only)."""
+    if "all" in enabled:
+        return True
+    seat_provider = SEAT_ROUTING.get(seat, {}).get("provider", "")
+    norm = _FRONTIER_PROVIDER_NORMALIZATION.get(seat_provider.upper())
+    if norm is None:
+        return True
+    return norm in enabled
+
+
 logger.info(
     "legal_council_config  allow_cloud=%s  anthropic=%s  xai=%s  hydra_32b=%s  hydra_120b=%s  vllm_120b=%s",
     ALLOW_CLOUD_LLM, ANTHROPIC_PROXY, XAI_BASE_URL, HYDRA_32B_URL, HYDRA_120B_URL, VLLM_120B_URL,
@@ -1428,6 +1473,55 @@ async def run_council_deliberation(
                 "message": "No legal personas found in " + PERSONAS_DIR,
             })
         return
+
+    # ── Frontier-provider gating (degraded-mode safeguard) ───────────────
+    # Skip seats whose frontier provider is not allowlisted. This prevents
+    # silent fallback to local Ollama poisoning llm_training_captures with
+    # HYDRA outputs disguised as frontier consensus when an upstream
+    # provider's auth is broken at the gateway.
+    enabled_providers = _get_enabled_frontier_providers()
+    active_personas: List[LegalPersona] = []
+    skipped_personas: List[LegalPersona] = []
+    for _p in personas:
+        (active_personas if _seat_frontier_provider_enabled(_p.seat, enabled_providers)
+         else skipped_personas).append(_p)
+    if skipped_personas:
+        logger.warning(
+            "council_seats_skipped_disabled_provider",
+            extra={
+                "skipped_count": len(skipped_personas),
+                "active_count": len(active_personas),
+                "enabled_providers": sorted(enabled_providers),
+                "skipped_seats": [
+                    {
+                        "seat":     _p.seat,
+                        "persona":  _p.name,
+                        "provider": SEAT_ROUTING.get(_p.seat, {}).get("provider"),
+                    }
+                    for _p in skipped_personas
+                ],
+            },
+        )
+        if progress_callback:
+            await progress_callback({
+                "type": "seats_skipped",
+                "skipped_count": len(skipped_personas),
+                "active_count": len(active_personas),
+                "enabled_providers": sorted(enabled_providers),
+            })
+    if not active_personas:
+        _active_sessions[session_id] = {
+            "status": "error",
+            "error": "All Council seats disabled by COUNCIL_FRONTIER_PROVIDERS_ENABLED",
+        }
+        if progress_callback:
+            await progress_callback({
+                "type": "error",
+                "message": "All Council seats disabled by COUNCIL_FRONTIER_PROVIDERS_ENABLED — "
+                           f"enabled={sorted(enabled_providers)}, no seat routes match",
+            })
+        return
+    personas = active_personas
 
     # ── Pillar 2: Context Freezing — evidence + controlling authority ──
     evidence_vector_ids, evidence_chunks_raw = await freeze_context(

--- a/fortress-guest-platform/backend/tests/test_legal_council_provider_gating.py
+++ b/fortress-guest-platform/backend/tests/test_legal_council_provider_gating.py
@@ -1,0 +1,302 @@
+"""Tests for the COUNCIL_FRONTIER_PROVIDERS_ENABLED degraded-mode safeguard.
+
+Background: when an upstream provider's API key is missing or stale at the
+LiteLLM gateway, every seat using that provider returns 4xx. legal_council
+silently falls back to local Ollama (qwen2.5:7b) and the resulting opinions
+land in llm_training_captures looking like frontier consensus. The gating
+flag lets operators restrict deliberation to a known-good provider subset
+until upstream keys are fixed, and explicitly *skips* disabled seats rather
+than letting them fall back.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+import run  # noqa: F401  # Install runtime import fallback used in production launch.
+
+import pytest
+
+from backend.services import legal_council
+
+
+def _build_persona(seat: int, name: str = "Test Persona") -> legal_council.LegalPersona:
+    return legal_council.LegalPersona(
+        name=name,
+        slug=f"persona-seat-{seat}",
+        seat=seat,
+        archetype="test",
+        domain="legal",
+        god_head_domain="legal",
+        worldview="Test worldview.",
+        bias=["Test bias."],
+        focus_areas=["Test focus."],
+        trigger_events=["test trigger"],
+        godhead_prompt=f"You are persona at seat {seat}.",
+        vector_collection="legal_library",
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Allowlist parser
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_default_enabled_providers_is_anthropic_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("COUNCIL_FRONTIER_PROVIDERS_ENABLED", raising=False)
+    enabled = legal_council._get_enabled_frontier_providers()
+    assert enabled == frozenset({"anthropic"})
+
+
+def test_enabled_providers_parses_comma_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COUNCIL_FRONTIER_PROVIDERS_ENABLED", "anthropic, openai ,xai")
+    enabled = legal_council._get_enabled_frontier_providers()
+    assert enabled == frozenset({"anthropic", "openai", "xai"})
+
+
+def test_google_alias_normalizes_to_gemini(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COUNCIL_FRONTIER_PROVIDERS_ENABLED", "anthropic,google")
+    enabled = legal_council._get_enabled_frontier_providers()
+    assert enabled == frozenset({"anthropic", "gemini"})
+
+
+def test_all_token_enables_every_seat(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COUNCIL_FRONTIER_PROVIDERS_ENABLED", "all")
+    enabled = legal_council._get_enabled_frontier_providers()
+    for seat in range(1, 10):
+        assert legal_council._seat_frontier_provider_enabled(seat, enabled), (
+            f"seat {seat} should be enabled when allowlist is 'all'"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Per-seat gating — given the live SEAT_ROUTING (seats 1, 5 = ANTHROPIC,
+# seat 9 = ANTHROPIC_OPUS, all of which normalize to "anthropic")
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "enabled_csv,expected_active_seats",
+    [
+        ("anthropic",                  {1, 5, 9}),
+        ("openai",                     {2, 6}),
+        ("xai",                        {3, 7}),
+        ("deepseek",                   {4, 8}),
+        ("anthropic,openai",           {1, 2, 5, 6, 9}),
+        ("anthropic,openai,xai,deepseek", {1, 2, 3, 4, 5, 6, 7, 8, 9}),
+        ("all",                        {1, 2, 3, 4, 5, 6, 7, 8, 9}),
+    ],
+)
+def test_seat_gating_matches_seat_routing(
+    monkeypatch: pytest.MonkeyPatch, enabled_csv: str, expected_active_seats: set[int],
+) -> None:
+    monkeypatch.setenv("COUNCIL_FRONTIER_PROVIDERS_ENABLED", enabled_csv)
+    enabled = legal_council._get_enabled_frontier_providers()
+    active = {
+        seat for seat in legal_council.SEAT_ROUTING
+        if legal_council._seat_frontier_provider_enabled(seat, enabled)
+    }
+    assert active == expected_active_seats
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Deliberation-level behavior
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_council_skips_disabled_providers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Personas whose seat routes to a disabled provider are filtered out
+    of the deliberation entirely — they never reach analyze_with_persona."""
+    monkeypatch.setenv("COUNCIL_FRONTIER_PROVIDERS_ENABLED", "anthropic")
+
+    personas = [_build_persona(seat) for seat in range(1, 10)]
+    monkeypatch.setattr(
+        legal_council.LegalPersona, "load_all", classmethod(lambda cls: list(personas)),
+    )
+
+    invoked_seats: List[int] = []
+
+    async def fake_analyze(persona, *args, **kwargs):
+        invoked_seats.append(persona.seat)
+        return legal_council._make_error_opinion(persona, "stub", 0.0)
+
+    monkeypatch.setattr(legal_council, "analyze_with_persona", fake_analyze)
+    monkeypatch.setattr(legal_council, "freeze_context", _stub_freeze_context)
+    monkeypatch.setattr(legal_council, "freeze_caselaw_context", _stub_freeze_caselaw_context)
+
+    events: List[dict[str, Any]] = []
+
+    async def progress_callback(evt: dict[str, Any]) -> None:
+        events.append(evt)
+
+    await legal_council.run_council_deliberation(
+        session_id="test-skip-disabled",
+        case_brief="Smoke test brief.",
+        progress_callback=progress_callback,
+    )
+
+    # Only seats 1, 5, 9 (ANTHROPIC / ANTHROPIC_OPUS) should have been invoked.
+    assert set(invoked_seats) == {1, 5, 9}, (
+        f"expected only Anthropic-provider seats to fan out, got {sorted(invoked_seats)}"
+    )
+
+    skipped_evt = next((e for e in events if e.get("type") == "seats_skipped"), None)
+    assert skipped_evt is not None, "expected a seats_skipped progress event"
+    assert skipped_evt["skipped_count"] == 6
+    assert skipped_evt["active_count"] == 3
+    assert skipped_evt["enabled_providers"] == ["anthropic"]
+
+
+@pytest.mark.asyncio
+async def test_council_does_not_fallback_to_local_for_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A disabled-provider seat must not reach _call_llm at all — neither
+    the primary frontier path nor the HYDRA/Ollama fallback path. Filtering
+    happens before any per-seat LLM invocation."""
+    monkeypatch.setenv("COUNCIL_FRONTIER_PROVIDERS_ENABLED", "anthropic")
+
+    personas = [_build_persona(seat) for seat in range(1, 10)]
+    monkeypatch.setattr(
+        legal_council.LegalPersona, "load_all", classmethod(lambda cls: list(personas)),
+    )
+
+    seen_models: List[str] = []
+    seen_base_urls: List[str] = []
+
+    async def fake_call_llm(
+        system_prompt: str, user_prompt: str,
+        model: str = "", base_url: str = "", api_key: str = "",
+        temperature: float = 0.3, max_tokens: int = 4096,
+    ) -> tuple[str, str]:
+        seen_models.append(model)
+        seen_base_urls.append(base_url)
+        return ('{"signal":"NEUTRAL","conviction":0.5,"reasoning":"stub",'
+                '"defense_arguments":[],"risk_factors":[],"recommended_actions":[]}',
+                model or "fake-model")
+
+    monkeypatch.setattr(legal_council, "_call_llm", fake_call_llm)
+    monkeypatch.setattr(legal_council, "ALLOW_CLOUD_LLM", True)
+    monkeypatch.setattr(legal_council, "freeze_context", _stub_freeze_context)
+    monkeypatch.setattr(legal_council, "freeze_caselaw_context", _stub_freeze_caselaw_context)
+
+    await legal_council.run_council_deliberation(
+        session_id="test-no-fallback",
+        case_brief="Smoke test brief.",
+    )
+
+    # No call from a disabled-provider seat should reach _call_llm. The
+    # fallback chain in _call_llm would route disabled providers to HYDRA
+    # if they ever got there, so the absence of HYDRA URLs here is the
+    # actual guarantee we care about.
+    forbidden_urls = {
+        legal_council.HYDRA_120B_URL,
+        legal_council.HYDRA_32B_URL,
+        legal_council.SWARM_URL,
+        legal_council.SPARK2_URL,
+        legal_council.SPARK_LOCAL_URL,
+        legal_council.OPENAI_BASE_URL,
+        legal_council.XAI_BASE_URL,
+        legal_council.DEEPSEEK_BASE_URL,
+        legal_council.GEMINI_BASE_URL,
+    } - {legal_council.ANTHROPIC_PROXY}
+    leaked = set(seen_base_urls) & forbidden_urls
+    assert not leaked, f"disabled providers leaked into _call_llm via {leaked}"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_only_deliberation_completes_with_3_seats(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end happy path for the degraded-mode floor.
+
+    Note: the user-facing description originally said '2 seats' (Sonnet,
+    Opus). The live SEAT_ROUTING actually maps seats 1, 5, 9 to Anthropic
+    (Sonnet, Sonnet, Opus) — three seats running two distinct models.
+    This test asserts what the deliberation actually does so the count
+    discrepancy is visible to anyone editing SEAT_ROUTING in the future.
+    """
+    monkeypatch.setenv("COUNCIL_FRONTIER_PROVIDERS_ENABLED", "anthropic")
+
+    personas = [_build_persona(seat) for seat in range(1, 10)]
+    monkeypatch.setattr(
+        legal_council.LegalPersona, "load_all", classmethod(lambda cls: list(personas)),
+    )
+
+    completed_seats: List[int] = []
+
+    async def fake_analyze(persona, *args, **kwargs):
+        completed_seats.append(persona.seat)
+        return legal_council._make_error_opinion(persona, "stub", 0.0)
+
+    monkeypatch.setattr(legal_council, "analyze_with_persona", fake_analyze)
+    monkeypatch.setattr(legal_council, "freeze_context", _stub_freeze_context)
+    monkeypatch.setattr(legal_council, "freeze_caselaw_context", _stub_freeze_caselaw_context)
+
+    events: List[dict[str, Any]] = []
+
+    async def progress_callback(evt: dict[str, Any]) -> None:
+        events.append(evt)
+
+    await legal_council.run_council_deliberation(
+        session_id="test-anthropic-only",
+        case_brief="Smoke test brief.",
+        progress_callback=progress_callback,
+    )
+
+    assert sorted(completed_seats) == [1, 5, 9], (
+        "Anthropic-only allowlist should fan out exactly to seats 1 (Sonnet), "
+        f"5 (Sonnet), 9 (Opus); got {sorted(completed_seats)}"
+    )
+
+    error_evt = next((e for e in events if e.get("type") == "error"), None)
+    assert error_evt is None, f"unexpected error event: {error_evt!r}"
+
+
+@pytest.mark.asyncio
+async def test_council_emits_error_when_allowlist_excludes_every_seat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty active set is a hard error, not a silent zero-seat deliberation."""
+    monkeypatch.setenv("COUNCIL_FRONTIER_PROVIDERS_ENABLED", "")
+
+    personas = [_build_persona(seat) for seat in range(1, 10)]
+    monkeypatch.setattr(
+        legal_council.LegalPersona, "load_all", classmethod(lambda cls: list(personas)),
+    )
+
+    async def fake_analyze(persona, *args, **kwargs):
+        pytest.fail("no seat should be invoked when allowlist excludes everything")
+
+    monkeypatch.setattr(legal_council, "analyze_with_persona", fake_analyze)
+    monkeypatch.setattr(legal_council, "freeze_context", _stub_freeze_context)
+    monkeypatch.setattr(legal_council, "freeze_caselaw_context", _stub_freeze_caselaw_context)
+
+    events: List[dict[str, Any]] = []
+
+    async def progress_callback(evt: dict[str, Any]) -> None:
+        events.append(evt)
+
+    await legal_council.run_council_deliberation(
+        session_id="test-all-disabled",
+        case_brief="Smoke test brief.",
+        progress_callback=progress_callback,
+    )
+
+    error_evt = next((e for e in events if e.get("type") == "error"), None)
+    assert error_evt is not None
+    assert "COUNCIL_FRONTIER_PROVIDERS_ENABLED" in error_evt["message"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Stubs
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def _stub_freeze_context(case_brief: str, top_k: int = 20, case_slug=None):
+    return [], []
+
+
+async def _stub_freeze_caselaw_context(case_brief: str, top_k: int = 8):
+    return [], []


### PR DESCRIPTION
## Summary

Adds an allowlist-based degraded-mode safeguard so Council deliberation can be restricted to a known-good subset of frontier providers while upstream gateway auth is unstable.

- New env var `COUNCIL_FRONTIER_PROVIDERS_ENABLED` carries a comma-separated list of logical provider names (`anthropic`, `openai`, `xai`, `deepseek`, `gemini`; alias `google` → `gemini`; special token `all` re-enables every frontier provider).
- Seats whose `SEAT_ROUTING` provider does not normalize to an allowlisted name are filtered out of `run_council_deliberation` **before any LLM invocation** — they neither hit the frontier path nor the HYDRA fallback chain. Sovereign/local provider strings (`HYDRA`, `SPARK`, `SWARM`, `VLLM`) are always allowed — gating only applies to frontier auth.
- Default is `"anthropic"` — the conservative floor matching the current operational state on `spark-node-2`.

## Why now

The 2026-04-23 LiteLLM `master_key` rotation (PR #180) fixed the gateway-side auth, but a follow-on probe surfaced that `/etc/fortress/secrets.env` only contains `ANTHROPIC_API_KEY`. The gateway has no working key for OpenAI, xAI, DeepSeek, or Gemini today, so every Council fan-out to those seats returns 4xx and falls through to local Ollama (`qwen2.5:7b`) via `HYDRA_120B`. Those local-model outputs land in `llm_training_captures` carrying `served_by_endpoint` metadata that points at HYDRA, but the same captures are used by the nightly distillation job. The upstream-key fix is deferred (Gary will obtain new keys from the provider portals tomorrow); this PR makes the system **safe to run in the meantime** by skipping the contaminated paths entirely.

## Active seat count under the default

`SEAT_ROUTING` currently maps:

- seats 1, 5 → `ANTHROPIC` (Claude Sonnet)
- seat 9 → `ANTHROPIC_OPUS` (Claude Opus)
- seats 2, 6 → `OPENAI`; seats 3, 7 → `XAI`; seats 4, 8 → `DEEPSEEK_REASONER`

Anthropic-only therefore activates **3 seats running 2 distinct models** (Sonnet ×2, Opus ×1). The original task description framed this as "2 seats" — the live count is 3. The test `test_anthropic_only_deliberation_completes_with_3_seats` asserts the live behavior so the count discrepancy is visible to anyone editing `SEAT_ROUTING` in the future. If the intent was truly 2 seats (one Sonnet + one Opus), `SEAT_ROUTING` needs a separate edit to remove the duplicate Sonnet at seat 5; this PR does not make that judgment call.

## What's NOT in this PR

- The actual upstream-provider key fix (deferred to tomorrow).
- The contamination cleanup on `llm_training_captures` (Step 4, scheduled to follow this PR's merge).
- A change to `_call_llm`'s runtime fallback chain. An *enabled* provider that fails at runtime still falls back to HYDRA — that is the existing safety net for transient errors and is intentionally untouched. Gating only prevents *known-disabled* seats from ever reaching `_call_llm`.

## Test plan

- [x] `pytest backend/tests/test_legal_council_provider_gating.py -x` → 15/15 pass
- [x] `pytest backend/tests/test_legal_council_retry.py backend/tests/test_legal_council_caselaw_retrieval.py -x` → 9/9 pass (no regression)
- [ ] After merge: restart `fortress-backend.service` on spark-node-2, then trigger a Council deliberation. Expected:
  - `journalctl -u fortress-backend` shows a `council_seats_skipped_disabled_provider` warning with `skipped_count=6, active_count=3`.
  - Frontend SSE consumers receive a `seats_skipped` progress event.
  - `journalctl -u litellm-gateway` shows only HTTP 200 entries against `/v1/chat/completions` for that deliberation (no 401/500 to OpenAI/xAI/DeepSeek/Gemini, no fallback to HYDRA).
  - `llm_training_captures` rows for that deliberation all have `served_by_endpoint` resolving to a real Anthropic endpoint, not HYDRA.

## Rollback

`COUNCIL_FRONTIER_PROVIDERS_ENABLED=all` in `.env` + `systemctl restart fortress-backend` restores legacy 9-seat behavior without a code revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)