### PR TITLE
feat(legal): 11th Circuit CourtListener → legal_caselaw_federal ingest

### DIFF
--- a/fortress-guest-platform/backend/scripts/ingest_courtlistener_11th_cir.py
+++ b/fortress-guest-platform/backend/scripts/ingest_courtlistener_11th_cir.py
@@ -1,0 +1,552 @@
+"""
+CourtListener → Qdrant — 11th Circuit federal-precedent ingest.
+
+Fetches ca11 opinions from CourtListener API v4, caches them as a NAS
+JSONL, then runs the same chunk/embed/upsert pipeline as the GA-state
+sibling script (`ingest_courtlistener.py`). New target collection:
+`legal_caselaw_federal` — kept distinct so 11th-Cir precedent doesn't
+mix with the GA-state Phase 4 citation index.
+
+Fetch + ingest are decoupled. The fetch step is idempotent: re-runs
+skip opinions already in the NAS JSONL. The ingest step is idempotent
+via the existing sqlite resume log + UUID5 deterministic point IDs.
+
+Reuses, unmodified, from `ingest_courtlistener`:
+  - `RealEmbedder` — nomic-embed-text via legal_ediscovery._embed_single
+  - `DryRunEmbedder`, `DryRunSink` — explosive stubs proving --dry-run
+  - `QdrantSink` — qdrant_client.QdrantClient wrapper
+  - `chunk_by_words` — word-based 1500/150 chunker
+  - `IngestState` — sqlite (opinion_id, chunks_upserted, run_id, completed_at)
+  - `IngestStats` — counters
+
+Adds:
+  - `fetch_ca11_to_jsonl()` — paginated CourtListener API client
+  - `build_point()` — 11th-Cir payload schema (jurisdiction='ca11',
+    authored_judge if available)
+  - `--since` flag for fetch date floor
+  - Same CLI surface as the sibling: --reset --limit --batch-size
+    --dry-run --source --log-every
+
+Usage after merge:
+    python -m backend.scripts.ingest_courtlistener_11th_cir --dry-run --limit 10
+    python -m backend.scripts.ingest_courtlistener_11th_cir
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator, Sequence
+
+from backend.scripts.ingest_courtlistener import (
+    DryRunEmbedder,
+    DryRunSink,
+    IngestState,
+    IngestStats,
+    QdrantSink,
+    RealEmbedder,
+    chunk_by_words,
+)
+
+logger = logging.getLogger("ingest_courtlistener_11th_cir")
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Defaults
+# ──────────────────────────────────────────────────────────────────────────────
+
+DEFAULT_SOURCE = Path(
+    "/mnt/fortress_nas/legal-corpus/courtlistener/opinions-ca11.jsonl"
+)
+DEFAULT_STATE_DB = Path(
+    "/mnt/fortress_nas/legal-corpus/courtlistener/.ingest_state_ca11.db"
+)
+
+COLLECTION_NAME = "legal_caselaw_federal"
+JURISDICTION_TAG = "ca11"
+COURT_ID = "ca11"
+VECTOR_DIM = 768
+DEFAULT_SINCE = "2005-01-01"          # default 20-year horizon
+DEFAULT_CHUNK_TOKENS = 1500
+DEFAULT_OVERLAP_TOKENS = 150
+
+CL_BASE_URL = "https://www.courtlistener.com/api/rest/v4"
+CL_RATE_LIMIT_S = 0.5                 # be nice to CourtListener
+CL_PAGE_SIZE = 100                    # CL max per page
+
+# Same UUID5 namespace as the GA-state ingest — opinion_ids are globally
+# unique within CourtListener so a cross-collection collision is impossible.
+POINT_NS = uuid.UUID("7f2e1a6c-5d31-4b0a-9d4d-6a3e1a8c0f7e")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Config
+# ──────────────────────────────────────────────────────────────────────────────
+
+@dataclass
+class IngestConfig:
+    source:           Path
+    state_db:         Path
+    collection:       str = COLLECTION_NAME
+    batch_size:       int = 64
+    limit:            int | None = None
+    reset:            bool = False
+    dry_run:          bool = False
+    skip_fetch:       bool = False
+    log_every:        int = 50
+    chunk_tokens:     int = DEFAULT_CHUNK_TOKENS
+    overlap_tokens:   int = DEFAULT_OVERLAP_TOKENS
+    since:            str = DEFAULT_SINCE
+    fetch_max:        int | None = None      # cap on API fetch per run
+    run_id:           str = field(
+        default_factory=lambda: datetime.now(timezone.utc).strftime(
+            "ca11run-%Y%m%dT%H%M%SZ"
+        )
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# CourtListener API client (paginated, idempotent fetch → JSONL)
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _cl_token() -> str:
+    tok = os.environ.get("COURTLISTENER_API_TOKEN", "").strip()
+    if not tok:
+        raise RuntimeError(
+            "COURTLISTENER_API_TOKEN is unset — required for ca11 fetch"
+        )
+    return tok
+
+
+def _cl_get(url: str, token: str, http_get: Any | None = None) -> dict:
+    """GET with auth header. http_get is injectable for tests."""
+    if http_get is not None:
+        return http_get(url, token)
+    req = urllib.request.Request(
+        url, headers={"Authorization": f"Token {token}"}
+    )
+    # CourtListener filtered list endpoints can take 10-30s on cold queries;
+    # 90s gives headroom without making test failures slow (tests inject
+    # http_get and never hit this branch).
+    with urllib.request.urlopen(req, timeout=90) as resp:
+        return json.loads(resp.read())
+
+
+def _existing_opinion_ids(jsonl: Path) -> set[str]:
+    if not jsonl.exists():
+        return set()
+    seen: set[str] = set()
+    with jsonl.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            oid = str(rec.get("opinion_id") or "").strip()
+            if oid:
+                seen.add(oid)
+    return seen
+
+
+def _normalize_cluster_record(cluster: dict, opinion: dict) -> dict:
+    """Flatten a (cluster, opinion) pair into a JSONL record matching the
+    schema the GA-state ingest reads."""
+    text = (opinion.get("plain_text") or "").strip()
+    if not text:
+        # Fallback to html_with_citations stripped of tags
+        html = opinion.get("html_with_citations") or opinion.get("html") or ""
+        if html:
+            import re
+            text = re.sub(r"<[^>]+>", " ", html)
+            text = re.sub(r"\s+", " ", text).strip()
+    citations = []
+    for c in (cluster.get("citations") or []):
+        # CourtListener cluster citations are dicts; render to a flat string.
+        parts = [c.get(k) for k in ("volume", "reporter", "page") if c.get(k)]
+        if parts:
+            citations.append(" ".join(str(p) for p in parts))
+    authored_judge = (
+        opinion.get("author_str")
+        or (opinion.get("author") or {}).get("name_full")
+        or ""
+    )
+    if isinstance(authored_judge, dict):
+        authored_judge = authored_judge.get("name_full") or ""
+    return {
+        "opinion_id":       str(opinion.get("id") or ""),
+        "cluster_id":       str(cluster.get("id") or ""),
+        "case_name":        cluster.get("case_name") or cluster.get("case_name_short") or "",
+        "court":            "United States Court of Appeals for the Eleventh Circuit",
+        "court_id":         COURT_ID,
+        "date_filed":       cluster.get("date_filed") or "",
+        "citation":         citations,
+        "plain_text":       text,
+        "plain_text_chars": len(text),
+        "authored_judge":   str(authored_judge or ""),
+        "fetched_at":       datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def fetch_ca11_to_jsonl(
+    jsonl: Path,
+    since: str,
+    fetch_max: int | None = None,
+    http_get: Any | None = None,
+    rate_limit_s: float = CL_RATE_LIMIT_S,
+) -> tuple[int, int]:
+    """
+    Fetch ca11 clusters since `since` (YYYY-MM-DD), plus their first
+    opinion's full text, and append unseen ones to `jsonl`. Returns
+    (new_records, total_records_in_file).
+
+    Idempotent: existing opinion_ids in `jsonl` are skipped.
+    """
+    token = _cl_token()
+    seen = _existing_opinion_ids(jsonl)
+    jsonl.parent.mkdir(parents=True, exist_ok=True)
+
+    params = urllib.parse.urlencode({
+        "docket__court__id":  COURT_ID,
+        "date_filed__gte":    since,
+        "page_size":          CL_PAGE_SIZE,
+        "order_by":           "-date_filed",
+    })
+    url: str | None = f"{CL_BASE_URL}/clusters/?{params}"
+    new = 0
+    page = 0
+
+    with jsonl.open("a", encoding="utf-8") as out:
+        while url:
+            page += 1
+            try:
+                data = _cl_get(url, token, http_get=http_get)
+            except urllib.error.HTTPError as exc:
+                logger.error(
+                    "cl_http_error",
+                    extra={"page": page, "status": exc.code, "url": url[:160]},
+                )
+                break
+            except Exception as exc:
+                logger.error(
+                    "cl_fetch_failed",
+                    extra={"page": page, "error": str(exc)[:200]},
+                )
+                break
+
+            results = data.get("results") or []
+            for cluster in results:
+                if fetch_max is not None and new >= fetch_max:
+                    return new, len(seen) + new
+
+                # The cluster may carry an embedded list of opinions or a list
+                # of URLs. Hit the first opinion endpoint to get plain_text.
+                sub_ops = cluster.get("sub_opinions") or []
+                if not sub_ops:
+                    continue
+                op_ref = sub_ops[0]
+                if isinstance(op_ref, str):
+                    if rate_limit_s:
+                        time.sleep(rate_limit_s)
+                    try:
+                        op_data = _cl_get(op_ref, token, http_get=http_get)
+                    except Exception as exc:
+                        logger.warning(
+                            "cl_opinion_fetch_failed",
+                            extra={"url": op_ref[:160], "error": str(exc)[:200]},
+                        )
+                        continue
+                else:
+                    op_data = op_ref
+
+                opinion_id = str(op_data.get("id") or "")
+                if not opinion_id or opinion_id in seen:
+                    continue
+                rec = _normalize_cluster_record(cluster, op_data)
+                if not rec.get("plain_text"):
+                    # Skip empties — nothing to chunk/embed.
+                    continue
+                out.write(json.dumps(rec) + "\n")
+                seen.add(opinion_id)
+                new += 1
+            url = data.get("next") or None
+            if rate_limit_s:
+                time.sleep(rate_limit_s)
+    return new, len(seen)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Source iteration (single JSONL — dedup is via fetch step)
+# ──────────────────────────────────────────────────────────────────────────────
+
+def iter_opinions_jsonl(
+    src: Path, limit: int | None = None,
+) -> Iterator[dict]:
+    if not src.exists():
+        return
+    yielded = 0
+    with src.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not str(rec.get("opinion_id") or "").strip():
+                continue
+            yield rec
+            yielded += 1
+            if limit is not None and yielded >= limit:
+                return
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Point construction — ca11 payload schema
+# ──────────────────────────────────────────────────────────────────────────────
+
+def build_point(
+    opinion: dict, chunk_index: int, chunk_text: str,
+    vector: list[float], run_id: str,
+) -> dict:
+    opinion_id = str(opinion.get("opinion_id") or "")
+    point_id = str(uuid.uuid5(POINT_NS, f"{opinion_id}:{chunk_index}"))
+    return {
+        "id":     point_id,
+        "vector": vector,
+        "payload": {
+            "opinion_id":             opinion_id,
+            "cluster_id":             str(opinion.get("cluster_id") or ""),
+            "case_name":              opinion.get("case_name") or "",
+            "court":                  opinion.get("court") or "",
+            "date_filed":             opinion.get("date_filed") or "",
+            "citation":               list(opinion.get("citation") or []),
+            "chunk_index":            chunk_index,
+            "text_chunk":             chunk_text,
+            "plain_text_chars_total": int(opinion.get("plain_text_chars") or 0),
+            "jurisdiction":           JURISDICTION_TAG,
+            "authored_judge":         str(opinion.get("authored_judge") or ""),
+            "ingested_at":            datetime.now(timezone.utc).isoformat(),
+            "ingestion_run_id":       run_id,
+        },
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Ingest driver (mirrors GA-state pattern)
+# ──────────────────────────────────────────────────────────────────────────────
+
+async def run_ingest(
+    cfg: IngestConfig,
+    state: IngestState,
+    embedder: Any,
+    sink: Any,
+) -> IngestStats:
+    stats = IngestStats()
+
+    if cfg.reset:
+        if not cfg.dry_run:
+            sink.reset()
+        state.reset()
+        logger.info("collection_and_state_reset", extra={"run_id": cfg.run_id})
+
+    if not cfg.dry_run:
+        sink.ensure_collection(VECTOR_DIM)
+
+    batch: list[dict] = []
+
+    async def flush_batch() -> None:
+        if not batch:
+            return
+        if not cfg.dry_run:
+            sink.upsert(batch)
+        stats.points_upserted += len(batch)
+        batch.clear()
+
+    for opinion in iter_opinions_jsonl(cfg.source, limit=cfg.limit):
+        stats.opinions_seen += 1
+        opinion_id = str(opinion.get("opinion_id") or "")
+
+        if not cfg.reset and state.already_completed(opinion_id):
+            stats.opinions_skipped_completed += 1
+            continue
+
+        text = opinion.get("plain_text") or ""
+        chunks = chunk_by_words(
+            text, size=cfg.chunk_tokens, overlap=cfg.overlap_tokens,
+        )
+        if not chunks:
+            continue
+
+        try:
+            opinion_chunks_written = 0
+            for idx, chunk in enumerate(chunks):
+                if cfg.dry_run:
+                    vec: list[float] = []
+                else:
+                    vec = await embedder.embed(chunk)
+                    if not vec:
+                        raise RuntimeError(
+                            f"empty embedding for opinion {opinion_id} chunk {idx}"
+                        )
+                point = build_point(opinion, idx, chunk, vec, cfg.run_id)
+                batch.append(point)
+                stats.chunks_written += 1
+                opinion_chunks_written += 1
+                if len(batch) >= cfg.batch_size:
+                    await flush_batch()
+            stats.opinions_processed += 1
+            if not cfg.dry_run:
+                state.mark_completed(
+                    opinion_id, opinion_chunks_written, cfg.run_id,
+                )
+        except Exception as exc:
+            stats.errors += 1
+            logger.error(
+                "opinion_failed",
+                extra={"opinion_id": opinion_id, "error": str(exc)[:200]},
+            )
+            batch.clear()
+
+        if stats.opinions_processed and stats.opinions_processed % cfg.log_every == 0:
+            eps = stats.chunks_written / max(1e-6, stats.elapsed())
+            logger.info(
+                "progress",
+                extra={
+                    "opinions_processed": stats.opinions_processed,
+                    "chunks_written":     stats.chunks_written,
+                    "points_upserted":    stats.points_upserted,
+                    "embeddings_per_sec": round(eps, 2),
+                },
+            )
+
+    await flush_batch()
+    return stats
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# CLI
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="11th Circuit CourtListener → Qdrant ingest"
+    )
+    p.add_argument("--reset", action="store_true",
+                   help="drop+recreate collection and state before ingest")
+    p.add_argument("--limit", type=int, default=None,
+                   help="process at most N opinions during ingest")
+    p.add_argument("--batch-size", type=int, default=64,
+                   help="points per qdrant upsert (default 64)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="parse+chunk+count only; no embed or upsert")
+    p.add_argument("--source", type=Path, default=DEFAULT_SOURCE,
+                   help="override JSONL source")
+    p.add_argument("--log-every", type=int, default=50)
+    p.add_argument("--state-db", type=Path, default=DEFAULT_STATE_DB)
+    p.add_argument("--collection", type=str, default=COLLECTION_NAME)
+    p.add_argument("--chunk-tokens", type=int, default=DEFAULT_CHUNK_TOKENS)
+    p.add_argument("--overlap-tokens", type=int, default=DEFAULT_OVERLAP_TOKENS)
+    p.add_argument("--since", type=str, default=DEFAULT_SINCE,
+                   help="fetch ca11 clusters with date_filed >= this date")
+    p.add_argument("--fetch-max", type=int, default=None,
+                   help="cap on opinions fetched from CourtListener API")
+    p.add_argument("--skip-fetch", action="store_true",
+                   help="use existing JSONL only; do not call CourtListener")
+    return p.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = _parse_args(list(argv) if argv is not None else sys.argv[1:])
+
+    cfg = IngestConfig(
+        source=args.source,
+        state_db=args.state_db,
+        collection=args.collection,
+        batch_size=args.batch_size,
+        limit=args.limit,
+        reset=args.reset,
+        dry_run=args.dry_run,
+        skip_fetch=args.skip_fetch,
+        log_every=args.log_every,
+        chunk_tokens=args.chunk_tokens,
+        overlap_tokens=args.overlap_tokens,
+        since=args.since,
+        fetch_max=args.fetch_max,
+    )
+
+    if not cfg.skip_fetch:
+        # In --dry-run we still fetch (idempotent, JSONL-cached) so the
+        # smoke test exercises the full pipeline; pass --fetch-max to bound
+        # the API hit. With real CL token absent, we fall through to the
+        # existing JSONL.
+        try:
+            new, total = fetch_ca11_to_jsonl(
+                cfg.source, cfg.since, fetch_max=cfg.fetch_max or cfg.limit,
+            )
+            logger.info(
+                "ca11_fetch_complete",
+                extra={
+                    "jsonl":          str(cfg.source),
+                    "new_records":    new,
+                    "total_records":  total,
+                    "since":          cfg.since,
+                    "fetch_max":      cfg.fetch_max or cfg.limit,
+                },
+            )
+        except RuntimeError as exc:
+            logger.error("ca11_fetch_skipped", extra={"reason": str(exc)})
+            if not cfg.source.exists():
+                logger.error("ca11_no_source_after_failed_fetch", extra={
+                    "source": str(cfg.source),
+                })
+                return 2
+
+    state = IngestState(cfg.state_db)
+    try:
+        if cfg.dry_run:
+            embedder: Any = DryRunEmbedder()
+            sink: Any = DryRunSink()
+        else:
+            embedder = RealEmbedder()
+            sink = QdrantSink(collection=cfg.collection)
+        stats = asyncio.run(run_ingest(cfg, state, embedder, sink))
+    finally:
+        state.close()
+
+    logger.info(
+        "ingest_complete",
+        extra={
+            "run_id":             cfg.run_id,
+            "dry_run":            cfg.dry_run,
+            "total_opinions":     stats.opinions_seen,
+            "opinions_processed": stats.opinions_processed,
+            "opinions_skipped":   stats.opinions_skipped_completed,
+            "chunks_written":     stats.chunks_written,
+            "points_upserted":    stats.points_upserted,
+            "errors":             stats.errors,
+            "duration_seconds":   round(stats.elapsed(), 2),
+        },
+    )
+    return 0 if stats.errors == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fortress-guest-platform/backend/tests/test_ingest_courtlistener_11th_cir.py
+++ b/fortress-guest-platform/backend/tests/test_ingest_courtlistener_11th_cir.py
@@ -1,0 +1,352 @@
+"""
+Tests for backend.scripts.ingest_courtlistener_11th_cir.
+
+CourtListener API is fully stubbed via http_get injection; embedder
+and Qdrant sink are stubbed; sqlite state goes to tmp_path. No real
+network, no real Qdrant, no real Ollama.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from backend.scripts.ingest_courtlistener_11th_cir import (
+    COLLECTION_NAME,
+    DEFAULT_SINCE,
+    JURISDICTION_TAG,
+    VECTOR_DIM,
+    IngestConfig,
+    IngestState,
+    build_point,
+    fetch_ca11_to_jsonl,
+    run_ingest,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fixtures / fakes
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _ca11_opinion(
+    opinion_id: str = "OP1",
+    case_name: str = "Smith v. Jones",
+    text: str | None = None,
+    judge: str = "Hon. Jane Doe",
+) -> dict:
+    if text is None:
+        # 4000 words → multiple chunks at default 1500/150 tokens
+        text = " ".join(f"word{n:04d}" for n in range(4000))
+    return {
+        "opinion_id":       opinion_id,
+        "cluster_id":       f"c-{opinion_id}",
+        "case_name":        case_name,
+        "court":            "United States Court of Appeals for the Eleventh Circuit",
+        "court_id":         "ca11",
+        "date_filed":       "2024-06-15",
+        "citation":         ["20 F.4th 999"],
+        "plain_text":       text,
+        "plain_text_chars": len(text),
+        "authored_judge":   judge,
+        "fetched_at":       "2026-04-24T00:00:00+00:00",
+    }
+
+
+def _write_source(path: Path, opinions: list[dict]) -> Path:
+    with path.open("w", encoding="utf-8") as fh:
+        for op in opinions:
+            fh.write(json.dumps(op) + "\n")
+    return path
+
+
+class _RecordingEmbedder:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def embed(self, text: str) -> list[float]:
+        self.calls.append(text)
+        return [0.0001 * (len(text) % 1000)] * VECTOR_DIM
+
+
+class _RecordingSink:
+    def __init__(self) -> None:
+        self.ensure_calls: list[int] = []
+        self.reset_calls = 0
+        self.upsert_batches: list[list[dict]] = []
+
+    def ensure_collection(self, dim: int) -> None:
+        self.ensure_calls.append(dim)
+
+    def reset(self) -> None:
+        self.reset_calls += 1
+
+    def upsert(self, points: list[dict]) -> None:
+        self.upsert_batches.append(list(points))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. New collection name + payload schema
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestPayloadSchema:
+    def test_collection_name_is_legal_caselaw_federal(self):
+        assert COLLECTION_NAME == "legal_caselaw_federal"
+
+    def test_jurisdiction_tag_is_ca11(self):
+        assert JURISDICTION_TAG == "ca11"
+
+    def test_payload_carries_all_required_fields(self):
+        op = _ca11_opinion()
+        vec = [0.0] * VECTOR_DIM
+        p = build_point(op, chunk_index=2, chunk_text="chunked", vector=vec, run_id="r1")
+        required = {
+            "opinion_id", "cluster_id", "case_name", "court", "date_filed",
+            "citation", "chunk_index", "text_chunk", "plain_text_chars_total",
+            "jurisdiction", "authored_judge", "ingested_at", "ingestion_run_id",
+        }
+        assert set(p["payload"].keys()) == required
+        assert p["payload"]["jurisdiction"] == "ca11"
+        assert p["payload"]["authored_judge"] == "Hon. Jane Doe"
+        assert p["payload"]["chunk_index"] == 2
+        assert p["payload"]["text_chunk"] == "chunked"
+        assert p["vector"] is vec
+
+    def test_point_id_is_deterministic_per_opinion_chunk(self):
+        op = _ca11_opinion("STABLE")
+        v = [0.0] * VECTOR_DIM
+        a = build_point(op, 0, "c0", v, "run1")
+        b = build_point(op, 0, "c0", v, "run2")           # different run_id
+        c = build_point(op, 1, "c1", v, "run1")           # different chunk_index
+        assert a["id"] == b["id"]
+        assert a["id"] != c["id"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. Idempotent re-run
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestIdempotency:
+    def test_rerun_skips_completed_opinion_ids(self, tmp_path: Path):
+        src = _write_source(tmp_path / "ca11.jsonl", [
+            _ca11_opinion("CA11-A"), _ca11_opinion("CA11-B"),
+        ])
+        state_path = tmp_path / ".state.db"
+        cfg = IngestConfig(
+            source=src, state_db=state_path,
+            batch_size=4, chunk_tokens=500, overlap_tokens=50, log_every=999,
+            skip_fetch=True,
+        )
+
+        st1 = IngestState(state_path)
+        emb1 = _RecordingEmbedder(); sink1 = _RecordingSink()
+        s1 = asyncio.run(run_ingest(cfg, st1, emb1, sink1))
+        st1.close()
+        assert s1.opinions_processed == 2
+        assert s1.opinions_skipped_completed == 0
+        first_chunks = s1.chunks_written
+        assert first_chunks >= 2
+
+        st2 = IngestState(state_path)
+        emb2 = _RecordingEmbedder(); sink2 = _RecordingSink()
+        s2 = asyncio.run(run_ingest(cfg, st2, emb2, sink2))
+        st2.close()
+        assert s2.opinions_processed == 0
+        assert s2.opinions_skipped_completed == 2
+        assert s2.chunks_written == 0
+        assert emb2.calls == []
+        assert sink2.upsert_batches == []
+
+    def test_reset_drops_collection_and_reprocesses(self, tmp_path: Path):
+        src = _write_source(tmp_path / "ca11.jsonl", [_ca11_opinion("CA11-X")])
+        state_path = tmp_path / ".state.db"
+        cfg = IngestConfig(
+            source=src, state_db=state_path,
+            batch_size=4, chunk_tokens=500, overlap_tokens=50, log_every=999,
+            skip_fetch=True,
+        )
+        # Pre-populate state to simulate a prior run
+        st = IngestState(state_path)
+        st.mark_completed("CA11-X", 3, "prior")
+        st.close()
+
+        st2 = IngestState(state_path)
+        emb = _RecordingEmbedder(); sink = _RecordingSink()
+        cfg_reset = IngestConfig(**{**cfg.__dict__, "reset": True})
+        stats = asyncio.run(run_ingest(cfg_reset, st2, emb, sink))
+        st2.close()
+
+        assert sink.reset_calls == 1
+        assert stats.opinions_processed == 1
+        assert stats.opinions_skipped_completed == 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. Dry-run no-side-effects
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestDryRun:
+    def test_dry_run_does_not_call_embed_or_qdrant(self, tmp_path: Path):
+        from backend.scripts.ingest_courtlistener_11th_cir import (
+            DryRunEmbedder, DryRunSink,
+        )
+        src = _write_source(tmp_path / "ca11.jsonl", [
+            _ca11_opinion("D1"), _ca11_opinion("D2"),
+        ])
+        state = IngestState(tmp_path / ".state.db")
+        cfg = IngestConfig(
+            source=src, state_db=tmp_path / ".state.db",
+            batch_size=4, chunk_tokens=500, overlap_tokens=50,
+            dry_run=True, log_every=999, skip_fetch=True,
+        )
+        stats = asyncio.run(run_ingest(cfg, state, DryRunEmbedder(), DryRunSink()))
+        state.close()
+        assert stats.errors == 0
+        assert stats.opinions_processed == 2
+        assert stats.chunks_written >= 2
+        # Dry-run intentionally does NOT write state
+        st2 = IngestState(tmp_path / ".state.db")
+        assert not st2.already_completed("D1")
+        assert not st2.already_completed("D2")
+        st2.close()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. Collection creation goes through the existing QdrantSink path
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestCollectionEnsure:
+    def test_ensure_collection_called_with_768_dim(self, tmp_path: Path):
+        src = _write_source(tmp_path / "ca11.jsonl", [_ca11_opinion("C1")])
+        state = IngestState(tmp_path / ".state.db")
+        cfg = IngestConfig(
+            source=src, state_db=tmp_path / ".state.db",
+            batch_size=4, chunk_tokens=500, overlap_tokens=50, log_every=999,
+            skip_fetch=True,
+        )
+        sink = _RecordingSink()
+        emb = _RecordingEmbedder()
+        asyncio.run(run_ingest(cfg, state, emb, sink))
+        state.close()
+        assert sink.ensure_calls == [VECTOR_DIM]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. CourtListener API client — paginates + dedups + writes JSONL
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestFetchCa11ToJsonl:
+    def _fake_http(self):
+        """Return an http_get that simulates 2 pages of clusters + sub-opinion fetches."""
+        cluster_pages = [
+            {
+                "next": "http://fake/clusters/?cursor=p2",
+                "results": [
+                    {
+                        "id": 100, "case_name": "United States v. Alpha",
+                        "date_filed": "2024-05-01",
+                        "citations": [{"volume": "1", "reporter": "F.4th", "page": "11"}],
+                        "sub_opinions": ["http://fake/opinions/1001/"],
+                    },
+                    {
+                        "id": 101, "case_name": "United States v. Bravo",
+                        "date_filed": "2024-05-02",
+                        "citations": [{"volume": "2", "reporter": "F.4th", "page": "22"}],
+                        "sub_opinions": ["http://fake/opinions/1002/"],
+                    },
+                ],
+            },
+            {
+                "next": None,
+                "results": [
+                    {
+                        "id": 102, "case_name": "United States v. Charlie",
+                        "date_filed": "2024-05-03",
+                        "citations": [],
+                        "sub_opinions": ["http://fake/opinions/1003/"],
+                    },
+                ],
+            },
+        ]
+        opinion_data = {
+            "http://fake/opinions/1001/": {
+                "id": 1001, "plain_text": "Alpha opinion text body. " * 100,
+                "author_str": "J. Marcus",
+            },
+            "http://fake/opinions/1002/": {
+                "id": 1002, "plain_text": "Bravo opinion text body. " * 100,
+                "author_str": "J. Wilson",
+            },
+            "http://fake/opinions/1003/": {
+                "id": 1003, "plain_text": "Charlie opinion text body. " * 100,
+                "author_str": "J. Hull",
+            },
+        }
+        page_idx = {"i": 0}
+
+        def http_get(url: str, token: str) -> dict:
+            assert token == "test-token"
+            if "/clusters/" in url and "cursor=p2" in url:
+                return cluster_pages[1]
+            if "/clusters/" in url:
+                return cluster_pages[0]
+            return opinion_data[url]
+        return http_get
+
+    def test_fetch_paginates_and_writes_three_records(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("COURTLISTENER_API_TOKEN", "test-token")
+        jsonl = tmp_path / "ca11.jsonl"
+        new, total = fetch_ca11_to_jsonl(
+            jsonl, since="2024-01-01",
+            http_get=self._fake_http(),
+            rate_limit_s=0,
+        )
+        assert new == 3
+        assert total == 3
+        records = [json.loads(line) for line in jsonl.read_text().splitlines() if line]
+        assert {r["opinion_id"] for r in records} == {"1001", "1002", "1003"}
+        first = records[0]
+        assert first["court_id"] == "ca11"
+        assert first["court"].startswith("United States Court of Appeals")
+        assert first["authored_judge"] in {"J. Marcus", "J. Wilson", "J. Hull"}
+        assert first["plain_text_chars"] > 0
+
+    def test_fetch_is_idempotent_skips_existing_opinion_ids(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("COURTLISTENER_API_TOKEN", "test-token")
+        jsonl = tmp_path / "ca11.jsonl"
+        # Pre-populate JSONL with 1001
+        with jsonl.open("w") as fh:
+            fh.write(json.dumps({"opinion_id": "1001", "plain_text": "x"}) + "\n")
+        new, total = fetch_ca11_to_jsonl(
+            jsonl, since="2024-01-01",
+            http_get=self._fake_http(),
+            rate_limit_s=0,
+        )
+        # Only 1002 and 1003 are new
+        assert new == 2
+        # Total is len(seen at end) — but count is the size of the seen set which started with 1
+        assert total == 3
+        records = [json.loads(line) for line in jsonl.read_text().splitlines() if line]
+        # Original line for 1001 + appended 1002/1003 = 3
+        ids = [r["opinion_id"] for r in records]
+        assert ids.count("1001") == 1
+        assert "1002" in ids and "1003" in ids
+
+    def test_fetch_max_caps_api_pull(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("COURTLISTENER_API_TOKEN", "test-token")
+        jsonl = tmp_path / "ca11.jsonl"
+        new, _ = fetch_ca11_to_jsonl(
+            jsonl, since="2024-01-01", fetch_max=2,
+            http_get=self._fake_http(), rate_limit_s=0,
+        )
+        assert new == 2
+        records = [json.loads(line) for line in jsonl.read_text().splitlines() if line]
+        assert len(records) == 2
+
+    def test_fetch_raises_when_token_missing(self, tmp_path: Path, monkeypatch):
+        monkeypatch.delenv("COURTLISTENER_API_TOKEN", raising=False)
+        try:
+            fetch_ca11_to_jsonl(tmp_path / "ca11.jsonl", since="2024-01-01")
+        except RuntimeError as exc:
+            assert "COURTLISTENER_API_TOKEN" in str(exc)
+        else:
+            raise AssertionError("expected RuntimeError when token unset")


### PR DESCRIPTION
## Summary
New script + tests for ca11 (11th Circuit) federal-precedent ingest. Fetches CourtListener clusters + opinions, caches to a NAS JSONL, then runs the same chunk → embed → upsert pipeline as the GA-state sibling, writing into a **new** Qdrant collection `legal_caselaw_federal` (768-dim cosine, on_disk_payload=true). GA-state and federal precedent kept distinct so the Phase-4 citation index can target each independently.

## Reuse, no reinvention
All embedding + chunking + state + Qdrant code imported unchanged from `ingest_courtlistener`:
- `RealEmbedder`, `DryRunEmbedder`, `DryRunSink`, `QdrantSink`, `chunk_by_words`, `IngestState`, `IngestStats`.

## ca11-specific additions
- `fetch_ca11_to_jsonl()` — paginates `/api/rest/v4/clusters/?docket__court__id=ca11`, pulls full `plain_text` via the linked first `sub_opinions[0]`. Idempotent (skips opinion_ids already in JSONL). Auth via `COURTLISTENER_API_TOKEN`. `urllib` timeout 90s — CL filtered list endpoints commonly take 10-30s on cold queries.
- `build_point()` payload: `opinion_id, cluster_id, case_name, court, date_filed, citation[], chunk_index, text_chunk, plain_text_chars_total, jurisdiction='ca11', authored_judge, ingested_at, ingestion_run_id`.
- Same UUID5 namespace as the GA-state sibling — opinion_ids are globally unique within CourtListener, so cross-collection collisions can't happen.

## CLI
Mirrors the GA-state sibling, plus:
- `--since 2005-01-01` — fetch floor (default 20-year horizon)
- `--fetch-max N` — cap on opinions pulled from CL per run
- `--skip-fetch` — run on existing JSONL only

## Test plan
- [x] `pytest backend/tests/test_ingest_courtlistener_11th_cir.py backend/tests/test_ingest_courtlistener.py` → **21 passed** (12 new + 9 GA-state regression).
- [x] **Live dry-run smoke** with `--dry-run --fetch-max 10 --limit 10 --since 2024-01-01`: fetched 10 real ca11 opinions including `United States v. Amaury Rodriguez` (opinion_id 11315277, 31,690 chars, `USCA11 Case: 24-12052` docket header confirmed in plain_text). `ingest_complete` with 0 errors.
- [ ] Real ingest (Gary's call): full corpus is ~90,608 ca11 clusters; expect 30-90 min depending on CL throttling + GPU pressure.

## ca11 corpus size
CL `/api/rest/v4/clusters/?docket__court__id=ca11` reports **count: 90,608** opinions. Default `--since 2005-01-01` will hit roughly 60-70k of those. Real ingest commands suggested for Gary in a follow-up message.

## Constraints satisfied
- No DB migration / no new SQL tables.
- `legal_caselaw` (GA-state) unchanged.
- Embedder + chunker + state + Qdrant code fully shared with GA-state ingest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)