### PR TITLE
feat(legal-cases): per-case nas_layout for real-world folder structures

### DIFF
--- a/fortress-guest-platform/backend/alembic/versions/e7f9a3c2d8b1_add_legal_cases_nas_layout.py
+++ b/fortress-guest-platform/backend/alembic/versions/e7f9a3c2d8b1_add_legal_cases_nas_layout.py
@@ -1,0 +1,64 @@
+"""Add nas_layout JSONB column to legal.cases.
+
+Revision ID: e7f9a3c2d8b1
+Revises: d4e5f6a7b8c9
+Create Date: 2026-04-25
+
+Per-case override of the canonical NAS folder layout used by the
+/cases/{slug}/files and /cases/{slug}/download/{filename} endpoints.
+
+NULL (default) preserves existing behaviour: walk
+/mnt/fortress_nas/sectors/legal/{slug} with the canonical
+six-subdir tree (certified_mail, correspondence, evidence, receipts,
+filings/incoming, filings/outgoing).
+
+When populated, the JSON has shape:
+
+    {
+      "root": "/absolute/nas/path",
+      "subdirs": {
+        "filings_incoming": "relative/path/to/pleadings",
+        "filings_outgoing": "relative/path/to/outgoing",
+        "correspondence":   "relative/path/to/correspondence",
+        "evidence":         "relative/path/to/evidence",
+        "certified_mail":   "relative/path/to/certmail",
+        "receipts":         "relative/path/to/receipts"
+      },
+      "recursive": false
+    }
+
+Idempotent — uses ADD COLUMN IF NOT EXISTS so applying via raw psql
+to a sibling database does not break a later `alembic upgrade head`.
+"""
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "e7f9a3c2d8b1"
+down_revision = "d4e5f6a7b8c9"
+branch_labels = None
+depends_on = None
+
+
+_COLUMN_COMMENT = (
+    "Per-case NAS folder layout override. NULL = use default "
+    "/mnt/fortress_nas/sectors/legal/{slug}/{6-subdir} convention. "
+    "JSON shape: {root, subdirs:{filings_incoming, filings_outgoing, "
+    "correspondence, evidence, certified_mail, receipts}, "
+    "recursive: bool}."
+)
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE legal.cases "
+        "ADD COLUMN IF NOT EXISTS nas_layout JSONB DEFAULT NULL"
+    )
+    op.execute(
+        f"COMMENT ON COLUMN legal.cases.nas_layout IS $${_COLUMN_COMMENT}$$"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE legal.cases DROP COLUMN IF EXISTS nas_layout")

--- a/fortress-guest-platform/backend/api/legal_cases.py
+++ b/fortress-guest-platform/backend/api/legal_cases.py
@@ -464,7 +464,76 @@ async def get_correspondence_content(corr_id: int):
 
 # ── Case File Download (NAS) ──────────────────────────────────────────
 
-_CASE_SUBDIRS = ("certified_mail", "correspondence", "evidence", "receipts", "filings/incoming", "filings/outgoing")
+# Physical layout used when legal.cases.nas_layout IS NULL — preserves the
+# pre-existing behaviour so canonical cases (Generali, Prime Trust, MVP)
+# keep working unchanged. Logical names (returned to the UI) match the
+# physical paths under /mnt/fortress_nas/sectors/legal/{slug}/.
+_CASE_SUBDIRS = ("certified_mail", "correspondence", "evidence", "receipts",
+                 "filings/incoming", "filings/outgoing")
+_DEFAULT_SUBDIR_MAP: dict[str, str] = {
+    "certified_mail":   "certified_mail",
+    "correspondence":   "correspondence",
+    "evidence":         "evidence",
+    "receipts":         "receipts",
+    "filings_incoming": "filings/incoming",
+    "filings_outgoing": "filings/outgoing",
+}
+
+
+def _resolve_case_layout(
+    slug: str, nas_layout: dict | None,
+) -> tuple[Path, dict[str, str], bool]:
+    """
+    Return (case_root, logical→physical subdir map, recursive_flag).
+
+    NULL nas_layout → canonical {NAS_LEGAL_ROOT}/{slug} + _DEFAULT_SUBDIR_MAP,
+    recursive=False. Populated nas_layout → use the configured `root`
+    + `subdirs` map; missing keys are skipped silently. `recursive`
+    defaults to False when omitted.
+    """
+    if not nas_layout:
+        return Path(NAS_LEGAL_ROOT) / slug, dict(_DEFAULT_SUBDIR_MAP), False
+
+    root = Path(str(nas_layout.get("root") or "")).expanduser()
+    raw_subdirs = nas_layout.get("subdirs") or {}
+    if not isinstance(raw_subdirs, dict):
+        raw_subdirs = {}
+    subdir_map = {
+        str(k): str(v) for k, v in raw_subdirs.items()
+        if v is not None and v != ""
+    }
+    recursive = bool(nas_layout.get("recursive"))
+    return root, subdir_map, recursive
+
+
+def _walk_case_subdir(base: Path, recursive: bool) -> list[Path]:
+    """
+    Yield files under `base`, sorted. Skips:
+      - dotfiles (anywhere in the path)
+      - Synology @eaDir metadata folders
+      - directories themselves
+    """
+    if not base.is_dir():
+        return []
+    candidates = base.rglob("*") if recursive else base.iterdir()
+    out: list[Path] = []
+    for p in candidates:
+        if not p.is_file():
+            continue
+        if any(part.startswith(".") or part == "@eaDir" for part in p.parts):
+            continue
+        out.append(p)
+    out.sort()
+    return out
+
+
+def _is_under(child: Path, parent: Path) -> bool:
+    """True iff `child` is the same as or contained in `parent` after resolving."""
+    try:
+        child.resolve().relative_to(parent.resolve())
+    except ValueError:
+        return False
+    return True
 
 
 @router.get("/cases/{slug}/download/{filename}", summary="Download a file from a case's NAS vault")
@@ -474,23 +543,41 @@ async def download_case_file(slug: str, filename: str):
 
     async with LegacySession() as session:
         case_r = await session.execute(
-            text("SELECT id FROM legal.cases WHERE case_slug = :slug"),
+            text("SELECT id, nas_layout FROM legal.cases WHERE case_slug = :slug"),
             {"slug": slug},
         )
-        if not case_r.fetchone():
+        row = case_r.fetchone()
+        if not row:
             raise HTTPException(status_code=404, detail=f"Case '{slug}' not found")
 
-    case_root = Path(NAS_LEGAL_ROOT) / slug
-    for subdir in _CASE_SUBDIRS:
-        candidate = case_root / subdir / filename
-        if candidate.is_file():
-            resolved = candidate.resolve()
-            if not str(resolved).startswith(NAS_LEGAL_ROOT):
-                raise HTTPException(status_code=403, detail="Access denied")
+    nas_layout = getattr(row, "nas_layout", None)
+    case_root, subdir_map, recursive = _resolve_case_layout(slug, nas_layout)
+
+    for logical_name, relative_path in subdir_map.items():
+        d = case_root / relative_path
+        if not d.is_dir():
+            continue
+        if recursive:
+            iterator = (p for p in d.rglob(filename) if p.is_file())
+        else:
+            cand = d / filename
+            iterator = iter([cand]) if cand.is_file() else iter(())
+        for candidate in iterator:
+            if not _is_under(candidate, case_root):
+                # Path-traversal guard: a symlink could escape case_root.
+                continue
             ext = candidate.suffix.lower()
             media_type = MIME_MAP.get(ext, "application/octet-stream")
-            logger.info("legal_file_download", slug=slug, filename=filename, subdir=subdir)
-            return FileResponse(path=str(resolved), media_type=media_type, filename=filename)
+            logger.info(
+                "legal_file_download",
+                slug=slug, filename=filename, subdir=logical_name,
+                custom_layout=bool(nas_layout),
+            )
+            return FileResponse(
+                path=str(candidate.resolve()),
+                media_type=media_type,
+                filename=filename,
+            )
 
     raise HTTPException(status_code=404, detail=f"File '{filename}' not found in case vault")
 
@@ -499,26 +586,29 @@ async def download_case_file(slug: str, filename: str):
 async def list_case_files(slug: str):
     async with LegacySession() as session:
         case_r = await session.execute(
-            text("SELECT id FROM legal.cases WHERE case_slug = :slug"),
+            text("SELECT id, nas_layout FROM legal.cases WHERE case_slug = :slug"),
             {"slug": slug},
         )
-        if not case_r.fetchone():
+        row = case_r.fetchone()
+        if not row:
             raise HTTPException(status_code=404, detail=f"Case '{slug}' not found")
 
-    case_root = Path(NAS_LEGAL_ROOT) / slug
+    nas_layout = getattr(row, "nas_layout", None)
+    case_root, subdir_map, recursive = _resolve_case_layout(slug, nas_layout)
+
     files: list[dict[str, Any]] = []
-    for subdir in _CASE_SUBDIRS:
-        d = case_root / subdir
-        if not d.is_dir():
-            continue
-        for f in sorted(d.iterdir()):
-            if f.is_file():
-                files.append({
-                    "filename": f.name,
-                    "subdir": subdir,
-                    "size_bytes": f.stat().st_size,
-                    "download_url": f"{INTERNAL_LEGAL_API_PREFIX}/cases/{slug}/download/{f.name}",
-                })
+    for logical_name, relative_path in subdir_map.items():
+        d = case_root / relative_path
+        for f in _walk_case_subdir(d, recursive):
+            if not _is_under(f, case_root):
+                continue
+            files.append({
+                "filename":     f.name,
+                "subdir":       logical_name,            # logical, not physical
+                "relative_path": str(f.relative_to(d)),  # for nested layouts
+                "size_bytes":   f.stat().st_size,
+                "download_url": f"{INTERNAL_LEGAL_API_PREFIX}/cases/{slug}/download/{f.name}",
+            })
     return {"case_slug": slug, "files": files, "total": len(files)}
 
 

--- a/fortress-guest-platform/backend/tests/test_legal_cases_files.py
+++ b/fortress-guest-platform/backend/tests/test_legal_cases_files.py
@@ -1,0 +1,372 @@
+"""
+Tests for the legal-cases /files + /download endpoints with the
+nullable per-case nas_layout column.
+
+LegacySession is fully stubbed; filesystem fixtures use tmp_path.
+No real DB or NAS access.
+"""
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import backend.api.legal_cases as lc
+from backend.api.legal_cases import (
+    _DEFAULT_SUBDIR_MAP,
+    _is_under,
+    _resolve_case_layout,
+    _walk_case_subdir,
+    download_case_file,
+    list_case_files,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fakes
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _row(nas_layout=None, id_=1):
+    """Build a SQLAlchemy-Row-shaped namespace for case lookup."""
+    return SimpleNamespace(id=id_, nas_layout=nas_layout)
+
+
+def _patch_legacy_session(monkeypatch, row_to_return):
+    """Replace LegacySession() with a context-managed mock returning one row."""
+    session = AsyncMock()
+    result = AsyncMock()
+    result.fetchone = lambda: row_to_return  # synchronous on Result, mirrors live API
+    session.execute = AsyncMock(return_value=result)
+
+    @asynccontextmanager
+    async def fake_session():
+        yield session
+
+    monkeypatch.setattr(lc, "LegacySession", fake_session)
+    return session
+
+
+def _seed_canonical_case(root: Path, slug: str) -> dict[str, list[str]]:
+    """Create the 6-subdir tree under root/slug, return {subdir: [filenames]}."""
+    placed: dict[str, list[str]] = {}
+    layout = {
+        "filings/incoming":  ["Complaint.pdf"],
+        "filings/outgoing":  ["Answer.docx", "Motion.docx"],
+        "correspondence":    ["letter1.txt", "letter2.txt"],
+        "evidence":          ["exhibit_a.jpg"],
+        "certified_mail":    [],            # subdir absent on purpose
+        "receipts":          ["receipt1.pdf"],
+    }
+    case_root = root / slug
+    for sub, files in layout.items():
+        if not files and sub == "certified_mail":
+            continue   # skip — proves the "missing subdir silently skipped" path
+        d = case_root / sub
+        d.mkdir(parents=True, exist_ok=True)
+        for f in files:
+            (d / f).write_bytes(b"x")
+        placed[sub] = files
+    return placed
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. test_list_files_default_layout — Generali-style canonical case
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestListFilesDefaultLayout:
+    @pytest.mark.asyncio
+    async def test_list_files_default_layout_walks_canonical_subdirs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        # Point NAS_LEGAL_ROOT at our tmp dir
+        monkeypatch.setattr(lc, "NAS_LEGAL_ROOT", str(tmp_path))
+        slug = "fish-trap-suv2026000013"
+        _seed_canonical_case(tmp_path, slug)
+        _patch_legacy_session(monkeypatch, _row(nas_layout=None, id_=2))
+
+        result = await list_case_files(slug)
+        assert result["case_slug"] == slug
+        # filings/incoming(1) + filings/outgoing(2) + correspondence(2)
+        # + evidence(1) + receipts(1) = 7. certified_mail subdir was skipped
+        # by the seed helper so the "missing subdir silent skip" branch fires.
+        assert result["total"] == 7
+        names = {f["filename"] for f in result["files"]}
+        assert names == {
+            "Complaint.pdf", "Answer.docx", "Motion.docx",
+            "letter1.txt", "letter2.txt", "exhibit_a.jpg", "receipt1.pdf",
+        }
+        # Logical subdir names returned to UI:
+        subdirs = {f["subdir"] for f in result["files"]}
+        assert subdirs <= set(_DEFAULT_SUBDIR_MAP.keys())
+        # Each entry has a download_url referencing the slug
+        assert all(
+            f["download_url"] == f"/api/internal/legal/cases/{slug}/download/{f['filename']}"
+            for f in result["files"]
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. test_list_files_custom_layout — synthetic 7IL-shaped case
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestListFilesCustomLayout:
+    @pytest.mark.asyncio
+    async def test_list_files_custom_layout_resolves_per_case_paths(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        # Build a real-world-shaped tree:
+        #   tmp/Business_Legal/# Pleadings - GAND/Complaint.pdf
+        #   tmp/Business_Legal/Discovery/RFP_Resp.pdf
+        #   tmp/Business_Legal/Correspondence/oc_email.eml
+        bl = tmp_path / "Business_Legal"
+        (bl / "# Pleadings - GAND").mkdir(parents=True)
+        (bl / "# Pleadings - GAND" / "Complaint.pdf").write_bytes(b"complaint")
+        (bl / "Discovery").mkdir()
+        (bl / "Discovery" / "RFP_Resp.pdf").write_bytes(b"rfp-response")
+        (bl / "Correspondence").mkdir()
+        (bl / "Correspondence" / "oc_email.eml").write_bytes(b"email")
+
+        layout = {
+            "root": str(bl),
+            "subdirs": {
+                "filings_incoming": "# Pleadings - GAND",
+                "evidence":         "Discovery",
+                "correspondence":   "Correspondence",
+                # filings_outgoing / certified_mail / receipts not provided
+            },
+        }
+        slug = "7il-v-knight"
+        _patch_legacy_session(monkeypatch, _row(nas_layout=layout))
+
+        result = await list_case_files(slug)
+        assert result["total"] == 3
+        names = {(f["subdir"], f["filename"]) for f in result["files"]}
+        assert names == {
+            ("filings_incoming", "Complaint.pdf"),
+            ("evidence",         "RFP_Resp.pdf"),
+            ("correspondence",   "oc_email.eml"),
+        }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. test_list_files_recursive_flag — nested folder structure
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestListFilesRecursiveFlag:
+    @pytest.mark.asyncio
+    async def test_recursive_walks_nested_dirs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        bl = tmp_path / "Business_Legal"
+        d = bl / "Discovery"
+        (d / "Production").mkdir(parents=True)
+        (d / "Production" / "Set1.pdf").write_bytes(b"x")
+        (d / "Production" / "Set2.pdf").write_bytes(b"x")
+        (d / "Depo Exhibits" / "Wilson").mkdir(parents=True)
+        (d / "Depo Exhibits" / "Wilson" / "Exhibit_M.pdf").write_bytes(b"x")
+        (d / "@eaDir" / "thumbs").mkdir(parents=True)         # synology garbage
+        (d / "@eaDir" / "thumbs" / "thumb.jpg").write_bytes(b"junk")
+        (d / ".DS_Store").write_bytes(b"junk")                # mac metadata
+
+        layout = {"root": str(bl), "subdirs": {"evidence": "Discovery"},
+                  "recursive": True}
+        _patch_legacy_session(monkeypatch, _row(nas_layout=layout))
+
+        result = await list_case_files("nested-case")
+        names = sorted(f["filename"] for f in result["files"])
+        assert names == ["Exhibit_M.pdf", "Set1.pdf", "Set2.pdf"]
+        # @eaDir AND .DS_Store filtered out:
+        joined = " ".join(names)
+        assert "@eaDir" not in joined and "DS_Store" not in joined
+        # Each entry carries a relative_path so the UI can render the tree:
+        rel = {f["relative_path"] for f in result["files"]}
+        assert "Production/Set1.pdf" in rel
+        assert "Depo Exhibits/Wilson/Exhibit_M.pdf" in rel
+
+    @pytest.mark.asyncio
+    async def test_non_recursive_default_does_not_descend(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        bl = tmp_path / "Business_Legal"
+        (bl / "Discovery" / "Nested").mkdir(parents=True)
+        (bl / "Discovery" / "top.pdf").write_bytes(b"x")
+        (bl / "Discovery" / "Nested" / "deep.pdf").write_bytes(b"x")
+
+        layout = {"root": str(bl), "subdirs": {"evidence": "Discovery"}}
+        _patch_legacy_session(monkeypatch, _row(nas_layout=layout))
+
+        result = await list_case_files("flat-case")
+        names = {f["filename"] for f in result["files"]}
+        assert names == {"top.pdf"}, "non-recursive must skip nested dirs"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. test_list_files_missing_subdir_silent_skip
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestMissingSubdirSilentSkip:
+    @pytest.mark.asyncio
+    async def test_missing_canonical_subdir_returns_empty_total(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        # Only create one of the six canonical subdirs.
+        slug = "sparse-case"
+        (tmp_path / slug / "evidence").mkdir(parents=True)
+        (tmp_path / slug / "evidence" / "only.pdf").write_bytes(b"x")
+        monkeypatch.setattr(lc, "NAS_LEGAL_ROOT", str(tmp_path))
+        _patch_legacy_session(monkeypatch, _row(nas_layout=None))
+
+        result = await list_case_files(slug)
+        assert result["total"] == 1
+        assert result["files"][0]["subdir"] == "evidence"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. test_list_files_nonexistent_case_404
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestNonexistentCase404:
+    @pytest.mark.asyncio
+    async def test_unknown_slug_raises_404(self, monkeypatch: pytest.MonkeyPatch):
+        from fastapi import HTTPException
+        _patch_legacy_session(monkeypatch, None)        # no row returned
+        try:
+            await list_case_files("ghost-case")
+        except HTTPException as exc:
+            assert exc.status_code == 404
+        else:
+            raise AssertionError("expected 404 for unknown case_slug")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 6. test_download_respects_custom_layout
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestDownloadCustomLayout:
+    @pytest.mark.asyncio
+    async def test_download_finds_file_under_custom_layout_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        bl = tmp_path / "Business_Legal"
+        (bl / "# Pleadings - GAND").mkdir(parents=True)
+        target = bl / "# Pleadings - GAND" / "#1 Complaint.pdf"
+        target.write_bytes(b"<<pdf>>")
+        layout = {"root": str(bl),
+                  "subdirs": {"filings_incoming": "# Pleadings - GAND"}}
+        _patch_legacy_session(monkeypatch, _row(nas_layout=layout))
+
+        # The download handler returns a FileResponse — easiest verification
+        # is to assert it doesn't raise + the path resolves to our file.
+        from fastapi.responses import FileResponse
+        resp = await download_case_file("7il", "#1 Complaint.pdf")
+        assert isinstance(resp, FileResponse)
+        assert Path(resp.path).resolve() == target.resolve()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 7. test_download_path_traversal_rejected
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestPathTraversalRejected:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("evil", [
+        "../etc/passwd", "..\\..\\Windows\\System32\\config\\sam",
+        "subdir/file.pdf", "/absolute/path",
+    ])
+    async def test_evil_filename_rejected_400(
+        self, monkeypatch: pytest.MonkeyPatch, evil: str,
+    ):
+        from fastapi import HTTPException
+        # Note: handler rejects before touching DB/filesystem.
+        try:
+            await download_case_file("any-case", evil)
+        except HTTPException as exc:
+            assert exc.status_code == 400, f"expected 400 for {evil!r}"
+        else:
+            raise AssertionError(f"expected 400 for {evil!r}")
+
+    @pytest.mark.asyncio
+    async def test_resolved_path_must_stay_under_case_root(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        # Build: case_root/evidence/safe.pdf, plus a symlink in evidence/
+        # that escapes case_root pointing at outside_secret.txt.
+        from fastapi import HTTPException
+        case_root = tmp_path / "case_dir"
+        outside = tmp_path / "outside_secret.txt"
+        outside.write_bytes(b"top secret")
+
+        ev = case_root / "evidence"
+        ev.mkdir(parents=True)
+        (ev / "safe.pdf").write_bytes(b"x")
+        (ev / "escape.lnk").symlink_to(outside)
+
+        layout = {"root": str(case_root),
+                  "subdirs": {"evidence": "evidence"}}
+        _patch_legacy_session(monkeypatch, _row(nas_layout=layout))
+
+        # safe.pdf works
+        from fastapi.responses import FileResponse
+        ok = await download_case_file("c", "safe.pdf")
+        assert isinstance(ok, FileResponse)
+
+        # escape.lnk resolves outside case_root → 404 (skipped, not served)
+        try:
+            await download_case_file("c", "escape.lnk")
+        except HTTPException as exc:
+            assert exc.status_code == 404
+        else:
+            raise AssertionError("symlink escape should not have been served")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helper-function unit tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestHelpers:
+    def test_resolve_layout_null_returns_canonical(self, monkeypatch):
+        monkeypatch.setattr(lc, "NAS_LEGAL_ROOT", "/mnt/x/legal")
+        root, m, rec = _resolve_case_layout("fish-trap", None)
+        assert root == Path("/mnt/x/legal/fish-trap")
+        assert m == _DEFAULT_SUBDIR_MAP
+        assert rec is False
+
+    def test_resolve_layout_populated_returns_custom(self):
+        layout = {"root": "/mnt/y", "subdirs": {"evidence": "ev"}, "recursive": True}
+        root, m, rec = _resolve_case_layout("any", layout)
+        assert root == Path("/mnt/y")
+        assert m == {"evidence": "ev"}
+        assert rec is True
+
+    def test_resolve_layout_skips_empty_subdir_values(self):
+        layout = {"root": "/mnt/y", "subdirs": {"a": "x", "b": "", "c": None}}
+        _, m, _ = _resolve_case_layout("any", layout)
+        assert m == {"a": "x"}
+
+    def test_walk_skips_eadir_and_dotfiles(self, tmp_path: Path):
+        (tmp_path / "@eaDir").mkdir()
+        (tmp_path / "@eaDir" / "thumb.jpg").write_bytes(b"x")
+        (tmp_path / ".DS_Store").write_bytes(b"x")
+        (tmp_path / "real.pdf").write_bytes(b"x")
+        (tmp_path / "sub").mkdir()
+        (tmp_path / "sub" / "nested.pdf").write_bytes(b"x")
+        (tmp_path / "sub" / "@eaDir").mkdir()
+        (tmp_path / "sub" / "@eaDir" / "junk.txt").write_bytes(b"x")
+
+        flat = _walk_case_subdir(tmp_path, recursive=False)
+        assert [p.name for p in flat] == ["real.pdf"]
+
+        rec = _walk_case_subdir(tmp_path, recursive=True)
+        assert sorted(p.name for p in rec) == ["nested.pdf", "real.pdf"]
+
+    def test_is_under_rejects_paths_outside_parent(self, tmp_path: Path):
+        parent = tmp_path / "case"
+        parent.mkdir()
+        (parent / "ok.txt").write_bytes(b"x")
+        (tmp_path / "outside.txt").write_bytes(b"x")
+        assert _is_under(parent / "ok.txt", parent) is True
+        assert _is_under(tmp_path / "outside.txt", parent) is False


### PR DESCRIPTION
## Summary
Adds nullable `nas_layout` JSONB column to `legal.cases`. When `NULL` (default), `GET /cases/{slug}/files` preserves existing behavior walking `/mnt/fortress_nas/sectors/legal/{slug}/` with the canonical six subdirs. When populated, the handler resolves the configured `root` + `subdirs` mapping, enabling cases whose files already live outside the canonical template (e.g. **7IL's existing `/Corporate_Legal/Business_Legal/{# Pleadings - GAND, Discovery, Depositions}` structure**).

## Schema migration
- Alembic revision **`e7f9a3c2d8b1`** (parent `d4e5f6a7b8c9`, prod head).
- `ADD COLUMN IF NOT EXISTS` — idempotent. `DROP COLUMN IF EXISTS` on downgrade.
- `COMMENT ON COLUMN` documents the JSON shape for operators.
- **Applied to `fortress_prod` AND `fortress_db`** via raw psql; both confirmed `data_type=jsonb`, `is_nullable=YES`, default `NULL`. All 3 existing case rows have `nas_layout IS NULL` → no behavior change for Generali / Prime Trust / Legal-Fortress-MVP.
- `fortress_shadow` intentionally untouched (different alembic chain head). `alembic_version` pointers **not modified** — operator can run `alembic upgrade head` on prod later for a no-op that bumps the marker.

## Handler refactor
- `/cases/{slug}/files` (`legal_cases.py:498`) and `/cases/{slug}/download/{filename}` (`legal_cases.py:470`) now `SELECT (id, nas_layout)` and route through new `_resolve_case_layout(slug, nas_layout)`:
  - `None` → canonical `Path(NAS_LEGAL_ROOT)/slug` + `_DEFAULT_SUBDIR_MAP` (logical key == physical path).
  - Populated → `Path(layout["root"])` + `layout["subdirs"]` (logical → physical relpath).
- Optional `"recursive": true` flag walks `Path.rglob("*")` under each configured subdir. Default `false` for canonical cases.
- `_walk_case_subdir()` filters `@eaDir` (Synology metadata folders) and dotfiles at every depth.
- `/files` response now also carries `relative_path` so the UI can render nested trees when `recursive=true`. Existing top-level keys (`filename`, `subdir`, `size_bytes`, `download_url`) unchanged.

## Security
- `..` / `/` / `\\` in `filename` still rejected with 400.
- Stronger path-traversal guard: every resolved candidate must satisfy `resolve().relative_to(case_root.resolve())` before being served. Protects against symlink escapes inside a configured layout `root` (the previous `str.startswith(NAS_LEGAL_ROOT)` check doesn't apply when a custom root sits outside `NAS_LEGAL_ROOT`).

## Test plan
- [x] `pytest backend/tests/test_legal_cases_files.py` → **17 passed** (default-layout regression for Generali shape, custom-layout for 7IL shape, recursive on/off, missing subdir silent-skip, 404 for unknown slug, custom-layout download, 5 path-traversal cases incl. symlink escape, helper unit tests).
- [x] `legal.cases.nas_layout` column verified in both `fortress_prod` and `fortress_db`. All 3 existing rows are NULL.
- [ ] `fortress-backend` not restarted in this PR — PR B will restart after seeding 7IL's layout.

## Out of scope (PR B)
- No `nas_layout` values inserted. Generali / Prime Trust / legal-fortress-mvp keep `nas_layout=NULL`, so their `/files` endpoints behave identically to today.
- 7IL `legal.cases` row not added. That insert + the per-case layout JSON for `/Corporate_Legal/Business_Legal/{# Pleadings - GAND, Discovery, …}` belong in PR B.
- `fortress_shadow` not migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)