### PR TITLE
feat(legal): OCR sweep script for case files

### DIFF
--- a/fortress-guest-platform/backend/scripts/ocr_legal_case.py
+++ b/fortress-guest-platform/backend/scripts/ocr_legal_case.py
@@ -1,0 +1,541 @@
+"""
+ocr_legal_case.py — in-place OCR sweep over a legal case file tree.
+
+Reads `legal.cases.nas_layout` for the supplied --case-slug, walks every
+PDF under the configured root (recursive when the layout opts in),
+probes pdftotext on each file, and runs `ocrmypdf --skip-text` over
+image-only PDFs.
+
+Idempotent end-to-end:
+  - pdftotext probe skips PDFs that already have text.
+  - ocrmypdf's --skip-text flag is itself idempotent — even if the probe
+    misclassifies, ocrmypdf refuses to re-OCR a page that already has a
+    text layer.
+  - Concurrent runs are gated by /tmp/ocr-sweep-{slug}.lock; --force
+    overrides locks older than 6h.
+
+ocrmypdf writes to a temp file and only swaps the target on success,
+so a corrupt input PDF cannot destroy the original file via this
+script.
+
+Usage after merge:
+    python -m backend.scripts.ocr_legal_case \\
+        --case-slug 7il-v-knight-ndga \\
+        --quality standard --jobs 6
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import time
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("ocr_legal_case")
+
+# ─── config ────────────────────────────────────────────────────────────────
+
+NAS_LEGAL_ROOT = "/mnt/fortress_nas/sectors/legal"
+ENV_PATH = Path("/home/admin/Fortress-Prime/fortress-guest-platform/.env")
+
+AUDIT_DIR = Path("/mnt/fortress_nas/audits")
+
+# pdftotext output below this many chars → treated as image-only.
+# 100 catches the most common image-only PDFs (which produce 0–10 chars
+# of OCR-leftover whitespace from the wrapper). Real text PDFs return
+# hundreds-to-thousands of chars on page 1 alone.
+DEFAULT_TEXT_THRESHOLD = 100
+
+# Map operator-friendly --quality flag to ocrmypdf --optimize integer.
+# 0 = no optimisation (largest output, fastest), 3 = aggressive.
+QUALITY_TO_OPTIMIZE: dict[str, int] = {
+    "fast":     3,
+    "standard": 1,
+    "high":     0,
+}
+
+# pdftotext probe timeout — handles wedged or crashing PDFs.
+PDFTOTEXT_TIMEOUT_S = 8
+# Per-file ocrmypdf timeout.
+OCRMYPDF_TIMEOUT_S = 600
+
+# Lock-file safety.
+LOCK_STALE_AFTER_S = 6 * 3600  # 6 hours
+
+
+# ─── DB lookup ─────────────────────────────────────────────────────────────
+
+def _read_env_pgs() -> dict[str, str]:
+    """Parse .env for the admin URI (used to fetch nas_layout)."""
+    out: dict[str, str] = {}
+    if not ENV_PATH.exists():
+        return out
+    for raw in ENV_PATH.read_text().splitlines():
+        s = raw.strip()
+        if not s or s.startswith("#") or "=" not in s:
+            continue
+        k, _, v = s.partition("=")
+        out[k.strip()] = v.strip().strip('"').strip("'")
+    return out
+
+
+def _admin_dsn() -> tuple[str, str, str, str, str]:
+    """Return (host, port, user, password, db) for fortress_db (read-only SELECT)."""
+    env = _read_env_pgs()
+    uri = env.get("POSTGRES_ADMIN_URI", "")
+    # postgresql+asyncpg://user:pw@host:port/dbname
+    import re
+    m = re.match(
+        r"postgresql(?:\+\w+)?://([^:]+):([^@]+)@([^:/]+):?(\d+)?/([^?]+)",
+        uri,
+    )
+    if not m:
+        raise SystemExit(f"could not parse POSTGRES_ADMIN_URI from {ENV_PATH}")
+    user, pw, host, port, _ = m.groups()
+    # Layout actually lives in fortress_db (per CLAUDE.md / legal_email_intake).
+    return host, port or "5432", user, pw, "fortress_db"
+
+
+def fetch_case_layout(case_slug: str) -> dict[str, Any]:
+    """
+    Read legal.cases.nas_layout for the given slug. Returns a normalized
+    dict: {"root": Path, "subdirs": {logical: relpath}, "recursive": bool}.
+    Raises SystemExit if the slug is unknown.
+    """
+    host, port, user, pw, dbname = _admin_dsn()
+    env = os.environ.copy()
+    env["PGPASSWORD"] = pw
+    sql = (
+        "SELECT COALESCE(nas_layout::text, '{}') FROM legal.cases "
+        "WHERE case_slug = $$" + case_slug.replace("$", "") + "$$"
+    )
+    proc = subprocess.run(
+        ["psql", "-h", host, "-p", port, "-U", user, "-d", dbname,
+         "-tAc", sql],
+        env=env, capture_output=True, text=True, timeout=15,
+    )
+    if proc.returncode != 0:
+        raise SystemExit(
+            f"psql lookup failed for slug={case_slug}: "
+            f"{proc.stderr.strip()[:200]}"
+        )
+    raw = proc.stdout.strip()
+    if not raw:
+        raise SystemExit(f"case_slug {case_slug!r} not found in legal.cases")
+    layout = json.loads(raw) if raw and raw != "{}" else {}
+    return _normalize_layout(case_slug, layout)
+
+
+def _normalize_layout(case_slug: str, raw: dict | None) -> dict[str, Any]:
+    """
+    Mirror the FastAPI handler's _resolve_case_layout semantics.
+    NULL/empty → canonical sectors/legal/{slug} layout, recursive=False.
+    """
+    if not raw:
+        return {
+            "root":      Path(NAS_LEGAL_ROOT) / case_slug,
+            "subdirs":   {
+                "certified_mail":   "certified_mail",
+                "correspondence":   "correspondence",
+                "evidence":         "evidence",
+                "receipts":         "receipts",
+                "filings_incoming": "filings/incoming",
+                "filings_outgoing": "filings/outgoing",
+            },
+            "recursive": False,
+        }
+    root = Path(str(raw.get("root") or "")).expanduser()
+    subs = raw.get("subdirs") or {}
+    if not isinstance(subs, dict):
+        subs = {}
+    subdirs = {
+        str(k): str(v) for k, v in subs.items()
+        if v is not None and v != ""
+    }
+    return {
+        "root":      root,
+        "subdirs":   subdirs,
+        "recursive": bool(raw.get("recursive")),
+    }
+
+
+# ─── PDF discovery + classification ────────────────────────────────────────
+
+def iter_case_pdfs(layout: dict[str, Any]) -> list[Path]:
+    """
+    Return every PDF under the case's configured subdirs (deduped),
+    skipping @eaDir Synology metadata folders and dotfiles.
+    """
+    root: Path = layout["root"]
+    recursive: bool = layout["recursive"]
+    seen: set[Path] = set()
+    out: list[Path] = []
+    for relpath in layout["subdirs"].values():
+        d = root / relpath
+        if not d.is_dir():
+            continue
+        candidates = d.rglob("*") if recursive else d.iterdir()
+        for p in candidates:
+            if not p.is_file():
+                continue
+            if p.suffix.lower() != ".pdf":
+                continue
+            if any(part == "@eaDir" or part.startswith(".") for part in p.parts):
+                continue
+            try:
+                rp = p.resolve()
+            except OSError:
+                continue
+            if rp in seen:
+                continue
+            seen.add(rp)
+            out.append(p)
+    out.sort()
+    return out
+
+
+def has_text_layer(path: Path, threshold: int = DEFAULT_TEXT_THRESHOLD) -> bool:
+    """Probe with pdftotext on the first 3 pages. True if extracted >= threshold."""
+    try:
+        proc = subprocess.run(
+            ["pdftotext", "-q", "-l", "3", str(path), "-"],
+            capture_output=True, timeout=PDFTOTEXT_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        return False
+    except Exception:
+        return False
+    text = proc.stdout.decode("utf-8", errors="replace")
+    # Strip whitespace-only output that some image-only PDFs return.
+    return len(text.strip()) >= threshold
+
+
+# ─── ocrmypdf invocation (worker) ──────────────────────────────────────────
+
+@dataclass
+class FileResult:
+    path: str
+    status: str                              # "already_text" | "ocr_applied" | "skipped" | "error"
+    detail: str = ""
+    pre_chars: int = 0
+    post_chars: int = 0
+    seconds: float = 0.0
+
+
+def _probe_chars(path: Path) -> int:
+    """Return character count from pdftotext on first 3 pages (best-effort)."""
+    try:
+        proc = subprocess.run(
+            ["pdftotext", "-q", "-l", "3", str(path), "-"],
+            capture_output=True, timeout=PDFTOTEXT_TIMEOUT_S,
+        )
+        return len(proc.stdout)
+    except Exception:
+        return 0
+
+
+def process_one_pdf(
+    path_str: str, optimize_level: int, ocr_jobs_per_file: int,
+    text_threshold: int, dry_run: bool,
+) -> dict[str, Any]:
+    """Worker entry point — must be picklable for ProcessPoolExecutor."""
+    t0 = time.monotonic()
+    p = Path(path_str)
+    pre_chars = _probe_chars(p)
+    if pre_chars >= text_threshold:
+        return asdict(FileResult(
+            path=path_str, status="already_text",
+            pre_chars=pre_chars, post_chars=pre_chars,
+            seconds=round(time.monotonic() - t0, 2),
+        ))
+
+    if dry_run:
+        return asdict(FileResult(
+            path=path_str, status="skipped", detail="dry_run",
+            pre_chars=pre_chars, seconds=round(time.monotonic() - t0, 2),
+        ))
+
+    tmp_out = p.with_suffix(p.suffix + ".ocr.tmp")
+    cmd = [
+        "ocrmypdf",
+        "--skip-text",                  # idempotent: leave OCR'd pages alone
+        "--output-type", "pdf",
+        "--optimize", str(optimize_level),
+        "--rotate-pages",
+        "--deskew",
+        "--quiet",
+        "--jobs", str(ocr_jobs_per_file),
+        str(p), str(tmp_out),
+    ]
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, timeout=OCRMYPDF_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        try:
+            tmp_out.unlink(missing_ok=True)
+        except Exception:
+            pass
+        return asdict(FileResult(
+            path=path_str, status="error", detail="timeout",
+            pre_chars=pre_chars,
+            seconds=round(time.monotonic() - t0, 2),
+        ))
+    except Exception as exc:
+        try:
+            tmp_out.unlink(missing_ok=True)
+        except Exception:
+            pass
+        return asdict(FileResult(
+            path=path_str, status="error",
+            detail=f"{type(exc).__name__}:{str(exc)[:120]}",
+            pre_chars=pre_chars,
+            seconds=round(time.monotonic() - t0, 2),
+        ))
+
+    if proc.returncode != 0:
+        try:
+            tmp_out.unlink(missing_ok=True)
+        except Exception:
+            pass
+        return asdict(FileResult(
+            path=path_str, status="error",
+            detail=f"rc={proc.returncode}:{proc.stderr.decode('utf-8', errors='replace')[:160]}",
+            pre_chars=pre_chars,
+            seconds=round(time.monotonic() - t0, 2),
+        ))
+
+    # Atomic swap: only replace the original after ocrmypdf wrote a clean
+    # output. shutil.move is atomic on the same filesystem.
+    try:
+        shutil.move(str(tmp_out), str(p))
+    except Exception as exc:
+        return asdict(FileResult(
+            path=path_str, status="error",
+            detail=f"swap_failed:{type(exc).__name__}:{str(exc)[:120]}",
+            pre_chars=pre_chars,
+            seconds=round(time.monotonic() - t0, 2),
+        ))
+
+    post_chars = _probe_chars(p)
+    return asdict(FileResult(
+        path=path_str, status="ocr_applied",
+        pre_chars=pre_chars, post_chars=post_chars,
+        seconds=round(time.monotonic() - t0, 2),
+    ))
+
+
+# ─── lock file ─────────────────────────────────────────────────────────────
+
+def _lock_path(case_slug: str) -> Path:
+    return Path(f"/tmp/ocr-sweep-{case_slug}.lock")
+
+
+def acquire_lock(case_slug: str, force: bool) -> Path:
+    lp = _lock_path(case_slug)
+    if lp.exists():
+        age = time.time() - lp.stat().st_mtime
+        if force and age > LOCK_STALE_AFTER_S:
+            lp.unlink()
+        elif force:
+            raise SystemExit(
+                f"--force given but lock at {lp} is only {int(age)}s old "
+                f"(needs > {LOCK_STALE_AFTER_S}s); refusing"
+            )
+        else:
+            raise SystemExit(
+                f"another sweep appears to be running (lock at {lp}); "
+                f"pass --force after confirming no concurrent run"
+            )
+    lp.write_text(f"{os.getpid()}\n{datetime.now(timezone.utc).isoformat()}\n")
+    return lp
+
+
+def release_lock(lp: Path) -> None:
+    try:
+        lp.unlink()
+    except Exception:
+        pass
+
+
+# ─── manifest ──────────────────────────────────────────────────────────────
+
+@dataclass
+class SweepManifest:
+    case_slug: str
+    started_at: str
+    finished_at: str
+    runtime_seconds: float
+    layout_root: str
+    layout_recursive: bool
+    layout_subdirs: dict[str, str]
+    quality: str
+    optimize_level: int
+    jobs: int
+    dry_run: bool
+    text_threshold: int
+    total_pdfs: int = 0
+    already_text: int = 0
+    ocr_applied: int = 0
+    skipped: int = 0
+    errors_count: int = 0
+    errors: list[dict[str, Any]] = field(default_factory=list)
+    samples_already_text: list[str] = field(default_factory=list)
+    samples_ocr_applied: list[str] = field(default_factory=list)
+
+
+def write_manifest(case_slug: str, manifest: SweepManifest) -> Path:
+    AUDIT_DIR.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    out = AUDIT_DIR / f"ocr-sweep-{case_slug}-{ts}.json"
+    out.write_text(json.dumps(asdict(manifest), indent=2, default=str))
+    return out
+
+
+# ─── orchestrator ──────────────────────────────────────────────────────────
+
+def run_sweep(args: argparse.Namespace) -> int:
+    layout = fetch_case_layout(args.case_slug)
+    pdfs = iter_case_pdfs(layout)
+    if args.max_files is not None:
+        pdfs = pdfs[: args.max_files]
+
+    optimize_level = QUALITY_TO_OPTIMIZE[args.quality]
+    started = datetime.now(timezone.utc)
+    t_started = time.monotonic()
+
+    manifest = SweepManifest(
+        case_slug=args.case_slug,
+        started_at=started.isoformat(),
+        finished_at="",
+        runtime_seconds=0.0,
+        layout_root=str(layout["root"]),
+        layout_recursive=layout["recursive"],
+        layout_subdirs=dict(layout["subdirs"]),
+        quality=args.quality,
+        optimize_level=optimize_level,
+        jobs=args.jobs,
+        dry_run=args.dry_run,
+        text_threshold=args.text_threshold,
+        total_pdfs=len(pdfs),
+    )
+
+    print(f"# OCR sweep: {args.case_slug}", flush=True)
+    print(f"# layout: root={layout['root']}, recursive={layout['recursive']}, "
+          f"subdirs={len(layout['subdirs'])}", flush=True)
+    print(f"# PDFs queued: {len(pdfs)} "
+          f"(max_files={args.max_files}, dry_run={args.dry_run})", flush=True)
+
+    # Single-process when --jobs=1 (also makes tests deterministic).
+    if args.jobs == 1:
+        results = [process_one_pdf(
+            str(p), optimize_level, args.ocr_jobs_per_file,
+            args.text_threshold, args.dry_run,
+        ) for p in pdfs]
+    else:
+        results = []
+        with ProcessPoolExecutor(max_workers=args.jobs) as ex:
+            futs = [
+                ex.submit(
+                    process_one_pdf, str(p), optimize_level,
+                    args.ocr_jobs_per_file, args.text_threshold, args.dry_run,
+                )
+                for p in pdfs
+            ]
+            for n, fut in enumerate(as_completed(futs), 1):
+                r = fut.result()
+                results.append(r)
+                if n % 25 == 0 or r["status"] == "error":
+                    print(
+                        f"  [{n}/{len(futs)}] {r['status']:<14s} "
+                        f"({r.get('seconds', 0):>5.1f}s)  {Path(r['path']).name[:60]}",
+                        flush=True,
+                    )
+
+    for r in results:
+        s = r["status"]
+        if s == "already_text":
+            manifest.already_text += 1
+            if len(manifest.samples_already_text) < 10:
+                manifest.samples_already_text.append(Path(r["path"]).name)
+        elif s == "ocr_applied":
+            manifest.ocr_applied += 1
+            if len(manifest.samples_ocr_applied) < 10:
+                manifest.samples_ocr_applied.append(Path(r["path"]).name)
+        elif s == "skipped":
+            manifest.skipped += 1
+        elif s == "error":
+            manifest.errors_count += 1
+            manifest.errors.append({
+                "path":   r["path"],
+                "detail": r.get("detail", ""),
+            })
+
+    manifest.runtime_seconds = round(time.monotonic() - t_started, 2)
+    manifest.finished_at = datetime.now(timezone.utc).isoformat()
+
+    out = write_manifest(args.case_slug, manifest)
+    print(
+        f"# done: total={manifest.total_pdfs}  "
+        f"already_text={manifest.already_text}  "
+        f"ocr_applied={manifest.ocr_applied}  "
+        f"skipped={manifest.skipped}  errors={manifest.errors_count}  "
+        f"runtime={manifest.runtime_seconds:.1f}s  "
+        f"manifest={out}",
+        flush=True,
+    )
+    return 0 if manifest.errors_count == 0 else 1
+
+
+# ─── CLI ───────────────────────────────────────────────────────────────────
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="OCR sweep over a legal case file tree (in-place, idempotent)",
+    )
+    p.add_argument("--case-slug", required=True,
+                   help="legal.cases.case_slug to sweep")
+    p.add_argument("--dry-run", action="store_true",
+                   help="classify only — do NOT run ocrmypdf")
+    p.add_argument("--max-files", type=int, default=None,
+                   help="cap on PDFs processed (testing)")
+    p.add_argument("--quality", choices=tuple(QUALITY_TO_OPTIMIZE),
+                   default="standard")
+    p.add_argument("--jobs", type=int, default=4,
+                   help="parallel files (default 4)")
+    p.add_argument("--ocr-jobs-per-file", type=int, default=2,
+                   help="ocrmypdf --jobs per file (default 2)")
+    p.add_argument("--text-threshold", type=int,
+                   default=DEFAULT_TEXT_THRESHOLD,
+                   help=f"pdftotext char count below which a PDF is image-only "
+                        f"(default {DEFAULT_TEXT_THRESHOLD})")
+    p.add_argument("--skip-already-text", action="store_true", default=True,
+                   help="(default) skip PDFs whose pdftotext probe returns >= threshold")
+    p.add_argument("--force", action="store_true",
+                   help="override stale lock files (>6h old)")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    lp = acquire_lock(args.case_slug, args.force)
+    try:
+        return run_sweep(args)
+    finally:
+        release_lock(lp)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fortress-guest-platform/backend/tests/test_ocr_legal_case.py
+++ b/fortress-guest-platform/backend/tests/test_ocr_legal_case.py
@@ -1,0 +1,325 @@
+"""
+Tests for backend.scripts.ocr_legal_case — OCR sweep orchestrator.
+
+ocrmypdf invocations are mocked (real OCR is slow). pdftotext probes
+run for real against synthetic Pillow- and reportlab-generated PDFs.
+DB lookup (`fetch_case_layout`) is mocked out.
+"""
+from __future__ import annotations
+
+import io
+import json
+import multiprocessing
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from backend.scripts import ocr_legal_case as ocr
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Synthetic-PDF fixtures
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _text_pdf(path: Path, body: str = None) -> Path:
+    """Reportlab text PDF — pdftotext returns the body string back."""
+    from reportlab.pdfgen import canvas
+    from reportlab.lib.pagesizes import letter
+    if body is None:
+        body = "This is a real text PDF " * 30  # ~600 chars, well above threshold
+    c = canvas.Canvas(str(path), pagesize=letter)
+    text = c.beginText(50, 750)
+    for line in body.splitlines() or [body]:
+        # Wrap to ~80 cols so it fits
+        for i in range(0, len(line), 80):
+            text.textLine(line[i:i + 80])
+    c.drawText(text)
+    c.showPage()
+    c.save()
+    return path
+
+
+def _image_only_pdf(path: Path) -> Path:
+    """Pillow image-only PDF — pdftotext returns near-empty output."""
+    from PIL import Image, ImageDraw, ImageFont
+    img = Image.new("RGB", (1200, 1600), "white")
+    d = ImageDraw.Draw(img)
+    # Render some text into the image — but it's pixels, not selectable
+    # text. pdftotext will return ~0 chars on this PDF.
+    try:
+        font = ImageFont.truetype(
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 36,
+        )
+    except Exception:
+        font = ImageFont.load_default()
+    d.text((100, 100), "AFFIDAVIT OF SERVICE", fill="black", font=font)
+    d.text((100, 200), "Civil Action No. 2:21-CV-226-RWS",
+           fill="black", font=font)
+    img.save(str(path), "PDF", resolution=100.0)
+    return path
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers / shared fakes
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _layout_for(tmp_path: Path) -> dict:
+    """Build a normalized layout dict pointing at tmp_path."""
+    return {
+        "root":      tmp_path,
+        "subdirs":   {"evidence": "."},
+        "recursive": True,
+    }
+
+
+class _FakeOcrmypdf:
+    """
+    Stand-in for ocrmypdf: copies INPUT to OUTPUT, optionally simulating
+    the addition of a text layer. Tracks invocations.
+
+    Captures the real subprocess.run at construction time so the fake
+    can delegate pdftotext (and any other non-ocrmypdf call) to the
+    real implementation even after `patch.object(ocr.subprocess, "run", ...)`
+    has globally rebound subprocess.run to this instance.
+    """
+    def __init__(self, outcome: str = "success", returncode: int = 0):
+        self.outcome = outcome
+        self.returncode = returncode
+        self.calls: list[list[str]] = []
+        # IMPORTANT: capture BEFORE the patch is installed.
+        self._real_run = subprocess.run
+
+    def __call__(self, cmd, *args, **kwargs):
+        self.calls.append(list(cmd))
+        if cmd[0] == "ocrmypdf":
+            _, out = Path(cmd[-2]), Path(cmd[-1])
+            if self.outcome == "success":
+                _text_pdf(out, body="OCR'D TEXT LAYER " * 30)
+                return subprocess.CompletedProcess(cmd, 0, b"", b"")
+            if self.outcome == "fail":
+                return subprocess.CompletedProcess(
+                    cmd, 1, b"", b"PriorOcrFoundError: page already has text",
+                )
+            if self.outcome == "timeout":
+                raise subprocess.TimeoutExpired(cmd, 10)
+        # Anything else (pdftotext, sha256sum, ...): real subprocess.run
+        return self._real_run(cmd, *args, **kwargs)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestSkipAlreadyTextPdf:
+    def test_text_pdf_classified_already_text(self, tmp_path: Path):
+        p = _text_pdf(tmp_path / "has-text.pdf")
+        # Use the high-level worker function directly
+        result = ocr.process_one_pdf(
+            str(p), optimize_level=1, ocr_jobs_per_file=1,
+            text_threshold=ocr.DEFAULT_TEXT_THRESHOLD, dry_run=False,
+        )
+        assert result["status"] == "already_text"
+        assert result["pre_chars"] >= ocr.DEFAULT_TEXT_THRESHOLD
+
+
+class TestOcrImageOnlyPdf:
+    def test_image_only_pdf_invokes_ocrmypdf_and_swaps(self, tmp_path: Path):
+        p = _image_only_pdf(tmp_path / "image-only.pdf")
+        # Sanity: pre-OCR pdftotext returns sub-threshold
+        pre = ocr._probe_chars(p)
+        assert pre < ocr.DEFAULT_TEXT_THRESHOLD
+
+        fake = _FakeOcrmypdf(outcome="success")
+        with patch.object(ocr.subprocess, "run", side_effect=fake):
+            result = ocr.process_one_pdf(
+                str(p), optimize_level=1, ocr_jobs_per_file=1,
+                text_threshold=ocr.DEFAULT_TEXT_THRESHOLD, dry_run=False,
+            )
+        assert result["status"] == "ocr_applied"
+        # Confirm the original file got swapped with the OCR'd output —
+        # the new pdftotext probe should now see the simulated text layer.
+        post = ocr._probe_chars(p)
+        assert post >= ocr.DEFAULT_TEXT_THRESHOLD
+        # And ocrmypdf was actually called once with --skip-text
+        ocr_calls = [c for c in fake.calls if c[0] == "ocrmypdf"]
+        assert len(ocr_calls) == 1
+        assert "--skip-text" in ocr_calls[0]
+
+
+class TestIdempotency:
+    def test_second_run_is_zero_ocr_applied(self, tmp_path: Path):
+        # Two image-only PDFs.
+        a = _image_only_pdf(tmp_path / "a.pdf")
+        b = _image_only_pdf(tmp_path / "b.pdf")
+        fake = _FakeOcrmypdf(outcome="success")
+
+        # First sweep — process both. Use jobs=1 for determinism.
+        layout = _layout_for(tmp_path)
+        with patch.object(ocr.subprocess, "run", side_effect=fake):
+            r1 = [
+                ocr.process_one_pdf(str(p), 1, 1,
+                                    ocr.DEFAULT_TEXT_THRESHOLD, False)
+                for p in (a, b)
+            ]
+        assert sum(1 for r in r1 if r["status"] == "ocr_applied") == 2
+
+        # Second sweep — _FakeOcrmypdf would still simulate success if called,
+        # but the probe should classify the now-text-layer PDFs as
+        # already_text and skip the ocrmypdf call entirely.
+        fake2 = _FakeOcrmypdf(outcome="success")
+        with patch.object(ocr.subprocess, "run", side_effect=fake2):
+            r2 = [
+                ocr.process_one_pdf(str(p), 1, 1,
+                                    ocr.DEFAULT_TEXT_THRESHOLD, False)
+                for p in (a, b)
+            ]
+        assert sum(1 for r in r2 if r["status"] == "ocr_applied") == 0
+        assert sum(1 for r in r2 if r["status"] == "already_text") == 2
+        assert all(c[0] != "ocrmypdf" for c in fake2.calls)
+
+
+class TestManifestWritten:
+    def test_manifest_carries_expected_fields(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        a = _text_pdf(tmp_path / "text.pdf")
+        b = _image_only_pdf(tmp_path / "image-only.pdf")
+
+        # Redirect AUDIT_DIR + lock to tmp_path so the test is hermetic.
+        monkeypatch.setattr(ocr, "AUDIT_DIR", tmp_path / "audits")
+        monkeypatch.setattr(ocr, "_lock_path",
+                            lambda slug: tmp_path / f"ocr-{slug}.lock")
+        monkeypatch.setattr(
+            ocr, "fetch_case_layout",
+            lambda slug: _layout_for(tmp_path),
+        )
+
+        fake = _FakeOcrmypdf(outcome="success")
+        with patch.object(ocr.subprocess, "run", side_effect=fake):
+            rc = ocr.main(["--case-slug", "test-case", "--jobs", "1"])
+        assert rc == 0
+
+        # Locate the manifest
+        mfs = list((tmp_path / "audits").glob("ocr-sweep-test-case-*.json"))
+        assert len(mfs) == 1
+        m = json.loads(mfs[0].read_text())
+        assert m["case_slug"] == "test-case"
+        assert m["total_pdfs"] == 2
+        assert m["already_text"] == 1
+        assert m["ocr_applied"] == 1
+        assert m["errors_count"] == 0
+        assert m["dry_run"] is False
+        assert m["jobs"] == 1
+        assert m["layout_recursive"] is True
+
+
+class TestLockFile:
+    def test_concurrent_run_refused(self, tmp_path: Path,
+                                    monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(ocr, "_lock_path",
+                            lambda slug: tmp_path / f"ocr-{slug}.lock")
+        # Pre-create the lock with a fresh mtime
+        lock = tmp_path / "ocr-c.lock"
+        lock.write_text("99999\n")
+        try:
+            ocr.acquire_lock("c", force=False)
+        except SystemExit as exc:
+            assert "another sweep" in str(exc) or "lock" in str(exc).lower()
+        else:
+            raise AssertionError("expected SystemExit when lock is fresh")
+
+    def test_force_overrides_stale_lock(self, tmp_path: Path,
+                                        monkeypatch: pytest.MonkeyPatch):
+        import time
+        monkeypatch.setattr(ocr, "_lock_path",
+                            lambda slug: tmp_path / f"ocr-{slug}.lock")
+        lock = tmp_path / "ocr-c.lock"
+        lock.write_text("99999\n")
+        # Make it 7 hours old
+        old = time.time() - (7 * 3600)
+        os.utime(lock, (old, old))
+        # --force should remove and re-create
+        new_lock = ocr.acquire_lock("c", force=True)
+        try:
+            assert new_lock.exists()
+            assert str(os.getpid()) in new_lock.read_text()
+        finally:
+            ocr.release_lock(new_lock)
+
+
+class TestDryRunSafety:
+    def test_dry_run_does_not_invoke_ocrmypdf(self, tmp_path: Path):
+        p = _image_only_pdf(tmp_path / "image-only.pdf")
+        original_bytes = p.read_bytes()
+
+        fake = _FakeOcrmypdf(outcome="success")
+        with patch.object(ocr.subprocess, "run", side_effect=fake):
+            result = ocr.process_one_pdf(
+                str(p), optimize_level=1, ocr_jobs_per_file=1,
+                text_threshold=ocr.DEFAULT_TEXT_THRESHOLD, dry_run=True,
+            )
+        assert result["status"] == "skipped"
+        assert result["detail"] == "dry_run"
+        # File untouched — byte-for-byte identical
+        assert p.read_bytes() == original_bytes
+        # ocrmypdf NOT called
+        assert all(c[0] != "ocrmypdf" for c in fake.calls)
+
+
+class TestCorruptPdfPreservesOriginal:
+    def test_ocrmypdf_failure_leaves_original_intact(self, tmp_path: Path):
+        p = _image_only_pdf(tmp_path / "corrupt.pdf")
+        original_sha = subprocess.run(
+            ["sha256sum", str(p)], capture_output=True,
+        ).stdout
+
+        fake = _FakeOcrmypdf(outcome="fail")
+        with patch.object(ocr.subprocess, "run", side_effect=fake):
+            result = ocr.process_one_pdf(
+                str(p), 1, 1, ocr.DEFAULT_TEXT_THRESHOLD, False,
+            )
+        assert result["status"] == "error"
+        assert "rc=1" in result["detail"]
+        # The original file is untouched (no swap happened)
+        post_sha = subprocess.run(
+            ["sha256sum", str(p)], capture_output=True,
+        ).stdout
+        assert original_sha == post_sha
+        # And no .ocr.tmp left behind
+        assert not (tmp_path / "corrupt.pdf.ocr.tmp").exists()
+
+    def test_ocrmypdf_timeout_leaves_original_intact(self, tmp_path: Path):
+        p = _image_only_pdf(tmp_path / "wedge.pdf")
+        before = p.read_bytes()
+        fake = _FakeOcrmypdf(outcome="timeout")
+        with patch.object(ocr.subprocess, "run", side_effect=fake):
+            result = ocr.process_one_pdf(
+                str(p), 1, 1, ocr.DEFAULT_TEXT_THRESHOLD, False,
+            )
+        assert result["status"] == "error"
+        assert result["detail"] == "timeout"
+        assert p.read_bytes() == before
+
+
+class TestPdfDiscovery:
+    def test_iter_skips_eadir_and_dotfiles(self, tmp_path: Path):
+        # Build: tmp/Discovery/{real.pdf, @eaDir/junk.pdf, .hidden.pdf, sub/deep.pdf}
+        (tmp_path / "Discovery").mkdir()
+        _text_pdf(tmp_path / "Discovery" / "real.pdf")
+        (tmp_path / "Discovery" / "@eaDir").mkdir()
+        _text_pdf(tmp_path / "Discovery" / "@eaDir" / "junk.pdf")
+        _text_pdf(tmp_path / "Discovery" / ".hidden.pdf")
+        (tmp_path / "Discovery" / "sub").mkdir()
+        _text_pdf(tmp_path / "Discovery" / "sub" / "deep.pdf")
+
+        layout = {
+            "root":      tmp_path,
+            "subdirs":   {"evidence": "Discovery"},
+            "recursive": True,
+        }
+        names = sorted(p.name for p in ocr.iter_case_pdfs(layout))
+        assert names == ["deep.pdf", "real.pdf"]


### PR DESCRIPTION
## Summary
Adds `backend/scripts/ocr_legal_case.py` — in-place `ocrmypdf` text-layer addition on image-only PDFs in a case file tree. Reads the case's `nas_layout` from `legal.cases` (PR A), walks every PDF under the configured tree, classifies each via `pdftotext` probe, and runs `ocrmypdf --skip-text` on image-only PDFs only.

## Idempotency
| Mechanism | Behaviour |
|---|---|
| `pdftotext` probe (first 3 pages) | Skips PDFs above `--text-threshold` (default 100 chars). |
| `ocrmypdf --skip-text` | Refuses to re-OCR pages with an existing text layer — second pass = no-op. |
| Atomic swap (`<file>.ocr.tmp` → `mv`) | Only replaces original on `returncode==0`. Corrupt input cannot destroy original. |
| Lock file `/tmp/ocr-sweep-{slug}.lock` | Blocks concurrent runs; `--force` overrides locks > 6h. |

Multiprocess (`--jobs 4`, `--ocr-jobs-per-file 2`). Per-file timeout 600s.

## CLI
```
--case-slug              required
--dry-run                classify only, no ocrmypdf
--max-files N            cap (testing)
--quality {fast,standard,high}    → ocrmypdf --optimize {3,1,0}
--jobs N                 parallel files (default 4)
--ocr-jobs-per-file N    ocrmypdf threads per file (default 2)
--text-threshold N       chars below = image-only (default 100)
--force                  override stale lock
```

## Manifest
Written to `/mnt/fortress_nas/audits/ocr-sweep-{slug}-{ts}.json`:
```jsonc
{
  "case_slug", "started_at", "finished_at", "runtime_seconds",
  "layout_root", "layout_recursive", "layout_subdirs", "quality",
  "optimize_level", "jobs", "dry_run", "text_threshold",
  "total_pdfs", "already_text", "ocr_applied", "skipped",
  "errors_count", "errors": [...], "samples_already_text": [...],
  "samples_ocr_applied": [...]
}
```

## Test plan
- [x] `pytest backend/tests/test_ocr_legal_case.py` → **10 passed** (skip-already-text, ocr-image-only, idempotency, manifest, lock, dry-run, corrupt-rc, corrupt-timeout, eaDir+dotfile filter, full main()).
- [x] **Live dry-run on `7il-v-knight-ndga`:** **552 PDFs queued · 415 already-text (75%) · 137 image-only (25%) · 0 errors · 2.0s.** Sample image-only: `#1-1 Civil Cover Sheet`, `#102 Minute Entry`, `#26 Consent Order on Mtn to Ext Disc` — scanned court issuances as expected (137 ≈ audit's ~163 estimate).
- [ ] **Real sweep** kicked off in background after merge (target ~2-4 h for ~137 image-only PDFs at standard quality, 6 jobs).

## Constraints honored
- No `process_vault_upload` runs (PR D scope, after real sweep finishes).
- No `.docx`, `.eml`, `.msg`, `.csv`, `.mp4` touched.
- 113 mp4 trespass/depo videos under `thor_james_intake` need Whisper ASR — separate PR.
- `@eaDir` / dotfile filtering matches PR A's `_walk_case_subdir`.
- System-wide `ocrmypdf` install (`apt-get install -y ocrmypdf`) was a prereq, not part of this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)