### PR TITLE
feat(legal): add ingest_runs audit table and tracker

### DIFF
--- a/docs/runbooks/legal-ingest-runs.md
+++ b/docs/runbooks/legal-ingest-runs.md
@@ -1,0 +1,243 @@
+# `legal.ingest_runs` runbook
+
+Audit trail for case-scoped ingest operations (OCR sweeps, vault
+ingestion, ASR runs, re-ingest passes). One row per script
+invocation.
+
+## Schema
+
+```
+id              UUID PK              gen_random_uuid()
+case_slug       TEXT NOT NULL        FK → legal.cases.case_slug ON DELETE CASCADE
+script_name     TEXT NOT NULL        e.g. "ocr_legal_case", "vault_ingest", "asr_legal_case"
+started_at      TIMESTAMPTZ          set by IngestRunTracker.__enter__
+ended_at        TIMESTAMPTZ          set by IngestRunTracker.__exit__
+args            JSONB                argparse Namespace dump
+status          TEXT                 'running' | 'complete' | 'error' | 'interrupted'   (CHECK)
+manifest_path   TEXT                 NAS path to per-run JSON manifest
+total_files     INTEGER              set by run.set_total_files(N)
+processed       INTEGER              cumulative running total
+errored         INTEGER              cumulative running total
+skipped         INTEGER              cumulative running total
+error_summary   TEXT                 last 12 traceback lines on exception, or short note
+host            TEXT                 socket.gethostname() at run start
+pid             INTEGER              os.getpid() at run start
+runtime_seconds NUMERIC(12,3)        ended_at - started_at, populated on exit
+created_at      TIMESTAMPTZ          immutable
+updated_at      TIMESTAMPTZ          touched on every update
+```
+
+## Status state machine
+
+```
+        ┌────────┐
+        │running │ ← INSERT at __enter__
+        └────┬───┘
+             │
+   clean exit│KeyboardInterrupt│other Exception
+             │                 │                │
+             ▼                 ▼                ▼
+        complete          interrupted          error
+                                                │
+                                                └─ error_summary populated
+```
+
+`KeyboardInterrupt` and other exceptions are **re-raised** by `__exit__`;
+the row write happens before the re-raise so the audit trail is
+durable even when the operator Ctrl-C's a long sweep.
+
+## DB-disconnect degradation
+
+If three retries (≤ 30 s total) fail to write the start INSERT or any
+update, the tracker:
+
+- Sets `self.degraded = True`.
+- Logs `[ingest_run_tracker] DEGRADED for {slug}/{script} pid={pid}: {reason}` to stderr.
+- Emits a structured logger record at `ERROR` level
+  (`ingest_run_tracker_degraded` event), greppable in journalctl.
+- **Continues without raising** — the parent ingest job runs to
+  completion. Subsequent counter calls are silent no-ops.
+
+A degraded run leaves either zero rows (if the start INSERT failed)
+or a stuck `running` row (if the start INSERT succeeded but updates
+later failed). Use the queries below to find them.
+
+## Operator queries
+
+### last 10 runs across all cases
+```sql
+SELECT id, case_slug, script_name, status,
+       to_char(started_at, 'YYYY-MM-DD HH24:MI') AS started,
+       runtime_seconds AS rt, processed, errored
+FROM legal.ingest_runs
+ORDER BY started_at DESC
+LIMIT 10;
+```
+
+### errored runs in last 7 days with summaries
+```sql
+SELECT id, case_slug, script_name,
+       to_char(started_at, 'YYYY-MM-DD HH24:MI') AS started,
+       errored, runtime_seconds,
+       LEFT(error_summary, 200) AS summary
+FROM legal.ingest_runs
+WHERE status = 'error'
+  AND started_at > NOW() - INTERVAL '7 days'
+ORDER BY started_at DESC;
+```
+
+### still-running ops > 6 h old (likely orphaned)
+```sql
+SELECT id, case_slug, script_name, host, pid,
+       to_char(started_at, 'YYYY-MM-DD HH24:MI') AS started,
+       NOW() - started_at AS age
+FROM legal.ingest_runs
+WHERE status = 'running'
+  AND started_at < NOW() - INTERVAL '6 hours'
+ORDER BY started_at;
+```
+
+### runtime histogram by script_name
+```sql
+SELECT script_name,
+       count(*)                          AS runs,
+       round(avg(runtime_seconds), 1)    AS avg_s,
+       round(max(runtime_seconds), 1)    AS max_s,
+       sum(processed)                    AS total_processed,
+       sum(errored)                      AS total_errored
+FROM legal.ingest_runs
+WHERE status = 'complete'
+GROUP BY script_name
+ORDER BY runs DESC;
+```
+
+### errors by case_slug
+```sql
+SELECT case_slug, script_name, count(*) AS error_count,
+       max(started_at) AS last_error_at
+FROM legal.ingest_runs
+WHERE status = 'error'
+GROUP BY case_slug, script_name
+ORDER BY error_count DESC;
+```
+
+### detail for a specific run
+```sql
+SELECT * FROM legal.ingest_runs WHERE id = '<uuid>';
+```
+
+### find the last successful sweep per case (for next-run dedup)
+```sql
+SELECT DISTINCT ON (case_slug, script_name)
+       case_slug, script_name, id,
+       started_at, manifest_path, runtime_seconds
+FROM legal.ingest_runs
+WHERE status = 'complete'
+ORDER BY case_slug, script_name, started_at DESC;
+```
+
+### count ingestions per case in last 30 days
+```sql
+SELECT case_slug, count(*) AS runs_30d,
+       sum(processed) AS files_30d,
+       count(*) FILTER (WHERE status = 'error') AS errors_30d
+FROM legal.ingest_runs
+WHERE started_at > NOW() - INTERVAL '30 days'
+GROUP BY case_slug
+ORDER BY runs_30d DESC;
+```
+
+### compare consecutive sweeps for the same case+script
+```sql
+SELECT id,
+       to_char(started_at, 'YYYY-MM-DD HH24:MI') AS started,
+       processed, errored, runtime_seconds,
+       processed - LAG(processed) OVER w AS delta_processed
+FROM legal.ingest_runs
+WHERE case_slug = '<slug>' AND script_name = '<name>'
+WINDOW w AS (ORDER BY started_at)
+ORDER BY started_at;
+```
+
+### orphaned (degraded-tracker) runs from a specific host
+```sql
+SELECT id, case_slug, script_name, pid,
+       to_char(started_at, 'YYYY-MM-DD HH24:MI') AS started,
+       updated_at - started_at AS write_silence
+FROM legal.ingest_runs
+WHERE status = 'running'
+  AND host = 'spark-node-2'
+  AND updated_at < NOW() - INTERVAL '1 hour'
+ORDER BY started_at;
+```
+
+## Cleanup: stuck `running` rows older than 24 h
+
+These represent either (a) a tracker that degraded after the start
+INSERT, or (b) a script killed without graceful exit.
+
+```sql
+-- review first
+SELECT id, case_slug, script_name, host, pid,
+       to_char(started_at, 'YYYY-MM-DD HH24:MI') AS started
+FROM legal.ingest_runs
+WHERE status = 'running'
+  AND started_at < NOW() - INTERVAL '24 hours';
+
+-- then update — mark them interrupted with a note
+UPDATE legal.ingest_runs
+   SET status        = 'interrupted',
+       ended_at      = updated_at,
+       error_summary = 'Auto-cleanup: stuck running >24h, likely orphaned tracker',
+       updated_at    = NOW()
+ WHERE status = 'running'
+   AND started_at < NOW() - INTERVAL '24 hours';
+```
+
+Verify the script is actually no longer running before cleanup:
+
+```bash
+ps aux | grep -E "<script_name>.*<case_slug>" | grep -v grep
+```
+
+If the process is alive, **do not** clean up — let it finish or kill
+it gracefully (`SIGTERM` → tracker writes `interrupted`).
+
+## Interaction with PR D rollback
+
+PR D (vault ingestion) will:
+- Open an `IngestRunTracker` per `process_vault_upload` invocation.
+- Insert a row into `legal.vault_documents` per file.
+- Roll back via deleting `legal.vault_documents` rows for the run's
+  `started_at` window.
+
+The `ingest_runs` row itself is **not** rolled back — it remains as a
+record that the operation happened (and was rolled back). When PR D's
+rollback tooling lands, it should set `status = 'error'` and append a
+note to `error_summary` rather than deleting the run row.
+
+`ON DELETE CASCADE` from `legal.cases.case_slug`: deleting a case
+deletes its run history. If you ever delete a real case, archive
+its `ingest_runs` first:
+
+```sql
+SELECT * FROM legal.ingest_runs
+ WHERE case_slug = '<slug>'
+\copy (SELECT * FROM legal.ingest_runs WHERE case_slug = '<slug>')
+       TO '/mnt/fortress_nas/audits/archive-ingest-runs-<slug>-<ts>.csv' CSV HEADER;
+```
+
+## Detecting orphaned rows in CI
+
+Add a periodic job (e.g. cron at 03:00 daily):
+
+```sql
+SELECT count(*) AS orphan_count
+FROM legal.ingest_runs
+WHERE status = 'running'
+  AND started_at < NOW() - INTERVAL '6 hours';
+```
+
+If `> 0`, page operators. The accompanying journalctl line
+`ingest_run_tracker_degraded` will show which host emitted the
+orphan.

--- a/fortress-guest-platform/backend/alembic/versions/c4d8b1a3f7e2_add_legal_ingest_runs.py
+++ b/fortress-guest-platform/backend/alembic/versions/c4d8b1a3f7e2_add_legal_ingest_runs.py
@@ -1,0 +1,110 @@
+"""Add legal.ingest_runs audit-trail table.
+
+Revision ID: c4d8b1a3f7e2
+Revises: e7f9a3c2d8b1
+Create Date: 2026-04-25
+
+Audit trail for case-scoped ingest operations (OCR sweeps, vault
+ingestion, future ASR runs, re-ingest passes). One row per script
+invocation. Status state machine:
+
+    running → complete | error | interrupted
+
+Foreign key to legal.cases.case_slug ON DELETE CASCADE — when a case
+is deleted, its ingest history goes with it.
+
+Idempotent: CREATE TABLE / INDEX use IF NOT EXISTS. UNIQUE on
+legal.cases.case_slug already exists (`cases_case_slug_key`) across
+all three legal-bearing databases per pre-flight verification, so
+this migration does not touch that constraint.
+"""
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "c4d8b1a3f7e2"
+down_revision = "e7f9a3c2d8b1"
+branch_labels = None
+depends_on = None
+
+
+_TABLE_COMMENT = (
+    "Audit trail for case-scoped ingest operations (OCR, vault, ASR). "
+    "One row per script invocation. "
+    "Status state machine: running -> complete | error | interrupted."
+)
+
+
+def upgrade() -> None:
+    # Sanity: ensure UNIQUE(case_slug) exists on legal.cases. Pre-flight
+    # showed `cases_case_slug_key` already present in fortress_prod,
+    # fortress_db, and fortress_shadow, but a fresh DB might not have it
+    # yet — add only if missing.
+    op.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conrelid = 'legal.cases'::regclass
+                  AND contype  = 'u'
+                  AND conkey = ARRAY[
+                    (SELECT attnum FROM pg_attribute
+                     WHERE attrelid = 'legal.cases'::regclass
+                       AND attname = 'case_slug')::smallint
+                  ]
+            ) THEN
+                ALTER TABLE legal.cases
+                ADD CONSTRAINT uq_cases_case_slug UNIQUE (case_slug);
+            END IF;
+        END $$;
+    """)
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS legal.ingest_runs (
+            id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            case_slug       TEXT NOT NULL,
+            script_name     TEXT NOT NULL,
+            started_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            ended_at        TIMESTAMPTZ,
+            args            JSONB NOT NULL DEFAULT '{}'::jsonb,
+            status          TEXT NOT NULL DEFAULT 'running'
+                            CHECK (status IN ('running','complete','error','interrupted')),
+            manifest_path   TEXT,
+            total_files     INTEGER,
+            processed       INTEGER,
+            errored         INTEGER,
+            skipped         INTEGER,
+            error_summary   TEXT,
+            host            TEXT,
+            pid             INTEGER,
+            runtime_seconds NUMERIC(12,3),
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+            CONSTRAINT fk_ingest_runs_case_slug
+                FOREIGN KEY (case_slug) REFERENCES legal.cases (case_slug)
+                ON DELETE CASCADE
+        )
+    """)
+
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_ingest_runs_case_slug "
+        "ON legal.ingest_runs (case_slug)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_ingest_runs_status "
+        "ON legal.ingest_runs (status) WHERE status IN ('running','error')"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_ingest_runs_started_at "
+        "ON legal.ingest_runs (started_at DESC)"
+    )
+
+    op.execute(f"COMMENT ON TABLE legal.ingest_runs IS $${_TABLE_COMMENT}$$")
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS legal.ingest_runs")
+    # Do NOT drop uq_cases_case_slug — it predates this migration in
+    # every existing DB and is depended on by other constraints.

--- a/fortress-guest-platform/backend/services/ingest_run_tracker.py
+++ b/fortress-guest-platform/backend/services/ingest_run_tracker.py
@@ -1,0 +1,296 @@
+"""
+Audit-trail tracker for case-scoped ingest operations.
+
+Wraps every script invocation (OCR sweep, vault ingestion, ASR run,
+re-ingest pass) in a `legal.ingest_runs` row that records start, end,
+counters, manifest path, status, and error summary.
+
+Usage:
+
+    with IngestRunTracker(case_slug, "ocr_legal_case",
+                          args=vars(parsed_args)) as run:
+        run.set_total_files(len(files))
+        for f in files:
+            try:
+                process(f)
+                run.inc_processed()
+            except Exception:
+                run.inc_errored()
+        run.set_manifest_path(manifest_path)
+
+Status state machine (handled automatically by `__exit__`):
+
+    running ──clean exit──▶ complete
+    running ──KeyboardInterrupt──▶ interrupted (re-raised)
+    running ──other Exception──▶ error (re-raised, error_summary set)
+
+Resilience contract: tracker DB writes are wrapped in retry+backoff
+(max 3 attempts, ~30 s total). On exhaustion, the tracker degrades —
+sets `self.degraded = True`, logs to stderr, and continues. Tracker
+failure NEVER aborts the parent ingest job.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import socket
+import sys
+import time
+import traceback
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
+
+logger = logging.getLogger("ingest_run_tracker")
+
+
+# ─── DB connection helpers ─────────────────────────────────────────────────
+
+# Tracker writes target fortress_db (where legal.* lives operationally) — same
+# database the FastAPI handler queries via LegacySession.
+_DEFAULT_TRACKER_DB = "fortress_db"
+
+_RETRY_BACKOFFS_S = (0.5, 2.0, 8.0)   # sums to 10.5 s + per-attempt latency
+_RETRY_TOTAL_CAP_S = 30.0
+
+
+def _admin_dsn() -> dict[str, str]:
+    """
+    Parse POSTGRES_ADMIN_URI from env (loaded by the caller's .env step) and
+    return a psycopg2 connection-keywords dict targeting fortress_db.
+    """
+    uri = os.environ.get("POSTGRES_ADMIN_URI", "")
+    m = re.match(
+        r"postgresql(?:\+\w+)?://([^:]+):([^@]+)@([^:/]+):?(\d+)?/[^?]+",
+        uri,
+    )
+    if not m:
+        raise RuntimeError(
+            "POSTGRES_ADMIN_URI not set or not parseable; "
+            "tracker requires admin DSN"
+        )
+    user, pw, host, port = m.groups()
+    return {
+        "host":     host,
+        "port":     int(port or 5432),
+        "user":     user,
+        "password": pw,
+        "dbname":   os.environ.get("INGEST_RUN_DB", _DEFAULT_TRACKER_DB),
+    }
+
+
+def _connect():
+    """Open a fresh autocommit psycopg2 connection. Caller closes."""
+    import psycopg2
+    conn = psycopg2.connect(**_admin_dsn())
+    conn.autocommit = True
+    return conn
+
+
+# ─── tracker ───────────────────────────────────────────────────────────────
+
+@dataclass
+class _State:
+    processed: int = 0
+    errored:   int = 0
+    skipped:   int = 0
+
+
+class IngestRunTracker:
+    """
+    Context manager that emits exactly one legal.ingest_runs row covering
+    the lifecycle of a script invocation.
+    """
+
+    def __init__(
+        self,
+        case_slug: str,
+        script_name: str,
+        args: dict[str, Any] | None = None,
+        connection_factory=None,        # injectable for tests
+    ) -> None:
+        self.case_slug = str(case_slug)
+        self.script_name = str(script_name)
+        self.args = dict(args or {})
+        self._connect = connection_factory or _connect
+        self.run_id: UUID | None = None
+        self.degraded: bool = False
+        self._started_monotonic: float | None = None
+        self._counters = _State()
+
+    # ─── lifecycle ─────────────────────────────────────────────────────────
+
+    def __enter__(self) -> "IngestRunTracker":
+        self._started_monotonic = time.monotonic()
+        host = socket.gethostname()
+        pid = os.getpid()
+        ok = self._exec_with_retry(
+            """
+            INSERT INTO legal.ingest_runs (
+                case_slug, script_name, args, host, pid, status,
+                started_at
+            ) VALUES (%s, %s, %s::jsonb, %s, %s, 'running', NOW())
+            RETURNING id
+            """,
+            (
+                self.case_slug, self.script_name,
+                json.dumps(self.args, default=str),
+                host, pid,
+            ),
+            fetch_one=True,
+        )
+        if ok is not None:
+            self.run_id = ok[0]
+        else:
+            # All retries failed. The parent script must continue regardless;
+            # we log loudly so an operator can spot the orphaned NOT-WRITTEN
+            # state in stderr capture.
+            self._log_degraded("INSERT (start row) failed")
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        elapsed = self._elapsed()
+        if exc_type is None:
+            self._update_status("complete", runtime=elapsed)
+            return False
+        if issubclass(exc_type, KeyboardInterrupt):
+            self._update_status("interrupted", runtime=elapsed,
+                                error_summary="KeyboardInterrupt")
+            return False                                # re-raise
+        # Other exceptions: capture short traceback and re-raise.
+        summary = self._format_error(exc_type, exc, tb)
+        self._update_status("error", runtime=elapsed, error_summary=summary)
+        return False                                    # re-raise
+
+    # ─── state setters ─────────────────────────────────────────────────────
+
+    def set_total_files(self, n: int) -> None:
+        self._update_counters(total_files=int(n))
+
+    def set_manifest_path(self, path) -> None:
+        self._update_counters(manifest_path=str(path))
+
+    def inc_processed(self, n: int = 1) -> None:
+        self._counters.processed += n
+        self._update_counters(processed=self._counters.processed)
+
+    def inc_errored(self, n: int = 1) -> None:
+        self._counters.errored += n
+        self._update_counters(errored=self._counters.errored)
+
+    def inc_skipped(self, n: int = 1) -> None:
+        self._counters.skipped += n
+        self._update_counters(skipped=self._counters.skipped)
+
+    def update(self, **fields: Any) -> None:
+        """Bulk update. Keys must be column names of legal.ingest_runs."""
+        if "processed" in fields: self._counters.processed = int(fields["processed"])
+        if "errored"   in fields: self._counters.errored   = int(fields["errored"])
+        if "skipped"   in fields: self._counters.skipped   = int(fields["skipped"])
+        self._update_counters(**fields)
+
+    # ─── private: writes ───────────────────────────────────────────────────
+
+    def _update_status(
+        self, status: str, *, runtime: float | None = None,
+        error_summary: str | None = None,
+    ) -> None:
+        if self.run_id is None:
+            return                          # tracker degraded at __enter__
+        sets = ["status = %s", "ended_at = NOW()", "updated_at = NOW()"]
+        params: list[Any] = [status]
+        if runtime is not None:
+            sets.append("runtime_seconds = %s")
+            params.append(round(runtime, 3))
+        if error_summary is not None:
+            sets.append("error_summary = %s")
+            params.append(error_summary[:4000])
+        params.append(self.run_id)
+        self._exec_with_retry(
+            f"UPDATE legal.ingest_runs SET {', '.join(sets)} WHERE id = %s",
+            tuple(params),
+        )
+
+    def _update_counters(self, **fields: Any) -> None:
+        if self.run_id is None or not fields:
+            return
+        sets = []
+        params: list[Any] = []
+        for k, v in fields.items():
+            sets.append(f"{k} = %s")
+            params.append(v)
+        sets.append("updated_at = NOW()")
+        params.append(self.run_id)
+        self._exec_with_retry(
+            f"UPDATE legal.ingest_runs SET {', '.join(sets)} WHERE id = %s",
+            tuple(params),
+        )
+
+    def _exec_with_retry(self, sql: str, params: tuple,
+                         fetch_one: bool = False):
+        if self.degraded:
+            return None
+        deadline = time.monotonic() + _RETRY_TOTAL_CAP_S
+        last_exc: Exception | None = None
+        for attempt, sleep_for in enumerate(_RETRY_BACKOFFS_S, start=1):
+            if time.monotonic() >= deadline:
+                break
+            try:
+                conn = self._connect()
+                try:
+                    with conn.cursor() as cur:
+                        cur.execute(sql, params)
+                        if fetch_one:
+                            row = cur.fetchone()
+                            return row
+                    return True
+                finally:
+                    try: conn.close()
+                    except Exception: pass
+            except Exception as exc:
+                last_exc = exc
+                logger.warning(
+                    "ingest_run_tracker_retry attempt=%d sleep=%.1fs error=%s",
+                    attempt, sleep_for, str(exc)[:120],
+                )
+                if attempt < len(_RETRY_BACKOFFS_S):
+                    time.sleep(min(sleep_for, max(0.0, deadline - time.monotonic())))
+        # All retries failed
+        self._log_degraded(f"DB write exhausted retries: {last_exc!s}"[:500])
+        return None
+
+    # ─── private: helpers ─────────────────────────────────────────────────
+
+    def _elapsed(self) -> float | None:
+        if self._started_monotonic is None:
+            return None
+        return time.monotonic() - self._started_monotonic
+
+    def _log_degraded(self, reason: str) -> None:
+        self.degraded = True
+        sys.stderr.write(
+            f"[ingest_run_tracker] DEGRADED for {self.case_slug}/"
+            f"{self.script_name} pid={os.getpid()}: {reason}\n"
+        )
+        sys.stderr.flush()
+        # Emit a structured log line too — operators querying logs by
+        # 'ingest_run_tracker_degraded' can find the stuck row.
+        logger.error(
+            "ingest_run_tracker_degraded case_slug=%s script=%s reason=%s",
+            self.case_slug, self.script_name, reason,
+        )
+
+    @staticmethod
+    def _format_error(exc_type, exc, tb) -> str:
+        """Two-line summary suitable for error_summary column (≤4000 chars)."""
+        try:
+            tb_text = "".join(traceback.format_exception(exc_type, exc, tb))
+        except Exception:
+            tb_text = f"{exc_type.__name__}: {exc!s}"
+        # First line + last 6 frames keeps the column readable.
+        lines = tb_text.splitlines()
+        head = lines[0] if lines else f"{exc_type.__name__}: {exc!s}"
+        tail = lines[-12:] if len(lines) > 12 else lines
+        return (head + "\n" + "\n".join(tail))[:4000]

--- a/fortress-guest-platform/backend/tests/test_ingest_run_tracker.py
+++ b/fortress-guest-platform/backend/tests/test_ingest_run_tracker.py
@@ -1,0 +1,344 @@
+"""
+Tests for the IngestRunTracker.
+
+Uses a `_FakeConn` injected via `connection_factory=` to avoid touching
+a real database. The fake speaks just enough psycopg2-shaped API to
+exercise the cursor + fetchone + close flows.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+
+from backend.services.ingest_run_tracker import IngestRunTracker
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fake psycopg2 connection
+# ─────────────────────────────────────────────────────────────────────────────
+
+class _FakeCursor:
+    def __init__(self, conn: "_FakeConn") -> None:
+        self._conn = conn
+        self._last_row = None
+
+    def execute(self, sql: str, params: tuple = ()) -> None:
+        self._conn.calls.append((sql, params))
+        # Drive optional behaviour from the parent connection
+        if self._conn.fail_next:
+            self._conn.fail_next -= 1
+            raise RuntimeError("simulated DB disconnect")
+        if "RETURNING id" in sql:
+            self._last_row = (uuid4(),)
+        else:
+            self._last_row = None
+        if self._conn.on_execute:
+            self._conn.on_execute(sql, params)
+
+    def fetchone(self):
+        return self._last_row
+
+    def __enter__(self): return self
+
+    def __exit__(self, exc_type, exc, tb): return False
+
+
+class _FakeConn:
+    """Tiny psycopg2 stand-in. Tracks every call; fail_next forces N raises."""
+    def __init__(self, fail_next: int = 0,
+                 on_execute=None) -> None:
+        self.autocommit = True
+        self.calls: list[tuple[str, tuple]] = []
+        self.fail_next = fail_next
+        self.on_execute = on_execute
+        self.closed = False
+
+    def cursor(self) -> _FakeCursor:
+        return _FakeCursor(self)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _factory(initial_fail: int = 0, on_execute=None):
+    """Build a connection_factory closure that returns a fresh _FakeConn each call."""
+    state = {"connections": []}
+
+    def make() -> _FakeConn:
+        # Only the first connection's `fail_next` matters for the
+        # 'fail-then-recover' tests because each retry re-connects.
+        # We therefore allocate the failure budget across attempts via
+        # the shared counter.
+        c = _FakeConn(fail_next=state.get("fail_remaining", initial_fail),
+                      on_execute=on_execute)
+        state["connections"].append(c)
+        return c
+
+    state["fail_remaining"] = initial_fail
+    return make, state
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestCleanRunMarksComplete:
+    def test_clean_run_marks_complete(self):
+        make, state = _factory()
+        with IngestRunTracker(
+            "fish-trap-suv2026000013", "ocr_legal_case",
+            args={"jobs": 6}, connection_factory=make,
+        ) as run:
+            run.set_total_files(10)
+            for _ in range(8):
+                run.inc_processed()
+            run.set_manifest_path("/tmp/manifest.json")
+
+        assert not run.degraded
+        # Last UPDATE must set status='complete'
+        last_status_set = next(
+            (call for c in reversed(state["connections"])
+             for call in reversed(c.calls)
+             if "SET status = %s" in call[0]),
+            None,
+        )
+        assert last_status_set is not None
+        assert last_status_set[1][0] == "complete"
+
+
+class TestExceptionMarksError:
+    def test_exception_marks_error_and_reraises(self):
+        make, state = _factory()
+        with pytest.raises(ValueError, match="boom"):
+            with IngestRunTracker(
+                "fish-trap-suv2026000013", "ocr_legal_case",
+                connection_factory=make,
+            ) as run:
+                raise ValueError("boom")
+
+        # Exception bubbled out of the with-block; tracker wrote 'error'.
+        # find the last SET status statement
+        all_calls = [c for conn in state["connections"] for c in conn.calls]
+        status_writes = [c for c in all_calls if "SET status = %s" in c[0]]
+        assert status_writes
+        last = status_writes[-1]
+        assert last[1][0] == "error"
+        # error_summary param present and contains the exception name
+        assert any("ValueError" in str(p) for p in last[1])
+
+
+class TestKeyboardInterruptMarksInterrupted:
+    def test_keyboard_interrupt_marks_interrupted_and_reraises(self):
+        make, state = _factory()
+        with pytest.raises(KeyboardInterrupt):
+            with IngestRunTracker(
+                "fish-trap-suv2026000013", "ocr_legal_case",
+                connection_factory=make,
+            ) as run:
+                raise KeyboardInterrupt()
+
+        all_calls = [c for conn in state["connections"] for c in conn.calls]
+        status_writes = [c for c in all_calls if "SET status = %s" in c[0]]
+        assert status_writes
+        assert status_writes[-1][1][0] == "interrupted"
+
+
+class TestIncCountersAtomic:
+    def test_inc_counters_emit_correct_running_totals(self):
+        make, state = _factory()
+        with IngestRunTracker(
+            "fish-trap-suv2026000013", "ocr_legal_case",
+            connection_factory=make,
+        ) as run:
+            run.inc_processed()
+            run.inc_processed(5)
+            run.inc_errored()
+            run.inc_skipped(3)
+            assert run._counters.processed == 6
+            assert run._counters.errored == 1
+            assert run._counters.skipped == 3
+
+        # Inspect the last UPDATE for each counter — should reflect the
+        # cumulative running total, not the delta.
+        all_calls = [c for conn in state["connections"] for c in conn.calls]
+        proc_updates = [c for c in all_calls if "processed = %s" in c[0]]
+        # Last processed-update should carry the total (6).
+        assert proc_updates and proc_updates[-1][1][0] == 6
+
+
+class TestSetManifestPath:
+    def test_set_manifest_path_writes_path(self):
+        make, state = _factory()
+        path = "/mnt/fortress_nas/audits/foo.json"
+        with IngestRunTracker(
+            "fish-trap-suv2026000013", "ocr_legal_case",
+            connection_factory=make,
+        ) as run:
+            run.set_manifest_path(path)
+
+        all_calls = [c for conn in state["connections"] for c in conn.calls]
+        manifest_writes = [c for c in all_calls if "manifest_path = %s" in c[0]]
+        assert manifest_writes
+        assert manifest_writes[-1][1][0] == path
+
+
+class TestConcurrentTrackersDontCollide:
+    def test_two_trackers_get_distinct_run_ids(self):
+        make, _ = _factory()
+        t1 = IngestRunTracker("a", "s", connection_factory=make)
+        t2 = IngestRunTracker("b", "s", connection_factory=make)
+        with t1, t2:
+            assert t1.run_id is not None
+            assert t2.run_id is not None
+            assert t1.run_id != t2.run_id
+
+    def test_concurrent_threads_dont_share_state(self):
+        # Each tracker has its own _counters dataclass + run_id.
+        make, _ = _factory()
+        run_ids = []
+        errors = []
+
+        def worker():
+            try:
+                with IngestRunTracker("a", "s", connection_factory=make) as r:
+                    r.inc_processed(7)
+                    run_ids.append(r.run_id)
+                    assert r._counters.processed == 7
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(4)]
+        for t in threads: t.start()
+        for t in threads: t.join()
+        assert not errors
+        assert len(run_ids) == 4
+        assert len(set(run_ids)) == 4
+
+
+class TestStatusCheckConstraint:
+    """The CHECK constraint lives in the DB. Verify the tracker only
+    writes the four allowed values."""
+    def test_tracker_only_writes_allowed_status_values(self):
+        # Every code path that calls _update_status uses one of the four
+        # accepted values; we enumerate them via a fake on_execute hook.
+        seen: list[str] = []
+
+        def hook(sql, params):
+            if "SET status = %s" in sql and params:
+                seen.append(params[0])
+
+        make, _ = _factory(on_execute=hook)
+        # complete
+        with IngestRunTracker("a", "s", connection_factory=make):
+            pass
+        # interrupted
+        with pytest.raises(KeyboardInterrupt):
+            with IngestRunTracker("a", "s", connection_factory=make):
+                raise KeyboardInterrupt()
+        # error
+        with pytest.raises(RuntimeError):
+            with IngestRunTracker("a", "s", connection_factory=make):
+                raise RuntimeError("x")
+
+        assert set(seen) == {"complete", "interrupted", "error"}
+        assert all(v in {"running", "complete", "error", "interrupted"}
+                   for v in seen)
+
+
+class TestDbDisconnectRetryThenDegrade:
+    def test_three_failures_then_degrade(self, monkeypatch):
+        """Inject 99 failures so even the start-row INSERT exhausts retries."""
+        # Speed up backoffs in tests
+        monkeypatch.setattr(
+            "backend.services.ingest_run_tracker._RETRY_BACKOFFS_S",
+            (0.0, 0.0, 0.0),
+        )
+
+        def make_failing():
+            return _FakeConn(fail_next=99)
+
+        # No exception in the with-block — tracker degradation alone
+        # must NOT abort the parent.
+        with IngestRunTracker(
+            "fish-trap-suv2026000013", "ocr_legal_case",
+            connection_factory=make_failing,
+        ) as run:
+            run.set_total_files(5)
+            run.inc_processed()
+            run.set_manifest_path("/tmp/x.json")
+
+        assert run.degraded is True
+        assert run.run_id is None
+
+    def test_retry_succeeds_on_third_attempt(self, monkeypatch):
+        monkeypatch.setattr(
+            "backend.services.ingest_run_tracker._RETRY_BACKOFFS_S",
+            (0.0, 0.0, 0.0),
+        )
+        # First two attempts fail, third succeeds.
+        attempt = {"i": 0}
+
+        def make():
+            attempt["i"] += 1
+            return _FakeConn(fail_next=1 if attempt["i"] <= 2 else 0)
+
+        tracker = IngestRunTracker(
+            "fish-trap-suv2026000013", "ocr_legal_case",
+            connection_factory=make,
+        )
+        with tracker as run:
+            pass
+
+        assert run.degraded is False
+        assert run.run_id is not None
+
+
+class TestDegradedTrackerDoesNotAbort:
+    def test_parent_script_completes_when_tracker_dies_at_start(self, monkeypatch):
+        monkeypatch.setattr(
+            "backend.services.ingest_run_tracker._RETRY_BACKOFFS_S",
+            (0.0, 0.0, 0.0),
+        )
+
+        def make_failing():
+            return _FakeConn(fail_next=99)
+
+        # Simulate parent script body that does real work after tracker setup.
+        work_done = []
+        with IngestRunTracker(
+            "fish-trap-suv2026000013", "ocr_legal_case",
+            connection_factory=make_failing,
+        ) as run:
+            for i in range(5):
+                # Counter calls return None silently when degraded
+                run.inc_processed()
+                work_done.append(i)
+        assert work_done == [0, 1, 2, 3, 4]
+        assert run.degraded is True
+
+
+class TestInvalidCaseSlugFailsFast:
+    """
+    The CHECK lives on the FK in the real DB; with the fake we verify the
+    INSERT round-trip semantics. Real-DB FK violation is exercised via
+    the integration smoke in PR D.
+    """
+    def test_tracker_passes_case_slug_through_to_insert(self):
+        seen: list[tuple] = []
+        def hook(sql, params):
+            if sql.lstrip().startswith("INSERT INTO legal.ingest_runs"):
+                seen.append(params)
+
+        make, _ = _factory(on_execute=hook)
+        with IngestRunTracker(
+            "ghost-case", "ocr_legal_case", connection_factory=make,
+        ):
+            pass
+
+        assert seen and seen[0][0] == "ghost-case"


### PR DESCRIPTION
## Summary
Adds enterprise audit trail for case-scoped ingest operations (OCR, vault, ASR, re-ingest). New `legal.ingest_runs` table + `IngestRunTracker` context manager + retroactive backfill of PR C's OCR sweep. Schema applied to both `fortress_prod` and `fortress_db`.

## Schema (alembic `c4d8b1a3f7e2`)

| column | type | notes |
|---|---|---|
| `id` | UUID PK | `gen_random_uuid()` |
| `case_slug` | TEXT NOT NULL | FK → `legal.cases.case_slug` ON DELETE CASCADE |
| `script_name` | TEXT NOT NULL | e.g. `ocr_legal_case` |
| `started_at` / `ended_at` | TIMESTAMPTZ | both set by tracker |
| `args` | JSONB | argparse Namespace dump |
| `status` | TEXT (CHECK) | `running` / `complete` / `error` / `interrupted` |
| `manifest_path` | TEXT | NAS path to per-run manifest |
| `total_files` / `processed` / `errored` / `skipped` | INTEGER | cumulative running totals |
| `error_summary` | TEXT | last 12 traceback lines |
| `host` / `pid` | TEXT / INTEGER | provenance |
| `runtime_seconds` | NUMERIC(12,3) | populated on exit |

3 indexes: `case_slug`, partial(`status` running|error), `started_at DESC`. `UNIQUE(case_slug)` on `legal.cases` already existed in all 3 DBs as `cases_case_slug_key`; migration's `DO` block adds only on fresh DBs.

## Tracker (`backend/services/ingest_run_tracker.py`)

```python
with IngestRunTracker(case_slug, "ocr_legal_case", args=vars(args)) as run:
    run.set_total_files(len(files))
    for f in files:
        try: process(f); run.inc_processed()
        except Exception: run.inc_errored()
    run.set_manifest_path(manifest_path)
```

State machine: `running` → `complete` / `error` / `interrupted` (handled by `__exit__`; exceptions re-raised after the row is durable).

**DB-disconnect resilience:** 3 retries with exponential backoff (0.5 s + 2 s + 8 s, ≤ 30 s total). On exhaustion: `degraded=True`, stderr log, structured `ingest_run_tracker_degraded` event, **parent script continues** without aborting. Tracker NEVER raises.

## Test plan
- [x] `pytest backend/tests/test_ingest_run_tracker.py` → **12 passed**.
- [x] Migration applied to both `fortress_prod` and `fortress_db` — schema verified (table, 3 indexes, CHECK constraint, FK, COMMENT).
- [x] PR C OCR sweep retroactively backfilled in both DBs:
  - `fortress_prod`: id `be4ebc75-cb7e-48c9-aff5-d8a93cffbb9f`
  - `fortress_db`: id `1385b61d-3ebc-48ab-997c-419895705c53`
  - status=complete, processed=549, errored=3, runtime=1046.5 s.

## Runbook
`docs/runbooks/legal-ingest-runs.md` — 10 operator queries (last runs, errored, orphans, runtime histogram, etc.), stuck-row cleanup recipe, PR D rollback interaction, CI orphan-detection cron query.

## Constraints
- ✅ No tables modified beyond the new `legal.ingest_runs` and the conditional UNIQUE constraint (already present everywhere).
- ✅ No `fortress-backend` modifications. No restart required.
- ✅ `fortress_shadow` not migrated (different alembic chain head — same pattern as PRs A/B).

## Followups (filed as #190 / #191 after merge)
- PACER digital-header pattern: 36 PDFs need `--force-ocr --pages` selective second pass.
- ocrmypdf 600 s timeout on 2 bates productions; bump per-file timeout or pre-split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
