### PR TITLE
feat(legal): vault ingestion script for case files (PR D)

### DIFF
--- a/fortress-guest-platform/backend/scripts/vault_ingest_legal_case.py
+++ b/fortress-guest-platform/backend/scripts/vault_ingest_legal_case.py
@@ -1,0 +1,1044 @@
+"""
+vault_ingest_legal_case.py — case-scoped vault ingestion into legal.vault_documents.
+
+Walks legal.cases.nas_layout for the supplied --case-slug, deduplicates physical
+file paths (the same file referenced by two logical subdirs is processed once),
+and runs each file through the canonical pipeline:
+
+    process_vault_upload()
+        ├── INSERT legal.vault_documents (status='pending', ON CONFLICT DO NOTHING)
+        ├── privilege classifier — sets 'locked_privileged' when triggered
+        ├── _extract_text — sets 'ocr_failed' when empty on a PDF
+        ├── chunk → nomic embed → qdrant upsert
+        └── UPDATE status to 'completed'
+
+The vault_documents row is then mirrored to fortress_db so the UI's
+LegacySession can read it.
+
+Idempotency: a file_hash that already has a row in {complete, completed,
+ocr_failed, locked_privileged} is skipped. Re-running this script is a clean
+no-op for fully-ingested cases.
+
+Atomicity: per-file try/except. One bad file does not abort the sweep.
+
+Audit: IngestRunTracker (PR D-pre1) emits a single legal.ingest_runs row
+covering the lifecycle. JSON manifest at /mnt/fortress_nas/audits/.
+
+Concurrency control: lock file at /tmp/vault-ingest-{case_slug}.lock with
+6 h staleness override (--force).
+
+Rollback: --rollback deletes vault_documents rows for the case in BOTH
+fortress_prod and fortress_db, plus Qdrant points whose payload.case_slug
+matches. Requires explicit confirmation (type the case_slug back) unless
+--force.
+
+Usage (production 7IL run):
+
+    python -m backend.scripts.vault_ingest_legal_case \\
+        --case-slug 7il-v-knight-ndga --jobs 6
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import logging
+import mimetypes
+import os
+import re
+import socket
+import sys
+import time
+import traceback
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("vault_ingest_legal_case")
+
+# ─── config ────────────────────────────────────────────────────────────────
+
+NAS_LEGAL_ROOT = "/mnt/fortress_nas/sectors/legal"
+ENV_PATH = Path("/home/admin/Fortress-Prime/fortress-guest-platform/.env")
+AUDIT_DIR = Path("/mnt/fortress_nas/audits")
+
+LOCK_STALE_AFTER_S = 6 * 3600
+HASH_STREAM_THRESHOLD_BYTES = 100 * 1024 * 1024  # 100 MB
+
+DEFAULT_MAX_FILE_SIZE_MB = 500
+DEFAULT_JOBS = 4
+
+QDRANT_COLLECTION = "legal_ediscovery"
+EXPECTED_VECTOR_SIZE = 768
+
+# vault_documents statuses that we treat as "already done — skip".
+TERMINAL_STATUSES_FOR_RESUME = (
+    "complete", "completed", "ocr_failed", "locked_privileged",
+)
+
+
+# ─── env + DSN ────────────────────────────────────────────────────────────
+
+
+def _read_env_pgs() -> dict[str, str]:
+    out: dict[str, str] = {}
+    if not ENV_PATH.exists():
+        return out
+    for raw in ENV_PATH.read_text().splitlines():
+        s = raw.strip()
+        if not s or s.startswith("#") or "=" not in s:
+            continue
+        k, _, v = s.partition("=")
+        out[k.strip()] = v.strip().strip('"').strip("'")
+    return out
+
+
+def _ensure_env_loaded() -> None:
+    """Best-effort .env load — only sets vars that aren't already in environ."""
+    for k, v in _read_env_pgs().items():
+        os.environ.setdefault(k, v)
+
+
+@dataclass
+class _DSN:
+    host: str
+    port: int
+    user: str
+    password: str
+    db: str
+
+
+def _parse_admin_dsn(dbname: str) -> _DSN:
+    uri = os.environ.get("POSTGRES_ADMIN_URI", "")
+    m = re.match(
+        r"postgresql(?:\+\w+)?://([^:]+):([^@]+)@([^:/]+):?(\d+)?/[^?]+",
+        uri,
+    )
+    if not m:
+        raise SystemExit(
+            "POSTGRES_ADMIN_URI not set or unparseable in environ; "
+            "load .env first"
+        )
+    user, pw, host, port = m.groups()
+    return _DSN(host=host, port=int(port or 5432), user=user, password=pw, db=dbname)
+
+
+def _connect(dbname: str):
+    import psycopg2
+    dsn = _parse_admin_dsn(dbname)
+    conn = psycopg2.connect(
+        host=dsn.host, port=dsn.port, user=dsn.user,
+        password=dsn.password, dbname=dsn.db,
+    )
+    conn.autocommit = True
+    return conn
+
+
+# ─── pre-flight ────────────────────────────────────────────────────────────
+
+
+class PreflightError(Exception):
+    pass
+
+
+def _preflight_case_exists(case_slug: str) -> dict[str, Any]:
+    """case_slug must be present in BOTH fortress_prod and fortress_db. Return the
+    fortress_prod row's nas_layout (dict) — the source of truth."""
+    layouts: dict[str, Any] = {}
+    for dbname in ("fortress_prod", "fortress_db"):
+        try:
+            conn = _connect(dbname)
+        except Exception as exc:
+            raise PreflightError(
+                f"cannot connect to {dbname}: {type(exc).__name__}:{exc!s}"
+            ) from exc
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT nas_layout FROM legal.cases WHERE case_slug = %s",
+                    (case_slug,),
+                )
+                row = cur.fetchone()
+            if row is None:
+                raise PreflightError(
+                    f"case_slug {case_slug!r} not found in {dbname}.legal.cases — "
+                    f"run PR B for this case first"
+                )
+            layouts[dbname] = row[0]
+        finally:
+            conn.close()
+    layout = layouts["fortress_prod"]
+    if not layout:
+        raise PreflightError(
+            f"nas_layout is NULL for {case_slug!r} in fortress_prod. "
+            f"Per PR A spec, non-canonical cases must declare a layout. "
+            f"Set legal.cases.nas_layout for this case before re-running."
+        )
+    return _normalize_layout(layout)
+
+
+def _preflight_paths_exist(layout: dict[str, Any]) -> None:
+    root = layout["root"]
+    if not root.is_dir():
+        raise PreflightError(f"nas_layout.root does not exist on disk: {root}")
+    missing: list[str] = []
+    for logical, rel in layout["subdirs"].items():
+        d = root / rel
+        if not d.is_dir():
+            missing.append(f"{logical} → {d}")
+    if missing:
+        raise PreflightError(
+            "nas_layout subdirs missing from disk:\n  " + "\n  ".join(missing)
+        )
+
+
+def _preflight_postgres_writable() -> None:
+    for dbname in ("fortress_prod", "fortress_db"):
+        try:
+            conn = _connect(dbname)
+        except Exception as exc:
+            raise PreflightError(f"{dbname} connect failed: {exc!s}") from exc
+        try:
+            with conn.cursor() as cur:
+                cur.execute("SELECT 1")
+                if cur.fetchone() != (1,):
+                    raise PreflightError(f"{dbname} SELECT 1 unexpected result")
+        finally:
+            conn.close()
+    # ingest_runs writability — fail-fast inside fortress_db (tracker target)
+    try:
+        conn = _connect("fortress_db")
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO legal.ingest_runs (case_slug, script_name, status) "
+                "VALUES ('__preflight__', '__preflight__', 'running') RETURNING id"
+            )
+            row = cur.fetchone()
+            if row is None:
+                raise PreflightError("preflight ingest_runs INSERT returned no id")
+            cur.execute(
+                "DELETE FROM legal.ingest_runs WHERE id = %s", (row[0],),
+            )
+        conn.close()
+    except Exception as exc:
+        raise PreflightError(
+            f"fortress_db.legal.ingest_runs not writable: {exc!s}"
+        ) from exc
+
+
+def _preflight_schema_constraints() -> None:
+    """Verify PR D-pre2 constraints are present on fortress_prod and fortress_db."""
+    required = {
+        "fk_vault_documents_case_slug",
+        "uq_vault_documents_case_hash",
+        "chk_vault_documents_status",
+    }
+    for dbname in ("fortress_prod", "fortress_db"):
+        conn = _connect(dbname)
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT conname FROM pg_constraint "
+                    "WHERE conrelid = 'legal.vault_documents'::regclass "
+                    "AND conname = ANY(%s)",
+                    (list(required),),
+                )
+                present = {r[0] for r in cur.fetchall()}
+        finally:
+            conn.close()
+        missing = required - present
+        if missing:
+            raise PreflightError(
+                f"{dbname} missing PR D-pre2 constraints: {sorted(missing)} — "
+                f"apply alembic d8e3c1f5b9a6 before ingesting"
+            )
+
+
+def _preflight_qdrant_reachable() -> None:
+    import urllib.error
+    import urllib.request
+    qdrant_url = os.environ.get("QDRANT_URL", "").rstrip("/")
+    if not qdrant_url:
+        raise PreflightError("QDRANT_URL not set in environ")
+    try:
+        with urllib.request.urlopen(
+            f"{qdrant_url}/collections/{QDRANT_COLLECTION}", timeout=10,
+        ) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            raise PreflightError(
+                f"qdrant collection {QDRANT_COLLECTION!r} not found at {qdrant_url} — "
+                f"create it with vector_size={EXPECTED_VECTOR_SIZE} distance=Cosine"
+            ) from exc
+        raise PreflightError(f"qdrant reachable but errored: {exc.code}") from exc
+    except Exception as exc:
+        raise PreflightError(
+            f"qdrant unreachable at {qdrant_url}: {type(exc).__name__}:{exc!s}"
+        ) from exc
+
+    cfg = (data.get("result") or {}).get("config", {}).get("params", {}).get("vectors", {})
+    size = cfg.get("size") if isinstance(cfg, dict) else None
+    if size is not None and int(size) != EXPECTED_VECTOR_SIZE:
+        raise PreflightError(
+            f"qdrant collection vector size is {size}, expected {EXPECTED_VECTOR_SIZE}"
+        )
+
+
+def _preflight_pipeline_importable() -> None:
+    try:
+        from backend.services.legal_ediscovery import process_vault_upload  # noqa: F401
+    except Exception as exc:
+        raise PreflightError(
+            f"process_vault_upload not importable: {type(exc).__name__}:{exc!s}"
+        ) from exc
+
+
+def run_preflight(case_slug: str) -> dict[str, Any]:
+    """Run every pre-flight gate. Raises PreflightError on the first failure."""
+    layout = _preflight_case_exists(case_slug)
+    _preflight_paths_exist(layout)
+    _preflight_postgres_writable()
+    _preflight_schema_constraints()
+    _preflight_qdrant_reachable()
+    _preflight_pipeline_importable()
+    return layout
+
+
+# ─── nas_layout ───────────────────────────────────────────────────────────
+
+
+def _normalize_layout(raw: Any) -> dict[str, Any]:
+    """nas_layout column may be dict, str, or None (caught above)."""
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except Exception:
+            raw = None
+    if not raw:
+        raise PreflightError("nas_layout is empty after normalize")
+    root = Path(str(raw.get("root") or "")).expanduser()
+    subs = raw.get("subdirs") or {}
+    if not isinstance(subs, dict):
+        subs = {}
+    subdirs = {
+        str(k): str(v) for k, v in subs.items() if v not in (None, "")
+    }
+    return {
+        "root": root,
+        "subdirs": subdirs,
+        "recursive": bool(raw.get("recursive")),
+    }
+
+
+# ─── physical-path dedup walk ─────────────────────────────────────────────
+
+
+def walk_unique_physical_files(layout: dict[str, Any]):
+    """Yield (canonical_path, logical_subdir) for every unique physical file
+    referenced from any logical subdir. Skips Synology @eaDir + dotfiles."""
+    root: Path = layout["root"]
+    recursive: bool = layout["recursive"]
+    seen: set[Path] = set()
+    for logical, rel in layout["subdirs"].items():
+        walk_root = root / rel
+        if not walk_root.is_dir():
+            continue
+        candidates = walk_root.rglob("*") if recursive else walk_root.iterdir()
+        for p in candidates:
+            try:
+                if not p.is_file():
+                    continue
+            except OSError:
+                continue
+            if any(part == "@eaDir" or part.startswith(".") for part in p.parts):
+                continue
+            try:
+                canonical = p.resolve()
+            except OSError:
+                continue
+            if canonical in seen:
+                continue
+            seen.add(canonical)
+            yield canonical, logical
+
+
+# ─── hashing + mime ───────────────────────────────────────────────────────
+
+
+def file_sha256(path: Path) -> str:
+    """SHA-256 of file contents. Streams when > HASH_STREAM_THRESHOLD_BYTES."""
+    size = path.stat().st_size
+    h = hashlib.sha256()
+    if size <= HASH_STREAM_THRESHOLD_BYTES:
+        h.update(path.read_bytes())
+        return h.hexdigest()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def detect_mime_type(path: Path) -> str:
+    """Best-effort mime from extension + magic-bytes peek for PDF/email."""
+    by_ext, _ = mimetypes.guess_type(str(path))
+    if by_ext:
+        return by_ext
+    try:
+        with open(path, "rb") as f:
+            head = f.read(8)
+    except OSError:
+        return "application/octet-stream"
+    if head.startswith(b"%PDF"):
+        return "application/pdf"
+    if head.startswith(b"From "):
+        return "message/rfc822"
+    return "application/octet-stream"
+
+
+# ─── lock file ────────────────────────────────────────────────────────────
+
+
+def _lock_path(case_slug: str) -> Path:
+    return Path(f"/tmp/vault-ingest-{case_slug}.lock")
+
+
+def acquire_lock(case_slug: str, force: bool) -> Path:
+    lp = _lock_path(case_slug)
+    if lp.exists():
+        try:
+            mtime = lp.stat().st_mtime
+        except OSError:
+            mtime = 0.0
+        age = time.time() - mtime
+        if force and age > LOCK_STALE_AFTER_S:
+            lp.unlink()
+        elif force:
+            raise SystemExit(
+                f"--force given but lock at {lp} is only {int(age)}s old "
+                f"(needs > {LOCK_STALE_AFTER_S}s to override)"
+            )
+        else:
+            raise SystemExit(
+                f"another vault ingest run appears active (lock at {lp}); "
+                f"after confirming no other run, pass --force"
+            )
+    lp.write_text(f"{os.getpid()}\n{datetime.now(timezone.utc).isoformat()}\n")
+    return lp
+
+
+def release_lock(lp: Path) -> None:
+    try:
+        lp.unlink()
+    except Exception:
+        pass
+
+
+# ─── per-file ingestion ───────────────────────────────────────────────────
+
+
+@dataclass
+class FileOutcome:
+    path: str
+    logical_subdir: str
+    file_hash: str
+    file_size_bytes: int
+    mime_type: str
+    status: str  # completed | ocr_failed | locked_privileged | failed | skipped | duplicate
+    document_id: str | None = None
+    chunks: int = 0
+    vectors_indexed: int = 0
+    error: str | None = None
+    skipped_reason: str | None = None
+
+
+async def _ingest_one(
+    *,
+    physical_path: Path,
+    logical_subdir: str,
+    case_slug: str,
+    max_size_bytes: int,
+    skip_status_set: frozenset[str],
+    resume: bool,
+    dry_run: bool,
+    semaphore: asyncio.Semaphore,
+) -> FileOutcome:
+    async with semaphore:
+        return await _ingest_one_inner(
+            physical_path=physical_path,
+            logical_subdir=logical_subdir,
+            case_slug=case_slug,
+            max_size_bytes=max_size_bytes,
+            skip_status_set=skip_status_set,
+            resume=resume,
+            dry_run=dry_run,
+        )
+
+
+async def _ingest_one_inner(
+    *,
+    physical_path: Path,
+    logical_subdir: str,
+    case_slug: str,
+    max_size_bytes: int,
+    skip_status_set: frozenset[str],
+    resume: bool,
+    dry_run: bool,
+) -> FileOutcome:
+    try:
+        size = physical_path.stat().st_size
+    except OSError as exc:
+        return FileOutcome(
+            path=str(physical_path), logical_subdir=logical_subdir,
+            file_hash="", file_size_bytes=0, mime_type="",
+            status="failed", error=f"stat_failed:{exc!s}",
+        )
+
+    if size > max_size_bytes:
+        return FileOutcome(
+            path=str(physical_path), logical_subdir=logical_subdir,
+            file_hash="", file_size_bytes=size,
+            mime_type=detect_mime_type(physical_path),
+            status="skipped",
+            skipped_reason=f"exceeds_max_size_mb:{size // (1024*1024)}MB",
+        )
+
+    fhash = file_sha256(physical_path)
+    mime = detect_mime_type(physical_path)
+
+    if resume:
+        existing_status = _check_existing_row("fortress_prod", case_slug, fhash)
+        if existing_status in skip_status_set:
+            return FileOutcome(
+                path=str(physical_path), logical_subdir=logical_subdir,
+                file_hash=fhash, file_size_bytes=size, mime_type=mime,
+                status="skipped",
+                skipped_reason=f"already_ingested:{existing_status}",
+            )
+
+    if dry_run:
+        return FileOutcome(
+            path=str(physical_path), logical_subdir=logical_subdir,
+            file_hash=fhash, file_size_bytes=size, mime_type=mime,
+            status="skipped", skipped_reason="dry_run",
+        )
+
+    try:
+        file_bytes = physical_path.read_bytes()
+    except OSError as exc:
+        return FileOutcome(
+            path=str(physical_path), logical_subdir=logical_subdir,
+            file_hash=fhash, file_size_bytes=size, mime_type=mime,
+            status="failed", error=f"read_failed:{exc!s}",
+        )
+
+    from backend.core.database import AsyncSessionLocal
+    from backend.services.legal_ediscovery import process_vault_upload
+
+    try:
+        async with AsyncSessionLocal() as db:
+            result = await process_vault_upload(
+                db=db,
+                case_slug=case_slug,
+                file_bytes=file_bytes,
+                file_name=physical_path.name,
+                mime_type=mime,
+            )
+    except Exception as exc:
+        return FileOutcome(
+            path=str(physical_path), logical_subdir=logical_subdir,
+            file_hash=fhash, file_size_bytes=size, mime_type=mime,
+            status="failed",
+            error=f"{type(exc).__name__}:{str(exc)[:200]}",
+        )
+
+    status = result.get("status", "failed")
+    doc_id = result.get("document_id")
+
+    if status in {"completed", "ocr_failed", "locked_privileged"} and doc_id:
+        try:
+            _mirror_row_to_fortress_db(case_slug=case_slug, doc_id=doc_id)
+        except Exception as exc:
+            return FileOutcome(
+                path=str(physical_path), logical_subdir=logical_subdir,
+                file_hash=fhash, file_size_bytes=size, mime_type=mime,
+                status="failed", document_id=doc_id,
+                error=f"mirror_failed:{type(exc).__name__}:{str(exc)[:200]}",
+            )
+
+    return FileOutcome(
+        path=str(physical_path), logical_subdir=logical_subdir,
+        file_hash=fhash, file_size_bytes=size, mime_type=mime,
+        status=status, document_id=doc_id,
+        chunks=int(result.get("chunks") or 0),
+        vectors_indexed=int(result.get("vectors_indexed") or 0),
+        error=str(result.get("error")) if status == "failed" else None,
+    )
+
+
+def _check_existing_row(dbname: str, case_slug: str, file_hash: str) -> str | None:
+    conn = _connect(dbname)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT processing_status FROM legal.vault_documents "
+                "WHERE case_slug = %s AND file_hash = %s",
+                (case_slug, file_hash),
+            )
+            row = cur.fetchone()
+        return row[0] if row else None
+    finally:
+        conn.close()
+
+
+def _mirror_row_to_fortress_db(*, case_slug: str, doc_id: str) -> None:
+    """After process_vault_upload writes to fortress_prod, copy the row to
+    fortress_db so the UI's LegacySession reads the same data."""
+    src = _connect("fortress_prod")
+    try:
+        with src.cursor() as cur:
+            cur.execute(
+                "SELECT id, case_slug, file_name, nfs_path, mime_type, "
+                "file_hash, file_size_bytes, processing_status, "
+                "chunk_count, error_detail, created_at "
+                "FROM legal.vault_documents WHERE id = %s AND case_slug = %s",
+                (doc_id, case_slug),
+            )
+            row = cur.fetchone()
+        if row is None:
+            raise RuntimeError(
+                f"row {doc_id} missing in fortress_prod for case {case_slug!r} "
+                f"— cannot mirror"
+            )
+    finally:
+        src.close()
+
+    dst = _connect("fortress_db")
+    try:
+        with dst.cursor() as cur:
+            cur.execute(
+                "INSERT INTO legal.vault_documents "
+                "(id, case_slug, file_name, nfs_path, mime_type, file_hash, "
+                " file_size_bytes, processing_status, chunk_count, error_detail, created_at) "
+                "VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s) "
+                "ON CONFLICT ON CONSTRAINT uq_vault_documents_case_hash DO UPDATE SET "
+                "  processing_status = EXCLUDED.processing_status, "
+                "  chunk_count = EXCLUDED.chunk_count, "
+                "  error_detail = EXCLUDED.error_detail",
+                row,
+            )
+    finally:
+        dst.close()
+
+
+# ─── manifest ─────────────────────────────────────────────────────────────
+
+
+@dataclass
+class IngestManifest:
+    case_slug: str
+    started_at: str
+    finished_at: str = ""
+    runtime_seconds: float = 0.0
+    args: dict[str, Any] = field(default_factory=dict)
+    host: str = ""
+    pid: int = 0
+    ingest_run_id: str | None = None
+    layout_root: str = ""
+    layout_recursive: bool = False
+    layout_subdirs: dict[str, str] = field(default_factory=dict)
+    total_unique_files: int = 0
+    processed: int = 0
+    skipped: int = 0
+    errored: int = 0
+    by_status: dict[str, int] = field(default_factory=dict)
+    by_logical_subdir: dict[str, int] = field(default_factory=dict)
+    by_mime_type: dict[str, int] = field(default_factory=dict)
+    errors: list[dict[str, Any]] = field(default_factory=list)
+    qdrant_points_estimate: int = 0
+    vault_documents_inserted: int = 0
+
+
+def write_manifest(case_slug: str, manifest: IngestManifest) -> Path:
+    AUDIT_DIR.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    out = AUDIT_DIR / f"vault-ingest-{case_slug}-{ts}.json"
+    out.write_text(json.dumps(asdict(manifest), indent=2, default=str))
+    return out
+
+
+def _summarize_outcomes(outcomes: list[FileOutcome], manifest: IngestManifest) -> None:
+    for o in outcomes:
+        manifest.by_status[o.status] = manifest.by_status.get(o.status, 0) + 1
+        if o.logical_subdir:
+            manifest.by_logical_subdir[o.logical_subdir] = (
+                manifest.by_logical_subdir.get(o.logical_subdir, 0) + 1
+            )
+        if o.mime_type:
+            manifest.by_mime_type[o.mime_type] = (
+                manifest.by_mime_type.get(o.mime_type, 0) + 1
+            )
+        if o.status == "failed":
+            manifest.errored += 1
+            manifest.errors.append({
+                "path": o.path, "logical_subdir": o.logical_subdir,
+                "error": o.error or "", "file_hash": o.file_hash,
+            })
+        elif o.status == "skipped":
+            manifest.skipped += 1
+        else:
+            manifest.processed += 1
+        if o.status in {"completed", "ocr_failed", "locked_privileged"}:
+            manifest.vault_documents_inserted += 1
+        if o.status == "completed":
+            manifest.qdrant_points_estimate += o.vectors_indexed
+
+
+# ─── orchestrator ─────────────────────────────────────────────────────────
+
+
+def run_ingestion(args: argparse.Namespace) -> int:
+    layout = run_preflight(args.case_slug)
+    lock = acquire_lock(args.case_slug, force=bool(args.force))
+
+    physical_files = list(walk_unique_physical_files(layout))
+    if args.limit is not None:
+        physical_files = physical_files[: args.limit]
+
+    print(
+        f"# vault ingest: case={args.case_slug} "
+        f"unique_physical_files={len(physical_files)} dry_run={args.dry_run}",
+        flush=True,
+    )
+
+    started = datetime.now(timezone.utc)
+    t0 = time.monotonic()
+    manifest = IngestManifest(
+        case_slug=args.case_slug,
+        started_at=started.isoformat(),
+        args={k: v for k, v in vars(args).items() if k != "force"},
+        host=socket.gethostname(),
+        pid=os.getpid(),
+        layout_root=str(layout["root"]),
+        layout_recursive=layout["recursive"],
+        layout_subdirs=dict(layout["subdirs"]),
+        total_unique_files=len(physical_files),
+    )
+
+    skip_status_set = frozenset(s.strip() for s in args.skip_status.split(","))
+
+    from backend.services.ingest_run_tracker import IngestRunTracker
+
+    try:
+        with IngestRunTracker(
+            args.case_slug, "vault_ingest_legal_case",
+            args=manifest.args,
+        ) as tracker:
+            tracker.set_total_files(len(physical_files))
+            manifest.ingest_run_id = (
+                str(tracker.run_id) if tracker.run_id is not None else None
+            )
+
+            outcomes = asyncio.run(
+                _drive_async_loop(
+                    physical_files=physical_files,
+                    case_slug=args.case_slug,
+                    max_size_bytes=args.max_file_size_mb * 1024 * 1024,
+                    skip_status_set=skip_status_set,
+                    resume=args.resume,
+                    dry_run=args.dry_run,
+                    jobs=args.jobs,
+                    tracker=tracker,
+                )
+            )
+            _summarize_outcomes(outcomes, manifest)
+            manifest.finished_at = datetime.now(timezone.utc).isoformat()
+            manifest.runtime_seconds = round(time.monotonic() - t0, 2)
+            manifest_path = write_manifest(args.case_slug, manifest)
+            tracker.set_manifest_path(manifest_path)
+
+            print(
+                f"# done: total={manifest.total_unique_files} "
+                f"processed={manifest.processed} skipped={manifest.skipped} "
+                f"errored={manifest.errored} "
+                f"by_status={dict(manifest.by_status)} "
+                f"runtime={manifest.runtime_seconds:.1f}s "
+                f"manifest={manifest_path}",
+                flush=True,
+            )
+            return 0 if manifest.errored == 0 else 1
+    finally:
+        release_lock(lock)
+
+
+async def _drive_async_loop(
+    *,
+    physical_files: list[tuple[Path, str]],
+    case_slug: str,
+    max_size_bytes: int,
+    skip_status_set: frozenset[str],
+    resume: bool,
+    dry_run: bool,
+    jobs: int,
+    tracker,
+) -> list[FileOutcome]:
+    semaphore = asyncio.Semaphore(max(1, jobs))
+    coros = [
+        _ingest_one(
+            physical_path=p,
+            logical_subdir=logical,
+            case_slug=case_slug,
+            max_size_bytes=max_size_bytes,
+            skip_status_set=skip_status_set,
+            resume=resume,
+            dry_run=dry_run,
+            semaphore=semaphore,
+        )
+        for p, logical in physical_files
+    ]
+    outcomes: list[FileOutcome] = []
+    total = len(coros)
+    for n, fut in enumerate(asyncio.as_completed(coros), start=1):
+        o = await fut
+        outcomes.append(o)
+        if o.status == "failed":
+            tracker.inc_errored()
+        elif o.status == "skipped":
+            tracker.inc_skipped()
+        else:
+            tracker.inc_processed()
+        if n % 25 == 0 or o.status == "failed":
+            print(
+                f"  [{n}/{total}] {o.status:<18s} "
+                f"{Path(o.path).name[:60]}",
+                flush=True,
+            )
+    return outcomes
+
+
+# ─── rollback ─────────────────────────────────────────────────────────────
+
+
+def run_rollback(args: argparse.Namespace) -> int:
+    """Delete every vault_documents row for the case in both DBs and every Qdrant
+    point with payload.case_slug == case_slug. Confirmation required unless --force."""
+    case_slug = args.case_slug
+    if not args.force:
+        print(
+            f"This will DELETE all legal.vault_documents rows for "
+            f"case_slug '{case_slug}' in fortress_prod AND fortress_db, "
+            f"plus all Qdrant points in {QDRANT_COLLECTION} where "
+            f"payload.case_slug = '{case_slug}'.",
+            flush=True,
+        )
+        try:
+            typed = input(f"Type the case_slug ({case_slug}) to confirm: ").strip()
+        except EOFError:
+            typed = ""
+        if typed != case_slug:
+            print("rollback cancelled — confirmation did not match", flush=True)
+            return 2
+
+    pre_counts: dict[str, int] = {}
+    for dbname in ("fortress_prod", "fortress_db"):
+        conn = _connect(dbname)
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT count(*) FROM legal.vault_documents WHERE case_slug = %s",
+                    (case_slug,),
+                )
+                row = cur.fetchone()
+                pre_counts[dbname] = int(row[0]) if row else 0
+        finally:
+            conn.close()
+    qdrant_pre = _count_qdrant_points(case_slug)
+    pre_counts["qdrant"] = qdrant_pre
+
+    print(f"# pre-rollback counts: {pre_counts}", flush=True)
+
+    started = datetime.now(timezone.utc)
+    t0 = time.monotonic()
+    deleted = {"fortress_prod": 0, "fortress_db": 0, "qdrant": 0}
+
+    from backend.services.ingest_run_tracker import IngestRunTracker
+    with IngestRunTracker(
+        case_slug, "vault_ingest_legal_case",
+        args={"rollback": True, "force": bool(args.force)},
+    ) as tracker:
+        for dbname in ("fortress_prod", "fortress_db"):
+            conn = _connect(dbname)
+            try:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "DELETE FROM legal.vault_documents WHERE case_slug = %s",
+                        (case_slug,),
+                    )
+                    deleted[dbname] = cur.rowcount or 0
+            finally:
+                conn.close()
+
+        deleted["qdrant"] = _delete_qdrant_points(case_slug)
+        post_qdrant = _count_qdrant_points(case_slug)
+
+        post_counts: dict[str, int] = {}
+        for dbname in ("fortress_prod", "fortress_db"):
+            conn = _connect(dbname)
+            try:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT count(*) FROM legal.vault_documents WHERE case_slug = %s",
+                        (case_slug,),
+                    )
+                    r = cur.fetchone()
+                    post_counts[dbname] = int(r[0]) if r else 0
+            finally:
+                conn.close()
+        post_counts["qdrant"] = post_qdrant
+
+        manifest = {
+            "case_slug": case_slug,
+            "started_at": started.isoformat(),
+            "finished_at": datetime.now(timezone.utc).isoformat(),
+            "runtime_seconds": round(time.monotonic() - t0, 2),
+            "host": socket.gethostname(),
+            "pid": os.getpid(),
+            "ingest_run_id": str(tracker.run_id) if tracker.run_id is not None else None,
+            "operation": "rollback",
+            "pre_counts": pre_counts,
+            "deleted": deleted,
+            "post_counts": post_counts,
+        }
+        AUDIT_DIR.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        out = AUDIT_DIR / f"vault-rollback-{case_slug}-{ts}.json"
+        out.write_text(json.dumps(manifest, indent=2, default=str))
+        tracker.set_manifest_path(out)
+        print(f"# rollback complete: {manifest}", flush=True)
+        if any(v != 0 for v in post_counts.values()):
+            print(
+                f"WARNING: post-rollback counts non-zero: {post_counts} — "
+                f"investigate concurrent writers",
+                flush=True,
+            )
+            return 1
+        return 0
+
+
+def _qdrant_url() -> str:
+    return os.environ["QDRANT_URL"].rstrip("/")
+
+
+def _count_qdrant_points(case_slug: str) -> int:
+    """Cheap probe: scroll up to 1 point with the case_slug filter, read total."""
+    import urllib.request
+    payload = {
+        "filter": {"must": [
+            {"key": "case_slug", "match": {"value": case_slug}}
+        ]},
+        "limit": 1,
+        "with_payload": False,
+        "with_vector": False,
+    }
+    req = urllib.request.Request(
+        f"{_qdrant_url()}/collections/{QDRANT_COLLECTION}/points/count",
+        data=json.dumps({
+            "filter": payload["filter"], "exact": True,
+        }).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+        return int((data.get("result") or {}).get("count") or 0)
+    except Exception:
+        return 0
+
+
+def _delete_qdrant_points(case_slug: str) -> int:
+    """Delete all points where payload.case_slug == case_slug. Returns count
+    deleted (best-effort — qdrant returns operation_id, not count, so we use
+    pre-/post-count delta)."""
+    import urllib.request
+    pre = _count_qdrant_points(case_slug)
+    body = {
+        "filter": {"must": [
+            {"key": "case_slug", "match": {"value": case_slug}}
+        ]},
+    }
+    req = urllib.request.Request(
+        f"{_qdrant_url()}/collections/{QDRANT_COLLECTION}/points/delete?wait=true",
+        data=json.dumps(body).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            resp.read()
+    except Exception as exc:
+        logger.warning("qdrant_delete_failed err=%s", str(exc)[:200])
+        return 0
+    post = _count_qdrant_points(case_slug)
+    return max(0, pre - post)
+
+
+# ─── CLI ──────────────────────────────────────────────────────────────────
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Case-scoped vault ingestion into legal.vault_documents",
+    )
+    p.add_argument("--case-slug", required=True)
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--limit", type=int, default=None,
+                   help="cap on unique physical files processed")
+    p.add_argument("--rollback", action="store_true",
+                   help="delete vault_documents rows + Qdrant points for the case")
+    p.add_argument("--max-file-size-mb", type=int, default=DEFAULT_MAX_FILE_SIZE_MB)
+    p.add_argument("--jobs", type=int, default=DEFAULT_JOBS,
+                   help="bounded concurrency for per-file processing")
+    p.add_argument(
+        "--skip-status", default=",".join(TERMINAL_STATUSES_FOR_RESUME),
+        help="comma-separated processing_status values to skip on re-run "
+             "(default: complete,completed,ocr_failed,locked_privileged)",
+    )
+    p.add_argument("--resume", action="store_true", default=True,
+                   help="skip files whose row already has a terminal status (default on)")
+    p.add_argument("--no-resume", dest="resume", action="store_false")
+    p.add_argument("--force", action="store_true",
+                   help="override stale lock (>6h) or skip rollback confirmation prompt")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    _ensure_env_loaded()
+    args = _parse_args(argv)
+
+    if args.rollback:
+        return run_rollback(args)
+
+    try:
+        return run_ingestion(args)
+    except PreflightError as exc:
+        print(f"PREFLIGHT FAILED: {exc}", file=sys.stderr, flush=True)
+        return 3
+    except KeyboardInterrupt:
+        print("\n# interrupted by operator — in-flight rows left for resume",
+              file=sys.stderr, flush=True)
+        return 130
+    except Exception as exc:
+        traceback.print_exc()
+        print(f"FATAL: {type(exc).__name__}:{exc!s}", file=sys.stderr, flush=True)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fortress-guest-platform/backend/tests/test_vault_ingest_legal_case.py
+++ b/fortress-guest-platform/backend/tests/test_vault_ingest_legal_case.py
@@ -1,0 +1,895 @@
+"""Tests for backend.scripts.vault_ingest_legal_case.
+
+DB connections (`_connect`) and the canonical pipeline (`process_vault_upload`)
+are mocked. NAS files are real synthetic PDFs in tmp_path. IngestRunTracker
+is patched to a trivial recorder so we can assert lifecycle behavior without
+touching legal.ingest_runs.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+import run  # noqa: F401  registers backend.* path
+from backend.scripts import vault_ingest_legal_case as vil
+
+
+# ─── synthetic PDF fixtures ──────────────────────────────────────────────
+
+
+def _text_pdf(path: Path, body: str = "Hello world. " * 50) -> Path:
+    from reportlab.pdfgen import canvas
+    c = canvas.Canvas(str(path))
+    text = c.beginText(40, 750)
+    for line in body.splitlines() or [body]:
+        text.textLine(line[:90])
+    c.drawText(text)
+    c.showPage()
+    c.save()
+    return path
+
+
+def _image_only_pdf(path: Path) -> Path:
+    from PIL import Image, ImageDraw
+    img = Image.new("RGB", (800, 1000), "white")
+    ImageDraw.Draw(img).rectangle([100, 100, 400, 400], fill="black")
+    img.save(path, "PDF")
+    return path
+
+
+def _corrupt_pdf(path: Path) -> Path:
+    path.write_bytes(b"%PDF-1.4\nthis is not a real pdf\n%%EOF")
+    return path
+
+
+# ─── DB connection mock ──────────────────────────────────────────────────
+
+
+class _MockCursor:
+    """Cursor that returns canned answers based on regex match on the SQL."""
+
+    def __init__(self, registry: list, dbname: str) -> None:
+        self._registry = registry
+        self._dbname = dbname
+        self._last_result: list = []
+        self.rowcount = 0
+        self.executed: list[tuple[str, tuple]] = []
+
+    def execute(self, sql: str, params=()):
+        self.executed.append((sql, tuple(params or ())))
+        for matcher, handler in self._registry:
+            if matcher(self._dbname, sql, params):
+                self._last_result, self.rowcount = handler(self._dbname, sql, params)
+                return
+        self._last_result = []
+        self.rowcount = 0
+
+    def fetchone(self):
+        return self._last_result[0] if self._last_result else None
+
+    def fetchall(self):
+        return list(self._last_result)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class _MockConn:
+    def __init__(self, registry: list, dbname: str) -> None:
+        self._registry = registry
+        self._dbname = dbname
+        self.autocommit = True
+        self.executed_cursors: list[_MockCursor] = []
+
+    def cursor(self):
+        c = _MockCursor(self._registry, self._dbname)
+        self.executed_cursors.append(c)
+        return c
+
+    def close(self):
+        pass
+
+
+def _build_connect(registry: list):
+    """Return a function-shaped replacement for vil._connect."""
+
+    def _connect(dbname: str):
+        return _MockConn(registry, dbname)
+
+    return _connect
+
+
+def _layout_with_subdirs(root: Path, subdirs: dict[str, str], recursive: bool = True):
+    return {"root": root, "subdirs": subdirs, "recursive": recursive}
+
+
+def _registry_full_preflight_pass(case_slug: str, layout: dict):
+    """Builds a registry that lets every preflight gate pass and lets
+    _check_existing_row return None (= no existing row)."""
+    reg: list = []
+
+    def _is_legal_cases(db, sql, params):
+        return "legal.cases" in sql and "nas_layout" in sql
+
+    def _legal_cases_handler(db, sql, params):
+        return [({
+            "root": str(layout["root"]),
+            "subdirs": layout["subdirs"],
+            "recursive": layout["recursive"],
+        },)], 1
+
+    reg.append((_is_legal_cases, _legal_cases_handler))
+
+    def _is_select_1(db, sql, params):
+        return sql.strip().upper().startswith("SELECT 1")
+
+    reg.append((_is_select_1, lambda *_: ([(1,)], 1)))
+
+    def _is_ingest_runs_insert(db, sql, params):
+        return "INSERT INTO legal.ingest_runs" in sql and "RETURNING id" in sql
+
+    reg.append((_is_ingest_runs_insert, lambda *_: ([("00000000-0000-0000-0000-000000000000",)], 1)))
+
+    def _is_ingest_runs_delete(db, sql, params):
+        return "DELETE FROM legal.ingest_runs" in sql
+
+    reg.append((_is_ingest_runs_delete, lambda *_: ([], 1)))
+
+    def _is_constraints_lookup(db, sql, params):
+        return "pg_constraint" in sql and "legal.vault_documents" in sql
+
+    def _constraints_handler(db, sql, params):
+        return [
+            ("fk_vault_documents_case_slug",),
+            ("uq_vault_documents_case_hash",),
+            ("chk_vault_documents_status",),
+        ], 3
+
+    reg.append((_is_constraints_lookup, _constraints_handler))
+
+    def _is_vault_doc_lookup(db, sql, params):
+        return ("FROM legal.vault_documents" in sql
+                and "processing_status" in sql
+                and "WHERE case_slug" in sql
+                and "INSERT" not in sql
+                and "DELETE" not in sql)
+
+    reg.append((_is_vault_doc_lookup, lambda *_: ([], 0)))
+
+    def _is_count_vault(db, sql, params):
+        return "SELECT count(*)" in sql and "vault_documents" in sql
+
+    reg.append((_is_count_vault, lambda *_: ([(0,)], 1)))
+
+    def _is_delete_vault(db, sql, params):
+        return "DELETE FROM legal.vault_documents" in sql
+
+    reg.append((_is_delete_vault, lambda *_: ([], 0)))
+
+    return reg
+
+
+# ─── Qdrant mock ─────────────────────────────────────────────────────────
+
+
+class _FakeQdrantUrlopen:
+    """Replaces urllib.request.urlopen for Qdrant HTTP. Default OK."""
+
+    def __init__(self, *,
+                 collection_ok: bool = True,
+                 vector_size: int = vil.EXPECTED_VECTOR_SIZE,
+                 count: int = 0):
+        self.collection_ok = collection_ok
+        self.vector_size = vector_size
+        self.count = count
+        self.calls: list[str] = []
+
+    def __call__(self, req, timeout=None):
+        url = req if isinstance(req, str) else req.full_url
+        self.calls.append(url)
+        body: dict
+        if "/collections/" in url and "/points" not in url:
+            if not self.collection_ok:
+                import urllib.error
+                raise urllib.error.HTTPError(
+                    url, 404, "not found", {}, None,  # type: ignore[arg-type]
+                )
+            body = {"result": {"config": {"params": {
+                "vectors": {"size": self.vector_size}
+            }}}}
+        elif "/points/count" in url:
+            body = {"result": {"count": self.count}}
+        elif "/points/delete" in url:
+            body = {"result": {"operation_id": 1, "status": "completed"}}
+        else:
+            body = {"result": {}}
+
+        class _Resp:
+            def __init__(self, payload):
+                self._payload = payload
+
+            def read(self):
+                return json.dumps(self._payload).encode("utf-8")
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+        return _Resp(body)
+
+
+# ─── tracker mock ────────────────────────────────────────────────────────
+
+
+class _FakeTracker:
+    """Records the lifecycle without touching the DB."""
+
+    instances: list["_FakeTracker"] = []
+
+    def __init__(self, case_slug: str, script_name: str, args=None) -> None:
+        self.case_slug = case_slug
+        self.script_name = script_name
+        self.args = args or {}
+        self.run_id = "fake-run-id"
+        self.processed = 0
+        self.errored = 0
+        self.skipped = 0
+        self.total_files: int | None = None
+        self.manifest_path: str | None = None
+        self.exit_status: str = "running"
+        type(self).instances.append(self)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        if exc_type is None:
+            self.exit_status = "complete"
+        elif issubclass(exc_type, KeyboardInterrupt):
+            self.exit_status = "interrupted"
+            return False
+        else:
+            self.exit_status = "error"
+            return False
+        return False
+
+    def set_total_files(self, n):
+        self.total_files = int(n)
+
+    def set_manifest_path(self, p):
+        self.manifest_path = str(p)
+
+    def inc_processed(self, n=1):
+        self.processed += n
+
+    def inc_errored(self, n=1):
+        self.errored += n
+
+    def inc_skipped(self, n=1):
+        self.skipped += n
+
+
+# ─── fixture: env + mocks ────────────────────────────────────────────────
+
+
+@pytest.fixture
+def env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("POSTGRES_ADMIN_URI",
+                       "postgresql://test:test@127.0.0.1:5432/fortress_test")
+    monkeypatch.setenv("QDRANT_URL", "http://127.0.0.1:6333")
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_tracker_instances():
+    _FakeTracker.instances = []
+    yield
+
+
+# ─── helper: run main() with all the mocks ───────────────────────────────
+
+
+def _run_main(
+    *,
+    monkeypatch: pytest.MonkeyPatch,
+    case_slug: str,
+    layout: dict,
+    upload_results: dict[str, dict],   # filename -> result dict
+    extra_argv: list[str] | None = None,
+    pre_existing_rows: dict[str, str] | None = None,  # file_hash -> status
+    qdrant: _FakeQdrantUrlopen | None = None,
+    upload_side_effect: Callable | None = None,
+    audit_dir: Path | None = None,
+    tmp_path: Path | None = None,
+    fail_constraint: bool = False,
+):
+    pre_existing_rows = pre_existing_rows or {}
+    qdrant = qdrant or _FakeQdrantUrlopen()
+    registry = _registry_full_preflight_pass(case_slug, layout)
+
+    if fail_constraint:
+        registry = [
+            (m, h if "pg_constraint" not in str(m) else (lambda *_: ([], 0)))
+            for m, h in registry
+        ]
+        registry = [
+            (m, (lambda *_: ([], 0)) if "pg_constraint" in m.__code__.co_consts.__repr__() else h)
+            for m, h in registry
+        ]
+
+    if pre_existing_rows:
+        # override the vault_doc lookup to return seeded statuses
+        def _seeded_vault_lookup(db, sql, params):
+            file_hash = params[1] if len(params) >= 2 else ""
+            status = pre_existing_rows.get(file_hash)
+            return ([(status,)], 1) if status else ([], 0)
+
+        registry = [
+            r for r in registry
+            if not (r[0].__name__ == "_is_vault_doc_lookup")
+        ]
+        registry.append((
+            lambda db, sql, params: ("FROM legal.vault_documents" in sql
+                                     and "processing_status" in sql
+                                     and "WHERE case_slug" in sql
+                                     and "INSERT" not in sql
+                                     and "DELETE" not in sql),
+            _seeded_vault_lookup,
+        ))
+
+    monkeypatch.setattr(vil, "_connect", _build_connect(registry))
+    import urllib.request as _ur
+    monkeypatch.setattr(_ur, "urlopen", qdrant)
+    monkeypatch.setattr(
+        "backend.services.ingest_run_tracker.IngestRunTracker", _FakeTracker,
+    )
+    if audit_dir is not None:
+        monkeypatch.setattr(vil, "AUDIT_DIR", audit_dir)
+    if tmp_path is not None:
+        monkeypatch.setattr(
+            vil, "_lock_path",
+            lambda slug: tmp_path / f"vault-ingest-{slug}.lock",
+        )
+
+    async def _fake_upload(*, db, case_slug, file_bytes, file_name, mime_type):
+        if upload_side_effect:
+            return await upload_side_effect(file_name)
+        result = upload_results.get(file_name) or upload_results.get("__default__")
+        if result is None:
+            return {"status": "completed", "document_id": f"id-{file_name}",
+                    "chunks": 1, "vectors_indexed": 1}
+        return result
+
+    class _FakeAsyncSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    monkeypatch.setattr(
+        "backend.core.database.AsyncSessionLocal",
+        lambda: _FakeAsyncSession(),
+    )
+    monkeypatch.setattr(
+        "backend.services.legal_ediscovery.process_vault_upload",
+        _fake_upload,
+    )
+
+    # Mirror writer needs to find the row in fortress_prod after upload — fold
+    # the canonical row into the registry on demand.
+    inserted_rows: dict[str, tuple] = {}
+
+    def _fake_mirror(*, case_slug, doc_id):
+        inserted_rows[doc_id] = (case_slug, doc_id)
+
+    monkeypatch.setattr(vil, "_mirror_row_to_fortress_db", _fake_mirror)
+
+    argv = ["--case-slug", case_slug] + (extra_argv or [])
+    rc = vil.main(argv)
+    return rc, inserted_rows
+
+
+# ─── 1. clean run ────────────────────────────────────────────────────────
+
+
+def test_clean_run_processes_all_files(env, monkeypatch, tmp_path):
+    case = "clean-run"
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    a = _text_pdf(docs / "a.pdf", "First file " * 80)
+    b = _text_pdf(docs / "b.pdf", "Second file " * 80)
+    layout = _layout_with_subdirs(tmp_path, {"docs": "docs"})
+
+    rc, _ = _run_main(
+        monkeypatch=monkeypatch, case_slug=case, layout=layout,
+        upload_results={
+            a.name: {"status": "completed", "document_id": "id-a",
+                     "chunks": 3, "vectors_indexed": 3},
+            b.name: {"status": "completed", "document_id": "id-b",
+                     "chunks": 2, "vectors_indexed": 2},
+        },
+        extra_argv=["--jobs", "1"],
+        audit_dir=tmp_path / "audits", tmp_path=tmp_path,
+    )
+
+    assert rc == 0
+    mfs = list((tmp_path / "audits").glob(f"vault-ingest-{case}-*.json"))
+    assert len(mfs) == 1
+    m = json.loads(mfs[0].read_text())
+    assert m["total_unique_files"] == 2
+    assert m["processed"] == 2
+    assert m["by_status"]["completed"] == 2
+    assert m["vault_documents_inserted"] == 2
+    assert m["qdrant_points_estimate"] == 5
+    assert _FakeTracker.instances[0].exit_status == "complete"
+
+
+# ─── 2. idempotency ──────────────────────────────────────────────────────
+
+
+def test_idempotency_second_run_skips_completed(env, monkeypatch, tmp_path):
+    case = "idem"
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    pdf = _text_pdf(docs / "x.pdf", "abc " * 200)
+    fhash = vil.file_sha256(pdf)
+    layout = _layout_with_subdirs(tmp_path, {"docs": "docs"})
+
+    rc, _ = _run_main(
+        monkeypatch=monkeypatch, case_slug=case, layout=layout,
+        upload_results={"__default__": {"status": "completed",
+                                         "document_id": "id-x",
+                                         "chunks": 1, "vectors_indexed": 1}},
+        pre_existing_rows={fhash: "completed"},
+        extra_argv=["--jobs", "1"],
+        audit_dir=tmp_path / "audits", tmp_path=tmp_path,
+    )
+
+    assert rc == 0
+    m = json.loads(next((tmp_path / "audits").glob(f"vault-ingest-{case}-*.json")).read_text())
+    assert m["skipped"] == 1
+    assert m["processed"] == 0
+
+
+# ─── 3. physical-path dedup over dual-listed subdirs ────────────────────
+
+
+def test_physical_path_dedup_handles_dual_listed_subdirs(env, monkeypatch, tmp_path):
+    """Two logical subdirs pointing at the same physical directory; the same
+    PDFs must be processed exactly once each."""
+    case = "dual"
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    _text_pdf(shared / "a.pdf", "A " * 80)
+    _text_pdf(shared / "b.pdf", "B " * 80)
+    layout = _layout_with_subdirs(
+        tmp_path,
+        {"correspondence": "shared", "certified_mail": "shared"},
+        recursive=False,
+    )
+
+    rc, _ = _run_main(
+        monkeypatch=monkeypatch, case_slug=case, layout=layout,
+        upload_results={"__default__": {"status": "completed",
+                                         "document_id": "id-shared",
+                                         "chunks": 1, "vectors_indexed": 1}},
+        extra_argv=["--jobs", "1"],
+        audit_dir=tmp_path / "audits", tmp_path=tmp_path,
+    )
+    assert rc == 0
+    m = json.loads(next((tmp_path / "audits").glob(f"vault-ingest-{case}-*.json")).read_text())
+    # Each physical file once, despite being referenced by two logical subdirs.
+    assert m["total_unique_files"] == 2
+    assert m["processed"] == 2
+
+
+# ─── 4. ocr_failed classification ────────────────────────────────────────
+
+
+def test_ocr_failed_classification(env, monkeypatch, tmp_path):
+    case = "ocrfail"
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    _image_only_pdf(docs / "img.pdf")
+    layout = _layout_with_subdirs(tmp_path, {"docs": "docs"})
+
+    rc, _ = _run_main(
+        monkeypatch=monkeypatch, case_slug=case, layout=layout,
+        upload_results={"img.pdf": {"status": "ocr_failed",
+                                      "document_id": "id-img"}},
+        extra_argv=["--jobs", "1"],
+        audit_dir=tmp_path / "audits", tmp_path=tmp_path,
+    )
+    assert rc == 0
+    m = json.loads(next((tmp_path / "audits").glob(f"vault-ingest-{case}-*.json")).read_text())
+    assert m["by_status"]["ocr_failed"] == 1
+    assert m["qdrant_points_estimate"] == 0
+    assert m["vault_documents_inserted"] == 1
+
+
+# ─── 5. corrupt file logs error, sweep continues ────────────────────────
+
+
+def test_corrupt_file_logs_error_continues(env, monkeypatch, tmp_path):
+    case = "corrupt"
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    _text_pdf(docs / "ok.pdf", "good " * 100)
+    _corrupt_pdf(docs / "bad.pdf")
+    layout = _layout_with_subdirs(tmp_path, {"docs": "docs"})
+
+    async def _maybe_fail(file_name):
+        if "bad" in file_name:
+            raise RuntimeError("synthetic upload failure")
+        return {"status": "completed", "document_id": f"id-{file_name}",
+                "chunks": 1, "vectors_indexed": 1}
+
+    rc, _ = _run_main(
+        monkeypatch=monkeypatch, case_slug=case, layout=layout,
+        upload_results={}, upload_side_effect=_maybe_fail,
+        extra_argv=["--jobs", "1"],
+        audit_dir=tmp_path / "audits", tmp_path=tmp_path,
+    )
+    assert rc == 1   # errored count > 0 → non-zero exit
+    m = json.loads(next((tmp_path / "audits").glob(f"vault-ingest-{case}-*.json")).read_text())
+    assert m["errored"] == 1
+    assert m["processed"] == 1
+    assert m["errors"][0]["error"].startswith("RuntimeError")
+
+
+# ─── 6. max file size ───────────────────────────────────────────────────
+
+
+def test_max_file_size_skip(env, monkeypatch, tmp_path):
+    case = "size"
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    huge = _text_pdf(docs / "huge.pdf", "X" * 1000)
+    layout = _layout_with_subdirs(tmp_path, {"docs": "docs"})
+
+    # Force max-file-size-mb=0 to make every file "too big".
+    rc, _ = _run_main(
+        monkeypatch=monkeypatch, case_slug=case, layout=layout,
+        upload_results={huge.name: {"status": "completed", "document_id": "x",
+                                     "chunks": 1, "vectors_indexed": 1}},
+        extra_argv=["--jobs", "1", "--max-file-size-mb", "0"],
+        audit_dir=tmp_path / "audits", tmp_path=tmp_path,
+    )
+    assert rc == 0
+    m = json.loads(next((tmp_path / "audits").glob(f"vault-ingest-{case}-*.json")).read_text())
+    assert m["skipped"] == 1
+    assert m["processed"] == 0
+
+
+# ─── 7. dry run ──────────────────────────────────────────────────────────
+
+
+def test_dry_run_no_writes(env, monkeypatch, tmp_path):
+    case = "dry"
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    _text_pdf(docs / "a.pdf", "txt " * 100)
+    layout = _layout_with_subdirs(tmp_path, {"docs": "docs"})
+
+    upload_called = {"n": 0}
+
+    async def _track_call(file_name):
+        upload_called["n"] += 1
+        return {"status": "completed", "document_id": "x",
+                "chunks": 1, "vectors_indexed": 1}
+
+    rc, _ = _run_main(
+        monkeypatch=monkeypatch, case_slug=case, layout=layout,
+        upload_results={}, upload_side_effect=_track_call,
+        extra_argv=["--jobs", "1", "--dry-run"],
+        audit_dir=tmp_path / "audits", tmp_path=tmp_path,
+    )
+    assert rc == 0
+    assert upload_called["n"] == 0
+    m = json.loads(next((tmp_path / "audits").glob(f"vault-ingest-{case}-*.json")).read_text())
+    assert m["skipped"] == 1
+    assert m["processed"] == 0
+
+
+# ─── 8. lock file ────────────────────────────────────────────────────────
+
+
+def test_lock_file_prevents_concurrent_runs(env, monkeypatch, tmp_path):
+    case = "locked"
+    monkeypatch.setattr(
+        vil, "_lock_path",
+        lambda slug: tmp_path / f"vault-ingest-{slug}.lock",
+    )
+    (tmp_path / f"vault-ingest-{case}.lock").write_text("99999\nstamp\n")
+    with pytest.raises(SystemExit) as ei:
+        vil.acquire_lock(case, force=False)
+    assert "another vault ingest" in str(ei.value)
+
+
+# ─── 9. preflight failure → no audit row ─────────────────────────────────
+
+
+def test_pre_flight_failure_no_audit_row(env, monkeypatch, tmp_path):
+    case = "missing-case"
+    layout = _layout_with_subdirs(tmp_path, {"docs": "docs"})
+
+    # Build a registry that returns nothing for legal.cases (case not found).
+    reg = _registry_full_preflight_pass(case, layout)
+    reg = [
+        (m, (lambda *_: ([], 0)) if m.__name__ == "_is_legal_cases" else h)
+        for m, h in reg
+    ]
+    monkeypatch.setattr(vil, "_connect", _build_connect(reg))
+    monkeypatch.setattr(
+        "backend.services.ingest_run_tracker.IngestRunTracker", _FakeTracker,
+    )
+    monkeypatch.setattr(vil, "AUDIT_DIR", tmp_path / "audits")
+    monkeypatch.setattr(
+        vil, "_lock_path",
+        lambda slug: tmp_path / f"vault-ingest-{slug}.lock",
+    )
+
+    rc = vil.main(["--case-slug", case])
+    assert rc == 3   # PreflightError exit
+    assert _FakeTracker.instances == []   # tracker never opened
+
+
+# ─── 10. KeyboardInterrupt → tracker marks interrupted ──────────────────
+
+
+def test_keyboard_interrupt_marks_run_interrupted(env, monkeypatch, tmp_path):
+    case = "interrupt"
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    _text_pdf(docs / "a.pdf", "abc " * 100)
+    layout = _layout_with_subdirs(tmp_path, {"docs": "docs"})
+
+    async def _kaboom(file_name):
+        raise KeyboardInterrupt()
+
+    rc, _ = _run_main(
+        monkeypatch=monkeypatch, case_slug=case, layout=layout,
+        upload_results={}, upload_side_effect=_kaboom,
+        extra_argv=["--jobs", "1"],
+        audit_dir=tmp_path / "audits", tmp_path=tmp_path,
+    )
+    assert rc == 130
+    assert _FakeTracker.instances[0].exit_status == "interrupted"
+
+
+# ─── 11. resume completes pending rows ──────────────────────────────────
+
+
+def test_resume_completes_pending_rows(env, monkeypatch, tmp_path):
+    """A row in 'pending' must NOT be skipped on resume — it should be
+    re-processed."""
+    case = "resume"
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    pdf = _text_pdf(docs / "p.pdf", "pending " * 100)
+    fhash = vil.file_sha256(pdf)
+    layout = _layout_with_subdirs(tmp_path, {"docs": "docs"})
+
+    rc, _ = _run_main(
+        monkeypatch=monkeypatch, case_slug=case, layout=layout,
+        upload_results={"__default__": {"status": "completed",
+                                         "document_id": "id-p",
+                                         "chunks": 1, "vectors_indexed": 1}},
+        pre_existing_rows={fhash: "pending"},
+        extra_argv=["--jobs", "1"],
+        audit_dir=tmp_path / "audits", tmp_path=tmp_path,
+    )
+    assert rc == 0
+    m = json.loads(next((tmp_path / "audits").glob(f"vault-ingest-{case}-*.json")).read_text())
+    assert m["processed"] == 1
+    assert m["skipped"] == 0
+
+
+# ─── 12. rollback deletes postgres + qdrant ─────────────────────────────
+
+
+def test_rollback_deletes_postgres_and_qdrant(env, monkeypatch, tmp_path):
+    case = "rb"
+    layout = _layout_with_subdirs(tmp_path, {"docs": "docs"})
+    reg = _registry_full_preflight_pass(case, layout)
+
+    counts = {"prod": 5, "db": 5}
+
+    def _is_count_vault_local(db, sql, params):
+        return "SELECT count(*)" in sql and "vault_documents" in sql
+
+    def _count_handler(db, sql, params):
+        if db == "fortress_prod":
+            return [(counts["prod"],)], 1
+        if db == "fortress_db":
+            return [(counts["db"],)], 1
+        return [(0,)], 1
+
+    reg = [(m, h) for m, h in reg if m.__name__ != "_is_count_vault"]
+    reg.append((_is_count_vault_local, _count_handler))
+
+    def _is_delete_local(db, sql, params):
+        return "DELETE FROM legal.vault_documents" in sql
+
+    def _delete_handler(db, sql, params):
+        if db == "fortress_prod":
+            counts["prod"] = 0
+            return [], 5
+        if db == "fortress_db":
+            counts["db"] = 0
+            return [], 5
+        return [], 0
+
+    reg = [(m, h) for m, h in reg if m.__name__ != "_is_delete_vault"]
+    reg.append((_is_delete_local, _delete_handler))
+
+    monkeypatch.setattr(vil, "_connect", _build_connect(reg))
+    monkeypatch.setattr(
+        "backend.services.ingest_run_tracker.IngestRunTracker", _FakeTracker,
+    )
+
+    qd = _FakeQdrantUrlopen(count=10)
+
+    def _qd_then_zero(req, timeout=None):
+        url = req if isinstance(req, str) else req.full_url
+        # Delete should drop the count to 0 on the next count call.
+        if "/points/delete" in url:
+            qd.count = 0
+        return qd(req, timeout=timeout)
+
+    import urllib.request as _ur
+    monkeypatch.setattr(_ur, "urlopen", _qd_then_zero)
+    monkeypatch.setattr(vil, "AUDIT_DIR", tmp_path / "audits")
+
+    rc = vil.main(["--case-slug", case, "--rollback", "--force"])
+    assert rc == 0
+    mfs = list((tmp_path / "audits").glob(f"vault-rollback-{case}-*.json"))
+    assert len(mfs) == 1
+    m = json.loads(mfs[0].read_text())
+    assert m["operation"] == "rollback"
+    assert m["pre_counts"]["fortress_prod"] == 5
+    assert m["pre_counts"]["fortress_db"] == 5
+    assert m["pre_counts"]["qdrant"] == 10
+    assert m["post_counts"] == {"fortress_prod": 0, "fortress_db": 0, "qdrant": 0}
+
+
+# ─── 13. rollback requires confirmation ─────────────────────────────────
+
+
+def test_rollback_requires_confirmation_unless_force(env, monkeypatch, tmp_path):
+    case = "rb-confirm"
+    layout = _layout_with_subdirs(tmp_path, {"docs": "docs"})
+    reg = _registry_full_preflight_pass(case, layout)
+    monkeypatch.setattr(vil, "_connect", _build_connect(reg))
+    monkeypatch.setattr(
+        "backend.services.ingest_run_tracker.IngestRunTracker", _FakeTracker,
+    )
+    import urllib.request as _ur
+    monkeypatch.setattr(_ur, "urlopen", _FakeQdrantUrlopen())
+    monkeypatch.setattr(vil, "AUDIT_DIR", tmp_path / "audits")
+
+    monkeypatch.setattr("builtins.input", lambda *_: "wrong-answer")
+    rc = vil.main(["--case-slug", case, "--rollback"])
+    assert rc == 2
+    assert _FakeTracker.instances == []   # tracker never opened
+
+
+# ─── 14. manifest schema complete ───────────────────────────────────────
+
+
+def test_manifest_schema_complete(env, monkeypatch, tmp_path):
+    case = "schema"
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    _text_pdf(docs / "z.pdf", "ZZZ " * 100)
+    layout = _layout_with_subdirs(tmp_path, {"docs": "docs"})
+
+    _run_main(
+        monkeypatch=monkeypatch, case_slug=case, layout=layout,
+        upload_results={"__default__": {"status": "completed",
+                                         "document_id": "id-z",
+                                         "chunks": 1, "vectors_indexed": 1}},
+        extra_argv=["--jobs", "1"],
+        audit_dir=tmp_path / "audits", tmp_path=tmp_path,
+    )
+    m = json.loads(next((tmp_path / "audits").glob(f"vault-ingest-{case}-*.json")).read_text())
+    for required_key in (
+        "case_slug", "started_at", "finished_at", "runtime_seconds", "args",
+        "host", "pid", "ingest_run_id", "layout_root", "layout_recursive",
+        "layout_subdirs", "total_unique_files", "processed", "skipped",
+        "errored", "by_status", "by_logical_subdir", "by_mime_type",
+        "errors", "qdrant_points_estimate", "vault_documents_inserted",
+    ):
+        assert required_key in m, f"manifest missing {required_key}"
+
+
+# ─── 15. qdrant failure leaves status=pending behavior ──────────────────
+
+
+def test_qdrant_failure_leaves_pending_status_for_retry(env, monkeypatch, tmp_path):
+    """When Qdrant returns 0 indexed, process_vault_upload still marks the row
+    'completed' (per design — operators triage by vectors_indexed=0). The script
+    surfaces this in the manifest so a follow-up run can target re-vectorize."""
+    case = "qdfail"
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    _text_pdf(docs / "q.pdf", "x " * 100)
+    layout = _layout_with_subdirs(tmp_path, {"docs": "docs"})
+
+    rc, _ = _run_main(
+        monkeypatch=monkeypatch, case_slug=case, layout=layout,
+        upload_results={"__default__": {
+            "status": "completed", "document_id": "id-q",
+            "chunks": 3, "vectors_indexed": 0,
+        }},
+        extra_argv=["--jobs", "1"],
+        audit_dir=tmp_path / "audits", tmp_path=tmp_path,
+    )
+    assert rc == 0
+    m = json.loads(next((tmp_path / "audits").glob(f"vault-ingest-{case}-*.json")).read_text())
+    assert m["qdrant_points_estimate"] == 0
+    assert m["by_status"]["completed"] == 1
+
+
+# ─── 16. privilege filter marks locked_privileged ───────────────────────
+
+
+def test_privilege_filter_marks_locked_privileged(env, monkeypatch, tmp_path):
+    case = "priv"
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    _text_pdf(docs / "priv.pdf", "Attorney-client privileged " * 50)
+    layout = _layout_with_subdirs(tmp_path, {"docs": "docs"})
+
+    rc, _ = _run_main(
+        monkeypatch=monkeypatch, case_slug=case, layout=layout,
+        upload_results={"priv.pdf": {
+            "status": "locked_privileged", "document_id": "id-priv",
+        }},
+        extra_argv=["--jobs", "1"],
+        audit_dir=tmp_path / "audits", tmp_path=tmp_path,
+    )
+    assert rc == 0
+    m = json.loads(next((tmp_path / "audits").glob(f"vault-ingest-{case}-*.json")).read_text())
+    assert m["by_status"]["locked_privileged"] == 1
+    assert m["qdrant_points_estimate"] == 0
+    # privilege rows still count toward vault_documents_inserted (visible in UI)
+    assert m["vault_documents_inserted"] == 1
+
+
+# ─── 17. dual-DB write ──────────────────────────────────────────────────
+
+
+def test_writes_to_both_fortress_prod_and_fortress_db(env, monkeypatch, tmp_path):
+    """Verify _mirror_row_to_fortress_db is called once per successful upload."""
+    case = "dual-db"
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    _text_pdf(docs / "a.pdf", "x " * 100)
+    _text_pdf(docs / "b.pdf", "y " * 100)
+    layout = _layout_with_subdirs(tmp_path, {"docs": "docs"})
+
+    rc, mirrored = _run_main(
+        monkeypatch=monkeypatch, case_slug=case, layout=layout,
+        upload_results={
+            "a.pdf": {"status": "completed", "document_id": "id-a",
+                      "chunks": 1, "vectors_indexed": 1},
+            "b.pdf": {"status": "completed", "document_id": "id-b",
+                      "chunks": 1, "vectors_indexed": 1},
+        },
+        extra_argv=["--jobs", "1"],
+        audit_dir=tmp_path / "audits", tmp_path=tmp_path,
+    )
+    assert rc == 0
+    assert set(mirrored.keys()) == {"id-a", "id-b"}
+    for case_key, _ in mirrored.values():
+        assert case_key == case

--- a/fortress-guest-platform/ci/schema.meta.json
+++ b/fortress-guest-platform/ci/schema.meta.json
@@ -1,10 +1,10 @@
 {
   "alembic_revisions": [
-    "l7e8f1a2b3c4",
+    "d8e3c1f5b9a6",
     "m8f9a1b2c3d4"
   ],
-  "alembic_versions_tree": "19a9e113b6d359f230e9e415dca9b99c004a1360",
-  "generated_at": "2026-04-22T14:00:00Z",
-  "source_db": "fortress_shadow",
-  "source_commit": "66735d72d"
+  "alembic_versions_tree": "4f5530e508f25809702a78b237988a2c1224b2d4",
+  "generated_at": "2026-04-25T12:12:32Z",
+  "source_db": "fortress_db",
+  "source_commit": "13866efa658ffe2950593d1e8a48dec8ca691608"
 }

--- a/fortress-guest-platform/ci/schema.sql
+++ b/fortress-guest-platform/ci/schema.sql
@@ -1,8 +1,8 @@
 -- CI schema snapshot for fortress-guest-platform
--- Generated: 2026-04-21T02:49:45Z
--- Source:    fortress_shadow
--- Commit:    3446e105817985d0c870aad9a782c12f06a5d862
--- Alembic:   l7e8f1a2b3c4
+-- Generated: 2026-04-25T12:12:32Z
+-- Source:    fortress_db
+-- Commit:    13866efa658ffe2950593d1e8a48dec8ca691608
+-- Alembic:   d8e3c1f5b9a6,m8f9a1b2c3d4
 -- NOTE: geometry/vector types replaced with text for CI compatibility.
 --       postgis/vector extensions omitted (postgres:16 has pgcrypto/uuid-ossp).
 
@@ -18,7 +18,7 @@ SET ROLE TO fortress_admin;
 -- PostgreSQL database dump
 --
 
-\restrict FdO3Ro8PL5WgXQeaZzwcBMCxYm7tASohFPK6iWWOA4tAqKqVEW35qN3uEPfbMbp
+\restrict VUrcdL6h86Va4b8PalMVliVEj9OibDpqKcdRaRctoyg85SNJEnJ3GJKYJj1pYCh
 
 -- Dumped from database version 16.13 (Ubuntu 16.13-0ubuntu0.24.04.1)
 -- Dumped by pg_dump version 16.13 (Ubuntu 16.13-0ubuntu0.24.04.1)
@@ -35,24 +35,45 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
--- Name: core; Type: SCHEMA; Schema: -; Owner: -
+-- Name: division_a; Type: SCHEMA; Schema: -; Owner: -
 --
 
-CREATE SCHEMA core;
-
-
---
--- Name: crog_acquisition; Type: SCHEMA; Schema: -; Owner: -
---
-
-CREATE SCHEMA crog_acquisition;
+CREATE SCHEMA division_a;
 
 
 --
--- Name: iot_schema; Type: SCHEMA; Schema: -; Owner: -
+-- Name: division_b; Type: SCHEMA; Schema: -; Owner: -
 --
 
-CREATE SCHEMA iot_schema;
+CREATE SCHEMA division_b;
+
+
+--
+-- Name: engineering; Type: SCHEMA; Schema: -; Owner: -
+--
+
+CREATE SCHEMA engineering;
+
+
+--
+-- Name: finance; Type: SCHEMA; Schema: -; Owner: -
+--
+
+CREATE SCHEMA finance;
+
+
+--
+-- Name: hedge_fund; Type: SCHEMA; Schema: -; Owner: -
+--
+
+CREATE SCHEMA hedge_fund;
+
+
+--
+-- Name: intelligence; Type: SCHEMA; Schema: -; Owner: -
+--
+
+CREATE SCHEMA intelligence;
 
 
 --
@@ -63,17 +84,10 @@ CREATE SCHEMA legal;
 
 
 --
--- Name: verses_schema; Type: SCHEMA; Schema: -; Owner: -
+-- Name: legal_cmd; Type: SCHEMA; Schema: -; Owner: -
 --
 
-CREATE SCHEMA verses_schema;
-
-
---
--- Name: dblink; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS dblink WITH SCHEMA public;
+CREATE SCHEMA legal_cmd;
 
 
 --
@@ -81,12 +95,6 @@ CREATE EXTENSION IF NOT EXISTS dblink WITH SCHEMA public;
 --
 
 CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
-
-
---
--- Name: postgis; Type: EXTENSION; Schema: -; Owner: -
---
-
 
 
 --
@@ -103,364 +111,131 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA public;
 
 
 --
--- Name: funnel_stage; Type: TYPE; Schema: crog_acquisition; Owner: -
+-- Name: update_timestamp(); Type: FUNCTION; Schema: legal_cmd; Owner: -
 --
 
-CREATE TYPE crog_acquisition.funnel_stage AS ENUM (
-    'RADAR',
-    'TARGET_LOCKED',
-    'DEPLOYED',
-    'ENGAGED',
-    'ACQUIRED',
-    'REJECTED'
-);
-
-
---
--- Name: market_state; Type: TYPE; Schema: crog_acquisition; Owner: -
---
-
-CREATE TYPE crog_acquisition.market_state AS ENUM (
-    'UNMANAGED',
-    'CROG_MANAGED',
-    'COMPETITOR_MANAGED',
-    'FOR_SALE'
-);
-
-
---
--- Name: signal_source; Type: TYPE; Schema: crog_acquisition; Owner: -
---
-
-CREATE TYPE crog_acquisition.signal_source AS ENUM (
-    'FOIA_CSV',
-    'OTA_FIRECRAWL_HEURISTIC',
-    'AGGREGATOR_API'
-);
-
-
---
--- Name: guest_quote_status; Type: TYPE; Schema: public; Owner: -
---
-
-CREATE TYPE public.guest_quote_status AS ENUM (
-    'pending',
-    'accepted',
-    'rejected',
-    'expired'
-);
-
-
---
--- Name: hunter_recovery_op_status; Type: TYPE; Schema: public; Owner: -
---
-
-CREATE TYPE public.hunter_recovery_op_status AS ENUM (
-    'QUEUED',
-    'EXECUTING',
-    'DRAFT_READY',
-    'DISPATCHED',
-    'REJECTED'
-);
-
-
---
--- Name: owner_charge_type_enum; Type: TYPE; Schema: public; Owner: -
---
-
-CREATE TYPE public.owner_charge_type_enum AS ENUM (
-    'cleaning_fee',
-    'maintenance',
-    'management_fee',
-    'supplies',
-    'landscaping',
-    'linen',
-    'electric_bill',
-    'housekeeper_pay',
-    'advertising_fee',
-    'third_party_ota_commission',
-    'travel_agent_fee',
-    'credit_card_dispute',
-    'federal_tax_withholding',
-    'adjust_owner_revenue',
-    'credit_from_management',
-    'pay_to_old_owner',
-    'misc_guest_charges',
-    'statement_marker',
-    'room_revenue',
-    'hacienda_tax',
-    'charge_expired_owner',
-    'owner_payment_received'
-);
-
-
---
--- Name: property_renting_state; Type: TYPE; Schema: public; Owner: -
---
-
-CREATE TYPE public.property_renting_state AS ENUM (
-    'active',
-    'pre_launch',
-    'paused',
-    'offboarded'
-);
-
-
---
--- Name: statement_period_status; Type: TYPE; Schema: public; Owner: -
---
-
-CREATE TYPE public.statement_period_status AS ENUM (
-    'draft',
-    'pending_approval',
-    'approved',
-    'paid',
-    'emailed',
-    'voided'
-);
-
-
---
--- Name: prevent_mutation(); Type: FUNCTION; Schema: public; Owner: -
---
-
-CREATE FUNCTION public.prevent_mutation() RETURNS trigger
+CREATE FUNCTION legal_cmd.update_timestamp() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN
-    RAISE EXCEPTION 'Immutable table: UPDATE and DELETE are strictly forbidden on %', TG_TABLE_NAME;
-    RETURN NULL;
+    NEW.updated_at = NOW();
+    RETURN NEW;
 END;
 $$;
+
+
+--
+-- Name: enforce_immutable_line_items(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.enforce_immutable_line_items() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    RAISE EXCEPTION 'FORTRESS PROTOCOL: journal_line_items is append-only. Issue a reversing journal entry via void_entry() instead.';
+END;
+$$;
+
+
+--
+-- Name: enforce_journal_entry_integrity(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.enforce_journal_entry_integrity() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'FORTRESS PROTOCOL: journal_entries cannot be deleted. Use void_entry() to mark entries as void.';
+    END IF;
+
+    IF TG_OP = 'UPDATE' THEN
+        IF OLD.entry_date IS DISTINCT FROM NEW.entry_date
+           OR OLD.description IS DISTINCT FROM NEW.description
+           OR OLD.reference_id IS DISTINCT FROM NEW.reference_id
+           OR OLD.reference_type IS DISTINCT FROM NEW.reference_type
+           OR OLD.property_id IS DISTINCT FROM NEW.property_id
+           OR OLD.posted_by IS DISTINCT FROM NEW.posted_by
+           OR OLD.source_system IS DISTINCT FROM NEW.source_system THEN
+            RAISE EXCEPTION 'FORTRESS PROTOCOL: Financial columns on journal_entries are immutable. Only void-related fields (is_void, void_reason, voided_at, voided_by) may be updated.';
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+
+--
+-- Name: update_updated_at_column(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.update_updated_at_column() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$;
+
+
+--
+-- Name: verify_journal_balance(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.verify_journal_balance() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $_$
+DECLARE
+    total_debits    NUMERIC(15, 2);
+    total_credits   NUMERIC(15, 2);
+BEGIN
+    SELECT
+        COALESCE(SUM(debit), 0),
+        COALESCE(SUM(credit), 0)
+    INTO total_debits, total_credits
+    FROM journal_line_items
+    WHERE journal_entry_id = NEW.journal_entry_id;
+
+    IF total_debits != total_credits THEN
+        RAISE EXCEPTION
+            '[IRON DOME] REJECTED: Entry #% — Debits ($%) != Credits ($%). Delta: $%',
+            NEW.journal_entry_id,
+            total_debits,
+            total_credits,
+            ABS(total_debits - total_credits);
+    END IF;
+
+    RETURN NEW;
+END;
+$_$;
 
 
 SET default_table_access_method = heap;
 
 --
--- Name: deliberation_logs; Type: TABLE; Schema: core; Owner: -
+-- Name: account_mappings; Type: TABLE; Schema: division_a; Owner: -
 --
 
-CREATE TABLE core.deliberation_logs (
-    id uuid NOT NULL,
-    verdict_type character varying(64) NOT NULL,
-    session_id character varying(128) NOT NULL,
-    guest_id uuid,
-    reservation_id uuid,
-    property_id uuid,
-    message_id uuid,
-    payload_json jsonb DEFAULT '{}'::jsonb NOT NULL,
-    created_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: acquisition_documents; Type: TABLE; Schema: crog_acquisition; Owner: -
---
-
-CREATE TABLE crog_acquisition.acquisition_documents (
-    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
-    pipeline_id uuid NOT NULL,
-    file_name character varying(255) NOT NULL,
-    nfs_path text NOT NULL,
-    mime_type character varying(100) DEFAULT 'application/octet-stream'::character varying NOT NULL,
-    file_hash character varying(64),
-    file_size_bytes integer,
-    doc_type character varying(50) DEFAULT 'general'::character varying NOT NULL,
-    uploaded_by character varying(255),
-    created_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
---
--- Name: acquisition_pipeline; Type: TABLE; Schema: crog_acquisition; Owner: -
---
-
-CREATE TABLE crog_acquisition.acquisition_pipeline (
-    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
-    property_id uuid NOT NULL,
-    stage crog_acquisition.funnel_stage DEFAULT 'RADAR'::crog_acquisition.funnel_stage NOT NULL,
-    llm_viability_score numeric(3,2),
-    lob_mail_sent_at timestamp with time zone,
-    instantly_campaign_id character varying(255),
-    vapi_call_status character varying(100),
-    next_action_date date,
-    rejection_reason text,
-    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
-);
-
-
---
--- Name: due_diligence; Type: TABLE; Schema: crog_acquisition; Owner: -
---
-
-CREATE TABLE crog_acquisition.due_diligence (
-    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
-    pipeline_id uuid NOT NULL,
-    item_key character varying(80) NOT NULL,
-    label character varying(255) NOT NULL,
-    display_order integer DEFAULT 0 NOT NULL,
-    status character varying(20) DEFAULT 'pending'::character varying NOT NULL,
-    notes text,
-    completed_at timestamp with time zone,
-    completed_by character varying(255),
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    CONSTRAINT chk_dd_status CHECK (((status)::text = ANY ((ARRAY['pending'::character varying, 'passed'::character varying, 'failed'::character varying, 'waived'::character varying])::text[])))
-);
-
-
---
--- Name: intel_events; Type: TABLE; Schema: crog_acquisition; Owner: -
---
-
-CREATE TABLE crog_acquisition.intel_events (
-    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
-    property_id uuid NOT NULL,
-    event_type character varying(100) NOT NULL,
-    event_description text NOT NULL,
-    raw_source_data jsonb,
-    detected_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
-);
-
-
---
--- Name: owner_contacts; Type: TABLE; Schema: crog_acquisition; Owner: -
---
-
-CREATE TABLE crog_acquisition.owner_contacts (
-    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
-    owner_id uuid NOT NULL,
-    contact_type character varying(50),
-    contact_value character varying(255) NOT NULL,
-    source character varying(100),
-    confidence_score numeric(3,2),
-    is_dnc boolean DEFAULT false NOT NULL,
-    CONSTRAINT ck_acquisition_owner_contacts_confidence_score CHECK (((confidence_score >= 0.00) AND (confidence_score <= 1.00))),
-    CONSTRAINT ck_acquisition_owner_contacts_contact_type CHECK (((contact_type)::text = ANY ((ARRAY['CELL'::character varying, 'LANDLINE'::character varying, 'EMAIL'::character varying])::text[])))
-);
-
-
---
--- Name: owners; Type: TABLE; Schema: crog_acquisition; Owner: -
---
-
-CREATE TABLE crog_acquisition.owners (
-    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
-    legal_name character varying(255) NOT NULL,
-    tax_mailing_address text NOT NULL,
-    primary_residence_state character varying(2),
-    psychological_profile jsonb,
-    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
-);
-
-
---
--- Name: parcels; Type: TABLE; Schema: crog_acquisition; Owner: -
---
-
-CREATE TABLE crog_acquisition.parcels (
-    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
-    county_name character varying(100) DEFAULT 'Fannin'::character varying NOT NULL,
-    parcel_id character varying(100) NOT NULL,
-    geom text,
-    assessed_value numeric(12,2) NOT NULL,
-    zoning_code character varying(50),
-    is_waterfront boolean DEFAULT false NOT NULL,
-    is_ridgeline boolean DEFAULT false NOT NULL,
-    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
-);
-
-
---
--- Name: properties; Type: TABLE; Schema: crog_acquisition; Owner: -
---
-
-CREATE TABLE crog_acquisition.properties (
-    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
-    parcel_id uuid NOT NULL,
-    owner_id uuid,
-    fannin_str_cert_id character varying(100),
-    blue_ridge_str_permit character varying(100),
-    zillow_zpid character varying(100),
-    google_place_id character varying(255),
-    airbnb_listing_id character varying(100),
-    vrbo_listing_id character varying(100),
-    status crog_acquisition.market_state DEFAULT 'UNMANAGED'::crog_acquisition.market_state NOT NULL,
-    management_company character varying(255),
-    bedrooms integer,
-    bathrooms numeric(3,1),
-    projected_adr numeric(8,2),
-    projected_annual_revenue numeric(10,2),
-    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
-);
-
-
---
--- Name: str_signals; Type: TABLE; Schema: crog_acquisition; Owner: -
---
-
-CREATE TABLE crog_acquisition.str_signals (
-    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
-    property_id uuid NOT NULL,
-    signal_source crog_acquisition.signal_source NOT NULL,
-    confidence_score numeric(3,2) NOT NULL,
-    raw_payload jsonb DEFAULT '{}'::jsonb NOT NULL,
-    detected_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    CONSTRAINT ck_acquisition_str_signals_confidence_score CHECK (((confidence_score >= 0.00) AND (confidence_score <= 1.00)))
-);
-
-
---
--- Name: device_events; Type: TABLE; Schema: iot_schema; Owner: -
---
-
-CREATE TABLE iot_schema.device_events (
-    id uuid NOT NULL,
-    device_id character varying(100) NOT NULL,
-    event_type character varying(100) NOT NULL,
-    payload jsonb DEFAULT '{}'::jsonb NOT NULL,
-    created_at timestamp with time zone DEFAULT now()
-);
-
-
---
--- Name: digital_twins; Type: TABLE; Schema: iot_schema; Owner: -
---
-
-CREATE TABLE iot_schema.digital_twins (
-    id uuid NOT NULL,
-    device_id character varying(100) NOT NULL,
-    property_id character varying(100) NOT NULL,
-    device_type character varying(50) NOT NULL,
-    device_name character varying(255),
-    state_json jsonb DEFAULT '{}'::jsonb NOT NULL,
-    battery_level integer,
-    is_online boolean,
-    last_event_ts timestamp with time zone DEFAULT now(),
-    created_at timestamp with time zone DEFAULT now(),
-    updated_at timestamp with time zone DEFAULT now()
-);
-
-
---
--- Name: ai_audit_ledger; Type: TABLE; Schema: legal; Owner: -
---
-
-CREATE TABLE legal.ai_audit_ledger (
+CREATE TABLE division_a.account_mappings (
     id integer NOT NULL,
-    case_slug text,
-    prompt_hash text,
-    retrieved_vectors jsonb DEFAULT '[]'::jsonb,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
+    vendor_name text NOT NULL,
+    plaid_category text DEFAULT ''::text,
+    debit_account text NOT NULL,
+    credit_account text NOT NULL,
+    confidence numeric(4,3) DEFAULT 0.0,
+    reasoning text DEFAULT ''::text,
+    learned_at timestamp with time zone DEFAULT now(),
+    source text DEFAULT 'llm'::text
 );
 
 
 --
--- Name: ai_audit_ledger_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
+-- Name: account_mappings_id_seq; Type: SEQUENCE; Schema: division_a; Owner: -
 --
 
-CREATE SEQUENCE legal.ai_audit_ledger_id_seq
+CREATE SEQUENCE division_a.account_mappings_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -470,10 +245,1590 @@ CREATE SEQUENCE legal.ai_audit_ledger_id_seq
 
 
 --
--- Name: ai_audit_ledger_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
+-- Name: account_mappings_id_seq; Type: SEQUENCE OWNED BY; Schema: division_a; Owner: -
 --
 
-ALTER SEQUENCE legal.ai_audit_ledger_id_seq OWNED BY legal.ai_audit_ledger.id;
+ALTER SEQUENCE division_a.account_mappings_id_seq OWNED BY division_a.account_mappings.id;
+
+
+--
+-- Name: audit_log; Type: TABLE; Schema: division_a; Owner: -
+--
+
+CREATE TABLE division_a.audit_log (
+    id integer NOT NULL,
+    action text NOT NULL,
+    agent text DEFAULT 'division_a.agent'::text,
+    detail jsonb,
+    created_at timestamp with time zone DEFAULT now()
+);
+
+
+--
+-- Name: audit_log_id_seq; Type: SEQUENCE; Schema: division_a; Owner: -
+--
+
+CREATE SEQUENCE division_a.audit_log_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: audit_log_id_seq; Type: SEQUENCE OWNED BY; Schema: division_a; Owner: -
+--
+
+ALTER SEQUENCE division_a.audit_log_id_seq OWNED BY division_a.audit_log.id;
+
+
+--
+-- Name: general_ledger; Type: TABLE; Schema: division_a; Owner: -
+--
+
+CREATE TABLE division_a.general_ledger (
+    id integer NOT NULL,
+    journal_entry_id text NOT NULL,
+    account_code text NOT NULL,
+    account_name text NOT NULL,
+    debit numeric(14,2) DEFAULT 0.00 NOT NULL,
+    credit numeric(14,2) DEFAULT 0.00 NOT NULL,
+    memo text DEFAULT ''::text,
+    created_at timestamp with time zone DEFAULT now(),
+    CONSTRAINT debit_xor_credit CHECK ((((debit > (0)::numeric) AND (credit = (0)::numeric)) OR ((debit = (0)::numeric) AND (credit > (0)::numeric))))
+);
+
+
+--
+-- Name: balance_check; Type: VIEW; Schema: division_a; Owner: -
+--
+
+CREATE VIEW division_a.balance_check AS
+ SELECT sum(debit) AS total_debits,
+    sum(credit) AS total_credits,
+    (sum(debit) - sum(credit)) AS imbalance,
+        CASE
+            WHEN (sum(debit) = sum(credit)) THEN 'BALANCED'::text
+            ELSE 'IMBALANCED'::text
+        END AS status
+   FROM division_a.general_ledger;
+
+
+--
+-- Name: chart_of_accounts; Type: TABLE; Schema: division_a; Owner: -
+--
+
+CREATE TABLE division_a.chart_of_accounts (
+    id integer NOT NULL,
+    code text NOT NULL,
+    name text NOT NULL,
+    account_type text NOT NULL,
+    parent_code text,
+    description text DEFAULT ''::text,
+    is_active boolean DEFAULT true,
+    qbo_id text,
+    qbo_name text,
+    normal_balance text DEFAULT 'debit'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now(),
+    updated_at timestamp with time zone DEFAULT now(),
+    CONSTRAINT valid_account_type CHECK ((account_type = ANY (ARRAY['asset'::text, 'liability'::text, 'equity'::text, 'revenue'::text, 'expense'::text, 'cogs'::text]))),
+    CONSTRAINT valid_normal_balance CHECK ((normal_balance = ANY (ARRAY['debit'::text, 'credit'::text])))
+);
+
+
+--
+-- Name: chart_of_accounts_id_seq; Type: SEQUENCE; Schema: division_a; Owner: -
+--
+
+CREATE SEQUENCE division_a.chart_of_accounts_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: chart_of_accounts_id_seq; Type: SEQUENCE OWNED BY; Schema: division_a; Owner: -
+--
+
+ALTER SEQUENCE division_a.chart_of_accounts_id_seq OWNED BY division_a.chart_of_accounts.id;
+
+
+--
+-- Name: general_ledger_id_seq; Type: SEQUENCE; Schema: division_a; Owner: -
+--
+
+CREATE SEQUENCE division_a.general_ledger_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: general_ledger_id_seq; Type: SEQUENCE OWNED BY; Schema: division_a; Owner: -
+--
+
+ALTER SEQUENCE division_a.general_ledger_id_seq OWNED BY division_a.general_ledger.id;
+
+
+--
+-- Name: journal_entries; Type: TABLE; Schema: division_a; Owner: -
+--
+
+CREATE TABLE division_a.journal_entries (
+    id integer NOT NULL,
+    entry_id text NOT NULL,
+    entry_date date NOT NULL,
+    description text NOT NULL,
+    source_type text DEFAULT 'plaid'::text,
+    source_ref text DEFAULT ''::text,
+    memo text DEFAULT ''::text,
+    is_posted boolean DEFAULT false,
+    created_by text DEFAULT 'fortress'::text,
+    created_at timestamp with time zone DEFAULT now(),
+    posted_at timestamp with time zone
+);
+
+
+--
+-- Name: journal_entries_id_seq; Type: SEQUENCE; Schema: division_a; Owner: -
+--
+
+CREATE SEQUENCE division_a.journal_entries_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: journal_entries_id_seq; Type: SEQUENCE OWNED BY; Schema: division_a; Owner: -
+--
+
+ALTER SEQUENCE division_a.journal_entries_id_seq OWNED BY division_a.journal_entries.id;
+
+
+--
+-- Name: predictions; Type: TABLE; Schema: division_a; Owner: -
+--
+
+CREATE TABLE division_a.predictions (
+    id integer NOT NULL,
+    metric_name text NOT NULL,
+    predicted_value numeric(14,4),
+    actual_value numeric(14,4),
+    variance_pct numeric(8,4),
+    cycle_id integer,
+    created_at timestamp with time zone DEFAULT now()
+);
+
+
+--
+-- Name: predictions_id_seq; Type: SEQUENCE; Schema: division_a; Owner: -
+--
+
+CREATE SEQUENCE division_a.predictions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: predictions_id_seq; Type: SEQUENCE OWNED BY; Schema: division_a; Owner: -
+--
+
+ALTER SEQUENCE division_a.predictions_id_seq OWNED BY division_a.predictions.id;
+
+
+--
+-- Name: transactions; Type: TABLE; Schema: division_a; Owner: -
+--
+
+CREATE TABLE division_a.transactions (
+    id integer NOT NULL,
+    plaid_txn_id text,
+    date date NOT NULL,
+    vendor text NOT NULL,
+    amount numeric(12,2) NOT NULL,
+    category text DEFAULT 'UNCATEGORIZED'::text NOT NULL,
+    confidence numeric(4,3) DEFAULT 0.0,
+    roi_impact text DEFAULT 'neutral'::text,
+    reasoning text,
+    method text DEFAULT 'manual'::text,
+    account_id text,
+    created_at timestamp with time zone DEFAULT now(),
+    updated_at timestamp with time zone DEFAULT now()
+);
+
+
+--
+-- Name: transactions_id_seq; Type: SEQUENCE; Schema: division_a; Owner: -
+--
+
+CREATE SEQUENCE division_a.transactions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: transactions_id_seq; Type: SEQUENCE OWNED BY; Schema: division_a; Owner: -
+--
+
+ALTER SEQUENCE division_a.transactions_id_seq OWNED BY division_a.transactions.id;
+
+
+--
+-- Name: trial_balance; Type: VIEW; Schema: division_a; Owner: -
+--
+
+CREATE VIEW division_a.trial_balance AS
+ SELECT coa.code,
+    coa.name,
+    coa.account_type,
+    coa.normal_balance,
+    COALESCE(sum(gl.debit), (0)::numeric) AS total_debits,
+    COALESCE(sum(gl.credit), (0)::numeric) AS total_credits,
+    (COALESCE(sum(gl.debit), (0)::numeric) - COALESCE(sum(gl.credit), (0)::numeric)) AS net_balance
+   FROM (division_a.chart_of_accounts coa
+     LEFT JOIN division_a.general_ledger gl ON ((gl.account_code = coa.code)))
+  WHERE (coa.is_active = true)
+  GROUP BY coa.code, coa.name, coa.account_type, coa.normal_balance
+  ORDER BY coa.code;
+
+
+--
+-- Name: account_mappings; Type: TABLE; Schema: division_b; Owner: -
+--
+
+CREATE TABLE division_b.account_mappings (
+    id integer NOT NULL,
+    vendor_name text NOT NULL,
+    plaid_category text DEFAULT ''::text,
+    debit_account text NOT NULL,
+    credit_account text NOT NULL,
+    confidence numeric(4,3) DEFAULT 0.0,
+    reasoning text DEFAULT ''::text,
+    learned_at timestamp with time zone DEFAULT now(),
+    source text DEFAULT 'llm'::text
+);
+
+
+--
+-- Name: account_mappings_id_seq; Type: SEQUENCE; Schema: division_b; Owner: -
+--
+
+CREATE SEQUENCE division_b.account_mappings_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: account_mappings_id_seq; Type: SEQUENCE OWNED BY; Schema: division_b; Owner: -
+--
+
+ALTER SEQUENCE division_b.account_mappings_id_seq OWNED BY division_b.account_mappings.id;
+
+
+--
+-- Name: general_ledger; Type: TABLE; Schema: division_b; Owner: -
+--
+
+CREATE TABLE division_b.general_ledger (
+    id integer NOT NULL,
+    journal_entry_id text NOT NULL,
+    account_code text NOT NULL,
+    account_name text NOT NULL,
+    debit numeric(14,2) DEFAULT 0.00 NOT NULL,
+    credit numeric(14,2) DEFAULT 0.00 NOT NULL,
+    memo text DEFAULT ''::text,
+    created_at timestamp with time zone DEFAULT now(),
+    CONSTRAINT debit_xor_credit CHECK ((((debit > (0)::numeric) AND (credit = (0)::numeric)) OR ((debit = (0)::numeric) AND (credit > (0)::numeric))))
+);
+
+
+--
+-- Name: balance_check; Type: VIEW; Schema: division_b; Owner: -
+--
+
+CREATE VIEW division_b.balance_check AS
+ SELECT sum(debit) AS total_debits,
+    sum(credit) AS total_credits,
+    (sum(debit) - sum(credit)) AS imbalance,
+        CASE
+            WHEN (sum(debit) = sum(credit)) THEN 'BALANCED'::text
+            ELSE 'IMBALANCED'::text
+        END AS status
+   FROM division_b.general_ledger;
+
+
+--
+-- Name: chart_of_accounts; Type: TABLE; Schema: division_b; Owner: -
+--
+
+CREATE TABLE division_b.chart_of_accounts (
+    id integer NOT NULL,
+    code text NOT NULL,
+    name text NOT NULL,
+    account_type text NOT NULL,
+    parent_code text,
+    description text DEFAULT ''::text,
+    is_active boolean DEFAULT true,
+    qbo_id text,
+    qbo_name text,
+    normal_balance text DEFAULT 'debit'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now(),
+    updated_at timestamp with time zone DEFAULT now(),
+    CONSTRAINT valid_account_type CHECK ((account_type = ANY (ARRAY['asset'::text, 'liability'::text, 'equity'::text, 'revenue'::text, 'expense'::text, 'cogs'::text]))),
+    CONSTRAINT valid_normal_balance CHECK ((normal_balance = ANY (ARRAY['debit'::text, 'credit'::text])))
+);
+
+
+--
+-- Name: chart_of_accounts_id_seq; Type: SEQUENCE; Schema: division_b; Owner: -
+--
+
+CREATE SEQUENCE division_b.chart_of_accounts_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: chart_of_accounts_id_seq; Type: SEQUENCE OWNED BY; Schema: division_b; Owner: -
+--
+
+ALTER SEQUENCE division_b.chart_of_accounts_id_seq OWNED BY division_b.chart_of_accounts.id;
+
+
+--
+-- Name: escrow; Type: TABLE; Schema: division_b; Owner: -
+--
+
+CREATE TABLE division_b.escrow (
+    id integer NOT NULL,
+    reservation_id text NOT NULL,
+    guest_name text NOT NULL,
+    cabin_id text NOT NULL,
+    amount numeric(12,2) NOT NULL,
+    deposit_date date NOT NULL,
+    checkout_date date,
+    release_date date,
+    status text DEFAULT 'held'::text,
+    notes text,
+    created_at timestamp with time zone DEFAULT now(),
+    updated_at timestamp with time zone DEFAULT now()
+);
+
+
+--
+-- Name: escrow_id_seq; Type: SEQUENCE; Schema: division_b; Owner: -
+--
+
+CREATE SEQUENCE division_b.escrow_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: escrow_id_seq; Type: SEQUENCE OWNED BY; Schema: division_b; Owner: -
+--
+
+ALTER SEQUENCE division_b.escrow_id_seq OWNED BY division_b.escrow.id;
+
+
+--
+-- Name: general_ledger_id_seq; Type: SEQUENCE; Schema: division_b; Owner: -
+--
+
+CREATE SEQUENCE division_b.general_ledger_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: general_ledger_id_seq; Type: SEQUENCE OWNED BY; Schema: division_b; Owner: -
+--
+
+ALTER SEQUENCE division_b.general_ledger_id_seq OWNED BY division_b.general_ledger.id;
+
+
+--
+-- Name: journal_entries; Type: TABLE; Schema: division_b; Owner: -
+--
+
+CREATE TABLE division_b.journal_entries (
+    id integer NOT NULL,
+    entry_id text NOT NULL,
+    entry_date date NOT NULL,
+    description text NOT NULL,
+    source_type text DEFAULT 'plaid'::text,
+    source_ref text DEFAULT ''::text,
+    memo text DEFAULT ''::text,
+    is_posted boolean DEFAULT false,
+    created_by text DEFAULT 'fortress'::text,
+    created_at timestamp with time zone DEFAULT now(),
+    posted_at timestamp with time zone
+);
+
+
+--
+-- Name: journal_entries_id_seq; Type: SEQUENCE; Schema: division_b; Owner: -
+--
+
+CREATE SEQUENCE division_b.journal_entries_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: journal_entries_id_seq; Type: SEQUENCE OWNED BY; Schema: division_b; Owner: -
+--
+
+ALTER SEQUENCE division_b.journal_entries_id_seq OWNED BY division_b.journal_entries.id;
+
+
+--
+-- Name: predictions; Type: TABLE; Schema: division_b; Owner: -
+--
+
+CREATE TABLE division_b.predictions (
+    id integer NOT NULL,
+    metric_name text NOT NULL,
+    predicted_value numeric(14,4),
+    actual_value numeric(14,4),
+    variance_pct numeric(8,4),
+    cycle_id integer,
+    created_at timestamp with time zone DEFAULT now()
+);
+
+
+--
+-- Name: predictions_id_seq; Type: SEQUENCE; Schema: division_b; Owner: -
+--
+
+CREATE SEQUENCE division_b.predictions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: predictions_id_seq; Type: SEQUENCE OWNED BY; Schema: division_b; Owner: -
+--
+
+ALTER SEQUENCE division_b.predictions_id_seq OWNED BY division_b.predictions.id;
+
+
+--
+-- Name: transactions; Type: TABLE; Schema: division_b; Owner: -
+--
+
+CREATE TABLE division_b.transactions (
+    id integer NOT NULL,
+    plaid_txn_id text,
+    date date NOT NULL,
+    vendor text NOT NULL,
+    amount numeric(12,2) NOT NULL,
+    category text DEFAULT 'UNCATEGORIZED'::text NOT NULL,
+    confidence numeric(4,3) DEFAULT 0.0,
+    trust_related boolean DEFAULT false,
+    reservation_id text,
+    reasoning text,
+    method text DEFAULT 'manual'::text,
+    account_id text,
+    created_at timestamp with time zone DEFAULT now()
+);
+
+
+--
+-- Name: transactions_id_seq; Type: SEQUENCE; Schema: division_b; Owner: -
+--
+
+CREATE SEQUENCE division_b.transactions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: transactions_id_seq; Type: SEQUENCE OWNED BY; Schema: division_b; Owner: -
+--
+
+ALTER SEQUENCE division_b.transactions_id_seq OWNED BY division_b.transactions.id;
+
+
+--
+-- Name: trial_balance; Type: VIEW; Schema: division_b; Owner: -
+--
+
+CREATE VIEW division_b.trial_balance AS
+ SELECT coa.code,
+    coa.name,
+    coa.account_type,
+    coa.normal_balance,
+    COALESCE(sum(gl.debit), (0)::numeric) AS total_debits,
+    COALESCE(sum(gl.credit), (0)::numeric) AS total_credits,
+    (COALESCE(sum(gl.debit), (0)::numeric) - COALESCE(sum(gl.credit), (0)::numeric)) AS net_balance
+   FROM (division_b.chart_of_accounts coa
+     LEFT JOIN division_b.general_ledger gl ON ((gl.account_code = coa.code)))
+  WHERE (coa.is_active = true)
+  GROUP BY coa.code, coa.name, coa.account_type, coa.normal_balance
+  ORDER BY coa.code;
+
+
+--
+-- Name: trust_ledger; Type: TABLE; Schema: division_b; Owner: -
+--
+
+CREATE TABLE division_b.trust_ledger (
+    id integer NOT NULL,
+    entry_type text NOT NULL,
+    amount numeric(12,2) NOT NULL,
+    reference_id text,
+    description text,
+    running_balance numeric(14,2),
+    created_at timestamp with time zone DEFAULT now()
+);
+
+
+--
+-- Name: trust_ledger_id_seq; Type: SEQUENCE; Schema: division_b; Owner: -
+--
+
+CREATE SEQUENCE division_b.trust_ledger_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: trust_ledger_id_seq; Type: SEQUENCE OWNED BY; Schema: division_b; Owner: -
+--
+
+ALTER SEQUENCE division_b.trust_ledger_id_seq OWNED BY division_b.trust_ledger.id;
+
+
+--
+-- Name: vendor_payouts; Type: TABLE; Schema: division_b; Owner: -
+--
+
+CREATE TABLE division_b.vendor_payouts (
+    id integer NOT NULL,
+    vendor_name text NOT NULL,
+    amount numeric(12,2) NOT NULL,
+    invoice_number text,
+    invoice_date date,
+    cabin_id text,
+    category text DEFAULT 'MAINTENANCE'::text,
+    status text DEFAULT 'pending'::text,
+    approved_by text,
+    plaid_txn_id text,
+    created_at timestamp with time zone DEFAULT now()
+);
+
+
+--
+-- Name: vendor_payouts_id_seq; Type: SEQUENCE; Schema: division_b; Owner: -
+--
+
+CREATE SEQUENCE division_b.vendor_payouts_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: vendor_payouts_id_seq; Type: SEQUENCE OWNED BY; Schema: division_b; Owner: -
+--
+
+ALTER SEQUENCE division_b.vendor_payouts_id_seq OWNED BY division_b.vendor_payouts.id;
+
+
+--
+-- Name: change_orders; Type: TABLE; Schema: engineering; Owner: -
+--
+
+CREATE TABLE engineering.change_orders (
+    id integer NOT NULL,
+    project_id integer NOT NULL,
+    co_number character varying(20) NOT NULL,
+    description text NOT NULL,
+    reason character varying(50),
+    discipline character varying(30),
+    cost_impact numeric(12,2),
+    schedule_impact_days integer,
+    status character varying(20) DEFAULT 'proposed'::character varying NOT NULL,
+    submitted_date date,
+    approved_date date,
+    approved_by character varying(100),
+    document_path text,
+    notes text,
+    ai_json jsonb,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: change_orders_id_seq; Type: SEQUENCE; Schema: engineering; Owner: -
+--
+
+CREATE SEQUENCE engineering.change_orders_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: change_orders_id_seq; Type: SEQUENCE OWNED BY; Schema: engineering; Owner: -
+--
+
+ALTER SEQUENCE engineering.change_orders_id_seq OWNED BY engineering.change_orders.id;
+
+
+--
+-- Name: compliance_log; Type: TABLE; Schema: engineering; Owner: -
+--
+
+CREATE TABLE engineering.compliance_log (
+    id integer NOT NULL,
+    project_id integer,
+    property_id integer,
+    drawing_id integer,
+    issue_type character varying(50) NOT NULL,
+    severity character varying(20) DEFAULT 'HIGH'::character varying NOT NULL,
+    discipline character varying(30),
+    code_reference character varying(100),
+    description text NOT NULL,
+    recommended_action text,
+    status character varying(20) DEFAULT 'open'::character varying NOT NULL,
+    resolved_date date,
+    resolution_notes text,
+    resolved_by character varying(100),
+    detected_by character varying(50) DEFAULT 'architect_agent'::character varying,
+    ai_json jsonb,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: compliance_log_id_seq; Type: SEQUENCE; Schema: engineering; Owner: -
+--
+
+CREATE SEQUENCE engineering.compliance_log_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: compliance_log_id_seq; Type: SEQUENCE OWNED BY; Schema: engineering; Owner: -
+--
+
+ALTER SEQUENCE engineering.compliance_log_id_seq OWNED BY engineering.compliance_log.id;
+
+
+--
+-- Name: cost_estimates; Type: TABLE; Schema: engineering; Owner: -
+--
+
+CREATE TABLE engineering.cost_estimates (
+    id integer NOT NULL,
+    project_id integer NOT NULL,
+    estimate_type character varying(30) NOT NULL,
+    version integer DEFAULT 1,
+    architectural_cost numeric(12,2) DEFAULT 0,
+    civil_cost numeric(12,2) DEFAULT 0,
+    structural_cost numeric(12,2) DEFAULT 0,
+    mechanical_cost numeric(12,2) DEFAULT 0,
+    electrical_cost numeric(12,2) DEFAULT 0,
+    plumbing_cost numeric(12,2) DEFAULT 0,
+    fire_protection_cost numeric(12,2) DEFAULT 0,
+    general_conditions numeric(12,2) DEFAULT 0,
+    contingency numeric(12,2) DEFAULT 0,
+    total_estimate numeric(12,2) NOT NULL,
+    cost_per_sqft numeric(8,2),
+    total_sqft numeric(10,2),
+    prepared_by character varying(100),
+    estimate_date date,
+    document_path text,
+    notes text,
+    ai_json jsonb,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: cost_estimates_id_seq; Type: SEQUENCE; Schema: engineering; Owner: -
+--
+
+CREATE SEQUENCE engineering.cost_estimates_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: cost_estimates_id_seq; Type: SEQUENCE OWNED BY; Schema: engineering; Owner: -
+--
+
+ALTER SEQUENCE engineering.cost_estimates_id_seq OWNED BY engineering.cost_estimates.id;
+
+
+--
+-- Name: drawings; Type: TABLE; Schema: engineering; Owner: -
+--
+
+CREATE TABLE engineering.drawings (
+    id integer NOT NULL,
+    property_id integer,
+    project_id integer,
+    discipline character varying(30) DEFAULT 'general'::character varying NOT NULL,
+    doc_type character varying(50) DEFAULT 'Unknown'::character varying NOT NULL,
+    file_path text,
+    filename text,
+    extension character varying(10),
+    file_size bigint,
+    sheet_number character varying(20),
+    title character varying(200),
+    revision character varying(10),
+    revision_date date,
+    scale character varying(30),
+    ocr_text text,
+    confidence character varying(20),
+    ai_json jsonb,
+    phase integer DEFAULT 1,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: drawings_id_seq; Type: SEQUENCE; Schema: engineering; Owner: -
+--
+
+CREATE SEQUENCE engineering.drawings_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: drawings_id_seq; Type: SEQUENCE OWNED BY; Schema: engineering; Owner: -
+--
+
+ALTER SEQUENCE engineering.drawings_id_seq OWNED BY engineering.drawings.id;
+
+
+--
+-- Name: inspections; Type: TABLE; Schema: engineering; Owner: -
+--
+
+CREATE TABLE engineering.inspections (
+    id integer NOT NULL,
+    project_id integer,
+    permit_id integer,
+    property_id integer,
+    inspection_type character varying(50) NOT NULL,
+    discipline character varying(30),
+    scheduled_date date,
+    actual_date date,
+    inspector_name character varying(150),
+    result character varying(20),
+    deficiencies text,
+    corrections_required text,
+    re_inspection_date date,
+    report_path text,
+    notes text,
+    ai_json jsonb,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: inspections_id_seq; Type: SEQUENCE; Schema: engineering; Owner: -
+--
+
+CREATE SEQUENCE engineering.inspections_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: inspections_id_seq; Type: SEQUENCE OWNED BY; Schema: engineering; Owner: -
+--
+
+ALTER SEQUENCE engineering.inspections_id_seq OWNED BY engineering.inspections.id;
+
+
+--
+-- Name: mep_systems; Type: TABLE; Schema: engineering; Owner: -
+--
+
+CREATE TABLE engineering.mep_systems (
+    id integer NOT NULL,
+    property_id integer NOT NULL,
+    property_name character varying(100),
+    system_type character varying(50) NOT NULL,
+    discipline character varying(30),
+    manufacturer character varying(100),
+    model_number character varying(100),
+    serial_number character varying(100),
+    capacity character varying(50),
+    fuel_type character varying(30),
+    install_date date,
+    warranty_expiry date,
+    expected_life_years integer,
+    condition character varying(20) DEFAULT 'good'::character varying,
+    last_service_date date,
+    next_service_due date,
+    location character varying(100),
+    install_cost numeric(10,2),
+    replacement_cost numeric(10,2),
+    notes text,
+    ai_json jsonb,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: mep_systems_id_seq; Type: SEQUENCE; Schema: engineering; Owner: -
+--
+
+CREATE SEQUENCE engineering.mep_systems_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: mep_systems_id_seq; Type: SEQUENCE OWNED BY; Schema: engineering; Owner: -
+--
+
+ALTER SEQUENCE engineering.mep_systems_id_seq OWNED BY engineering.mep_systems.id;
+
+
+--
+-- Name: permits; Type: TABLE; Schema: engineering; Owner: -
+--
+
+CREATE TABLE engineering.permits (
+    id integer NOT NULL,
+    project_id integer,
+    property_id integer,
+    permit_type character varying(50) NOT NULL,
+    permit_number character varying(50),
+    jurisdiction character varying(100) DEFAULT 'Fannin County'::character varying,
+    issuing_authority character varying(150),
+    status character varying(30) DEFAULT 'draft'::character varying NOT NULL,
+    application_date date,
+    approval_date date,
+    expiration_date date,
+    renewal_date date,
+    application_fee numeric(10,2),
+    impact_fee numeric(10,2),
+    conditions text,
+    special_inspections text[],
+    application_doc text,
+    approval_doc text,
+    notes text,
+    ai_json jsonb,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: permits_id_seq; Type: SEQUENCE; Schema: engineering; Owner: -
+--
+
+CREATE SEQUENCE engineering.permits_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: permits_id_seq; Type: SEQUENCE OWNED BY; Schema: engineering; Owner: -
+--
+
+ALTER SEQUENCE engineering.permits_id_seq OWNED BY engineering.permits.id;
+
+
+--
+-- Name: projects; Type: TABLE; Schema: engineering; Owner: -
+--
+
+CREATE TABLE engineering.projects (
+    id integer NOT NULL,
+    project_code character varying(20) NOT NULL,
+    name character varying(200) NOT NULL,
+    description text,
+    property_id integer,
+    property_name character varying(100),
+    phase character varying(30) DEFAULT 'concept'::character varying NOT NULL,
+    status character varying(20) DEFAULT 'active'::character varying NOT NULL,
+    project_type character varying(50),
+    disciplines text[],
+    start_date date,
+    target_completion date,
+    actual_completion date,
+    estimated_cost numeric(12,2),
+    actual_cost numeric(12,2),
+    contingency_pct numeric(5,2) DEFAULT 10.00,
+    architect_of_record character varying(150),
+    engineer_of_record character varying(150),
+    general_contractor character varying(150),
+    project_manager character varying(150),
+    jurisdiction character varying(100) DEFAULT 'Fannin County'::character varying,
+    permit_number character varying(50),
+    notes text,
+    ai_json jsonb,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: projects_id_seq; Type: SEQUENCE; Schema: engineering; Owner: -
+--
+
+CREATE SEQUENCE engineering.projects_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: projects_id_seq; Type: SEQUENCE OWNED BY; Schema: engineering; Owner: -
+--
+
+ALTER SEQUENCE engineering.projects_id_seq OWNED BY engineering.projects.id;
+
+
+--
+-- Name: punch_items; Type: TABLE; Schema: engineering; Owner: -
+--
+
+CREATE TABLE engineering.punch_items (
+    id integer NOT NULL,
+    project_id integer NOT NULL,
+    inspection_id integer,
+    item_number integer NOT NULL,
+    description text NOT NULL,
+    discipline character varying(30),
+    location character varying(100),
+    priority character varying(20) DEFAULT 'normal'::character varying,
+    assigned_to character varying(100),
+    due_date date,
+    status character varying(20) DEFAULT 'open'::character varying NOT NULL,
+    completed_date date,
+    verified_by character varying(100),
+    photo_before text,
+    photo_after text,
+    notes text,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: punch_items_id_seq; Type: SEQUENCE; Schema: engineering; Owner: -
+--
+
+CREATE SEQUENCE engineering.punch_items_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: punch_items_id_seq; Type: SEQUENCE OWNED BY; Schema: engineering; Owner: -
+--
+
+ALTER SEQUENCE engineering.punch_items_id_seq OWNED BY engineering.punch_items.id;
+
+
+--
+-- Name: rfis; Type: TABLE; Schema: engineering; Owner: -
+--
+
+CREATE TABLE engineering.rfis (
+    id integer NOT NULL,
+    project_id integer NOT NULL,
+    rfi_number character varying(20) NOT NULL,
+    subject character varying(200) NOT NULL,
+    question text NOT NULL,
+    discipline character varying(30),
+    drawing_reference character varying(50),
+    response text,
+    responded_by character varying(100),
+    response_date date,
+    cost_impact numeric(12,2),
+    schedule_impact_days integer,
+    status character varying(20) DEFAULT 'open'::character varying NOT NULL,
+    submitted_date date,
+    due_date date,
+    submitted_by character varying(100),
+    notes text,
+    ai_json jsonb,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: rfis_id_seq; Type: SEQUENCE; Schema: engineering; Owner: -
+--
+
+CREATE SEQUENCE engineering.rfis_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: rfis_id_seq; Type: SEQUENCE OWNED BY; Schema: engineering; Owner: -
+--
+
+ALTER SEQUENCE engineering.rfis_id_seq OWNED BY engineering.rfis.id;
+
+
+--
+-- Name: submittals; Type: TABLE; Schema: engineering; Owner: -
+--
+
+CREATE TABLE engineering.submittals (
+    id integer NOT NULL,
+    project_id integer NOT NULL,
+    submittal_number character varying(20) NOT NULL,
+    description character varying(200) NOT NULL,
+    discipline character varying(30),
+    spec_section character varying(20),
+    status character varying(30) DEFAULT 'pending'::character varying NOT NULL,
+    submitted_date date,
+    review_date date,
+    reviewed_by character varying(100),
+    review_comments text,
+    document_path text,
+    notes text,
+    ai_json jsonb,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: submittals_id_seq; Type: SEQUENCE; Schema: engineering; Owner: -
+--
+
+CREATE SEQUENCE engineering.submittals_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: submittals_id_seq; Type: SEQUENCE OWNED BY; Schema: engineering; Owner: -
+--
+
+ALTER SEQUENCE engineering.submittals_id_seq OWNED BY engineering.submittals.id;
+
+
+--
+-- Name: classification_rules; Type: TABLE; Schema: finance; Owner: -
+--
+
+CREATE TABLE finance.classification_rules (
+    id integer NOT NULL,
+    vendor_pattern text NOT NULL,
+    assigned_category text NOT NULL,
+    reasoning text,
+    source_vendor_id integer,
+    embedding public.vector(768),
+    created_at timestamp with time zone DEFAULT now(),
+    created_by text DEFAULT 'CFO-MANUAL'::text
+);
+
+
+--
+-- Name: classification_rules_id_seq; Type: SEQUENCE; Schema: finance; Owner: -
+--
+
+CREATE SEQUENCE finance.classification_rules_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: classification_rules_id_seq; Type: SEQUENCE OWNED BY; Schema: finance; Owner: -
+--
+
+ALTER SEQUENCE finance.classification_rules_id_seq OWNED BY finance.classification_rules.id;
+
+
+--
+-- Name: vendor_classifications; Type: TABLE; Schema: finance; Owner: -
+--
+
+CREATE TABLE finance.vendor_classifications (
+    id integer NOT NULL,
+    vendor_pattern text NOT NULL,
+    vendor_label text NOT NULL,
+    classification text NOT NULL,
+    is_revenue boolean DEFAULT false,
+    is_expense boolean DEFAULT false,
+    titan_notes text,
+    classified_at timestamp without time zone DEFAULT now(),
+    classified_by text DEFAULT 'TITAN-R1-671B'::text,
+    CONSTRAINT vendor_classifications_classification_check CHECK ((classification = ANY (ARRAY['OWNER_PRINCIPAL'::text, 'REAL_BUSINESS'::text, 'CONTRACTOR'::text, 'CROG_INTERNAL'::text, 'FAMILY_INTERNAL'::text, 'FINANCIAL_SERVICE'::text, 'PROFESSIONAL_SERVICE'::text, 'LEGAL_SERVICE'::text, 'INSURANCE'::text, 'OPERATIONAL_EXPENSE'::text, 'SUBSCRIPTION'::text, 'MARKETING'::text, 'TENANT_GUEST'::text, 'PERSONAL_EXPENSE'::text, 'GOVERNMENT'::text, 'LITIGATION_RECOVERY'::text, 'NOISE'::text, 'UNKNOWN'::text])))
+);
+
+
+--
+-- Name: vendor_classifications_id_seq; Type: SEQUENCE; Schema: finance; Owner: -
+--
+
+CREATE SEQUENCE finance.vendor_classifications_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: vendor_classifications_id_seq; Type: SEQUENCE OWNED BY; Schema: finance; Owner: -
+--
+
+ALTER SEQUENCE finance.vendor_classifications_id_seq OWNED BY finance.vendor_classifications.id;
+
+
+--
+-- Name: active_strategies; Type: TABLE; Schema: hedge_fund; Owner: -
+--
+
+CREATE TABLE hedge_fund.active_strategies (
+    id integer NOT NULL,
+    strategy_name character varying(100) NOT NULL,
+    description text,
+    allocation_limit numeric(12,2),
+    risk_level character varying(20),
+    status character varying(20) DEFAULT 'ACTIVE'::character varying,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: active_strategies_id_seq; Type: SEQUENCE; Schema: hedge_fund; Owner: -
+--
+
+CREATE SEQUENCE hedge_fund.active_strategies_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: active_strategies_id_seq; Type: SEQUENCE OWNED BY; Schema: hedge_fund; Owner: -
+--
+
+ALTER SEQUENCE hedge_fund.active_strategies_id_seq OWNED BY hedge_fund.active_strategies.id;
+
+
+--
+-- Name: extraction_log; Type: TABLE; Schema: hedge_fund; Owner: -
+--
+
+CREATE TABLE hedge_fund.extraction_log (
+    id integer NOT NULL,
+    email_id integer,
+    status character varying(20),
+    signals_found integer DEFAULT 0,
+    model_used character varying(50),
+    latency_ms integer,
+    error_message text,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: extraction_log_id_seq; Type: SEQUENCE; Schema: hedge_fund; Owner: -
+--
+
+CREATE SEQUENCE hedge_fund.extraction_log_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: extraction_log_id_seq; Type: SEQUENCE OWNED BY; Schema: hedge_fund; Owner: -
+--
+
+ALTER SEQUENCE hedge_fund.extraction_log_id_seq OWNED BY hedge_fund.extraction_log.id;
+
+
+--
+-- Name: market_signals; Type: TABLE; Schema: hedge_fund; Owner: -
+--
+
+CREATE TABLE hedge_fund.market_signals (
+    id integer NOT NULL,
+    ticker character varying(10) NOT NULL,
+    signal_type character varying(50),
+    action character varying(20),
+    sentiment_score double precision,
+    confidence_score integer DEFAULT 0,
+    price_target numeric(12,2),
+    source_email_id integer,
+    source_sender text,
+    source_subject text,
+    raw_reasoning text,
+    model_used character varying(50),
+    extracted_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: market_signals_id_seq; Type: SEQUENCE; Schema: hedge_fund; Owner: -
+--
+
+CREATE SEQUENCE hedge_fund.market_signals_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: market_signals_id_seq; Type: SEQUENCE OWNED BY; Schema: hedge_fund; Owner: -
+--
+
+ALTER SEQUENCE hedge_fund.market_signals_id_seq OWNED BY hedge_fund.market_signals.id;
+
+
+--
+-- Name: watchlist; Type: TABLE; Schema: hedge_fund; Owner: -
+--
+
+CREATE TABLE hedge_fund.watchlist (
+    id integer NOT NULL,
+    ticker character varying(10) NOT NULL,
+    sector character varying(50),
+    thesis text,
+    added_by character varying(50) DEFAULT 'system'::character varying,
+    signal_count integer DEFAULT 0,
+    last_signal_at timestamp without time zone,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: watchlist_id_seq; Type: SEQUENCE; Schema: hedge_fund; Owner: -
+--
+
+CREATE SEQUENCE hedge_fund.watchlist_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: watchlist_id_seq; Type: SEQUENCE OWNED BY; Schema: hedge_fund; Owner: -
+--
+
+ALTER SEQUENCE hedge_fund.watchlist_id_seq OWNED BY hedge_fund.watchlist.id;
+
+
+--
+-- Name: entities; Type: TABLE; Schema: intelligence; Owner: -
+--
+
+CREATE TABLE intelligence.entities (
+    id integer NOT NULL,
+    entity_type text NOT NULL,
+    entity_key text NOT NULL,
+    display_name text NOT NULL,
+    metadata jsonb DEFAULT '{}'::jsonb,
+    source_table text,
+    source_id text,
+    created_at timestamp without time zone DEFAULT now(),
+    updated_at timestamp without time zone DEFAULT now()
+);
+
+
+--
+-- Name: entities_id_seq; Type: SEQUENCE; Schema: intelligence; Owner: -
+--
+
+CREATE SEQUENCE intelligence.entities_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: entities_id_seq; Type: SEQUENCE OWNED BY; Schema: intelligence; Owner: -
+--
+
+ALTER SEQUENCE intelligence.entities_id_seq OWNED BY intelligence.entities.id;
+
+
+--
+-- Name: golden_reasoning; Type: TABLE; Schema: intelligence; Owner: -
+--
+
+CREATE TABLE intelligence.golden_reasoning (
+    id integer NOT NULL,
+    topic text NOT NULL,
+    entity_key text,
+    bad_reasoning text,
+    correct_reasoning text NOT NULL,
+    correction_type text DEFAULT 'FACTUAL'::text,
+    created_by text DEFAULT 'Gary'::text,
+    created_at timestamp without time zone DEFAULT now(),
+    used_count integer DEFAULT 0,
+    CONSTRAINT golden_reasoning_correction_type_check CHECK ((correction_type = ANY (ARRAY['FACTUAL'::text, 'CLASSIFICATION'::text, 'MISSING_LINK'::text, 'LOGIC_ERROR'::text])))
+);
+
+
+--
+-- Name: golden_reasoning_id_seq; Type: SEQUENCE; Schema: intelligence; Owner: -
+--
+
+CREATE SEQUENCE intelligence.golden_reasoning_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: golden_reasoning_id_seq; Type: SEQUENCE OWNED BY; Schema: intelligence; Owner: -
+--
+
+ALTER SEQUENCE intelligence.golden_reasoning_id_seq OWNED BY intelligence.golden_reasoning.id;
+
+
+--
+-- Name: relationships; Type: TABLE; Schema: intelligence; Owner: -
+--
+
+CREATE TABLE intelligence.relationships (
+    id integer NOT NULL,
+    from_entity_id integer NOT NULL,
+    to_entity_id integer NOT NULL,
+    relationship_type text NOT NULL,
+    confidence numeric(3,2) DEFAULT 1.00,
+    metadata jsonb DEFAULT '{}'::jsonb,
+    source text DEFAULT 'SYSTEM'::text,
+    created_at timestamp without time zone DEFAULT now()
+);
+
+
+--
+-- Name: relationships_id_seq; Type: SEQUENCE; Schema: intelligence; Owner: -
+--
+
+CREATE SEQUENCE intelligence.relationships_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: relationships_id_seq; Type: SEQUENCE OWNED BY; Schema: intelligence; Owner: -
+--
+
+ALTER SEQUENCE intelligence.relationships_id_seq OWNED BY intelligence.relationships.id;
+
+
+--
+-- Name: titan_traces; Type: TABLE; Schema: intelligence; Owner: -
+--
+
+CREATE TABLE intelligence.titan_traces (
+    id integer NOT NULL,
+    trace_id uuid DEFAULT gen_random_uuid(),
+    session_type text NOT NULL,
+    defcon_mode text DEFAULT 'TITAN'::text,
+    system_prompt text,
+    user_context text,
+    context_chars integer,
+    thinking_trace text,
+    response text,
+    thinking_tokens integer,
+    response_tokens integer,
+    latency_ms integer,
+    model text,
+    corrections jsonb DEFAULT '[]'::jsonb,
+    score integer,
+    score_comment text,
+    created_at timestamp without time zone DEFAULT now()
+);
+
+
+--
+-- Name: titan_traces_id_seq; Type: SEQUENCE; Schema: intelligence; Owner: -
+--
+
+CREATE SEQUENCE intelligence.titan_traces_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: titan_traces_id_seq; Type: SEQUENCE OWNED BY; Schema: intelligence; Owner: -
+--
+
+ALTER SEQUENCE intelligence.titan_traces_id_seq OWNED BY intelligence.titan_traces.id;
+
+
+--
+-- Name: case_actions; Type: TABLE; Schema: legal; Owner: -
+--
+
+CREATE TABLE legal.case_actions (
+    id integer NOT NULL,
+    case_id integer,
+    action_type text NOT NULL,
+    action_date timestamp with time zone DEFAULT now(),
+    description text NOT NULL,
+    status text DEFAULT 'pending'::text,
+    tracking_number text,
+    attachments text[],
+    notes text,
+    created_at timestamp with time zone DEFAULT now()
+);
+
+
+--
+-- Name: case_actions_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
+--
+
+CREATE SEQUENCE legal.case_actions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: case_actions_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
+--
+
+ALTER SEQUENCE legal.case_actions_id_seq OWNED BY legal.case_actions.id;
 
 
 --
@@ -481,96 +1836,23 @@ ALTER SEQUENCE legal.ai_audit_ledger_id_seq OWNED BY legal.ai_audit_ledger.id;
 --
 
 CREATE TABLE legal.case_evidence (
-    id uuid NOT NULL,
-    case_slug character varying(255) NOT NULL,
-    entity_id uuid,
-    file_name character varying(500) NOT NULL,
-    nas_path text NOT NULL,
-    qdrant_point_id character varying(255),
-    sha256_hash character varying(128) NOT NULL,
-    uploaded_at timestamp with time zone NOT NULL
-);
-
-
---
--- Name: case_graph_edges; Type: TABLE; Schema: legal; Owner: -
---
-
-CREATE TABLE legal.case_graph_edges (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    case_id uuid NOT NULL,
-    source_node_id uuid NOT NULL,
-    target_node_id uuid NOT NULL,
-    relationship_type character varying(128) NOT NULL,
-    weight double precision DEFAULT 1.0 NOT NULL,
-    source_ref character varying(500),
-    created_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
---
--- Name: case_graph_edges_v2; Type: TABLE; Schema: legal; Owner: -
---
-
-CREATE TABLE legal.case_graph_edges_v2 (
-    id uuid NOT NULL,
-    case_slug character varying(255) NOT NULL,
-    source_node_id uuid NOT NULL,
-    target_node_id uuid NOT NULL,
-    relationship_type character varying(128) NOT NULL,
-    weight double precision NOT NULL,
-    source_evidence_id uuid
-);
-
-
---
--- Name: case_graph_nodes; Type: TABLE; Schema: legal; Owner: -
---
-
-CREATE TABLE legal.case_graph_nodes (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    case_id uuid NOT NULL,
-    entity_type character varying(64) NOT NULL,
-    label character varying(500) NOT NULL,
-    metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
---
--- Name: case_graph_nodes_v2; Type: TABLE; Schema: legal; Owner: -
---
-
-CREATE TABLE legal.case_graph_nodes_v2 (
-    id uuid NOT NULL,
-    case_slug character varying(255) NOT NULL,
-    entity_type character varying(64) NOT NULL,
-    entity_reference_id uuid,
-    label character varying(500) NOT NULL,
-    properties_json jsonb NOT NULL
-);
-
-
---
--- Name: case_statements; Type: TABLE; Schema: legal; Owner: -
---
-
-CREATE TABLE legal.case_statements (
     id integer NOT NULL,
-    case_slug text NOT NULL,
-    entity_name text,
-    quote_text text,
-    source_ref text,
-    stated_at timestamp with time zone,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
+    case_id integer,
+    evidence_type text NOT NULL,
+    email_id integer,
+    file_path text,
+    description text NOT NULL,
+    relevance text,
+    discovered_at timestamp with time zone DEFAULT now(),
+    is_critical boolean DEFAULT false
 );
 
 
 --
--- Name: case_statements_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
+-- Name: case_evidence_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
 --
 
-CREATE SEQUENCE legal.case_statements_id_seq
+CREATE SEQUENCE legal.case_evidence_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -580,26 +1862,81 @@ CREATE SEQUENCE legal.case_statements_id_seq
 
 
 --
--- Name: case_statements_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
+-- Name: case_evidence_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
 --
 
-ALTER SEQUENCE legal.case_statements_id_seq OWNED BY legal.case_statements.id;
+ALTER SEQUENCE legal.case_evidence_id_seq OWNED BY legal.case_evidence.id;
 
 
 --
--- Name: case_statements_v2; Type: TABLE; Schema: legal; Owner: -
+-- Name: case_precedents; Type: TABLE; Schema: legal; Owner: -
 --
 
-CREATE TABLE legal.case_statements_v2 (
-    id uuid NOT NULL,
-    case_slug character varying(255) NOT NULL,
-    entity_id uuid,
-    quote_text text NOT NULL,
-    source_ref text,
-    doc_id character varying(255),
-    stated_at timestamp with time zone,
-    created_at timestamp with time zone NOT NULL
+CREATE TABLE legal.case_precedents (
+    id integer NOT NULL,
+    case_slug text NOT NULL,
+    citation text NOT NULL,
+    url text,
+    relevance_score integer NOT NULL,
+    justification text NOT NULL,
+    extracted_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT case_precedents_relevance_score_check CHECK (((relevance_score >= 0) AND (relevance_score <= 100)))
 );
+
+
+--
+-- Name: case_precedents_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
+--
+
+CREATE SEQUENCE legal.case_precedents_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: case_precedents_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
+--
+
+ALTER SEQUENCE legal.case_precedents_id_seq OWNED BY legal.case_precedents.id;
+
+
+--
+-- Name: case_watchdog; Type: TABLE; Schema: legal; Owner: -
+--
+
+CREATE TABLE legal.case_watchdog (
+    id integer NOT NULL,
+    case_id integer,
+    search_type text NOT NULL,
+    search_term text NOT NULL,
+    priority text DEFAULT 'P2'::text,
+    is_active boolean DEFAULT true,
+    created_at timestamp with time zone DEFAULT now()
+);
+
+
+--
+-- Name: case_watchdog_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
+--
+
+CREATE SEQUENCE legal.case_watchdog_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: case_watchdog_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
+--
+
+ALTER SEQUENCE legal.case_watchdog_id_seq OWNED BY legal.case_watchdog.id;
 
 
 --
@@ -609,16 +1946,32 @@ CREATE TABLE legal.case_statements_v2 (
 CREATE TABLE legal.cases (
     id integer NOT NULL,
     case_slug text NOT NULL,
-    case_number text,
-    case_name text,
+    case_number text NOT NULL,
+    case_name text NOT NULL,
     court text,
     judge text,
-    case_type text DEFAULT 'civil'::text,
+    case_type text DEFAULT 'bankruptcy'::text,
     our_role text DEFAULT 'creditor'::text,
     status text DEFAULT 'active'::text,
+    critical_date date,
+    critical_note text,
+    plan_admin text,
+    plan_admin_email text,
+    plan_admin_address text,
+    fiduciary text,
+    opposing_counsel text,
+    our_claim_basis text,
+    petition_date date,
+    notes text,
+    created_at timestamp with time zone DEFAULT now(),
+    updated_at timestamp with time zone DEFAULT now(),
+    risk_score integer,
+    extraction_status text DEFAULT 'none'::text,
     extracted_entities jsonb DEFAULT '{}'::jsonb,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
+    active_brief text,
+    active_consensus jsonb,
+    nas_layout jsonb,
+    CONSTRAINT cases_risk_score_check CHECK (((risk_score >= 1) AND (risk_score <= 5)))
 );
 
 
@@ -643,172 +1996,38 @@ ALTER SEQUENCE legal.cases_id_seq OWNED BY legal.cases.id;
 
 
 --
--- Name: deposition_kill_sheets_v2; Type: TABLE; Schema: legal; Owner: -
+-- Name: correspondence; Type: TABLE; Schema: legal; Owner: -
 --
 
-CREATE TABLE legal.deposition_kill_sheets_v2 (
-    id uuid NOT NULL,
-    case_slug character varying(255) NOT NULL,
-    deponent_entity character varying(255) NOT NULL,
-    status character varying(32) NOT NULL,
-    summary text NOT NULL,
-    high_risk_topics_json jsonb NOT NULL,
-    document_sequence_json jsonb NOT NULL,
-    suggested_questions_json jsonb NOT NULL,
-    created_at timestamp with time zone NOT NULL
-);
-
-
---
--- Name: discovery_draft_items_v2; Type: TABLE; Schema: legal; Owner: -
---
-
-CREATE TABLE legal.discovery_draft_items_v2 (
-    id uuid NOT NULL,
-    pack_id uuid NOT NULL,
-    category character varying(32) NOT NULL,
-    content text NOT NULL,
-    rationale_from_graph text NOT NULL,
-    sequence_number integer NOT NULL,
-    lethality_score integer,
-    proportionality_score integer,
-    correction_notes character varying(2000)
-);
-
-
---
--- Name: discovery_draft_packs_v2; Type: TABLE; Schema: legal; Owner: -
---
-
-CREATE TABLE legal.discovery_draft_packs_v2 (
-    id uuid NOT NULL,
-    case_slug character varying(255) NOT NULL,
-    target_entity character varying(255) NOT NULL,
-    status character varying(32) NOT NULL,
-    created_at timestamp with time zone NOT NULL
-);
-
-
---
--- Name: distillation_memory; Type: TABLE; Schema: legal; Owner: -
---
-
-CREATE TABLE legal.distillation_memory (
-    id uuid NOT NULL,
-    context_hash character varying(128) NOT NULL,
-    frontier_insight text NOT NULL,
-    local_correction text NOT NULL,
-    created_at timestamp with time zone NOT NULL
-);
-
-
---
--- Name: entities; Type: TABLE; Schema: legal; Owner: -
---
-
-CREATE TABLE legal.entities (
-    id uuid NOT NULL,
-    name character varying(255) NOT NULL,
-    type character varying(100) NOT NULL,
-    role character varying(100)
-);
-
-
---
--- Name: legal_cases; Type: TABLE; Schema: legal; Owner: -
---
-
-CREATE TABLE legal.legal_cases (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    slug character varying(255) NOT NULL,
-    court character varying(255) DEFAULT ''::character varying NOT NULL,
-    jurisdiction character varying(255) DEFAULT ''::character varying NOT NULL,
-    status character varying(64) DEFAULT 'open'::character varying NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
---
--- Name: legal_exemplars; Type: TABLE; Schema: legal; Owner: -
---
-
-CREATE TABLE legal.legal_exemplars (
-    id uuid NOT NULL,
-    category character varying(32) NOT NULL,
-    rationale_context text NOT NULL,
-    perfect_output text NOT NULL,
-    source_model character varying(128) NOT NULL,
-    created_at timestamp with time zone NOT NULL
-);
-
-
---
--- Name: sanctions_alerts_v2; Type: TABLE; Schema: legal; Owner: -
---
-
-CREATE TABLE legal.sanctions_alerts_v2 (
-    id uuid NOT NULL,
-    case_slug character varying(255) NOT NULL,
-    alert_type character varying(32) NOT NULL,
-    contradiction_summary text NOT NULL,
-    confidence_score integer NOT NULL,
-    status character varying(32) NOT NULL,
-    created_at timestamp with time zone NOT NULL
-);
-
-
---
--- Name: sanctions_tripwire_runs_v2; Type: TABLE; Schema: legal; Owner: -
---
-
-CREATE TABLE legal.sanctions_tripwire_runs_v2 (
-    id uuid NOT NULL,
-    case_slug character varying(255) NOT NULL,
-    trigger_source character varying(64) NOT NULL,
-    status character varying(32) NOT NULL,
-    model_used character varying(128),
-    alerts_found integer NOT NULL,
-    alerts_saved integer NOT NULL,
-    error_detail text,
-    started_at timestamp with time zone NOT NULL,
-    completed_at timestamp with time zone
-);
-
-
---
--- Name: timeline_events; Type: TABLE; Schema: legal; Owner: -
---
-
-CREATE TABLE legal.timeline_events (
-    id uuid NOT NULL,
-    case_slug character varying(255) NOT NULL,
-    event_date date NOT NULL,
-    description text NOT NULL,
-    source_evidence_id uuid
-);
-
-
---
--- Name: vault_documents; Type: TABLE; Schema: legal; Owner: -
---
-
-CREATE TABLE legal.vault_documents (
+CREATE TABLE legal.correspondence (
     id integer NOT NULL,
-    case_slug text NOT NULL,
-    file_name text,
-    nfs_path text,
-    mime_type text,
-    chunk_count integer,
-    processing_status text DEFAULT 'pending'::text NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
+    case_id integer,
+    direction text DEFAULT 'outbound'::text NOT NULL,
+    comm_type text NOT NULL,
+    recipient text,
+    recipient_email text,
+    subject text NOT NULL,
+    body text,
+    status text DEFAULT 'draft'::text,
+    gmail_draft_id text,
+    tracking_number text,
+    file_path text,
+    approved_by text,
+    approved_at timestamp with time zone,
+    sent_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now(),
+    risk_score integer,
+    extraction_status text DEFAULT 'none'::text,
+    extracted_entities jsonb DEFAULT '{}'::jsonb,
+    CONSTRAINT correspondence_risk_score_check CHECK (((risk_score >= 1) AND (risk_score <= 5)))
 );
 
 
 --
--- Name: vault_documents_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
+-- Name: correspondence_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
 --
 
-CREATE SEQUENCE legal.vault_documents_id_seq
+CREATE SEQUENCE legal.correspondence_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -818,10 +2037,564 @@ CREATE SEQUENCE legal.vault_documents_id_seq
 
 
 --
--- Name: vault_documents_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
+-- Name: correspondence_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
 --
 
-ALTER SEQUENCE legal.vault_documents_id_seq OWNED BY legal.vault_documents.id;
+ALTER SEQUENCE legal.correspondence_id_seq OWNED BY legal.correspondence.id;
+
+
+--
+-- Name: deadlines; Type: TABLE; Schema: legal; Owner: -
+--
+
+CREATE TABLE legal.deadlines (
+    id integer NOT NULL,
+    case_id integer,
+    deadline_type text NOT NULL,
+    description text NOT NULL,
+    due_date date NOT NULL,
+    alert_days_before integer DEFAULT 7,
+    status text DEFAULT 'pending'::text,
+    extended_to date,
+    extension_reason text,
+    created_at timestamp with time zone DEFAULT now(),
+    source_document text,
+    auto_extracted boolean DEFAULT false,
+    review_status character varying(20) DEFAULT 'pending_review'::character varying,
+    content_hash character varying(32)
+);
+
+
+--
+-- Name: deadlines_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
+--
+
+CREATE SEQUENCE legal.deadlines_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: deadlines_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
+--
+
+ALTER SEQUENCE legal.deadlines_id_seq OWNED BY legal.deadlines.id;
+
+
+--
+-- Name: email_intake_queue; Type: TABLE; Schema: legal; Owner: -
+--
+
+CREATE TABLE legal.email_intake_queue (
+    id integer NOT NULL,
+    message_uid text NOT NULL,
+    sender_email text NOT NULL,
+    sender_name text,
+    subject text,
+    body_text text,
+    case_slug text,
+    triage_result jsonb,
+    intake_status text DEFAULT 'pending'::text NOT NULL,
+    attachment_count integer DEFAULT 0,
+    correspondence_id integer,
+    received_at timestamp with time zone DEFAULT now() NOT NULL,
+    processed_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: email_intake_queue_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
+--
+
+CREATE SEQUENCE legal.email_intake_queue_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: email_intake_queue_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
+--
+
+ALTER SEQUENCE legal.email_intake_queue_id_seq OWNED BY legal.email_intake_queue.id;
+
+
+--
+-- Name: expense_intake; Type: TABLE; Schema: legal; Owner: -
+--
+
+CREATE TABLE legal.expense_intake (
+    id integer NOT NULL,
+    case_slug text,
+    vendor text NOT NULL,
+    amount numeric(15,2) DEFAULT 0 NOT NULL,
+    description text,
+    rag_category text,
+    rag_reasoning text,
+    audit_trail jsonb DEFAULT '[]'::jsonb,
+    source_system text DEFAULT 'triage_router'::text,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: expense_intake_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
+--
+
+CREATE SEQUENCE legal.expense_intake_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: expense_intake_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
+--
+
+ALTER SEQUENCE legal.expense_intake_id_seq OWNED BY legal.expense_intake.id;
+
+
+--
+-- Name: filings; Type: TABLE; Schema: legal; Owner: -
+--
+
+CREATE TABLE legal.filings (
+    id integer NOT NULL,
+    case_id integer,
+    filing_type text NOT NULL,
+    title text NOT NULL,
+    filed_date date,
+    filed_by text,
+    filed_with text,
+    filing_location text,
+    status text DEFAULT 'filed'::text,
+    served_on text,
+    served_date date,
+    served_method text,
+    original_path text,
+    stamped_path text,
+    notes text,
+    created_at timestamp with time zone DEFAULT now(),
+    updated_at timestamp with time zone DEFAULT now()
+);
+
+
+--
+-- Name: filings_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
+--
+
+CREATE SEQUENCE legal.filings_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: filings_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
+--
+
+ALTER SEQUENCE legal.filings_id_seq OWNED BY legal.filings.id;
+
+
+--
+-- Name: ingest_runs; Type: TABLE; Schema: legal; Owner: -
+--
+
+CREATE TABLE legal.ingest_runs (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    case_slug text NOT NULL,
+    script_name text NOT NULL,
+    started_at timestamp with time zone DEFAULT now() NOT NULL,
+    ended_at timestamp with time zone,
+    args jsonb DEFAULT '{}'::jsonb NOT NULL,
+    status text DEFAULT 'running'::text NOT NULL,
+    manifest_path text,
+    total_files integer,
+    processed integer,
+    errored integer,
+    skipped integer,
+    error_summary text,
+    host text,
+    pid integer,
+    runtime_seconds numeric(12,3),
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT ingest_runs_status_check CHECK ((status = ANY (ARRAY['running'::text, 'complete'::text, 'error'::text, 'interrupted'::text])))
+);
+
+
+--
+-- Name: timeline_events; Type: TABLE; Schema: legal; Owner: -
+--
+
+CREATE TABLE legal.timeline_events (
+    id integer NOT NULL,
+    case_slug text NOT NULL,
+    event_date date DEFAULT CURRENT_DATE NOT NULL,
+    description text,
+    source_evidence_id integer,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: timeline_events_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
+--
+
+CREATE SEQUENCE legal.timeline_events_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: timeline_events_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
+--
+
+ALTER SEQUENCE legal.timeline_events_id_seq OWNED BY legal.timeline_events.id;
+
+
+--
+-- Name: uploads; Type: TABLE; Schema: legal; Owner: -
+--
+
+CREATE TABLE legal.uploads (
+    id integer NOT NULL,
+    case_id integer,
+    filename text NOT NULL,
+    original_name text NOT NULL,
+    content_type text DEFAULT 'application/pdf'::text,
+    file_size integer,
+    nas_path text NOT NULL,
+    upload_type text DEFAULT 'general'::text,
+    description text,
+    filing_id integer,
+    uploaded_by text DEFAULT 'admin'::text,
+    created_at timestamp with time zone DEFAULT now()
+);
+
+
+--
+-- Name: uploads_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
+--
+
+CREATE SEQUENCE legal.uploads_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: uploads_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
+--
+
+ALTER SEQUENCE legal.uploads_id_seq OWNED BY legal.uploads.id;
+
+
+--
+-- Name: vault_documents; Type: TABLE; Schema: legal; Owner: -
+--
+
+CREATE TABLE legal.vault_documents (
+    id uuid NOT NULL,
+    case_slug text NOT NULL,
+    file_name text NOT NULL,
+    nfs_path text NOT NULL,
+    mime_type text NOT NULL,
+    file_hash text NOT NULL,
+    file_size_bytes bigint NOT NULL,
+    processing_status text DEFAULT 'pending'::text NOT NULL,
+    chunk_count integer,
+    error_detail text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT chk_vault_documents_status CHECK ((processing_status = ANY (ARRAY['pending'::text, 'processing'::text, 'vectorizing'::text, 'complete'::text, 'completed'::text, 'ocr_failed'::text, 'error'::text, 'failed'::text, 'locked_privileged'::text])))
+);
+
+
+--
+-- Name: attorney_scoring; Type: TABLE; Schema: legal_cmd; Owner: -
+--
+
+CREATE TABLE legal_cmd.attorney_scoring (
+    id integer NOT NULL,
+    attorney_id uuid,
+    sota_match_score integer,
+    eckles_competency boolean DEFAULT false,
+    commercial_litigation_focus boolean DEFAULT false,
+    fannin_jurisdiction_match boolean DEFAULT false,
+    ai_rationale text,
+    scored_by_model text,
+    scored_at timestamp without time zone DEFAULT now(),
+    CONSTRAINT attorney_scoring_sota_match_score_check CHECK (((sota_match_score >= 0) AND (sota_match_score <= 100)))
+);
+
+
+--
+-- Name: attorney_scoring_id_seq; Type: SEQUENCE; Schema: legal_cmd; Owner: -
+--
+
+CREATE SEQUENCE legal_cmd.attorney_scoring_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: attorney_scoring_id_seq; Type: SEQUENCE OWNED BY; Schema: legal_cmd; Owner: -
+--
+
+ALTER SEQUENCE legal_cmd.attorney_scoring_id_seq OWNED BY legal_cmd.attorney_scoring.id;
+
+
+--
+-- Name: attorneys; Type: TABLE; Schema: legal_cmd; Owner: -
+--
+
+CREATE TABLE legal_cmd.attorneys (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    first_name text NOT NULL,
+    last_name text NOT NULL,
+    firm_name text,
+    specialty text,
+    email text,
+    phone text,
+    address text,
+    website text,
+    bar_number text,
+    bar_state text,
+    hourly_rate numeric(10,2),
+    retainer_amount numeric(10,2),
+    retainer_status text DEFAULT 'none'::text,
+    engagement_date date,
+    status text DEFAULT 'active'::text,
+    rating integer,
+    notes text,
+    tags text[],
+    created_at timestamp with time zone DEFAULT now(),
+    updated_at timestamp with time zone DEFAULT now(),
+    case_id integer,
+    source text,
+    source_url text,
+    ai_score numeric(3,1),
+    ai_score_reasoning text,
+    practice_areas text[],
+    jurisdiction text[],
+    admission_date date,
+    outreach_status text DEFAULT 'prospect'::text,
+    last_contacted_at timestamp with time zone,
+    firm_size character varying(50),
+    CONSTRAINT attorneys_rating_check CHECK (((rating >= 1) AND (rating <= 5)))
+);
+
+
+--
+-- Name: deliberation_events; Type: TABLE; Schema: legal_cmd; Owner: -
+--
+
+CREATE TABLE legal_cmd.deliberation_events (
+    event_id uuid DEFAULT gen_random_uuid() NOT NULL,
+    case_slug character varying(255) NOT NULL,
+    case_number character varying(255),
+    "timestamp" timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    trigger_type character varying(50) NOT NULL,
+    qdrant_vector_ids text[],
+    context_chunks text[],
+    user_prompt text NOT NULL,
+    moe_roster_snapshot jsonb NOT NULL,
+    seat_opinions jsonb NOT NULL,
+    counsel_results jsonb NOT NULL,
+    consensus_signal character varying(50),
+    consensus_conviction numeric(4,3),
+    execution_time_ms integer,
+    sha256_signature character varying(64) NOT NULL
+);
+
+
+--
+-- Name: documents; Type: TABLE; Schema: legal_cmd; Owner: -
+--
+
+CREATE TABLE legal_cmd.documents (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    matter_id uuid,
+    title text NOT NULL,
+    doc_type text,
+    file_path text,
+    file_url text,
+    description text,
+    uploaded_by text DEFAULT 'owner'::text,
+    tags text[],
+    created_at timestamp with time zone DEFAULT now()
+);
+
+
+--
+-- Name: matters; Type: TABLE; Schema: legal_cmd; Owner: -
+--
+
+CREATE TABLE legal_cmd.matters (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    title text NOT NULL,
+    reference_code text,
+    category text NOT NULL,
+    status text DEFAULT 'open'::text,
+    priority text DEFAULT 'normal'::text,
+    description text,
+    attorney_id uuid,
+    opposing_party text,
+    opposing_counsel text,
+    amount_at_stake numeric(12,2),
+    outcome text,
+    outcome_date date,
+    next_action text,
+    next_action_date date,
+    tags text[],
+    created_at timestamp with time zone DEFAULT now(),
+    updated_at timestamp with time zone DEFAULT now()
+);
+
+
+--
+-- Name: meetings; Type: TABLE; Schema: legal_cmd; Owner: -
+--
+
+CREATE TABLE legal_cmd.meetings (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    matter_id uuid,
+    attorney_id uuid,
+    title text NOT NULL,
+    meeting_type text DEFAULT 'in_person'::text,
+    meeting_date timestamp with time zone NOT NULL,
+    duration_minutes integer,
+    location text,
+    attendees text,
+    summary text,
+    action_items text,
+    key_decisions text,
+    documents_discussed text,
+    billable boolean DEFAULT false,
+    cost numeric(10,2),
+    follow_up_date date,
+    follow_up_notes text,
+    tags text[],
+    created_at timestamp with time zone DEFAULT now(),
+    updated_at timestamp with time zone DEFAULT now()
+);
+
+
+--
+-- Name: timeline; Type: TABLE; Schema: legal_cmd; Owner: -
+--
+
+CREATE TABLE legal_cmd.timeline (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    matter_id uuid NOT NULL,
+    entry_type text NOT NULL,
+    title text NOT NULL,
+    body text,
+    entered_by text DEFAULT 'owner'::text,
+    importance text DEFAULT 'normal'::text,
+    related_meeting_id uuid,
+    related_attorney_id uuid,
+    document_ref text,
+    tags text[],
+    created_at timestamp with time zone DEFAULT now()
+);
+
+
+--
+-- Name: ab_test_observations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ab_test_observations (
+    id integer NOT NULL,
+    test_id integer,
+    variant text NOT NULL,
+    metric_value numeric(15,4),
+    context jsonb,
+    created_at timestamp without time zone DEFAULT now()
+);
+
+
+--
+-- Name: ab_test_observations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ab_test_observations_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: ab_test_observations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ab_test_observations_id_seq OWNED BY public.ab_test_observations.id;
+
+
+--
+-- Name: ab_tests; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ab_tests (
+    id integer NOT NULL,
+    test_name text NOT NULL,
+    agent_id text NOT NULL,
+    variant_a text NOT NULL,
+    variant_b text NOT NULL,
+    metric_name text NOT NULL,
+    status text DEFAULT 'active'::text,
+    winner text,
+    created_at timestamp without time zone DEFAULT now(),
+    concluded_at timestamp without time zone
+);
+
+
+--
+-- Name: ab_tests_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ab_tests_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: ab_tests_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ab_tests_id_seq OWNED BY public.ab_tests.id;
 
 
 --
@@ -829,9 +2602,19 @@ ALTER SEQUENCE legal.vault_documents_id_seq OWNED BY legal.vault_documents.id;
 --
 
 CREATE TABLE public.accounts (
-    id bigint NOT NULL,
-    code character varying(32) NOT NULL,
-    name character varying(255) NOT NULL
+    id integer NOT NULL,
+    code text NOT NULL,
+    name text NOT NULL,
+    account_type text NOT NULL,
+    sub_type text,
+    normal_balance text NOT NULL,
+    parent_id integer,
+    property_id text,
+    is_active boolean DEFAULT true,
+    description text,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT accounts_account_type_check CHECK ((account_type = ANY (ARRAY['Asset'::text, 'Liability'::text, 'Equity'::text, 'Revenue'::text, 'Expense'::text]))),
+    CONSTRAINT accounts_normal_balance_check CHECK ((normal_balance = ANY (ARRAY['debit'::text, 'credit'::text])))
 );
 
 
@@ -840,6 +2623,7 @@ CREATE TABLE public.accounts (
 --
 
 CREATE SEQUENCE public.accounts_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -855,77 +2639,45 @@ ALTER SEQUENCE public.accounts_id_seq OWNED BY public.accounts.id;
 
 
 --
--- Name: activities; Type: TABLE; Schema: public; Owner: -
+-- Name: active_learning_queue; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.activities (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    title character varying(500) NOT NULL,
-    slug character varying(255) NOT NULL,
-    activity_slug character varying(500),
-    body text,
-    body_summary text,
-    address text,
-    activity_type character varying(255),
-    activity_type_tid integer,
-    area character varying(255),
-    area_tid integer,
-    people character varying(255),
-    people_tid integer,
-    difficulty_level character varying(255),
-    difficulty_level_tid integer,
-    season character varying(255),
-    season_tid integer,
-    featured_image_url text,
-    featured_image_alt character varying(500),
-    featured_image_title character varying(500),
-    video_urls jsonb,
-    latitude double precision,
-    longitude double precision,
-    status character varying(50) DEFAULT 'published'::character varying,
-    is_featured boolean DEFAULT false,
-    display_order integer DEFAULT 0,
-    drupal_nid integer,
-    drupal_vid integer,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    published_at timestamp with time zone
+CREATE TABLE public.active_learning_queue (
+    id integer NOT NULL,
+    judgment_id integer,
+    agent_id text NOT NULL,
+    metric_name text NOT NULL,
+    predicted_value numeric(15,4),
+    actual_value numeric(15,4),
+    variance_pct numeric(8,4),
+    context jsonb,
+    status text DEFAULT 'pending'::text,
+    reviewer text,
+    review_result text,
+    review_notes text,
+    created_at timestamp without time zone DEFAULT now(),
+    reviewed_at timestamp without time zone
 );
 
 
 --
--- Name: agent_queue; Type: TABLE; Schema: public; Owner: -
+-- Name: active_learning_queue_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.agent_queue (
-    id uuid NOT NULL,
-    guest_id uuid,
-    property_id uuid,
-    original_ai_draft text NOT NULL,
-    final_human_message text,
-    status character varying(30) NOT NULL,
-    delivery_channel character varying(20) DEFAULT 'email'::character varying NOT NULL,
-    twilio_sid character varying(128),
-    error_log text,
-    created_at timestamp with time zone NOT NULL,
-    updated_at timestamp with time zone NOT NULL,
-    CONSTRAINT ck_agent_queue_status CHECK (((status)::text = ANY ((ARRAY['pending_review'::character varying, 'approved'::character varying, 'edited'::character varying, 'rejected'::character varying, 'sending'::character varying, 'delivered'::character varying, 'failed'::character varying])::text[])))
-);
+CREATE SEQUENCE public.active_learning_queue_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
 
 
 --
--- Name: agent_registry; Type: TABLE; Schema: public; Owner: -
+-- Name: active_learning_queue_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE public.agent_registry (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    name character varying(255) NOT NULL,
-    role character varying(100) NOT NULL,
-    is_active boolean DEFAULT true NOT NULL,
-    scope_boundary jsonb NOT NULL,
-    daily_tool_budget integer NOT NULL,
-    CONSTRAINT ck_agent_registry_daily_tool_budget_nonnegative CHECK ((daily_tool_budget >= 0))
-);
+ALTER SEQUENCE public.active_learning_queue_id_seq OWNED BY public.active_learning_queue.id;
 
 
 --
@@ -933,64 +2685,360 @@ CREATE TABLE public.agent_registry (
 --
 
 CREATE TABLE public.agent_response_queue (
-    id uuid NOT NULL,
-    message_id uuid NOT NULL,
-    guest_id uuid,
-    reservation_id uuid,
+    id bigint NOT NULL,
+    inbound_message_id bigint,
+    phone_number character varying(20) NOT NULL,
+    guest_name character varying(255),
+    cabin_name character varying(100),
+    reservation_id character varying(100),
+    guest_message text NOT NULL,
     intent character varying(50),
-    sentiment_label character varying(30),
-    sentiment_score double precision,
-    urgency_level integer,
-    proposed_response text NOT NULL,
-    confidence double precision NOT NULL,
-    action character varying(80),
+    intent_confidence numeric(4,3),
+    sentiment character varying(20),
+    urgency_level integer DEFAULT 1,
+    escalation_required boolean DEFAULT false,
     escalation_reason text,
-    status character varying(30) NOT NULL,
+    ai_draft text NOT NULL,
+    ai_model character varying(100),
+    ai_duration_ms integer,
+    knowledge_sources jsonb,
+    confidence_score numeric(4,3),
+    status character varying(20) DEFAULT 'pending_review'::character varying NOT NULL,
     reviewed_by character varying(100),
     reviewed_at timestamp without time zone,
-    final_response text,
-    sent_message_id uuid,
-    decision_metadata jsonb,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone
+    edited_draft text,
+    review_notes text,
+    sent_at timestamp without time zone,
+    sent_via character varying(20),
+    outbound_message_id bigint,
+    delivery_status character varying(20),
+    created_at timestamp without time zone DEFAULT now(),
+    updated_at timestamp without time zone DEFAULT now(),
+    expires_at timestamp without time zone,
+    quality_grade integer,
+    edit_distance_pct numeric(5,2),
+    grade_notes text,
+    guest_tier character varying(20) DEFAULT 'new'::character varying,
+    converted_at timestamp with time zone,
+    revenue_generated numeric(10,2) DEFAULT 0.00,
+    CONSTRAINT agent_response_queue_quality_grade_check CHECK (((quality_grade >= 1) AND (quality_grade <= 5)))
 );
 
 
 --
--- Name: agent_runs; Type: TABLE; Schema: public; Owner: -
+-- Name: agent_grade_summary; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE TABLE public.agent_runs (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    agent_id uuid NOT NULL,
-    trigger_source character varying(100) NOT NULL,
-    status character varying(9) DEFAULT 'queued'::character varying NOT NULL,
-    started_at timestamp with time zone DEFAULT now() NOT NULL,
-    completed_at timestamp with time zone,
-    CONSTRAINT agent_run_status CHECK (((status)::text = ANY ((ARRAY['queued'::character varying, 'running'::character varying, 'completed'::character varying, 'failed'::character varying, 'escalated'::character varying, 'blocked'::character varying])::text[])))
+CREATE VIEW public.agent_grade_summary AS
+ SELECT intent,
+    ai_model,
+    count(*) AS total,
+    count(*) FILTER (WHERE (quality_grade IS NOT NULL)) AS graded,
+    round(avg(quality_grade), 2) AS avg_grade,
+    round(avg(edit_distance_pct), 1) AS avg_edit_pct,
+    count(*) FILTER (WHERE ((status)::text = 'approved'::text)) AS approved_as_is,
+    count(*) FILTER (WHERE ((status)::text = 'edited'::text)) AS needed_edit,
+    count(*) FILTER (WHERE ((status)::text = 'rejected'::text)) AS rejected,
+    round(avg(ai_duration_ms), 0) AS avg_duration_ms
+   FROM public.agent_response_queue
+  GROUP BY intent, ai_model
+  ORDER BY (count(*)) DESC;
+
+
+--
+-- Name: agent_learning_log; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.agent_learning_log (
+    id bigint NOT NULL,
+    queue_id bigint,
+    pattern_type character varying(50) NOT NULL,
+    intent character varying(50),
+    cabin_name character varying(100),
+    ai_draft text,
+    human_edit text,
+    correction_summary text,
+    quality_grade integer,
+    edit_distance_pct numeric(5,2),
+    learned_at timestamp without time zone DEFAULT now()
 );
 
 
 --
--- Name: agreement_templates; Type: TABLE; Schema: public; Owner: -
+-- Name: agent_learning_log_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.agreement_templates (
-    id uuid NOT NULL,
-    name character varying(255) NOT NULL,
-    description text,
-    agreement_type character varying(50) NOT NULL,
-    content_markdown text NOT NULL,
-    required_variables jsonb,
-    is_active boolean,
-    requires_signature boolean,
-    requires_initials boolean,
-    auto_send boolean,
-    send_days_before_checkin integer,
-    property_ids jsonb,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone
+CREATE SEQUENCE public.agent_learning_log_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: agent_learning_log_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.agent_learning_log_id_seq OWNED BY public.agent_learning_log.id;
+
+
+--
+-- Name: agent_memory; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.agent_memory (
+    id bigint NOT NULL,
+    request_id uuid NOT NULL,
+    model character varying(128) NOT NULL,
+    reasoning_block text,
+    outcome_tags jsonb DEFAULT '[]'::jsonb,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    retained_until timestamp with time zone
 );
+
+
+--
+-- Name: agent_memory_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.agent_memory_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: agent_memory_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.agent_memory_id_seq OWNED BY public.agent_memory.id;
+
+
+--
+-- Name: agent_performance_log; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.agent_performance_log (
+    id bigint NOT NULL,
+    date date DEFAULT CURRENT_DATE NOT NULL,
+    messages_received integer DEFAULT 0,
+    drafts_generated integer DEFAULT 0,
+    drafts_approved integer DEFAULT 0,
+    drafts_edited integer DEFAULT 0,
+    drafts_rejected integer DEFAULT 0,
+    auto_sent integer DEFAULT 0,
+    avg_confidence numeric(4,3),
+    avg_response_time_ms integer,
+    escalation_count integer DEFAULT 0,
+    intent_breakdown jsonb,
+    created_at timestamp without time zone DEFAULT now()
+);
+
+
+--
+-- Name: agent_performance_log_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.agent_performance_log_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: agent_performance_log_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.agent_performance_log_id_seq OWNED BY public.agent_performance_log.id;
+
+
+--
+-- Name: agent_response_queue_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.agent_response_queue_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: agent_response_queue_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.agent_response_queue_id_seq OWNED BY public.agent_response_queue.id;
+
+
+--
+-- Name: agent_telemetry; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.agent_telemetry (
+    id bigint NOT NULL,
+    request_id uuid NOT NULL,
+    prompt_hash character varying(64),
+    model character varying(128) NOT NULL,
+    route character varying(256),
+    latency_ms integer,
+    retries smallint DEFAULT '0'::smallint NOT NULL,
+    error_class character varying(256),
+    user_feedback_signal character varying(32),
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    retained_until timestamp with time zone
+);
+
+
+--
+-- Name: agent_telemetry_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.agent_telemetry_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: agent_telemetry_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.agent_telemetry_id_seq OWNED BY public.agent_telemetry.id;
+
+
+--
+-- Name: ai_training_labels; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ai_training_labels (
+    id bigint NOT NULL,
+    message_id bigint,
+    labeled_intent character varying(50) NOT NULL,
+    labeled_sentiment character varying(20),
+    labeled_urgency integer,
+    requires_human boolean,
+    response_appropriateness integer,
+    response_accuracy integer,
+    response_tone integer,
+    labeled_by character varying(100) NOT NULL,
+    labeled_at timestamp without time zone DEFAULT now(),
+    labeling_confidence integer,
+    notes text,
+    used_in_training_run character varying(100),
+    training_epoch integer,
+    CONSTRAINT valid_accuracy CHECK ((((response_accuracy >= 1) AND (response_accuracy <= 5)) OR (response_accuracy IS NULL))),
+    CONSTRAINT valid_appropriateness CHECK ((((response_appropriateness >= 1) AND (response_appropriateness <= 5)) OR (response_appropriateness IS NULL)))
+);
+
+
+--
+-- Name: message_archive; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.message_archive (
+    id bigint NOT NULL,
+    source character varying(50) NOT NULL,
+    external_id character varying(255),
+    provider_account character varying(100),
+    phone_number character varying(20),
+    guest_name character varying(255),
+    message_body text NOT NULL,
+    direction character varying(10) NOT NULL,
+    media_url text[],
+    sent_at timestamp without time zone,
+    received_at timestamp without time zone,
+    delivered_at timestamp without time zone,
+    read_at timestamp without time zone,
+    failed_at timestamp without time zone,
+    property_id integer,
+    cabin_name character varying(100),
+    reservation_id character varying(100),
+    reservation_checkin date,
+    reservation_checkout date,
+    intent character varying(50),
+    intent_confidence numeric(4,3),
+    sub_intent character varying(50),
+    sentiment character varying(20),
+    urgency_level integer,
+    contains_question boolean DEFAULT false,
+    requires_human boolean DEFAULT false,
+    response_generated_by character varying(50),
+    response_time_seconds integer,
+    ai_model_used character varying(100),
+    response_quality_score integer,
+    resolution_status character varying(20),
+    used_for_training boolean DEFAULT false,
+    training_label character varying(50),
+    training_split character varying(10),
+    human_reviewed boolean DEFAULT false,
+    human_reviewer character varying(100),
+    review_notes text,
+    approved_for_fine_tuning boolean DEFAULT false,
+    status character varying(50),
+    error_code character varying(50),
+    error_message text,
+    num_segments integer DEFAULT 1,
+    cost_usd numeric(10,6),
+    provider_cost_usd numeric(10,6),
+    created_at timestamp without time zone DEFAULT now(),
+    updated_at timestamp without time zone DEFAULT now(),
+    extracted_at timestamp without time zone,
+    extraction_method character varying(50),
+    channel character varying(20) DEFAULT 'sms'::character varying,
+    sender_email text,
+    CONSTRAINT valid_direction CHECK (((direction)::text = ANY ((ARRAY['inbound'::character varying, 'outbound'::character varying])::text[]))),
+    CONSTRAINT valid_quality CHECK ((((response_quality_score >= 1) AND (response_quality_score <= 5)) OR (response_quality_score IS NULL))),
+    CONSTRAINT valid_sentiment CHECK ((((sentiment)::text = ANY ((ARRAY['positive'::character varying, 'neutral'::character varying, 'negative'::character varying, 'urgent'::character varying])::text[])) OR (sentiment IS NULL))),
+    CONSTRAINT valid_urgency CHECK ((((urgency_level >= 1) AND (urgency_level <= 5)) OR (urgency_level IS NULL)))
+);
+
+
+--
+-- Name: ai_training_dataset; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.ai_training_dataset AS
+ SELECT ma.id,
+    ma.message_body AS input_text,
+    ma.intent AS intent_label,
+    ma.sentiment AS sentiment_label,
+    ma.direction,
+    atl.labeled_intent,
+    atl.labeled_sentiment,
+    atl.response_appropriateness,
+    ma.phone_number,
+    ma.property_id,
+    ma.sent_at
+   FROM (public.message_archive ma
+     LEFT JOIN public.ai_training_labels atl ON ((ma.id = atl.message_id)))
+  WHERE ((ma.used_for_training = true) AND (ma.human_reviewed = true));
+
+
+--
+-- Name: ai_training_labels_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ai_training_labels_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: ai_training_labels_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ai_training_labels_id_seq OWNED BY public.ai_training_labels.id;
 
 
 --
@@ -1003,112 +3051,35 @@ CREATE TABLE public.alembic_version (
 
 
 --
--- Name: analytics_events; Type: TABLE; Schema: public; Owner: -
+-- Name: anomaly_flags; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.analytics_events (
-    id uuid NOT NULL,
-    event_type character varying(100) NOT NULL,
-    guest_id uuid,
-    reservation_id uuid,
-    property_id uuid,
-    event_data jsonb,
-    session_id uuid,
-    user_agent text,
-    ip_address inet,
-    created_at timestamp without time zone
+CREATE TABLE public.anomaly_flags (
+    id integer NOT NULL,
+    journal_entry_id integer NOT NULL,
+    account_id integer,
+    flag_type text NOT NULL,
+    severity text NOT NULL,
+    deviation_pct numeric(8,2),
+    expected_amount numeric(15,2),
+    actual_amount numeric(15,2),
+    ai_explanation text,
+    reviewed boolean DEFAULT false,
+    reviewed_by text,
+    reviewed_at timestamp without time zone,
+    review_notes text,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT anomaly_flags_flag_type_check CHECK ((flag_type = ANY (ARRAY['amount_deviation'::text, 'unusual_category'::text, 'duplicate_suspect'::text, 'missing_reference'::text, 'trust_imbalance'::text, 'manual_review'::text]))),
+    CONSTRAINT anomaly_flags_severity_check CHECK ((severity = ANY (ARRAY['low'::text, 'medium'::text, 'high'::text, 'critical'::text])))
 );
 
 
 --
--- Name: async_job_runs; Type: TABLE; Schema: public; Owner: -
+-- Name: anomaly_flags_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.async_job_runs (
-    id uuid NOT NULL,
-    job_name character varying(100) NOT NULL,
-    queue_name character varying(100) NOT NULL,
-    status character varying(20) NOT NULL,
-    requested_by character varying(255),
-    tenant_id character varying(100),
-    request_id character varying(100),
-    arq_job_id character varying(100),
-    attempts integer NOT NULL,
-    payload_json jsonb NOT NULL,
-    result_json jsonb NOT NULL,
-    error_text text,
-    created_at timestamp with time zone NOT NULL,
-    started_at timestamp with time zone,
-    finished_at timestamp with time zone,
-    updated_at timestamp with time zone NOT NULL,
-    CONSTRAINT ck_async_job_runs_status CHECK (((status)::text = ANY ((ARRAY['queued'::character varying, 'running'::character varying, 'succeeded'::character varying, 'failed'::character varying, 'cancelled'::character varying])::text[])))
-);
-
-
---
--- Name: blocked_days; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.blocked_days (
-    id uuid NOT NULL,
-    property_id uuid NOT NULL,
-    start_date date NOT NULL,
-    end_date date NOT NULL,
-    block_type character varying(50),
-    confirmation_code character varying(50),
-    source character varying(20),
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone
-);
-
-
---
--- Name: blogs; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.blogs (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    title character varying(500) NOT NULL,
-    slug character varying(255) NOT NULL,
-    body text,
-    author_name character varying(255),
-    status character varying(50) DEFAULT 'published'::character varying,
-    is_promoted boolean DEFAULT false,
-    is_sticky boolean DEFAULT false,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    published_at timestamp with time zone
-);
-
-
---
--- Name: capex_staging; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.capex_staging (
-    id bigint NOT NULL,
-    property_id character varying(100) NOT NULL,
-    vendor character varying(255) NOT NULL,
-    amount numeric(12,2) NOT NULL,
-    total_owner_charge numeric(12,2) NOT NULL,
-    description text,
-    journal_lines jsonb,
-    audit_trail jsonb,
-    compliance_status character varying(64) DEFAULT 'PENDING_CAPEX_APPROVAL'::character varying NOT NULL,
-    approved_by character varying(100),
-    approved_at timestamp with time zone,
-    rejected_by character varying(100),
-    rejected_at timestamp with time zone,
-    rejection_reason text,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
---
--- Name: capex_staging_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.capex_staging_id_seq
+CREATE SEQUENCE public.anomaly_flags_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1117,193 +3088,261 @@ CREATE SEQUENCE public.capex_staging_id_seq
 
 
 --
--- Name: capex_staging_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+-- Name: anomaly_flags_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.capex_staging_id_seq OWNED BY public.capex_staging.id;
+ALTER SEQUENCE public.anomaly_flags_id_seq OWNED BY public.anomaly_flags.id;
 
 
 --
--- Name: capture_labels; Type: TABLE; Schema: public; Owner: -
+-- Name: api_key_vault; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.capture_labels (
+CREATE TABLE public.api_key_vault (
+    id integer NOT NULL,
+    key_name character varying(100) NOT NULL,
+    encrypted_value text NOT NULL,
+    label character varying(100),
+    description text,
+    category character varying(50) DEFAULT 'General'::character varying,
+    last_rotated timestamp with time zone DEFAULT now(),
+    created_at timestamp with time zone DEFAULT now(),
+    updated_by character varying(50)
+);
+
+
+--
+-- Name: api_key_vault_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.api_key_vault_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: api_key_vault_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.api_key_vault_id_seq OWNED BY public.api_key_vault.id;
+
+
+--
+-- Name: asset_docs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.asset_docs (
+    id integer NOT NULL,
+    property_id integer,
+    property_name text,
+    doc_type character varying(50),
+    file_path text,
+    filename text,
+    extension text,
+    file_size bigint,
+    ocr_text text,
+    recording_date date,
+    book_page character varying(50),
+    grantor text,
+    grantee text,
+    parcel_id character varying(50),
+    confidence text,
+    ai_json text,
+    phase integer DEFAULT 1,
+    last_updated timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: asset_docs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.asset_docs_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: asset_docs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.asset_docs_id_seq OWNED BY public.asset_docs.id;
+
+
+--
+-- Name: conversation_threads; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.conversation_threads (
+    id bigint NOT NULL,
+    phone_number character varying(20) NOT NULL,
+    property_id integer,
+    thread_hash character varying(64),
+    started_at timestamp without time zone NOT NULL,
+    last_message_at timestamp without time zone NOT NULL,
+    message_count integer DEFAULT 0,
+    inbound_count integer DEFAULT 0,
+    outbound_count integer DEFAULT 0,
+    primary_intent character varying(50),
+    status character varying(20),
+    resolution_time_seconds integer,
+    handled_by_ai boolean DEFAULT false,
+    ai_success boolean,
+    escalated_to_human boolean DEFAULT false,
+    escalation_reason text,
+    guest_satisfaction_score integer,
+    guest_feedback text,
+    reservation_id character varying(100),
+    cabin_name character varying(100),
+    created_at timestamp without time zone DEFAULT now(),
+    updated_at timestamp without time zone DEFAULT now(),
+    CONSTRAINT valid_status CHECK (((status)::text = ANY ((ARRAY['active'::character varying, 'resolved'::character varying, 'escalated'::character varying, 'abandoned'::character varying])::text[])))
+);
+
+
+--
+-- Name: conversation_threads_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.conversation_threads_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: conversation_threads_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.conversation_threads_id_seq OWNED BY public.conversation_threads.id;
+
+
+--
+-- Name: council_votes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.council_votes (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
+    event text NOT NULL,
+    context text,
+    model_used character varying(100) DEFAULT 'qwen2.5:7b'::character varying NOT NULL,
+    consensus_signal character varying(20) NOT NULL,
+    consensus_conviction double precision NOT NULL,
+    agreement_rate double precision NOT NULL,
+    bullish_count integer DEFAULT 0 NOT NULL,
+    bearish_count integer DEFAULT 0 NOT NULL,
+    neutral_count integer DEFAULT 0 NOT NULL,
+    total_voters integer DEFAULT 9 NOT NULL,
+    opinions jsonb DEFAULT '[]'::jsonb NOT NULL,
+    signal_breakdown jsonb DEFAULT '{}'::jsonb NOT NULL,
+    mode character varying(50),
+    elapsed_seconds double precision,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
-    capture_id uuid NOT NULL,
-    capture_table character varying(32) NOT NULL,
-    task_type character varying(64) NOT NULL,
-    godhead_model character varying(128),
-    godhead_decision character varying(16),
-    godhead_reasoning text,
-    godhead_called_at timestamp with time zone,
-    godhead_cost_usd numeric(8,4),
-    qc_sampled boolean DEFAULT false NOT NULL,
-    qc_decision character varying(16),
-    qc_note text,
-    qc_reviewed_at timestamp with time zone,
-    final_decision character varying(16),
-    label_source character varying(16)
+    resolved_at timestamp with time zone,
+    actual_outcome character varying(20),
+    resolution_notes text
 );
 
 
 --
--- Name: channel_mappings; Type: TABLE; Schema: public; Owner: -
+-- Name: message_analytics; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.channel_mappings (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    property_id uuid NOT NULL,
-    channel character varying(50) NOT NULL,
-    external_listing_id character varying(255) NOT NULL,
-    sync_status character varying(30) DEFAULT 'active'::character varying NOT NULL,
-    last_synced_at timestamp with time zone,
-    sync_error text,
+CREATE TABLE public.message_analytics (
+    id bigint NOT NULL,
+    date date NOT NULL,
+    hour integer,
+    property_id integer,
+    source character varying(50),
+    total_messages integer DEFAULT 0,
+    inbound_messages integer DEFAULT 0,
+    outbound_messages integer DEFAULT 0,
+    ai_handled_count integer DEFAULT 0,
+    human_handled_count integer DEFAULT 0,
+    escalation_count integer DEFAULT 0,
+    ai_success_rate numeric(5,4),
+    avg_response_time_seconds integer,
+    median_response_time_seconds integer,
+    p95_response_time_seconds integer,
+    intent_distribution jsonb,
+    positive_messages integer DEFAULT 0,
+    neutral_messages integer DEFAULT 0,
+    negative_messages integer DEFAULT 0,
+    urgent_messages integer DEFAULT 0,
+    total_cost_usd numeric(10,2),
+    cost_per_message numeric(6,4),
+    avg_satisfaction_score numeric(3,2),
+    created_at timestamp without time zone DEFAULT now()
+);
+
+
+--
+-- Name: daily_performance; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.daily_performance AS
+ SELECT date,
+    sum(total_messages) AS total_messages,
+    sum(inbound_messages) AS inbound_messages,
+    sum(outbound_messages) AS outbound_messages,
+    avg(ai_success_rate) AS avg_ai_success_rate,
+    avg(avg_response_time_seconds) AS avg_response_time,
+    sum(total_cost_usd) AS total_cost,
+    avg(avg_satisfaction_score) AS avg_satisfaction
+   FROM public.message_analytics
+  WHERE (hour IS NULL)
+  GROUP BY date
+  ORDER BY date DESC;
+
+
+--
+-- Name: data_sanitizer_log; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.data_sanitizer_log (
+    id integer NOT NULL,
+    run_id uuid NOT NULL,
+    table_name text NOT NULL,
+    column_name text NOT NULL,
+    row_id text NOT NULL,
+    original_value text,
+    sanitized_value text,
+    rule_applied text NOT NULL,
+    anomalies text[],
+    severity character varying(20) NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
+    CONSTRAINT data_sanitizer_log_severity_check CHECK (((severity)::text = ANY ((ARRAY['auto_fix'::character varying, 'flag'::character varying, 'quarantine'::character varying])::text[])))
 );
 
 
 --
--- Name: citation_records; Type: TABLE; Schema: public; Owner: -
+-- Name: data_sanitizer_log_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.citation_records (
-    id uuid NOT NULL,
-    directory_domain character varying(255) NOT NULL,
-    profile_url character varying(1000),
-    found_name character varying(500),
-    found_address character varying(1000),
-    found_phone character varying(100),
-    match_status character varying(30) NOT NULL,
-    last_audited_at timestamp without time zone NOT NULL
-);
+CREATE SEQUENCE public.data_sanitizer_log_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
 
 
 --
--- Name: cleaners; Type: TABLE; Schema: public; Owner: -
+-- Name: data_sanitizer_log_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE public.cleaners (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    name character varying(200) NOT NULL,
-    phone character varying(40),
-    email character varying(255),
-    active boolean DEFAULT true NOT NULL,
-    per_clean_rate numeric(8,2),
-    hourly_rate numeric(8,2),
-    property_ids jsonb DEFAULT '[]'::jsonb NOT NULL,
-    regions jsonb DEFAULT '[]'::jsonb NOT NULL,
-    notes text,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
---
--- Name: competitor_listings; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.competitor_listings (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    property_id uuid NOT NULL,
-    platform character varying(11) NOT NULL,
-    external_url character varying(500),
-    external_id character varying(100),
-    dedupe_hash character varying(64) NOT NULL,
-    observed_nightly_rate numeric(12,2) NOT NULL,
-    observed_total_before_tax numeric(12,2) NOT NULL,
-    platform_fee numeric(12,2) DEFAULT 0 NOT NULL,
-    cleaning_fee numeric(12,2) DEFAULT 0 NOT NULL,
-    total_after_tax numeric(12,2) NOT NULL,
-    snapshot_payload jsonb NOT NULL,
-    last_observed timestamp with time zone DEFAULT now() NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    CONSTRAINT ota_provider CHECK (((platform)::text = ANY ((ARRAY['airbnb'::character varying, 'vrbo'::character varying, 'booking_com'::character varying])::text[])))
-);
-
-
---
--- Name: concierge_queue; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.concierge_queue (
-    id uuid NOT NULL,
-    guest_phone character varying(40) NOT NULL,
-    property_id uuid,
-    inbound_message text NOT NULL,
-    retrieved_context jsonb NOT NULL,
-    ai_draft_reply text,
-    reviewed_by character varying(120),
-    review_note text,
-    sent_at timestamp without time zone,
-    metadata_json jsonb NOT NULL,
-    status character varying(30) NOT NULL,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL,
-    CONSTRAINT ck_concierge_queue_status CHECK (((status)::text = ANY ((ARRAY['pending_review'::character varying, 'approved'::character varying, 'rejected'::character varying, 'sent'::character varying, 'failed'::character varying])::text[])))
-);
-
-
---
--- Name: concierge_recovery_dispatches; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.concierge_recovery_dispatches (
-    id uuid NOT NULL,
-    session_fp character varying(64),
-    guest_id uuid NOT NULL,
-    channel character varying(16) NOT NULL,
-    template_key character varying(64) DEFAULT 'abandon_cart_v1'::character varying NOT NULL,
-    body_preview text,
-    status character varying(24) DEFAULT 'sent'::character varying NOT NULL,
-    provider_metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
---
--- Name: damage_claims; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.damage_claims (
-    id uuid NOT NULL,
-    claim_number character varying(50) NOT NULL,
-    reservation_id uuid NOT NULL,
-    property_id uuid NOT NULL,
-    guest_id uuid NOT NULL,
-    damage_description text NOT NULL,
-    policy_violations text,
-    damage_areas text[],
-    estimated_cost numeric(10,2),
-    photo_urls text[],
-    reported_by character varying(200) NOT NULL,
-    inspection_date date NOT NULL,
-    inspection_notes text,
-    legal_draft text,
-    legal_draft_model character varying(100),
-    legal_draft_at timestamp without time zone,
-    rental_agreement_id uuid,
-    agreement_clauses jsonb,
-    status character varying(30) NOT NULL,
-    reviewed_by character varying(200),
-    reviewed_at timestamp without time zone,
-    final_response text,
-    sent_at timestamp without time zone,
-    sent_via character varying(30),
-    resolution text,
-    resolution_amount numeric(10,2),
-    resolved_at timestamp without time zone,
-    qdrant_point_id uuid,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone,
-    stripe_charge_id character varying(255),
-    amount_charged numeric(10,2),
-    charge_payment_method_id character varying(255),
-    charge_executed_at timestamp with time zone,
-    charge_executed_by character varying(255)
-);
+ALTER SEQUENCE public.data_sanitizer_log_id_seq OWNED BY public.data_sanitizer_log.id;
 
 
 --
@@ -1311,15 +3350,18 @@ CREATE TABLE public.damage_claims (
 --
 
 CREATE TABLE public.deferred_api_writes (
-    id bigint NOT NULL,
-    service character varying(128) NOT NULL,
-    method character varying(512) NOT NULL,
+    id integer NOT NULL,
+    service text NOT NULL,
+    method text NOT NULL,
     payload jsonb NOT NULL,
-    status character varying(64) DEFAULT 'pending'::character varying NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    retry_count integer DEFAULT 0 NOT NULL,
+    status character varying(20) DEFAULT 'pending'::character varying NOT NULL,
+    attempts integer DEFAULT 0 NOT NULL,
+    max_attempts integer DEFAULT 10 NOT NULL,
     last_error text,
-    reconciled_at timestamp with time zone
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    next_retry_at timestamp with time zone DEFAULT now() NOT NULL,
+    completed_at timestamp with time zone,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 
@@ -1328,6 +3370,7 @@ CREATE TABLE public.deferred_api_writes (
 --
 
 CREATE SEQUENCE public.deferred_api_writes_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1343,617 +3386,875 @@ ALTER SEQUENCE public.deferred_api_writes_id_seq OWNED BY public.deferred_api_wr
 
 
 --
--- Name: distillation_queue; Type: TABLE; Schema: public; Owner: -
+-- Name: document_oracle_manifest; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.distillation_queue (
-    id uuid NOT NULL,
-    source_module character varying(120) NOT NULL,
-    source_ref character varying(255) NOT NULL,
-    source_intelligence_id uuid,
-    input_payload jsonb NOT NULL,
-    output_payload jsonb NOT NULL,
-    status character varying(10) NOT NULL,
-    error text,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+CREATE TABLE public.document_oracle_manifest (
+    file_path text NOT NULL,
+    sha256_hash text NOT NULL,
+    chunk_count integer NOT NULL,
+    sector text NOT NULL,
+    ingested_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 
 --
--- Name: email_inquirers; Type: TABLE; Schema: public; Owner: -
+-- Name: email_archive; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.email_inquirers (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    email character varying(255) NOT NULL,
-    display_name character varying(255),
-    first_name character varying(100),
-    last_name character varying(100),
-    guest_id uuid,
-    inferred_party_size integer,
-    inferred_dates_text text,
-    opt_in_email boolean DEFAULT true NOT NULL,
-    first_seen_at timestamp with time zone DEFAULT now() NOT NULL,
-    last_seen_at timestamp with time zone DEFAULT now() NOT NULL,
-    inquiry_count integer DEFAULT 1 NOT NULL
-);
-
-
---
--- Name: email_messages; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.email_messages (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    inquirer_id uuid NOT NULL,
-    guest_id uuid,
-    reservation_id uuid,
-    in_reply_to_message_id uuid,
-    direction character varying(20) NOT NULL,
-    email_from character varying(255) NOT NULL,
-    email_to character varying(255) NOT NULL,
-    email_cc text,
+CREATE TABLE public.email_archive (
+    id integer NOT NULL,
+    category text,
+    file_path text,
+    sender text,
     subject text,
-    body_text text NOT NULL,
-    body_excerpt text,
-    imap_uid bigint,
-    imap_message_id text,
-    received_at timestamp with time zone,
-    intent character varying(50),
-    sentiment character varying(20),
-    category character varying(50),
-    ai_draft text,
-    ai_confidence numeric(4,3),
-    ai_meta jsonb,
-    approval_status character varying(30) DEFAULT 'pending_approval'::character varying NOT NULL,
-    requires_human_review boolean DEFAULT true NOT NULL,
-    human_reviewed_at timestamp with time zone,
-    human_reviewed_by uuid,
-    human_edited_body text,
-    sent_at timestamp with time zone,
-    smtp_message_id text,
-    error_code character varying(50),
-    error_message text,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    extra_data jsonb,
-    CONSTRAINT ck_email_messages_approval_status CHECK (((approval_status)::text = ANY ((ARRAY['pending_approval'::character varying, 'approved'::character varying, 'rejected'::character varying, 'sent'::character varying, 'send_failed'::character varying, 'no_draft_needed'::character varying])::text[]))),
-    CONSTRAINT ck_email_messages_direction CHECK (((direction)::text = ANY ((ARRAY['inbound'::character varying, 'outbound'::character varying])::text[])))
+    content text,
+    sent_at timestamp without time zone,
+    is_mined boolean DEFAULT false,
+    ts tsvector GENERATED ALWAYS AS (to_tsvector('english'::regconfig, ((COALESCE(subject, ''::text) || ' '::text) || COALESCE(content, ''::text)))) STORED,
+    retry_count integer DEFAULT 0,
+    last_error text,
+    division text,
+    division_confidence integer,
+    division_summary text,
+    is_vectorized boolean DEFAULT false,
+    to_addresses text,
+    cc_addresses text,
+    bcc_addresses text,
+    message_id text,
+    ingested_from text
 );
 
 
 --
--- Name: email_templates; Type: TABLE; Schema: public; Owner: -
+-- Name: email_archive_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.email_templates (
-    id uuid NOT NULL,
-    name character varying(255) NOT NULL,
-    trigger_event character varying(100) NOT NULL,
-    subject_template character varying(1000) NOT NULL,
-    body_template text NOT NULL,
-    is_active boolean DEFAULT true NOT NULL,
-    requires_human_approval boolean DEFAULT true NOT NULL,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone
-);
+CREATE SEQUENCE public.email_archive_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
 
 
 --
--- Name: extra_orders; Type: TABLE; Schema: public; Owner: -
+-- Name: email_archive_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE public.extra_orders (
-    id uuid NOT NULL,
-    reservation_id uuid NOT NULL,
-    extra_id uuid NOT NULL,
-    quantity integer,
-    unit_price numeric(10,2) NOT NULL,
-    total_price numeric(10,2) NOT NULL,
-    status character varying(50) NOT NULL,
-    fulfilled_at timestamp without time zone,
+ALTER SEQUENCE public.email_archive_id_seq OWNED BY public.email_archive.id;
+
+
+--
+-- Name: email_classification_rules; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.email_classification_rules (
+    id integer NOT NULL,
+    division character varying(30) NOT NULL,
+    match_field character varying(20) NOT NULL,
+    pattern text NOT NULL,
+    weight integer DEFAULT 10,
+    is_regex boolean DEFAULT false,
+    is_active boolean DEFAULT true,
+    hit_count integer DEFAULT 0,
     notes text,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone
+    created_at timestamp without time zone DEFAULT now(),
+    CONSTRAINT email_classification_rules_match_field_check CHECK (((match_field)::text = ANY ((ARRAY['sender'::character varying, 'subject'::character varying, 'content'::character varying, 'any'::character varying])::text[]))),
+    CONSTRAINT email_classification_rules_weight_check CHECK (((weight >= 1) AND (weight <= 100)))
 );
 
 
 --
--- Name: extras; Type: TABLE; Schema: public; Owner: -
+-- Name: email_classification_rules_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.extras (
-    id uuid NOT NULL,
-    name character varying(255) NOT NULL,
-    description text,
-    category character varying(50),
-    price numeric(10,2) NOT NULL,
-    currency character varying(3),
-    is_available boolean,
-    properties uuid[],
-    image_url text,
-    display_order integer,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone
+CREATE SEQUENCE public.email_classification_rules_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: email_classification_rules_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.email_classification_rules_id_seq OWNED BY public.email_classification_rules.id;
+
+
+--
+-- Name: email_dead_letter_queue; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.email_dead_letter_queue (
+    id integer NOT NULL,
+    fingerprint text NOT NULL,
+    source_tag text,
+    sender text,
+    subject text,
+    raw_payload jsonb NOT NULL,
+    error_message text,
+    error_traceback text,
+    retry_count integer DEFAULT 0,
+    max_retries integer DEFAULT 5,
+    next_retry_at timestamp with time zone,
+    status text DEFAULT 'pending'::text,
+    created_at timestamp with time zone DEFAULT now(),
+    updated_at timestamp with time zone DEFAULT now(),
+    CONSTRAINT email_dead_letter_queue_status_check CHECK ((status = ANY (ARRAY['pending'::text, 'retrying'::text, 'recovered'::text, 'dead'::text, 'manual_review'::text, 'discarded'::text])))
 );
 
 
 --
--- Name: fees; Type: TABLE; Schema: public; Owner: -
+-- Name: email_dead_letter_queue_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.fees (
-    id uuid NOT NULL,
-    name character varying(255) NOT NULL,
-    flat_amount numeric(12,2) NOT NULL,
-    is_pet_fee boolean DEFAULT false NOT NULL,
+CREATE SEQUENCE public.email_dead_letter_queue_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: email_dead_letter_queue_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.email_dead_letter_queue_id_seq OWNED BY public.email_dead_letter_queue.id;
+
+
+--
+-- Name: email_escalation_queue; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.email_escalation_queue (
+    id bigint NOT NULL,
+    email_id bigint,
+    trigger_type character varying(30) NOT NULL,
+    trigger_detail text,
+    priority character varying(5) DEFAULT 'P2'::character varying,
+    status character varying(20) DEFAULT 'pending'::character varying,
+    seen_by character varying(50),
+    seen_at timestamp without time zone,
+    action_taken text,
+    created_at timestamp without time zone DEFAULT now(),
+    snooze_until timestamp with time zone,
+    CONSTRAINT email_escalation_queue_priority_check CHECK (((priority)::text = ANY ((ARRAY['P0'::character varying, 'P1'::character varying, 'P2'::character varying, 'P3'::character varying])::text[]))),
+    CONSTRAINT email_escalation_queue_status_check CHECK (((status)::text = ANY ((ARRAY['pending'::character varying, 'seen'::character varying, 'actioned'::character varying, 'dismissed'::character varying, 'snoozed'::character varying])::text[]))),
+    CONSTRAINT email_escalation_queue_trigger_type_check CHECK (((trigger_type)::text = ANY ((ARRAY['vip_sender'::character varying, 'high_dollar'::character varying, 'legal_watchdog'::character varying, 'failed_classification'::character varying, 'negative_sentiment'::character varying, 'new_important_domain'::character varying, 'manual'::character varying, 'content_flag'::character varying])::text[])))
+);
+
+
+--
+-- Name: email_escalation_queue_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.email_escalation_queue_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: email_escalation_queue_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.email_escalation_queue_id_seq OWNED BY public.email_escalation_queue.id;
+
+
+--
+-- Name: email_escalation_rules; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.email_escalation_rules (
+    id integer NOT NULL,
+    rule_name character varying(100) NOT NULL,
+    trigger_type character varying(30) NOT NULL,
+    match_field character varying(20) NOT NULL,
+    pattern text NOT NULL,
+    priority character varying(5) DEFAULT 'P2'::character varying,
+    is_active boolean DEFAULT true,
+    notes text,
+    created_at timestamp without time zone DEFAULT now(),
+    CONSTRAINT email_escalation_rules_match_field_check CHECK (((match_field)::text = ANY ((ARRAY['sender'::character varying, 'subject'::character varying, 'content'::character varying, 'any'::character varying, 'amount'::character varying])::text[])))
+);
+
+
+--
+-- Name: email_escalation_rules_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.email_escalation_rules_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: email_escalation_rules_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.email_escalation_rules_id_seq OWNED BY public.email_escalation_rules.id;
+
+
+--
+-- Name: email_intake_review_log; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.email_intake_review_log (
+    id bigint NOT NULL,
+    escalation_id bigint,
+    email_id bigint,
+    actor character varying(50) NOT NULL,
+    action_type character varying(30) NOT NULL,
+    old_division character varying(30),
+    new_division character varying(30),
+    old_confidence integer,
+    new_confidence integer,
+    review_grade integer,
+    notes text,
+    created_at timestamp without time zone DEFAULT now(),
+    CONSTRAINT email_intake_review_log_action_type_check CHECK (((action_type)::text = ANY ((ARRAY['reclassify'::character varying, 'grade'::character varying, 'dismiss'::character varying, 'escalate'::character varying, 'approve'::character varying, 'add_rule'::character varying, 'bulk_action'::character varying])::text[]))),
+    CONSTRAINT email_intake_review_log_review_grade_check CHECK (((review_grade IS NULL) OR ((review_grade >= 1) AND (review_grade <= 5))))
+);
+
+
+--
+-- Name: email_intake_review_log_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.email_intake_review_log_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: email_intake_review_log_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.email_intake_review_log_id_seq OWNED BY public.email_intake_review_log.id;
+
+
+--
+-- Name: email_quarantine; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.email_quarantine (
+    id bigint NOT NULL,
+    sender text,
+    subject text,
+    content_preview text,
+    sent_at timestamp without time zone,
+    fingerprint character varying(64),
+    source_tag character varying(30),
+    rule_id integer,
+    rule_type character varying(30),
+    rule_reason text,
+    status character varying(20) DEFAULT 'quarantined'::character varying,
+    reviewed_by character varying(50),
+    reviewed_at timestamp without time zone,
+    created_at timestamp without time zone DEFAULT now(),
+    CONSTRAINT email_quarantine_status_check CHECK (((status)::text = ANY ((ARRAY['quarantined'::character varying, 'released'::character varying, 'deleted'::character varying, 'reviewed'::character varying])::text[])))
+);
+
+
+--
+-- Name: email_quarantine_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.email_quarantine_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: email_quarantine_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.email_quarantine_id_seq OWNED BY public.email_quarantine.id;
+
+
+--
+-- Name: email_routing_rules; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.email_routing_rules (
+    id integer NOT NULL,
+    rule_type character varying(30) NOT NULL,
+    pattern text NOT NULL,
+    action character varying(20) NOT NULL,
+    division character varying(30),
+    reason text,
+    is_active boolean DEFAULT true,
+    hit_count integer DEFAULT 0,
+    created_at timestamp without time zone DEFAULT now(),
+    updated_at timestamp without time zone DEFAULT now(),
+    CONSTRAINT email_routing_rules_action_check CHECK (((action)::text = ANY ((ARRAY['REJECT'::character varying, 'QUARANTINE'::character varying, 'ALLOW'::character varying, 'ESCALATE'::character varying, 'PRIORITY'::character varying])::text[]))),
+    CONSTRAINT email_routing_rules_rule_type_check CHECK (((rule_type)::text = ANY ((ARRAY['sender_block'::character varying, 'sender_vip'::character varying, 'domain_trust'::character varying, 'subject_block'::character varying, 'content_block'::character varying, 'sender_allow'::character varying])::text[])))
+);
+
+
+--
+-- Name: email_routing_rules_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.email_routing_rules_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: email_routing_rules_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.email_routing_rules_id_seq OWNED BY public.email_routing_rules.id;
+
+
+--
+-- Name: email_sensors; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.email_sensors (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    email_address text NOT NULL,
+    display_name text,
+    protocol character varying(10) DEFAULT 'pop3'::character varying NOT NULL,
+    server_address text NOT NULL,
+    server_port integer DEFAULT 995 NOT NULL,
+    encrypted_password text NOT NULL,
+    use_ssl boolean DEFAULT true NOT NULL,
     is_active boolean DEFAULT true NOT NULL,
-    created_at timestamp with time zone NOT NULL,
-    updated_at timestamp with time zone NOT NULL,
-    fee_type character varying(20) DEFAULT 'flat'::character varying NOT NULL,
-    percentage_rate numeric(6,3),
-    is_optional boolean DEFAULT false NOT NULL
+    last_sweep_at timestamp without time zone,
+    last_sweep_status character varying(20) DEFAULT 'pending'::character varying,
+    last_sweep_error text,
+    emails_ingested_total integer DEFAULT 0,
+    created_at timestamp without time zone DEFAULT now(),
+    updated_at timestamp without time zone DEFAULT now(),
+    CONSTRAINT email_sensors_last_sweep_status_check CHECK (((last_sweep_status)::text = ANY ((ARRAY['green'::character varying, 'red'::character varying, 'pending'::character varying])::text[]))),
+    CONSTRAINT email_sensors_protocol_check CHECK (((protocol)::text = ANY ((ARRAY['pop3'::character varying, 'imap'::character varying, 'gmail_api'::character varying])::text[])))
 );
 
 
 --
--- Name: financial_approvals; Type: TABLE; Schema: public; Owner: -
+-- Name: email_triage_precedents; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.financial_approvals (
-    id uuid NOT NULL,
-    reservation_id character varying(100) NOT NULL,
-    status character varying(30) DEFAULT 'pending'::character varying NOT NULL,
-    discrepancy_type character varying(100) NOT NULL,
-    local_total_cents integer NOT NULL,
-    streamline_total_cents integer NOT NULL,
-    delta_cents integer NOT NULL,
-    context_payload jsonb DEFAULT '{}'::jsonb NOT NULL,
-    resolution_strategy character varying(30),
-    stripe_invoice_id character varying(255),
-    resolved_by character varying(255),
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    resolved_at timestamp with time zone
+CREATE TABLE public.email_triage_precedents (
+    id integer NOT NULL,
+    email_id integer,
+    pattern_text text NOT NULL,
+    division text NOT NULL,
+    priority text DEFAULT 'P2'::text,
+    reasoning text,
+    created_by text DEFAULT 'HUMAN'::text,
+    embedding public.vector(768),
+    created_at timestamp with time zone DEFAULT now()
 );
 
 
 --
--- Name: functional_nodes; Type: TABLE; Schema: public; Owner: -
+-- Name: email_triage_precedents_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.functional_nodes (
-    id uuid NOT NULL,
-    legacy_node_id integer,
-    source_path character varying(255) NOT NULL,
-    canonical_path character varying(512) NOT NULL,
-    title character varying(255) NOT NULL,
-    node_type character varying(64) NOT NULL,
-    content_category character varying(64) NOT NULL,
-    functional_complexity character varying(64) NOT NULL,
-    crawl_status character varying(32) NOT NULL,
-    mirror_status character varying(32) NOT NULL,
-    cutover_status character varying(32) NOT NULL,
-    priority_tier integer NOT NULL,
-    is_published boolean NOT NULL,
-    http_status integer,
-    body_html text,
-    body_text_preview text,
-    form_fields jsonb NOT NULL,
-    taxonomy_terms jsonb NOT NULL,
-    media_refs jsonb NOT NULL,
-    source_metadata jsonb NOT NULL,
-    mirror_component_path character varying(512),
-    mirror_route_path character varying(512),
-    source_hash character varying(64),
-    last_crawled_at timestamp with time zone,
-    created_at timestamp with time zone NOT NULL,
-    updated_at timestamp with time zone NOT NULL
+CREATE SEQUENCE public.email_triage_precedents_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: email_triage_precedents_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.email_triage_precedents_id_seq OWNED BY public.email_triage_precedents.id;
+
+
+--
+-- Name: fin_owner_balances; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.fin_owner_balances (
+    property_id character varying(50) NOT NULL,
+    property_name character varying(200),
+    owner_name character varying(100),
+    bedrooms integer,
+    estimated_rate numeric(12,2),
+    total_booked_nights integer DEFAULT 0,
+    gross_revenue numeric(12,2) DEFAULT 0,
+    mgmt_fee_pct numeric(5,2) DEFAULT 25.00,
+    mgmt_fee_amount numeric(12,2) DEFAULT 0,
+    owner_payout numeric(12,2) DEFAULT 0,
+    last_calculated timestamp without time zone,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
 );
 
 
 --
--- Name: guest_activities; Type: TABLE; Schema: public; Owner: -
+-- Name: fin_reservations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.guest_activities (
-    id uuid NOT NULL,
-    guest_id uuid NOT NULL,
-    activity_type character varying(50) NOT NULL,
-    category character varying(30) NOT NULL,
-    title character varying(255) NOT NULL,
-    description text,
-    reservation_id uuid,
-    property_id uuid,
-    message_id uuid,
-    review_id uuid,
-    survey_id uuid,
-    agreement_id uuid,
-    work_order_id uuid,
-    performed_by character varying(100),
-    performed_by_type character varying(20),
-    metadata jsonb,
-    importance character varying(10),
-    is_visible_to_guest character varying(5),
-    created_at timestamp without time zone
-);
-
-
---
--- Name: guest_quotes; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.guest_quotes (
-    id uuid NOT NULL,
-    target_property_id character varying(255) NOT NULL,
-    property_id uuid,
-    status public.guest_quote_status NOT NULL,
-    campaign character varying(100) NOT NULL,
-    target_keyword character varying(255),
-    guest_name character varying(255),
-    guest_email character varying(255),
-    guest_phone character varying(40),
+CREATE TABLE public.fin_reservations (
+    res_id character varying(100) NOT NULL,
+    property_id character varying(50),
+    property_name character varying(200),
+    guest_name character varying(100),
     check_in date,
     check_out date,
     nights integer,
-    adults integer NOT NULL,
-    children integer NOT NULL,
-    pets integer NOT NULL,
-    currency character varying(10) NOT NULL,
-    base_rent numeric(12,2) NOT NULL,
-    taxes numeric(12,2) NOT NULL,
-    fees numeric(12,2) NOT NULL,
-    total_amount numeric(12,2) NOT NULL,
-    base_price double precision NOT NULL,
-    ai_adjusted_price double precision NOT NULL,
-    sovereign_narrative text NOT NULL,
-    quote_breakdown jsonb NOT NULL,
-    source_snapshot jsonb NOT NULL,
-    stripe_payment_link_url character varying(1024),
-    stripe_payment_link_id character varying(255),
-    note text,
-    expires_at timestamp without time zone NOT NULL,
-    accepted_at timestamp without time zone,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    nightly_rate numeric(12,2),
+    base_rent numeric(12,2),
+    taxes numeric(12,2) DEFAULT 0,
+    fees numeric(12,2) DEFAULT 0,
+    total_revenue numeric(12,2),
+    status character varying(50) DEFAULT 'Shadow-Booked'::character varying,
+    source character varying(50) DEFAULT 'shadow'::character varying,
+    is_estimation boolean DEFAULT true,
+    confidence character varying(20) DEFAULT 'medium'::character varying,
+    notes text,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
 );
 
 
 --
--- Name: guest_reviews; Type: TABLE; Schema: public; Owner: -
+-- Name: fin_revenue_snapshots; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.guest_reviews (
-    id uuid NOT NULL,
-    guest_id uuid NOT NULL,
-    reservation_id uuid,
-    property_id uuid NOT NULL,
-    direction character varying(30) NOT NULL,
-    overall_rating integer NOT NULL,
-    cleanliness_rating integer,
-    accuracy_rating integer,
-    communication_rating integer,
-    location_rating integer,
-    checkin_rating integer,
-    value_rating integer,
-    amenities_rating integer,
-    house_rules_rating integer,
-    cleanliness_left_rating integer,
-    communication_guest_rating integer,
-    respect_rating integer,
-    noise_rating integer,
-    checkout_compliance_rating integer,
-    title character varying(255),
-    body text,
-    response_body text,
-    response_by character varying(100),
-    response_at timestamp without time zone,
-    sentiment character varying(20),
-    sentiment_score numeric(4,3),
-    key_phrases jsonb,
-    improvement_suggestions jsonb,
-    is_published boolean,
-    published_at timestamp without time zone,
-    publish_to_website boolean,
-    publish_to_airbnb boolean,
-    publish_to_google boolean,
-    external_review_urls jsonb,
-    is_flagged boolean,
-    flag_reason character varying(255),
-    moderated_by character varying(100),
-    moderated_at timestamp without time zone,
-    solicitation_sent_at timestamp without time zone,
-    solicitation_method character varying(20),
-    solicitation_template_id uuid,
-    submitted_via character varying(30),
-    streamline_feedback_id character varying(100),
-    source character varying(50),
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone
+CREATE TABLE public.fin_revenue_snapshots (
+    snapshot_id integer NOT NULL,
+    period_start date,
+    period_end date,
+    total_properties integer,
+    total_nights integer,
+    gross_revenue numeric(12,2),
+    est_taxes numeric(12,2),
+    est_mgmt_fees numeric(12,2),
+    est_owner_payout numeric(12,2),
+    source character varying(50) DEFAULT 'shadow'::character varying,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
 );
 
 
 --
--- Name: guest_surveys; Type: TABLE; Schema: public; Owner: -
+-- Name: fin_revenue_snapshots_snapshot_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.guest_surveys (
-    id uuid NOT NULL,
-    guest_id uuid NOT NULL,
-    reservation_id uuid,
-    property_id uuid,
-    template_id uuid,
-    survey_type character varying(50) NOT NULL,
-    responses jsonb NOT NULL,
-    overall_score numeric(4,2),
-    nps_score integer,
-    nps_category character varying(20),
-    housekeeping_score integer,
-    maintenance_score integer,
-    communication_score integer,
-    amenities_score integer,
-    sentiment character varying(20),
-    key_themes jsonb,
-    action_items jsonb,
-    status character varying(30) NOT NULL,
-    sent_at timestamp without time zone,
-    started_at timestamp without time zone,
-    completed_at timestamp without time zone,
-    send_method character varying(20),
-    survey_url text,
-    follow_up_required boolean,
-    follow_up_notes text,
-    follow_up_completed_at timestamp without time zone,
-    follow_up_by character varying(100),
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone
+CREATE SEQUENCE public.fin_revenue_snapshots_snapshot_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: fin_revenue_snapshots_snapshot_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.fin_revenue_snapshots_snapshot_id_seq OWNED BY public.fin_revenue_snapshots.snapshot_id;
+
+
+--
+-- Name: finance_invoices; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.finance_invoices (
+    id integer NOT NULL,
+    vendor text NOT NULL,
+    amount numeric(10,2) NOT NULL,
+    date date NOT NULL,
+    category text,
+    source_email_id integer,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
 );
 
 
 --
--- Name: guest_verifications; Type: TABLE; Schema: public; Owner: -
+-- Name: finance_invoices_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.guest_verifications (
-    id uuid NOT NULL,
-    guest_id uuid NOT NULL,
-    reservation_id uuid,
-    verification_type character varying(50) NOT NULL,
-    status character varying(30) NOT NULL,
-    document_type character varying(50),
-    document_number_hash character varying(255),
-    document_country character varying(2),
-    document_state character varying(5),
-    document_expiration date,
-    document_front_url text,
-    document_back_url text,
-    selfie_url text,
-    confidence_score numeric(4,3),
-    match_details jsonb,
-    reviewed_by character varying(100),
-    reviewed_at timestamp without time zone,
-    rejection_reason text,
-    external_verification_id character varying(255),
-    provider character varying(50),
-    ip_address character varying(45),
-    user_agent text,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone,
-    expires_at timestamp without time zone
+CREATE SEQUENCE public.finance_invoices_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: finance_invoices_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.finance_invoices_id_seq OWNED BY public.finance_invoices.id;
+
+
+--
+-- Name: fortress_api_keys; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.fortress_api_keys (
+    id integer NOT NULL,
+    key_prefix character varying(12) NOT NULL,
+    key_hash character varying(255) NOT NULL,
+    name character varying(100) NOT NULL,
+    scopes text[] DEFAULT '{}'::text[],
+    owner_id integer,
+    is_active boolean DEFAULT true,
+    created_at timestamp without time zone DEFAULT now(),
+    last_used timestamp without time zone
 );
 
 
 --
--- Name: guestbook_guides; Type: TABLE; Schema: public; Owner: -
+-- Name: fortress_api_keys_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.guestbook_guides (
-    id uuid NOT NULL,
-    property_id uuid,
-    title character varying(255) NOT NULL,
-    slug character varying(255) NOT NULL,
-    guide_type character varying(50) NOT NULL,
-    category character varying(50),
-    content text NOT NULL,
-    icon character varying(50),
-    display_order integer,
-    is_visible boolean,
-    visibility_rules jsonb,
-    view_count integer,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone
-);
+CREATE SEQUENCE public.fortress_api_keys_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
 
 
 --
--- Name: guests; Type: TABLE; Schema: public; Owner: -
+-- Name: fortress_api_keys_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE public.guests (
-    id uuid NOT NULL,
-    phone character varying(20) NOT NULL,
-    phone_number_secondary character varying(20),
+ALTER SEQUENCE public.fortress_api_keys_id_seq OWNED BY public.fortress_api_keys.id;
+
+
+--
+-- Name: fortress_users; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.fortress_users (
+    id integer NOT NULL,
+    username character varying(50) NOT NULL,
     email character varying(255),
-    email_secondary character varying(255),
-    first_name character varying(100),
-    last_name character varying(100),
-    address_line1 character varying(255),
-    address_line2 character varying(255),
-    city character varying(100),
-    state character varying(50),
-    postal_code character varying(20),
-    country character varying(2),
-    date_of_birth date,
-    emergency_contact_name character varying(200),
-    emergency_contact_phone character varying(20),
-    emergency_contact_relationship character varying(50),
-    vehicle_make character varying(50),
-    vehicle_model character varying(50),
-    vehicle_color character varying(30),
-    vehicle_plate character varying(20),
-    vehicle_state character varying(5),
-    language_preference character varying(10),
-    opt_in_marketing boolean,
-    opt_in_sms boolean,
-    opt_in_email boolean,
-    preferred_contact_method character varying(20),
-    quiet_hours_start character varying(5),
-    quiet_hours_end character varying(5),
-    timezone character varying(50),
-    verification_status character varying(20),
-    verification_method character varying(50),
-    verified_at timestamp without time zone,
-    id_document_type character varying(50),
-    id_expiration_date date,
-    loyalty_tier character varying(20),
-    loyalty_points integer,
-    loyalty_enrolled_at timestamp without time zone,
-    lifetime_stays integer,
-    lifetime_nights integer,
-    lifetime_revenue numeric(12,2),
-    value_score integer,
-    risk_score integer,
-    satisfaction_score integer,
-    preferences jsonb,
-    special_requests text,
-    internal_notes text,
-    staff_notes text,
-    is_vip boolean,
-    is_blacklisted boolean,
-    blacklist_reason text,
-    blacklisted_at timestamp without time zone,
-    blacklisted_by character varying(100),
-    is_do_not_contact boolean,
-    requires_supervision boolean,
-    guest_source character varying(50),
-    referral_source character varying(255),
-    first_booking_source character varying(50),
-    acquisition_campaign character varying(100),
-    total_stays integer,
-    total_messages_sent integer,
-    total_messages_received integer,
-    average_rating numeric(3,2),
+    password character varying(255) NOT NULL,
+    role character varying(20) DEFAULT 'viewer'::character varying NOT NULL,
+    is_active boolean DEFAULT true,
+    created_at timestamp without time zone DEFAULT now(),
+    last_login timestamp without time zone,
+    full_name character varying(100),
+    web_ui_access boolean DEFAULT false NOT NULL,
+    vrs_access boolean DEFAULT false NOT NULL,
+    CONSTRAINT fortress_users_role_check CHECK (((role)::text = ANY ((ARRAY['admin'::character varying, 'operator'::character varying, 'viewer'::character varying])::text[])))
+);
+
+
+--
+-- Name: fortress_users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.fortress_users_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: fortress_users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.fortress_users_id_seq OWNED BY public.fortress_users.id;
+
+
+--
+-- Name: general_ledger; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.general_ledger (
+    id integer NOT NULL,
+    filepath text,
+    filename text,
+    extension text,
+    file_size bigint,
+    doc_type text,
+    category text,
+    vendor text,
+    client_name text,
+    date_detected text,
+    amount numeric(15,2),
+    tax_year text,
+    cabin text,
+    business text,
+    confidence text,
+    raw_text text,
+    ai_json text,
+    processed_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    phase integer DEFAULT 1
+);
+
+
+--
+-- Name: general_ledger_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.general_ledger_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: general_ledger_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.general_ledger_id_seq OWNED BY public.general_ledger.id;
+
+
+--
+-- Name: godhead_query_log; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.godhead_query_log (
+    id bigint NOT NULL,
+    session_id uuid DEFAULT gen_random_uuid(),
+    prompt text NOT NULL,
+    vaults_queried text[],
+    models_called text[],
+    synthesis text,
+    confidence numeric(4,3),
+    metadata jsonb DEFAULT '{}'::jsonb,
+    queried_at timestamp with time zone DEFAULT now()
+);
+
+
+--
+-- Name: godhead_query_log_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.godhead_query_log_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: godhead_query_log_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.godhead_query_log_id_seq OWNED BY public.godhead_query_log.id;
+
+
+--
+-- Name: guest_leads; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.guest_leads (
+    id integer NOT NULL,
+    guest_name text,
+    guest_email text,
+    guest_phone text,
+    event_type text,
+    cabin_names text[],
+    check_in date,
+    check_out date,
+    nights integer,
+    guest_count integer,
+    quoted_total numeric(12,2),
+    status text DEFAULT 'inquiry'::text,
+    source_email_id integer,
+    email_direction text,
+    thread_subject text,
+    taylor_response_summary text,
+    amenities_highlighted text[],
+    notes text,
+    extracted_at timestamp without time zone DEFAULT now()
+);
+
+
+--
+-- Name: guest_leads_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.guest_leads_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: guest_leads_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.guest_leads_id_seq OWNED BY public.guest_leads.id;
+
+
+--
+-- Name: guest_profiles; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.guest_profiles (
+    id bigint NOT NULL,
+    phone_number character varying(20) NOT NULL,
+    name character varying(255),
+    email character varying(255),
+    alternate_phones character varying(20)[],
+    total_messages integer DEFAULT 0,
+    total_conversations integer DEFAULT 0,
+    avg_response_time_seconds integer,
+    preferred_contact_time character varying(20),
+    typical_response_length character varying(20),
+    common_intents text[],
+    frequently_asked_questions text[],
+    overall_sentiment character varying(20),
+    sentiment_trend character varying(20),
+    positive_interaction_ratio numeric(3,2),
+    avg_satisfaction_score numeric(3,2),
+    total_stays integer DEFAULT 0,
+    favorite_cabins text[],
+    lifetime_value numeric(10,2),
     last_stay_date date,
-    streamline_guest_id character varying(100),
-    airbnb_guest_id character varying(100),
-    vrbo_guest_id character varying(100),
-    booking_com_guest_id character varying(100),
-    stripe_customer_id character varying(100),
-    tags character varying[],
-    notes text,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone,
-    last_contacted_at timestamp without time zone,
-    last_activity_at timestamp without time zone
+    next_booking_date date,
+    communication_style character varying(50),
+    language_preference character varying(10) DEFAULT 'en'::character varying,
+    accessibility_needs text[],
+    special_requests text[],
+    vip_guest boolean DEFAULT false,
+    requires_human_touch boolean DEFAULT false,
+    do_not_contact boolean DEFAULT false,
+    opted_out_at timestamp without time zone,
+    first_contact timestamp without time zone,
+    last_contact timestamp without time zone,
+    days_since_last_contact integer,
+    created_at timestamp without time zone DEFAULT now(),
+    updated_at timestamp without time zone DEFAULT now(),
+    CONSTRAINT valid_overall_sentiment CHECK ((((overall_sentiment)::text = ANY ((ARRAY['positive'::character varying, 'neutral'::character varying, 'negative'::character varying, 'urgent'::character varying])::text[])) OR (overall_sentiment IS NULL)))
 );
 
 
 --
--- Name: housekeeping_tasks; Type: TABLE; Schema: public; Owner: -
+-- Name: guest_profiles_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.housekeeping_tasks (
-    id uuid NOT NULL,
-    property_id uuid NOT NULL,
-    reservation_id uuid,
-    scheduled_date date NOT NULL,
-    scheduled_time time without time zone,
-    status character varying(20) NOT NULL,
-    assigned_to character varying(255),
-    cleaning_type character varying(20) NOT NULL,
-    estimated_minutes integer,
-    actual_minutes integer,
-    notes text,
-    completed_at timestamp without time zone,
-    streamline_source jsonb,
-    streamline_synced_at timestamp without time zone,
-    streamline_checklist_id character varying(100),
-    dispatched_by character varying(50),
-    dispatch_payload jsonb,
-    created_at timestamp without time zone,
-    legacy_assigned_to character varying(255),
-    assigned_cleaner_id uuid
+CREATE SEQUENCE public.guest_profiles_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: guest_profiles_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.guest_profiles_id_seq OWNED BY public.guest_profiles.id;
+
+
+--
+-- Name: images; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.images (
+    id integer NOT NULL,
+    filename text,
+    path text,
+    alt_text text,
+    ai_description text,
+    processed boolean DEFAULT false
 );
 
 
 --
--- Name: hunter_queue; Type: TABLE; Schema: public; Owner: -
+-- Name: images_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.hunter_queue (
-    id uuid NOT NULL,
-    session_fp character varying(128) NOT NULL,
-    property_id uuid,
-    reservation_id uuid,
-    guest_phone character varying(40),
-    guest_email character varying(255),
-    campaign character varying(120) NOT NULL,
+CREATE SEQUENCE public.images_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: images_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.images_id_seq OWNED BY public.images.id;
+
+
+--
+-- Name: ingestion_dlq; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ingestion_dlq (
+    id integer NOT NULL,
+    source text NOT NULL,
+    endpoint text,
+    record_id text,
     payload jsonb NOT NULL,
-    score integer NOT NULL,
-    status character varying(30) NOT NULL,
-    last_error text,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL,
-    CONSTRAINT ck_hunter_queue_status CHECK (((status)::text = ANY ((ARRAY['queued'::character varying, 'processing'::character varying, 'sent'::character varying, 'failed'::character varying, 'cancelled'::character varying])::text[])))
+    error_reason text NOT NULL,
+    field_errors jsonb,
+    resolved boolean DEFAULT false NOT NULL,
+    resolved_at timestamp with time zone,
+    resolved_by text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 
 --
--- Name: hunter_recovery_ops; Type: TABLE; Schema: public; Owner: -
+-- Name: ingestion_dlq_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.hunter_recovery_ops (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    cart_id character varying(255) NOT NULL,
-    guest_name character varying(255),
-    cabin_name character varying(255),
-    cart_value numeric(10,2),
-    status public.hunter_recovery_op_status DEFAULT 'QUEUED'::public.hunter_recovery_op_status NOT NULL,
-    ai_draft_body text,
-    assigned_worker character varying(32),
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
-);
+CREATE SEQUENCE public.ingestion_dlq_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
 
 
 --
--- Name: hunter_runs; Type: TABLE; Schema: public; Owner: -
+-- Name: ingestion_dlq_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE public.hunter_runs (
-    id uuid NOT NULL,
-    trigger character varying(120) NOT NULL,
-    campaign character varying(120) NOT NULL,
-    stats jsonb NOT NULL,
-    started_at timestamp without time zone NOT NULL,
-    completed_at timestamp without time zone
-);
-
-
---
--- Name: intelligence_ledger; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.intelligence_ledger (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    category character varying(64) NOT NULL,
-    title character varying(255) NOT NULL,
-    summary text NOT NULL,
-    market character varying(128) NOT NULL,
-    locality character varying(128),
-    dedupe_hash character varying(64) NOT NULL,
-    confidence_score double precision,
-    query_topic character varying(120),
-    scout_query text,
-    scout_run_key character varying(120),
-    target_property_ids jsonb NOT NULL,
-    target_tags jsonb NOT NULL,
-    source_urls jsonb NOT NULL,
-    grounding_payload jsonb NOT NULL,
-    finding_payload jsonb NOT NULL,
-    discovered_at timestamp with time zone NOT NULL,
-    created_at timestamp with time zone NOT NULL,
-    updated_at timestamp with time zone NOT NULL
-);
+ALTER SEQUENCE public.ingestion_dlq_id_seq OWNED BY public.ingestion_dlq.id;
 
 
 --
@@ -1961,16 +4262,21 @@ CREATE TABLE public.intelligence_ledger (
 --
 
 CREATE TABLE public.journal_entries (
-    id bigint NOT NULL,
-    property_id character varying(100) NOT NULL,
-    entry_date date DEFAULT CURRENT_DATE NOT NULL,
-    description text,
-    reference_type character varying(64) NOT NULL,
-    reference_id character varying(255) NOT NULL,
-    is_void boolean DEFAULT false NOT NULL,
-    posted_by character varying(100),
-    source_system character varying(64),
-    created_at timestamp with time zone DEFAULT now() NOT NULL
+    id integer NOT NULL,
+    entry_date date NOT NULL,
+    description text NOT NULL,
+    reference_id text,
+    reference_type text,
+    property_id text,
+    posted_by text DEFAULT 'system'::text,
+    source_system text DEFAULT 'fortress'::text,
+    is_void boolean DEFAULT false,
+    void_reason text,
+    voided_at timestamp without time zone,
+    voided_by text,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT journal_entries_reference_type_check CHECK ((reference_type = ANY (ARRAY['booking'::text, 'invoice'::text, 'payout'::text, 'adjustment'::text, 'cleaning_fee'::text, 'tax_remittance'::text, 'owner_draw'::text, 'security_deposit'::text, 'import'::text, 'manual'::text, NULL::text])))
 );
 
 
@@ -1979,6 +4285,7 @@ CREATE TABLE public.journal_entries (
 --
 
 CREATE SEQUENCE public.journal_entries_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1998,11 +4305,15 @@ ALTER SEQUENCE public.journal_entries_id_seq OWNED BY public.journal_entries.id;
 --
 
 CREATE TABLE public.journal_line_items (
-    id bigint NOT NULL,
-    journal_entry_id bigint NOT NULL,
-    account_id bigint NOT NULL,
-    debit numeric(18,2) DEFAULT '0'::numeric NOT NULL,
-    credit numeric(18,2) DEFAULT '0'::numeric NOT NULL
+    id integer NOT NULL,
+    journal_entry_id integer NOT NULL,
+    account_id integer NOT NULL,
+    debit numeric(15,2) DEFAULT 0 NOT NULL,
+    credit numeric(15,2) DEFAULT 0 NOT NULL,
+    memo text,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT chk_non_negative CHECK (((debit >= (0)::numeric) AND (credit >= (0)::numeric))),
+    CONSTRAINT chk_single_side CHECK ((((debit > (0)::numeric) AND (credit = (0)::numeric)) OR ((debit = (0)::numeric) AND (credit > (0)::numeric))))
 );
 
 
@@ -2011,6 +4322,7 @@ CREATE TABLE public.journal_line_items (
 --
 
 CREATE SEQUENCE public.journal_line_items_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2026,162 +4338,723 @@ ALTER SEQUENCE public.journal_line_items_id_seq OWNED BY public.journal_line_ite
 
 
 --
--- Name: knowledge_base_entries; Type: TABLE; Schema: public; Owner: -
+-- Name: learning_judgments; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.knowledge_base_entries (
-    id uuid NOT NULL,
-    category character varying(100) NOT NULL,
-    question text,
-    answer text NOT NULL,
-    keywords character varying[],
-    property_id uuid,
-    qdrant_point_id uuid,
-    usage_count integer,
-    helpful_count integer,
-    not_helpful_count integer,
-    last_used_at timestamp without time zone,
-    is_active boolean,
-    source character varying(100),
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone
+CREATE TABLE public.learning_judgments (
+    id integer NOT NULL,
+    agent_id text NOT NULL,
+    metric_name text NOT NULL,
+    predicted_value numeric(15,4),
+    actual_value numeric(15,4),
+    variance_pct numeric(8,4),
+    passed boolean,
+    action_taken text,
+    context jsonb,
+    created_at timestamp without time zone DEFAULT now()
 );
 
 
 --
--- Name: leads; Type: TABLE; Schema: public; Owner: -
+-- Name: learning_judgments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.leads (
-    id uuid NOT NULL,
-    streamline_lead_id character varying(100),
-    guest_name character varying(255),
-    email character varying(255),
-    phone character varying(20),
-    guest_message text,
-    status character varying(20) NOT NULL,
-    ai_score integer,
-    source character varying(50),
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone
+CREATE SEQUENCE public.learning_judgments_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: learning_judgments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.learning_judgments_id_seq OWNED BY public.learning_judgments.id;
+
+
+--
+-- Name: learning_optimizations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.learning_optimizations (
+    id integer NOT NULL,
+    agent_id text NOT NULL,
+    method text,
+    old_prompt_hash text,
+    new_prompt_hash text,
+    reasoning text,
+    failure_count integer,
+    created_at timestamp without time zone DEFAULT now()
 );
 
 
 --
--- Name: learned_rules; Type: TABLE; Schema: public; Owner: -
+-- Name: learning_optimizations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.learned_rules (
+CREATE SEQUENCE public.learning_optimizations_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: learning_optimizations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.learning_optimizations_id_seq OWNED BY public.learning_optimizations.id;
+
+
+--
+-- Name: legacy_cdc_checkpoints; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.legacy_cdc_checkpoints (
+    stream_name text NOT NULL,
+    log_file text,
+    log_pos bigint,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: legacy_cdc_event_queue; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.legacy_cdc_event_queue (
+    id bigint NOT NULL,
+    stream_name text NOT NULL,
+    source_schema text,
+    source_table text NOT NULL,
+    operation text NOT NULL,
+    primary_key jsonb NOT NULL,
+    row_data jsonb,
+    binlog_file text,
+    binlog_pos bigint,
+    event_time timestamp with time zone DEFAULT now() NOT NULL,
+    state text DEFAULT 'queued'::text NOT NULL,
+    attempts integer DEFAULT 0 NOT NULL,
+    last_error text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    applied_at timestamp with time zone
+);
+
+
+--
+-- Name: legacy_cdc_event_queue_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.legacy_cdc_event_queue_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: legacy_cdc_event_queue_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.legacy_cdc_event_queue_id_seq OWNED BY public.legacy_cdc_event_queue.id;
+
+
+--
+-- Name: legacy_cdc_row_state; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.legacy_cdc_row_state (
+    source_schema text,
+    source_table text NOT NULL,
+    primary_key_hash text NOT NULL,
+    primary_key jsonb NOT NULL,
+    row_data jsonb,
+    deleted boolean DEFAULT false NOT NULL,
+    last_event_id bigint,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: legal_clients; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.legal_clients (
+    client_id integer NOT NULL,
+    name character varying(200) NOT NULL,
+    industry character varying(100),
+    contact_name character varying(200),
+    contact_email character varying(200),
+    notes text,
+    status character varying(50) DEFAULT 'Active'::character varying,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: legal_clients_client_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.legal_clients_client_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: legal_clients_client_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.legal_clients_client_id_seq OWNED BY public.legal_clients.client_id;
+
+
+--
+-- Name: legal_docket; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.legal_docket (
+    doc_id integer NOT NULL,
+    matter_id character varying(50),
+    doc_type character varying(50),
+    title character varying(200) NOT NULL,
+    content text,
+    version integer DEFAULT 1,
+    status character varying(50) DEFAULT 'Draft'::character varying,
+    created_by character varying(100) DEFAULT 'system'::character varying,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: legal_docket_doc_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.legal_docket_doc_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: legal_docket_doc_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.legal_docket_doc_id_seq OWNED BY public.legal_docket.doc_id;
+
+
+--
+-- Name: legal_intel; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.legal_intel (
+    id integer NOT NULL,
+    case_name character varying(255),
+    case_number character varying(100),
+    court character varying(255),
+    status character varying(100),
+    priority character varying(50),
+    next_deadline date,
+    source_email_id integer,
+    content text,
+    created_at timestamp without time zone,
+    enriched_at timestamp without time zone
+);
+
+
+--
+-- Name: legal_intel_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.legal_intel_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: legal_intel_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.legal_intel_id_seq OWNED BY public.legal_intel.id;
+
+
+--
+-- Name: legal_matter_notes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.legal_matter_notes (
+    note_id integer NOT NULL,
+    matter_id character varying(50),
+    agent character varying(50) DEFAULT 'user'::character varying,
+    content text NOT NULL,
+    note_type character varying(50) DEFAULT 'note'::character varying,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: legal_matter_notes_note_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.legal_matter_notes_note_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: legal_matter_notes_note_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.legal_matter_notes_note_id_seq OWNED BY public.legal_matter_notes.note_id;
+
+
+--
+-- Name: legal_matters; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.legal_matters (
+    matter_id character varying(50) NOT NULL,
+    client_id integer,
+    title character varying(255) NOT NULL,
+    practice_area character varying(100),
+    description text,
+    opposing_counsel character varying(200),
+    jurisdiction character varying(100),
+    status character varying(50) DEFAULT 'Open'::character varying,
+    priority character varying(20) DEFAULT 'Normal'::character varying,
+    strategy_notes text,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: maintenance_log; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.maintenance_log (
+    id integer NOT NULL,
+    run_id text NOT NULL,
+    cabin_name text NOT NULL,
+    room_type text NOT NULL,
+    room_display text,
+    image_path text,
+    image_hash text,
+    image_size_bytes bigint,
+    overall_score numeric(5,1),
+    verdict text NOT NULL,
+    pass_threshold integer DEFAULT 80,
+    items_passed integer,
+    items_failed integer,
+    items_total integer,
+    ai_confidence_score numeric(5,4),
+    detected_by text,
+    json_parsed boolean DEFAULT false,
+    issues_found text,
+    checklist_json text,
+    overall_impression text,
+    raw_analysis text,
+    inspector_id text,
+    inference_time_s real,
+    engine_version text DEFAULT '1.0.0'::text,
+    generated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: maintenance_log_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.maintenance_log_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: maintenance_log_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.maintenance_log_id_seq OWNED BY public.maintenance_log.id;
+
+
+--
+-- Name: market_intel; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.market_intel (
+    id integer NOT NULL,
+    ticker text,
+    asset_class text,
+    content text,
+    signal_strength real,
+    sent_at timestamp without time zone,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    source_file text,
+    chunk_index integer,
+    sender text,
+    subject_line text,
+    signal_direction text,
+    broker text,
+    action text,
+    price numeric(15,4),
+    source_email_id integer,
+    enriched_at timestamp without time zone
+);
+
+
+--
+-- Name: market_intel_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.market_intel_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: market_intel_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.market_intel_id_seq OWNED BY public.market_intel.id;
+
+
+--
+-- Name: market_signals; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.market_signals (
+    id integer NOT NULL,
+    symbol text,
+    price real,
+    sentiment_score real,
+    source text,
+    "timestamp" timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    ticker text,
+    action text,
+    confidence_score numeric(3,2),
+    source_email_id integer,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: market_signals_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.market_signals_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: market_signals_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.market_signals_id_seq OWNED BY public.market_signals.id;
+
+
+--
+-- Name: message_analytics_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.message_analytics_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: message_analytics_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.message_analytics_id_seq OWNED BY public.message_analytics.id;
+
+
+--
+-- Name: message_archive_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.message_archive_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: message_archive_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.message_archive_id_seq OWNED BY public.message_archive.id;
+
+
+--
+-- Name: model_telemetry; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.model_telemetry (
+    id integer NOT NULL,
+    model_name text NOT NULL,
+    node text,
+    operation text,
+    success boolean,
+    latency_ms integer,
+    input_tokens integer,
+    output_tokens integer,
+    error_message text,
+    created_at timestamp without time zone DEFAULT now()
+);
+
+
+--
+-- Name: model_telemetry_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.model_telemetry_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: model_telemetry_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.model_telemetry_id_seq OWNED BY public.model_telemetry.id;
+
+
+--
+-- Name: nas_legal_vault; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.nas_legal_vault (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
-    property_id uuid,
-    rule_name character varying(255) NOT NULL,
-    trigger_condition jsonb NOT NULL,
-    adjustment_type character varying(20) NOT NULL,
-    adjustment_value double precision NOT NULL,
-    confidence_score double precision DEFAULT 0.0 NOT NULL,
-    status character varying(30) DEFAULT 'pending_approval'::character varying NOT NULL,
-    created_at timestamp without time zone DEFAULT now() NOT NULL,
+    source_file text NOT NULL,
+    chunk_index integer NOT NULL,
+    chunk_text text NOT NULL,
+    metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
+    embedding public.vector(768),
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: nim_arm64_probe_results; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.nim_arm64_probe_results (
+    id integer NOT NULL,
+    probe_date date NOT NULL,
+    image_path text NOT NULL,
+    tag text NOT NULL,
+    stage1_arm64 boolean,
+    arm64_digest text,
+    amd64_digest text,
+    arm64_manifest_bytes integer,
+    amd64_manifest_bytes integer,
+    possible_mismatch boolean,
+    verdict text,
+    probe_notes text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: nim_arm64_probe_results_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.nim_arm64_probe_results_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: nim_arm64_probe_results_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.nim_arm64_probe_results_id_seq OWNED BY public.nim_arm64_probe_results.id;
+
+
+--
+-- Name: ops_crew; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ops_crew (
+    id integer NOT NULL,
+    name character varying(100) NOT NULL,
+    role character varying(50) NOT NULL,
+    phone character varying(20),
+    email character varying(100),
+    status character varying(20) DEFAULT 'ACTIVE'::character varying,
+    current_location character varying(100),
+    skills jsonb DEFAULT '{}'::jsonb,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: ops_crew_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ops_crew_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: ops_crew_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ops_crew_id_seq OWNED BY public.ops_crew.id;
+
+
+--
+-- Name: ops_historical_guests; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ops_historical_guests (
+    id bigint NOT NULL,
+    guest_id text NOT NULL,
+    full_name text,
+    email text,
+    phone text,
+    address text,
+    reservation_history jsonb DEFAULT '[]'::jsonb NOT NULL,
+    total_spend numeric(14,2) DEFAULT 0 NOT NULL,
+    first_seen date,
+    last_seen date,
+    raw_json jsonb DEFAULT '{}'::jsonb NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: ops_historical_guests_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ops_historical_guests_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: ops_historical_guests_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ops_historical_guests_id_seq OWNED BY public.ops_historical_guests.id;
+
+
+--
+-- Name: ops_log; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ops_log (
+    id integer NOT NULL,
+    "timestamp" timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    actor character varying(100),
+    action text NOT NULL,
+    entity_type character varying(50),
+    entity_id integer,
+    metadata jsonb
+);
+
+
+--
+-- Name: ops_log_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ops_log_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: ops_log_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ops_log_id_seq OWNED BY public.ops_log.id;
+
+
+--
+-- Name: ops_overrides; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ops_overrides (
+    id integer NOT NULL,
+    entity_type character varying(50) NOT NULL,
+    entity_id character varying(100) NOT NULL,
+    override_type character varying(50) NOT NULL,
+    reason text,
+    issued_by character varying(100) DEFAULT '''commander'''::character varying,
+    effective_until timestamp without time zone,
+    active boolean DEFAULT true,
+    created_at timestamp without time zone DEFAULT now(),
     updated_at timestamp without time zone DEFAULT now()
 );
 
 
 --
--- Name: legacy_pages; Type: TABLE; Schema: public; Owner: -
+-- Name: ops_overrides_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.legacy_pages (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    slug character varying(255) NOT NULL,
-    title character varying(500) NOT NULL,
-    body_value text,
-    body_summary text,
-    body_format character varying(50) DEFAULT 'full_html'::character varying,
-    entity_type character varying(50) DEFAULT 'node'::character varying,
-    bundle character varying(100) DEFAULT 'page'::character varying,
-    language character varying(10) DEFAULT 'en'::character varying,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
---
--- Name: legal_case_statements; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.legal_case_statements (
-    id character varying NOT NULL,
-    case_slug character varying NOT NULL,
-    entity_name character varying NOT NULL,
-    quote_text character varying NOT NULL,
-    source_ref character varying NOT NULL,
-    stated_at timestamp without time zone,
-    created_at timestamp without time zone
-);
-
-
---
--- Name: legal_hive_mind_feedback_events; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.legal_hive_mind_feedback_events (
-    id character varying NOT NULL,
-    case_slug character varying NOT NULL,
-    module_type character varying NOT NULL,
-    original_swarm_text character varying NOT NULL,
-    human_edited_text character varying NOT NULL,
-    accepted boolean,
-    user_id character varying,
-    created_at timestamp without time zone
-);
-
-
---
--- Name: llm_training_captures; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.llm_training_captures (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    source_module character varying(120) NOT NULL,
-    model_used character varying(120) NOT NULL,
-    user_prompt text NOT NULL,
-    assistant_resp text NOT NULL,
-    quality_score double precision,
-    status character varying(20) DEFAULT 'pending'::character varying NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    eval_holdout boolean DEFAULT false NOT NULL,
-    served_by_endpoint character varying(256),
-    served_vector_store character varying(64),
-    escalated_from character varying(256),
-    sovereign_attempt text,
-    teacher_endpoint character varying(256),
-    teacher_model character varying(128),
-    task_type character varying(64),
-    judge_decision character varying(16),
-    judge_reasoning text,
-    capture_metadata jsonb
-);
-
-
---
--- Name: management_splits; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.management_splits (
-    id bigint NOT NULL,
-    property_id character varying(100) NOT NULL,
-    owner_pct numeric(6,2) NOT NULL,
-    pm_pct numeric(6,2) NOT NULL,
-    effective_date date NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
---
--- Name: management_splits_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.management_splits_id_seq
+CREATE SEQUENCE public.ops_overrides_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2190,55 +5063,92 @@ CREATE SEQUENCE public.management_splits_id_seq
 
 
 --
--- Name: management_splits_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+-- Name: ops_overrides_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.management_splits_id_seq OWNED BY public.management_splits.id;
+ALTER SEQUENCE public.ops_overrides_id_seq OWNED BY public.ops_overrides.id;
 
 
 --
--- Name: marketing_articles; Type: TABLE; Schema: public; Owner: -
+-- Name: ops_properties; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.marketing_articles (
-    id uuid NOT NULL,
-    title character varying(255) NOT NULL,
-    slug character varying(255) NOT NULL,
-    content_body_html text NOT NULL,
-    author character varying(255),
-    published_date timestamp with time zone,
-    category_id uuid NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
+CREATE TABLE public.ops_properties (
+    property_id character varying(50) NOT NULL,
+    internal_name character varying(100),
+    address text,
+    access_code_wifi character varying(50),
+    access_code_door character varying(50),
+    trash_pickup_day character varying(20),
+    cleaning_sla_minutes integer DEFAULT 240,
+    hvac_filter_size character varying(20),
+    hot_tub_gallons integer,
+    config_yaml text,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    streamline_id integer,
+    name text,
+    unit_code text,
+    status_name text DEFAULT 'Active'::text,
+    status_id integer DEFAULT 1,
+    address2 text,
+    city text,
+    state_name text,
+    zip text,
+    country_name text,
+    latitude numeric(10,7),
+    longitude numeric(11,7),
+    location_area_name text,
+    resort_area_name text,
+    view_name text,
+    bedrooms numeric(4,1),
+    bathrooms numeric(4,1),
+    max_occupants integer,
+    max_adults integer,
+    max_pets integer,
+    lodging_type_id integer,
+    square_feet integer,
+    company_id integer,
+    owning_type_id integer,
+    seo_title text,
+    flyer_url text,
+    default_image_url text,
+    description_short text,
+    streamline_created timestamp without time zone,
+    last_reservation timestamp without time zone,
+    last_synced timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    raw_json jsonb
 );
 
 
 --
--- Name: marketing_attribution; Type: TABLE; Schema: public; Owner: -
+-- Name: ops_tasks; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.marketing_attribution (
-    id bigint NOT NULL,
-    property_id character varying(100) NOT NULL,
-    period_start date NOT NULL,
-    period_end date NOT NULL,
-    ad_spend numeric(12,2) DEFAULT 0 NOT NULL,
-    impressions integer DEFAULT 0 NOT NULL,
-    clicks integer DEFAULT 0 NOT NULL,
-    direct_bookings integer DEFAULT 0 NOT NULL,
-    gross_revenue numeric(12,2) DEFAULT 0 NOT NULL,
-    roas numeric(12,2) DEFAULT 0 NOT NULL,
-    campaign_notes text,
-    entered_by character varying(100),
-    created_at timestamp with time zone DEFAULT now() NOT NULL
+CREATE TABLE public.ops_tasks (
+    id integer NOT NULL,
+    type character varying(50) NOT NULL,
+    priority character varying(20) DEFAULT 'NORMAL'::character varying,
+    property_id character varying(50),
+    assigned_to integer,
+    turnover_id integer,
+    description text,
+    deadline timestamp without time zone,
+    started_at timestamp without time zone,
+    completed_at timestamp without time zone,
+    status character varying(50) DEFAULT 'OPEN'::character varying,
+    evidence_photos jsonb,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
 );
 
 
 --
--- Name: marketing_attribution_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: ops_tasks_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.marketing_attribution_id_seq
+CREATE SEQUENCE public.ops_tasks_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2247,182 +5157,38 @@ CREATE SEQUENCE public.marketing_attribution_id_seq
 
 
 --
--- Name: marketing_attribution_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+-- Name: ops_tasks_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.marketing_attribution_id_seq OWNED BY public.marketing_attribution.id;
-
-
---
--- Name: message_queue; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.message_queue (
-    id uuid NOT NULL,
-    quote_id uuid NOT NULL,
-    template_id uuid NOT NULL,
-    status character varying(20) NOT NULL,
-    rendered_subject character varying(1000) NOT NULL,
-    rendered_body text NOT NULL,
-    created_at timestamp without time zone
-);
+ALTER SEQUENCE public.ops_tasks_id_seq OWNED BY public.ops_tasks.id;
 
 
 --
--- Name: message_templates; Type: TABLE; Schema: public; Owner: -
+-- Name: ops_turnovers; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.message_templates (
-    id uuid NOT NULL,
-    name character varying(255) NOT NULL,
-    category character varying(50) NOT NULL,
-    subject character varying(255),
-    body text NOT NULL,
-    variables character varying[],
-    trigger_type character varying(50),
-    trigger_offset_days integer,
-    trigger_time time without time zone,
-    is_active boolean,
-    send_priority integer,
-    language character varying(10),
-    usage_count integer,
-    last_used_at timestamp without time zone,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone
-);
-
-
---
--- Name: messages; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.messages (
-    id uuid NOT NULL,
-    external_id character varying(255),
-    guest_id uuid,
-    reservation_id uuid,
-    direction character varying(20) NOT NULL,
-    phone_from character varying(20) NOT NULL,
-    phone_to character varying(20) NOT NULL,
-    body text NOT NULL,
-    intent character varying(50),
-    sentiment character varying(20),
-    category character varying(50),
-    status character varying(50) NOT NULL,
-    is_auto_response boolean,
-    ai_confidence numeric(4,3),
-    requires_human_review boolean,
-    human_reviewed_at timestamp without time zone,
-    human_reviewed_by character varying(100),
-    sent_at timestamp without time zone,
-    delivered_at timestamp without time zone,
-    read_at timestamp without time zone,
-    error_code character varying(50),
-    error_message text,
-    provider character varying(50),
-    cost_amount numeric(8,4),
-    num_segments integer,
-    trace_id uuid,
-    metadata jsonb,
-    created_at timestamp without time zone
-);
-
-
---
--- Name: openshell_audit_logs; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.openshell_audit_logs (
-    id uuid NOT NULL,
-    actor_id character varying(255),
-    actor_email character varying(255),
-    action character varying(120) NOT NULL,
-    resource_type character varying(120) NOT NULL,
-    resource_id character varying(255),
-    purpose character varying(255),
-    tool_name character varying(120),
-    redaction_status character varying(50) NOT NULL,
-    model_route character varying(120),
-    outcome character varying(50) NOT NULL,
-    request_id character varying(100),
-    metadata_json jsonb NOT NULL,
-    payload_hash character varying(128) NOT NULL,
-    prev_hash character varying(128),
-    entry_hash character varying(128) NOT NULL,
-    signature text NOT NULL,
-    created_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: operator_overrides; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.operator_overrides (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    escalation_id uuid NOT NULL,
-    operator_email character varying(255) NOT NULL,
-    override_action character varying(7) NOT NULL,
-    final_payload jsonb NOT NULL,
-    "timestamp" timestamp with time zone DEFAULT now() NOT NULL,
-    CONSTRAINT operator_override_action CHECK (((override_action)::text = ANY ((ARRAY['approve'::character varying, 'reject'::character varying, 'modify'::character varying])::text[])))
-);
-
-
---
--- Name: ota_micro_updates; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.ota_micro_updates (
-    id uuid NOT NULL,
-    property_id uuid,
-    channel character varying(80) NOT NULL,
-    patch_payload jsonb NOT NULL,
-    status character varying(30) NOT NULL,
-    error text,
-    created_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: owner_balance_periods; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.owner_balance_periods (
-    id bigint NOT NULL,
-    owner_payout_account_id bigint NOT NULL,
-    period_start date NOT NULL,
-    period_end date NOT NULL,
-    opening_balance numeric(12,2) NOT NULL,
-    closing_balance numeric(12,2) NOT NULL,
-    total_revenue numeric(12,2) DEFAULT 0 NOT NULL,
-    total_commission numeric(12,2) DEFAULT 0 NOT NULL,
-    total_charges numeric(12,2) DEFAULT 0 NOT NULL,
-    total_payments numeric(12,2) DEFAULT 0 NOT NULL,
-    total_owner_income numeric(12,2) DEFAULT 0 NOT NULL,
-    status public.statement_period_status DEFAULT 'draft'::public.statement_period_status NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    approved_at timestamp with time zone,
-    approved_by character varying(255),
-    paid_at timestamp with time zone,
-    emailed_at timestamp with time zone,
+CREATE TABLE public.ops_turnovers (
+    id integer NOT NULL,
+    property_id character varying(50),
+    reservation_id_out character varying(50),
+    reservation_id_in character varying(50),
+    checkout_time timestamp without time zone NOT NULL,
+    checkin_time timestamp without time zone NOT NULL,
+    window_hours numeric(5,2),
+    status character varying(50) DEFAULT 'PENDING'::character varying,
+    cleanliness_score integer,
     notes text,
-    voided_at timestamp with time zone,
-    voided_by character varying(255),
-    paid_by character varying(255),
-    stripe_transfer_id character varying(100),
-    paid_amount numeric(12,2),
-    CONSTRAINT chk_obp_ledger_equation CHECK ((closing_balance = (((((opening_balance + total_revenue) - total_commission) - total_charges) - total_payments) + total_owner_income))),
-    CONSTRAINT chk_obp_period_order CHECK ((period_end > period_start))
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
 );
 
 
 --
--- Name: owner_balance_periods_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: ops_turnovers_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.owner_balance_periods_id_seq
+CREATE SEQUENCE public.ops_turnovers_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2431,285 +5197,46 @@ CREATE SEQUENCE public.owner_balance_periods_id_seq
 
 
 --
--- Name: owner_balance_periods_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+-- Name: ops_turnovers_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.owner_balance_periods_id_seq OWNED BY public.owner_balance_periods.id;
-
-
---
--- Name: owner_charges; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.owner_charges (
-    id bigint NOT NULL,
-    owner_payout_account_id bigint NOT NULL,
-    posting_date date NOT NULL,
-    transaction_type public.owner_charge_type_enum NOT NULL,
-    description character varying(500) NOT NULL,
-    amount numeric(12,2) NOT NULL,
-    reference_id character varying(100),
-    originating_work_order_id bigint,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    created_by character varying(255) NOT NULL,
-    voided_at timestamp with time zone,
-    voided_by character varying(255),
-    void_reason text,
-    vendor_id uuid,
-    markup_percentage numeric(5,2) DEFAULT 0.00 NOT NULL,
-    vendor_amount numeric(12,2),
-    CONSTRAINT chk_oc_amount_not_zero CHECK ((amount <> (0)::numeric)),
-    CONSTRAINT chk_oc_description_not_empty CHECK (((description)::text <> ''::text)),
-    CONSTRAINT chk_oc_void_pair CHECK ((((voided_at IS NULL) AND (voided_by IS NULL)) OR ((voided_at IS NOT NULL) AND (voided_by IS NOT NULL))))
-);
+ALTER SEQUENCE public.ops_turnovers_id_seq OWNED BY public.ops_turnovers.id;
 
 
 --
--- Name: owner_charges_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: ops_visuals; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.owner_charges_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: owner_charges_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.owner_charges_id_seq OWNED BY public.owner_charges.id;
-
-
---
--- Name: owner_magic_tokens; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.owner_magic_tokens (
-    id bigint NOT NULL,
-    token_hash character varying(128) NOT NULL,
-    owner_email character varying(255) NOT NULL,
-    sl_owner_id character varying(50) NOT NULL,
-    expires_at timestamp with time zone NOT NULL,
-    used_at timestamp with time zone,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    commission_rate numeric(5,4),
-    mailing_address_line1 character varying(255),
-    mailing_address_line2 character varying(255),
-    mailing_address_city character varying(100),
-    mailing_address_state character varying(50),
-    mailing_address_postal_code character varying(20),
-    mailing_address_country character varying(50) DEFAULT 'USA'::character varying,
-    CONSTRAINT chk_omt_commission_rate CHECK (((commission_rate >= (0)::numeric) AND (commission_rate <= 0.5000)))
-);
-
-
---
--- Name: owner_magic_tokens_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.owner_magic_tokens_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: owner_magic_tokens_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.owner_magic_tokens_id_seq OWNED BY public.owner_magic_tokens.id;
-
-
---
--- Name: owner_marketing_preferences; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.owner_marketing_preferences (
-    id bigint NOT NULL,
-    property_id character varying(100) NOT NULL,
-    marketing_pct numeric(6,2) DEFAULT 0 NOT NULL,
-    enabled boolean DEFAULT false NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_by character varying(100)
-);
-
-
---
--- Name: owner_marketing_preferences_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.owner_marketing_preferences_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: owner_marketing_preferences_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.owner_marketing_preferences_id_seq OWNED BY public.owner_marketing_preferences.id;
-
-
---
--- Name: owner_markup_rules; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.owner_markup_rules (
-    id bigint NOT NULL,
-    property_id character varying(100) NOT NULL,
-    expense_category character varying(64) DEFAULT 'ALL'::character varying NOT NULL,
-    markup_percentage numeric(6,2) NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
---
--- Name: owner_markup_rules_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.owner_markup_rules_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: owner_markup_rules_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.owner_markup_rules_id_seq OWNED BY public.owner_markup_rules.id;
-
-
---
--- Name: owner_payout_accounts; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.owner_payout_accounts (
-    id bigint NOT NULL,
-    property_id character varying(100) NOT NULL,
-    owner_name character varying(255) NOT NULL,
-    owner_email character varying(255),
-    stripe_account_id character varying(255),
-    account_status character varying(64) DEFAULT 'onboarding'::character varying NOT NULL,
-    instant_payout boolean DEFAULT false NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    payout_schedule character varying(20) DEFAULT 'manual'::character varying NOT NULL,
-    payout_day_of_week integer,
-    payout_day_of_month integer,
-    last_payout_at timestamp with time zone,
-    next_scheduled_payout timestamp with time zone,
-    minimum_payout_threshold numeric(10,2) DEFAULT 100.00 NOT NULL,
-    commission_rate numeric(5,4) NOT NULL,
-    streamline_owner_id integer,
-    mailing_address_line1 character varying(255),
-    mailing_address_line2 character varying(255),
-    mailing_address_city character varying(100),
-    mailing_address_state character varying(50),
-    mailing_address_postal_code character varying(20),
-    mailing_address_country character varying(50) DEFAULT 'USA'::character varying,
-    owner_middle_name character varying(100),
-    CONSTRAINT chk_opa_commission_rate CHECK (((commission_rate >= (0)::numeric) AND (commission_rate <= 0.5000)))
-);
-
-
---
--- Name: owner_payout_accounts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.owner_payout_accounts_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: owner_payout_accounts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.owner_payout_accounts_id_seq OWNED BY public.owner_payout_accounts.id;
-
-
---
--- Name: owner_property_map; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.owner_property_map (
-    id bigint NOT NULL,
-    sl_owner_id character varying(50) NOT NULL,
-    unit_id character varying(100) NOT NULL,
-    owner_name character varying(255) NOT NULL,
-    email character varying(255),
-    phone character varying(40),
-    property_name character varying(255),
-    live_balance numeric(12,2) DEFAULT 0 NOT NULL,
-    synced_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
---
--- Name: owner_property_map_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.owner_property_map_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: owner_property_map_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.owner_property_map_id_seq OWNED BY public.owner_property_map.id;
-
-
---
--- Name: owner_statement_sends; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.owner_statement_sends (
-    id bigint NOT NULL,
-    owner_payout_account_id bigint NOT NULL,
-    property_id uuid NOT NULL,
-    statement_period_start date NOT NULL,
-    statement_period_end date NOT NULL,
-    sent_at timestamp with time zone,
-    sent_to_email character varying(255),
-    crog_total_amount numeric(12,2),
-    streamline_total_amount numeric(12,2),
-    source_used character varying(20),
-    comparison_status character varying(30),
-    comparison_diff_cents integer,
-    email_message_id character varying(255),
+CREATE TABLE public.ops_visuals (
+    image_id integer NOT NULL,
+    file_path text NOT NULL,
+    file_name character varying(255),
+    file_size_bytes bigint,
+    file_ext character varying(10),
+    property_id character varying(50),
+    property_name character varying(200),
+    description text,
+    features jsonb DEFAULT '{}'::jsonb,
+    room_type character varying(50),
+    quality_score numeric(5,2),
+    embedding_id character varying(100),
+    collection_name character varying(100) DEFAULT 'fortress_docs'::character varying,
+    model_used character varying(100),
+    inference_time_s real,
+    status character varying(20) DEFAULT 'PENDING'::character varying,
     error_message text,
-    is_test boolean DEFAULT false NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    CONSTRAINT owner_statement_sends_comparison_status_check CHECK (((comparison_status)::text = ANY ((ARRAY['match'::character varying, 'mismatch'::character varying, 'streamline_unavailable'::character varying, 'not_compared'::character varying])::text[]))),
-    CONSTRAINT owner_statement_sends_source_used_check CHECK (((source_used)::text = ANY ((ARRAY['crog'::character varying, 'streamline'::character varying, 'failed'::character varying])::text[])))
+    scanned_at timestamp without time zone,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    visual_hash character varying(64)
 );
 
 
 --
--- Name: owner_statement_sends_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: ops_visuals_image_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.owner_statement_sends_id_seq
+CREATE SEQUENCE public.ops_visuals_image_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2718,56 +5245,31 @@ CREATE SEQUENCE public.owner_statement_sends_id_seq
 
 
 --
--- Name: owner_statement_sends_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+-- Name: ops_visuals_image_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.owner_statement_sends_id_seq OWNED BY public.owner_statement_sends.id;
+ALTER SEQUENCE public.ops_visuals_image_id_seq OWNED BY public.ops_visuals.image_id;
 
 
 --
--- Name: parity_audits; Type: TABLE; Schema: public; Owner: -
+-- Name: pages; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.parity_audits (
-    id uuid NOT NULL,
-    reservation_id uuid NOT NULL,
-    confirmation_id character varying(100) NOT NULL,
-    local_total numeric(12,2) NOT NULL,
-    streamline_total numeric(12,2) NOT NULL,
-    delta numeric(12,2) NOT NULL,
-    local_breakdown jsonb DEFAULT '{}'::jsonb NOT NULL,
-    streamline_breakdown jsonb DEFAULT '{}'::jsonb NOT NULL,
-    status character varying(30) NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
+CREATE TABLE public.pages (
+    id integer NOT NULL,
+    url text,
+    title text,
+    content text,
+    last_scraped timestamp without time zone DEFAULT CURRENT_TIMESTAMP
 );
 
 
 --
--- Name: payout_ledger; Type: TABLE; Schema: public; Owner: -
+-- Name: pages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.payout_ledger (
-    id bigint NOT NULL,
-    property_id character varying(100) NOT NULL,
-    confirmation_code character varying(100),
-    gross_amount numeric(12,2) DEFAULT 0 NOT NULL,
-    owner_amount numeric(12,2) DEFAULT 0 NOT NULL,
-    stripe_transfer_id character varying(255),
-    stripe_payout_id character varying(255),
-    status character varying(64) DEFAULT 'staged'::character varying NOT NULL,
-    initiated_at timestamp with time zone,
-    completed_at timestamp with time zone,
-    failure_reason text,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
---
--- Name: payout_ledger_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.payout_ledger_id_seq
+CREATE SEQUENCE public.pages_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2776,47 +5278,56 @@ CREATE SEQUENCE public.payout_ledger_id_seq
 
 
 --
--- Name: payout_ledger_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+-- Name: pages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.payout_ledger_id_seq OWNED BY public.payout_ledger.id;
-
-
---
--- Name: pending_sync; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.pending_sync (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    reservation_id uuid NOT NULL,
-    property_id uuid NOT NULL,
-    sync_type character varying(50) DEFAULT 'create_reservation'::character varying NOT NULL,
-    status character varying(30) DEFAULT 'pending'::character varying NOT NULL,
-    attempt_count integer DEFAULT 0 NOT NULL,
-    last_error text,
-    payload jsonb DEFAULT '{}'::jsonb NOT NULL,
-    created_at timestamp with time zone DEFAULT now(),
-    updated_at timestamp with time zone DEFAULT now(),
-    resolved_at timestamp with time zone
-);
+ALTER SEQUENCE public.pages_id_seq OWNED BY public.pages.id;
 
 
 --
--- Name: pricing_overrides; Type: TABLE; Schema: public; Owner: -
+-- Name: pending_reviews; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE TABLE public.pricing_overrides (
-    id uuid NOT NULL,
-    property_id uuid NOT NULL,
-    start_date date NOT NULL,
-    end_date date NOT NULL,
-    adjustment_percentage numeric(6,2) NOT NULL,
-    reason character varying(500) NOT NULL,
-    approved_by character varying(255) NOT NULL,
-    created_at timestamp with time zone NOT NULL,
-    updated_at timestamp with time zone NOT NULL,
-    CONSTRAINT ck_pricing_overrides_adjustment_range CHECK (((adjustment_percentage >= '-100.00'::numeric) AND (adjustment_percentage <= 100.00))),
-    CONSTRAINT ck_pricing_overrides_date_order CHECK ((end_date >= start_date))
+CREATE VIEW public.pending_reviews AS
+ SELECT arq.id,
+    arq.phone_number,
+    arq.guest_name,
+    arq.cabin_name,
+    arq.guest_message,
+    arq.intent,
+    arq.sentiment,
+    arq.urgency_level,
+    arq.escalation_required,
+    arq.ai_draft,
+    arq.confidence_score,
+    arq.ai_model,
+    arq.created_at,
+    arq.expires_at,
+    gp.communication_style,
+    gp.total_stays,
+    gp.vip_guest,
+    gp.overall_sentiment AS guest_overall_sentiment
+   FROM (public.agent_response_queue arq
+     LEFT JOIN public.guest_profiles gp ON (((arq.phone_number)::text = (gp.phone_number)::text)))
+  WHERE ((arq.status)::text = 'pending_review'::text)
+  ORDER BY arq.urgency_level DESC, arq.created_at;
+
+
+--
+-- Name: persona_scores; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.persona_scores (
+    persona_slug character varying(50) NOT NULL,
+    persona_name character varying(100) NOT NULL,
+    total_votes integer DEFAULT 0 NOT NULL,
+    correct_votes integer DEFAULT 0 NOT NULL,
+    brier_score double precision DEFAULT 0.0 NOT NULL,
+    streak integer DEFAULT 0 NOT NULL,
+    last_signal character varying(20),
+    last_conviction double precision,
+    last_voted_at timestamp with time zone,
+    last_updated timestamp with time zone DEFAULT now() NOT NULL
 );
 
 
@@ -2825,704 +5336,31 @@ CREATE TABLE public.pricing_overrides (
 --
 
 CREATE TABLE public.properties (
-    id uuid NOT NULL,
-    name character varying(255) NOT NULL,
-    slug character varying(255) NOT NULL,
-    property_type character varying(50) NOT NULL,
-    bedrooms integer NOT NULL,
-    bathrooms numeric(3,1) NOT NULL,
-    max_guests integer NOT NULL,
-    address text,
-    latitude numeric(10,8),
-    longitude numeric(11,8),
-    wifi_ssid character varying(255),
-    wifi_password character varying(255),
-    access_code_type character varying(50),
-    access_code_location text,
-    parking_instructions text,
-    rate_card jsonb,
-    availability jsonb,
-    default_housekeeper_id uuid,
-    default_clean_minutes integer,
-    streamline_checklist_id character varying(100),
-    amenities jsonb,
-    qdrant_point_id uuid,
-    streamline_property_id character varying(100),
-    ota_metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
-    owner_id character varying(100),
-    owner_name character varying(255),
-    owner_balance jsonb,
-    is_active boolean,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone,
-    rates_notes text,
-    video_urls jsonb,
-    county character varying(100),
-    city_limits boolean DEFAULT false NOT NULL,
-    cleaning_fee numeric(10,2),
-    renting_state public.property_renting_state DEFAULT 'active'::public.property_renting_state NOT NULL,
-    property_group character varying(100),
-    city character varying(100),
-    state character varying(50),
-    postal_code character varying(20)
+    id integer NOT NULL,
+    name character varying(100) NOT NULL,
+    address character varying(255),
+    parcel_id character varying(50),
+    county character varying(50) DEFAULT 'Fannin'::character varying,
+    acres numeric(5,2),
+    acquisition_date date,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    ownership_status character varying(20) DEFAULT 'UNKNOWN'::character varying NOT NULL,
+    cost_basis numeric(12,2),
+    current_value numeric(12,2),
+    depreciation_start date,
+    owner_contact_info jsonb,
+    streamline_id integer,
+    management_status character varying(20) DEFAULT 'active'::character varying,
+    launch_date date
 );
 
 
 --
--- Name: property_fees; Type: TABLE; Schema: public; Owner: -
+-- Name: properties_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.property_fees (
-    id uuid NOT NULL,
-    property_id uuid NOT NULL,
-    fee_id uuid NOT NULL,
-    is_active boolean DEFAULT true NOT NULL,
-    created_at timestamp with time zone NOT NULL,
-    updated_at timestamp with time zone NOT NULL
-);
-
-
---
--- Name: property_images; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.property_images (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    property_id uuid NOT NULL,
-    legacy_url character varying(2048) NOT NULL,
-    sovereign_url character varying(2048),
-    display_order integer DEFAULT 0 NOT NULL,
-    alt_text character varying(512) DEFAULT ''::character varying NOT NULL,
-    is_hero boolean DEFAULT false NOT NULL,
-    status character varying(20) DEFAULT 'pending'::character varying NOT NULL,
-    CONSTRAINT ck_property_images_status CHECK (((status)::text = ANY ((ARRAY['pending'::character varying, 'ingested'::character varying, 'failed'::character varying])::text[])))
-);
-
-
---
--- Name: property_knowledge; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.property_knowledge (
-    id uuid NOT NULL,
-    property_id uuid,
-    category character varying(80) NOT NULL,
-    content text NOT NULL,
-    source character varying(120) NOT NULL,
-    tags jsonb NOT NULL,
-    confidence character varying(20) NOT NULL,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: property_knowledge_chunks; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.property_knowledge_chunks (
-    id uuid NOT NULL,
-    property_id uuid NOT NULL,
-    content text NOT NULL,
-    embedding text NOT NULL,
-    created_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: property_stay_restrictions; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.property_stay_restrictions (
-    id uuid NOT NULL,
-    property_id uuid NOT NULL,
-    start_date date NOT NULL,
-    end_date date NOT NULL,
-    is_blackout boolean NOT NULL,
-    must_check_in_on_day smallint,
-    must_check_out_on_day smallint,
-    source character varying(32) NOT NULL,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: property_taxes; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.property_taxes (
-    id uuid NOT NULL,
-    property_id uuid NOT NULL,
-    tax_id uuid NOT NULL,
-    is_active boolean DEFAULT true NOT NULL,
-    created_at timestamp with time zone NOT NULL,
-    updated_at timestamp with time zone NOT NULL
-);
-
-
---
--- Name: property_utilities; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.property_utilities (
-    id uuid NOT NULL,
-    property_id uuid NOT NULL,
-    service_type character varying(50) NOT NULL,
-    provider_name character varying(255) NOT NULL,
-    account_number character varying(255),
-    account_holder character varying(255),
-    portal_url text,
-    portal_username text,
-    portal_password_enc text,
-    contact_phone character varying(50),
-    contact_email character varying(255),
-    notes text,
-    monthly_budget numeric(10,2),
-    is_active boolean,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone
-);
-
-
---
--- Name: quote_options; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.quote_options (
-    id uuid NOT NULL,
-    quote_id uuid NOT NULL,
-    property_id uuid NOT NULL,
-    check_in_date date NOT NULL,
-    check_out_date date NOT NULL,
-    base_rent numeric(12,2),
-    taxes numeric(12,2),
-    fees numeric(12,2),
-    total_price numeric(12,2),
-    booking_link character varying(500),
-    created_at timestamp without time zone
-);
-
-
---
--- Name: quotes; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.quotes (
-    id uuid NOT NULL,
-    lead_id uuid NOT NULL,
-    status character varying(20) NOT NULL,
-    payment_method character varying(20),
-    expires_at timestamp without time zone,
-    ai_drafted_email_body text,
-    ai_draft_model character varying(100),
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone
-);
-
-
---
--- Name: recovery_parity_comparisons; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.recovery_parity_comparisons (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    dedupe_hash character varying(64) NOT NULL,
-    session_fp character varying(128) NOT NULL,
-    guest_id uuid,
-    property_slug character varying(255),
-    drop_off_point character varying(64) NOT NULL,
-    intent_score_estimate double precision NOT NULL,
-    legacy_template_key character varying(80) NOT NULL,
-    legacy_body text NOT NULL,
-    sovereign_body text NOT NULL,
-    parity_summary jsonb NOT NULL,
-    candidate_snapshot jsonb NOT NULL,
-    async_job_run_id uuid,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
---
--- Name: rental_agreements; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.rental_agreements (
-    id uuid NOT NULL,
-    guest_id uuid NOT NULL,
-    reservation_id uuid,
-    property_id uuid,
-    template_id uuid,
-    agreement_type character varying(50) NOT NULL,
-    rendered_content text NOT NULL,
-    status character varying(30) NOT NULL,
-    sent_at timestamp without time zone,
-    sent_via character varying(20),
-    agreement_url text,
-    expires_at timestamp without time zone,
-    first_viewed_at timestamp without time zone,
-    view_count integer,
-    signed_at timestamp without time zone,
-    signature_type character varying(30),
-    signature_data text,
-    signer_name character varying(200),
-    signer_email character varying(255),
-    initials_data text,
-    initials_pages jsonb,
-    signer_ip_address character varying(45),
-    signer_user_agent text,
-    signer_device_fingerprint character varying(255),
-    consent_recorded boolean,
-    pdf_url text,
-    pdf_generated_at timestamp without time zone,
-    reminder_count integer,
-    last_reminder_at timestamp without time zone,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone
-);
-
-
---
--- Name: reservation_holds; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.reservation_holds (
-    id uuid NOT NULL,
-    property_id uuid NOT NULL,
-    guest_id uuid,
-    converted_reservation_id uuid,
-    session_id character varying(255) NOT NULL,
-    check_in_date date NOT NULL,
-    check_out_date date NOT NULL,
-    num_guests integer NOT NULL,
-    status character varying(50) NOT NULL,
-    amount_total numeric(12,2),
-    quote_snapshot jsonb,
-    payment_intent_id character varying(255),
-    special_requests text,
-    expires_at timestamp with time zone NOT NULL,
-    created_at timestamp with time zone NOT NULL,
-    updated_at timestamp with time zone NOT NULL,
-    CONSTRAINT ck_reservation_holds_date_order CHECK ((check_out_date > check_in_date)),
-    CONSTRAINT ck_reservation_holds_status CHECK (((status)::text = ANY ((ARRAY['active'::character varying, 'expired'::character varying, 'converted'::character varying])::text[])))
-);
-
-
---
--- Name: reservations; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.reservations (
-    id uuid NOT NULL,
-    confirmation_code character varying(50) NOT NULL,
-    guest_id uuid NOT NULL,
-    property_id uuid NOT NULL,
-    guest_email character varying(255) DEFAULT ''::character varying NOT NULL,
-    guest_name character varying(255) DEFAULT ''::character varying NOT NULL,
-    guest_phone character varying(50),
-    check_in_date date NOT NULL,
-    check_out_date date NOT NULL,
-    num_guests integer NOT NULL,
-    num_adults integer,
-    num_children integer,
-    num_pets integer,
-    special_requests text,
-    status character varying(50) NOT NULL,
-    access_code character varying(20),
-    access_code_valid_from timestamp with time zone,
-    access_code_valid_until timestamp with time zone,
-    booking_source character varying(100),
-    total_amount numeric(10,2),
-    paid_amount numeric(10,2),
-    balance_due numeric(10,2),
-    nightly_rate numeric(10,2),
-    cleaning_fee numeric(10,2),
-    pet_fee numeric(10,2),
-    damage_waiver_fee numeric(10,2),
-    service_fee numeric(10,2),
-    tax_amount numeric(10,2),
-    nights_count integer,
-    price_breakdown jsonb,
-    currency character varying(3),
-    digital_guide_sent boolean,
-    pre_arrival_sent boolean,
-    access_info_sent boolean,
-    mid_stay_checkin_sent boolean,
-    checkout_reminder_sent boolean,
-    post_stay_followup_sent boolean,
-    guest_rating integer,
-    guest_feedback text,
-    internal_notes text,
-    streamline_notes jsonb,
-    streamline_financial_detail jsonb,
-    qdrant_point_id uuid,
-    security_deposit_required boolean DEFAULT false NOT NULL,
-    security_deposit_amount numeric(12,2) DEFAULT 500.00 NOT NULL,
-    security_deposit_status character varying(20) DEFAULT 'none'::character varying NOT NULL,
-    security_deposit_stripe_pi character varying(255),
-    security_deposit_updated_at timestamp with time zone,
-    streamline_reservation_id character varying(100),
-    created_at timestamp with time zone,
-    updated_at timestamp with time zone,
-    tax_breakdown jsonb,
-    security_deposit_payment_method_id character varying(255),
-    is_owner_booking boolean DEFAULT false NOT NULL
-);
-
-
---
--- Name: restricted_captures; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.restricted_captures (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    prompt text NOT NULL,
-    response text NOT NULL,
-    source_persona character varying(128),
-    source_module character varying(128),
-    restriction_reason character varying(256) NOT NULL,
-    matched_patterns character varying[] DEFAULT '{}'::character varying[] NOT NULL,
-    capture_metadata jsonb,
-    eval_holdout boolean DEFAULT false NOT NULL,
-    served_by_endpoint character varying(256),
-    served_vector_store character varying(64),
-    escalated_from character varying(256),
-    sovereign_attempt text,
-    teacher_endpoint character varying(256),
-    teacher_model character varying(128),
-    task_type character varying(64),
-    judge_decision character varying(16),
-    judge_reasoning text
-);
-
-
---
--- Name: rue_bar_rue_legacy_recovery_templates; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.rue_bar_rue_legacy_recovery_templates (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    template_key character varying(80) NOT NULL,
-    channel character varying(16) NOT NULL,
-    audience_rule character varying(64) DEFAULT '*'::character varying NOT NULL,
-    body_template text NOT NULL,
-    is_active boolean DEFAULT true NOT NULL,
-    source_system character varying(64) DEFAULT 'rue_ba_rue'::character varying NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
---
--- Name: scheduled_messages; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.scheduled_messages (
-    id uuid NOT NULL,
-    guest_id uuid NOT NULL,
-    reservation_id uuid,
-    template_id uuid,
-    scheduled_for timestamp without time zone NOT NULL,
-    sent_at timestamp without time zone,
-    phone_to character varying(20) NOT NULL,
-    body text NOT NULL,
-    status character varying(50) NOT NULL,
-    message_id uuid,
-    error_message text,
-    created_at timestamp without time zone
-);
-
-
---
--- Name: seo_patch_queue; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.seo_patch_queue (
-    id uuid NOT NULL,
-    target_type character varying(32) NOT NULL,
-    target_slug character varying(255) NOT NULL,
-    property_id uuid,
-    status character varying(30) NOT NULL,
-    target_keyword character varying(255),
-    campaign character varying(100) NOT NULL,
-    rubric_version character varying(50),
-    source_hash character varying(128) NOT NULL,
-    proposed_title character varying(255) NOT NULL,
-    proposed_meta_description text NOT NULL,
-    proposed_h1 character varying(255) NOT NULL,
-    proposed_intro text NOT NULL,
-    proposed_faq jsonb NOT NULL,
-    proposed_json_ld jsonb NOT NULL,
-    fact_snapshot jsonb NOT NULL,
-    score_overall double precision,
-    score_breakdown jsonb NOT NULL,
-    proposed_by character varying(100) NOT NULL,
-    proposal_run_id character varying(100),
-    reviewed_by character varying(100),
-    review_note text,
-    approved_payload jsonb NOT NULL,
-    approved_at timestamp without time zone,
-    deployed_at timestamp without time zone,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL,
-    CONSTRAINT ck_seo_patch_queue_status CHECK (((status)::text = ANY ((ARRAY['proposed'::character varying, 'needs_revision'::character varying, 'approved'::character varying, 'rejected'::character varying, 'deployed'::character varying, 'superseded'::character varying])::text[]))),
-    CONSTRAINT ck_seo_patch_queue_target_type CHECK (((target_type)::text = ANY ((ARRAY['property'::character varying, 'archive_review'::character varying])::text[])))
-);
-
-
---
--- Name: seo_patches; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.seo_patches (
-    id uuid NOT NULL,
-    property_id uuid,
-    rubric_id uuid,
-    source_intelligence_id uuid,
-    source_agent character varying(120) NOT NULL,
-    page_path character varying NOT NULL,
-    patch_version integer NOT NULL,
-    title character varying(255),
-    meta_description text,
-    og_title character varying(255),
-    og_description text,
-    jsonld_payload jsonb,
-    canonical_url character varying(2048),
-    h1_suggestion character varying(255),
-    alt_tags jsonb,
-    godhead_score double precision,
-    godhead_model character varying(255),
-    godhead_feedback jsonb,
-    grade_attempts integer NOT NULL,
-    status character varying(50) NOT NULL,
-    reviewed_by character varying(255),
-    reviewed_at timestamp with time zone,
-    final_payload jsonb,
-    deployed_at timestamp with time zone,
-    deploy_task_id uuid,
-    deploy_status character varying(50),
-    deploy_queued_at timestamp with time zone,
-    deploy_acknowledged_at timestamp with time zone,
-    deploy_attempts integer DEFAULT 0 NOT NULL,
-    deploy_last_error text,
-    deploy_last_http_status integer,
-    swarm_model character varying(255),
-    swarm_node character varying(255),
-    generation_ms integer,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
---
--- Name: seo_rank_snapshots; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.seo_rank_snapshots (
-    id uuid NOT NULL,
-    property_id uuid,
-    keyword character varying(255) NOT NULL,
-    rank_position character varying(30) NOT NULL,
-    snapshot_date date NOT NULL,
-    source character varying(120) NOT NULL,
-    metadata_json jsonb NOT NULL
-);
-
-
---
--- Name: seo_redirect_remap_queue; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.seo_redirect_remap_queue (
-    id uuid NOT NULL,
-    source_path character varying(1024) NOT NULL,
-    current_destination_path character varying(1024),
-    proposed_destination_path character varying(1024) NOT NULL,
-    applied_destination_path character varying(1024),
-    grounding_mode character varying(100) NOT NULL,
-    status character varying(30) NOT NULL,
-    campaign character varying(100) NOT NULL,
-    rubric_version character varying(50) NOT NULL,
-    proposal_run_id character varying(100) NOT NULL,
-    proposed_by character varying(100) NOT NULL,
-    extracted_entities jsonb NOT NULL,
-    source_snapshot jsonb NOT NULL,
-    route_candidates jsonb NOT NULL,
-    rationale text NOT NULL,
-    grade_score double precision,
-    grade_payload jsonb NOT NULL,
-    reviewed_by character varying(255),
-    review_note text,
-    approved_at timestamp without time zone,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL,
-    CONSTRAINT ck_seo_redirect_remap_queue_status CHECK (((status)::text = ANY ((ARRAY['proposed'::character varying, 'promoted'::character varying, 'rejected'::character varying, 'applied'::character varying, 'superseded'::character varying])::text[])))
-);
-
-
---
--- Name: seo_redirects; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.seo_redirects (
-    id uuid NOT NULL,
-    source_path character varying(1024) NOT NULL,
-    destination_path character varying(1024) NOT NULL,
-    is_permanent boolean NOT NULL,
-    reason character varying(255),
-    created_by character varying(255),
-    updated_by character varying(255),
-    is_active boolean NOT NULL,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: seo_rubrics; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.seo_rubrics (
-    id uuid NOT NULL,
-    keyword_cluster text NOT NULL,
-    rubric_payload jsonb NOT NULL,
-    source_model character varying(255) NOT NULL,
-    min_pass_score double precision NOT NULL,
-    status character varying(50) NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
---
--- Name: shadow_discrepancies; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.shadow_discrepancies (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    "timestamp" timestamp without time zone DEFAULT now() NOT NULL,
-    property_id uuid NOT NULL,
-    legacy_total_cents integer NOT NULL,
-    dgx_total_cents integer NOT NULL,
-    delta_cents integer NOT NULL,
-    legacy_payload jsonb,
-    dgx_payload jsonb,
-    hermes_diagnosis text,
-    status character varying(20) DEFAULT 'pending'::character varying NOT NULL
-);
-
-
---
--- Name: staff_invites; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.staff_invites (
-    id uuid NOT NULL,
-    email character varying(255) NOT NULL,
-    first_name character varying(100) NOT NULL,
-    last_name character varying(100) NOT NULL,
-    role character varying(50) NOT NULL,
-    token character varying(128) NOT NULL,
-    invited_by uuid NOT NULL,
-    status character varying(20) NOT NULL,
-    expires_at timestamp without time zone NOT NULL,
-    accepted_at timestamp without time zone,
-    created_at timestamp without time zone
-);
-
-
---
--- Name: staff_users; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.staff_users (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    email character varying(255) NOT NULL,
-    password_hash character varying(255) NOT NULL,
-    first_name character varying(100) NOT NULL,
-    last_name character varying(100) NOT NULL,
-    role character varying(11) DEFAULT 'super_admin'::character varying NOT NULL,
-    permissions jsonb,
-    is_active boolean DEFAULT true NOT NULL,
-    last_login_at timestamp without time zone,
-    notification_phone character varying(20),
-    notification_email character varying(255),
-    notify_urgent boolean DEFAULT true NOT NULL,
-    notify_workorders boolean DEFAULT true NOT NULL,
-    created_at timestamp without time zone DEFAULT now() NOT NULL,
-    updated_at timestamp without time zone DEFAULT now() NOT NULL,
-    CONSTRAINT staff_role CHECK (((role)::text = ANY ((ARRAY['super_admin'::character varying, 'admin'::character varying, 'manager'::character varying, 'reviewer'::character varying, 'operator'::character varying, 'staff'::character varying, 'maintenance'::character varying])::text[])))
-);
-
-
---
--- Name: storefront_intent_events; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.storefront_intent_events (
-    id uuid NOT NULL,
-    session_fp character varying(64) NOT NULL,
-    event_type character varying(64) NOT NULL,
-    consent_marketing boolean DEFAULT false NOT NULL,
-    property_slug character varying(255),
-    meta jsonb DEFAULT '{}'::jsonb NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
---
--- Name: storefront_session_guest_links; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.storefront_session_guest_links (
-    id uuid NOT NULL,
-    session_fp character varying(64) NOT NULL,
-    guest_id uuid NOT NULL,
-    reservation_hold_id uuid,
-    source character varying(32) DEFAULT 'checkout_hold'::character varying NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
---
--- Name: streamline_payload_vault; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.streamline_payload_vault (
-    id uuid NOT NULL,
-    reservation_id character varying(100),
-    event_type character varying(100) NOT NULL,
-    raw_payload jsonb DEFAULT '{}'::jsonb NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
---
--- Name: stripe_connect_events; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.stripe_connect_events (
-    id bigint NOT NULL,
-    stripe_event_id character varying(255) NOT NULL,
-    event_type character varying(100) NOT NULL,
-    account_id character varying(255),
-    transfer_id character varying(255),
-    payout_id character varying(255),
-    amount numeric(12,2),
-    status character varying(64),
-    failure_code character varying(100),
-    failure_message text,
-    raw_payload jsonb,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
---
--- Name: stripe_connect_events_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.stripe_connect_events_id_seq
+CREATE SEQUENCE public.properties_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3531,108 +5369,992 @@ CREATE SEQUENCE public.stripe_connect_events_id_seq
 
 
 --
--- Name: stripe_connect_events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+-- Name: properties_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.stripe_connect_events_id_seq OWNED BY public.stripe_connect_events.id;
+ALTER SEQUENCE public.properties_id_seq OWNED BY public.properties.id;
 
 
 --
--- Name: survey_templates; Type: TABLE; Schema: public; Owner: -
+-- Name: property_events; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.survey_templates (
-    id uuid NOT NULL,
-    name character varying(255) NOT NULL,
-    description text,
-    survey_type character varying(50) NOT NULL,
-    questions jsonb NOT NULL,
-    trigger_type character varying(50),
-    trigger_offset_hours integer,
-    send_method character varying(20),
-    is_active boolean,
-    usage_count integer,
-    avg_completion_rate numeric(5,2),
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone
+CREATE TABLE public.property_events (
+    id integer NOT NULL,
+    property_id integer,
+    event_type character varying(50),
+    event_date date,
+    status character varying(20) DEFAULT 'PENDING'::character varying,
+    notes text,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
 );
 
 
 --
--- Name: swarm_escalations; Type: TABLE; Schema: public; Owner: -
+-- Name: property_events_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.swarm_escalations (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    decision_id uuid NOT NULL,
-    reason_code character varying(100) NOT NULL,
-    status character varying(8) DEFAULT 'pending'::character varying NOT NULL,
-    CONSTRAINT swarm_escalation_status CHECK (((status)::text = ANY ((ARRAY['pending'::character varying, 'resolved'::character varying])::text[])))
+CREATE SEQUENCE public.property_events_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: property_events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.property_events_id_seq OWNED BY public.property_events.id;
+
+
+--
+-- Name: property_sms_config; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.property_sms_config (
+    id integer NOT NULL,
+    property_id integer NOT NULL,
+    property_name character varying(255) NOT NULL,
+    cabin_name character varying(100),
+    assigned_phone_number character varying(20) NOT NULL,
+    provider_id integer,
+    ai_enabled boolean DEFAULT true,
+    ai_model_preference character varying(100),
+    auto_reply_enabled boolean DEFAULT true,
+    require_human_approval boolean DEFAULT false,
+    business_hours_start time without time zone,
+    business_hours_end time without time zone,
+    timezone character varying(50) DEFAULT 'America/New_York'::character varying,
+    after_hours_behavior character varying(50),
+    welcome_message_template text,
+    checkin_info_template text,
+    checkout_reminder_template text,
+    wifi_info_template text,
+    wifi_ssid character varying(100),
+    wifi_password character varying(100),
+    door_code character varying(20),
+    address text,
+    checkin_instructions text,
+    house_rules text,
+    emergency_contact character varying(20),
+    escalation_phone character varying(20),
+    escalation_email character varying(255),
+    escalation_keywords text[],
+    created_at timestamp without time zone DEFAULT now(),
+    updated_at timestamp without time zone DEFAULT now()
 );
 
 
 --
--- Name: taxes; Type: TABLE; Schema: public; Owner: -
+-- Name: property_sms_config_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.taxes (
-    id uuid NOT NULL,
-    name character varying(255) NOT NULL,
-    percentage_rate numeric(6,2) NOT NULL,
-    is_active boolean DEFAULT true NOT NULL,
-    created_at timestamp with time zone NOT NULL,
-    updated_at timestamp with time zone NOT NULL
+CREATE SEQUENCE public.property_sms_config_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: property_sms_config_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.property_sms_config_id_seq OWNED BY public.property_sms_config.id;
+
+
+--
+-- Name: quarantine_inbox; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.quarantine_inbox (
+    id integer NOT NULL,
+    sender text NOT NULL,
+    subject text,
+    content text,
+    sent_at timestamp without time zone,
+    blocked_by text NOT NULL,
+    blocked_reason text,
+    file_path text,
+    category text,
+    quarantined_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
 );
 
 
 --
--- Name: taxonomy_categories; Type: TABLE; Schema: public; Owner: -
+-- Name: quarantine_inbox_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.taxonomy_categories (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    name character varying(255) NOT NULL,
-    slug character varying(255) NOT NULL,
-    description text,
-    meta_title character varying(255),
-    meta_description text,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
+CREATE SEQUENCE public.quarantine_inbox_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: quarantine_inbox_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.quarantine_inbox_id_seq OWNED BY public.quarantine_inbox.id;
+
+
+--
+-- Name: rag_query_feedback; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.rag_query_feedback (
+    id integer NOT NULL,
+    query_text text NOT NULL,
+    brain text,
+    collection text,
+    top_k integer,
+    chunks_retrieved integer,
+    relevance_score numeric(5,4),
+    reranker_used boolean DEFAULT false,
+    response_quality integer,
+    latency_retrieval_ms integer,
+    latency_llm_ms integer,
+    created_at timestamp without time zone DEFAULT now()
+);
+
+
+--
+-- Name: rag_query_feedback_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.rag_query_feedback_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: rag_query_feedback_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.rag_query_feedback_id_seq OWNED BY public.rag_query_feedback.id;
+
+
+--
+-- Name: real_estate_intel; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.real_estate_intel (
+    id integer NOT NULL,
+    property_name character varying(255),
+    property_value numeric(15,2),
+    property_address text,
+    zillow_estimate numeric(15,2),
+    date date,
+    source_email_id integer,
+    raw_content text,
+    created_at timestamp without time zone
+);
+
+
+--
+-- Name: real_estate_intel_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.real_estate_intel_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: real_estate_intel_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.real_estate_intel_id_seq OWNED BY public.real_estate_intel.id;
+
+
+--
+-- Name: recent_conversations; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.recent_conversations AS
+ SELECT ct.id AS thread_id,
+    ct.phone_number,
+    gp.name AS guest_name,
+    ct.property_id,
+    psc.cabin_name,
+    ct.message_count,
+    ct.status,
+    ct.last_message_at,
+    ct.handled_by_ai,
+    gp.vip_guest,
+    ( SELECT message_archive.message_body
+           FROM public.message_archive
+          WHERE ((message_archive.phone_number)::text = (ct.phone_number)::text)
+          ORDER BY message_archive.sent_at DESC
+         LIMIT 1) AS last_message
+   FROM ((public.conversation_threads ct
+     LEFT JOIN public.guest_profiles gp ON (((ct.phone_number)::text = (gp.phone_number)::text)))
+     LEFT JOIN public.property_sms_config psc ON ((ct.property_id = psc.property_id)))
+  WHERE ((ct.status)::text = 'active'::text)
+  ORDER BY ct.last_message_at DESC;
+
+
+--
+-- Name: recursive_trace_log; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.recursive_trace_log (
+    id integer NOT NULL,
+    run_id text NOT NULL,
+    user_id text,
+    query text NOT NULL,
+    step_number integer NOT NULL,
+    stage text NOT NULL,
+    content text,
+    critic_score integer,
+    critic_tags text[],
+    model text,
+    latency_ms integer,
+    metadata jsonb DEFAULT '{}'::jsonb,
+    created_at timestamp without time zone DEFAULT now()
+);
+
+
+--
+-- Name: recursive_trace_log_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.recursive_trace_log_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: recursive_trace_log_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.recursive_trace_log_id_seq OWNED BY public.recursive_trace_log.id;
+
+
+--
+-- Name: revenue_ledger; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.revenue_ledger (
+    id integer NOT NULL,
+    run_id text NOT NULL,
+    cabin_name text NOT NULL,
+    target_date date NOT NULL,
+    target_dow text,
+    base_rate numeric(10,2),
+    seasonal_baseline numeric(10,2),
+    adjusted_rate numeric(10,2) NOT NULL,
+    alpha numeric(10,2),
+    previous_rate numeric(10,2),
+    rate_change numeric(10,2),
+    rate_change_pct numeric(6,2),
+    sentiment_score numeric(6,4),
+    weather_factor numeric(6,4),
+    event_factor numeric(6,4),
+    competitor_factor numeric(6,4),
+    volatility_index numeric(6,4),
+    trading_signal text,
+    confidence numeric(6,4),
+    weather_condition text,
+    weather_temp_f real,
+    event_name text,
+    event_weight integer,
+    competitor_direction text,
+    competitor_rate_change numeric(10,2),
+    days_until_checkin integer,
+    engine_version text DEFAULT '1.0.0'::text,
+    tier text,
+    generated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: revenue_ledger_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.revenue_ledger_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: revenue_ledger_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.revenue_ledger_id_seq OWNED BY public.revenue_ledger.id;
+
+
+--
+-- Name: ruebarue_area_guide; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ruebarue_area_guide (
+    id integer NOT NULL,
+    section character varying(100) NOT NULL,
+    entry_number integer,
+    place_name text,
+    address text,
+    distance text,
+    phone text,
+    rating text,
+    tip text,
+    raw_text text NOT NULL,
+    created_at timestamp without time zone DEFAULT now()
+);
+
+
+--
+-- Name: ruebarue_area_guide_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ruebarue_area_guide_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: ruebarue_area_guide_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ruebarue_area_guide_id_seq OWNED BY public.ruebarue_area_guide.id;
+
+
+--
+-- Name: ruebarue_contacts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ruebarue_contacts (
+    id integer NOT NULL,
+    name character varying(200) NOT NULL,
+    phone character varying(50),
+    email character varying(200),
+    role character varying(50),
+    properties text,
+    tags text,
+    created_at timestamp without time zone DEFAULT now()
+);
+
+
+--
+-- Name: ruebarue_contacts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ruebarue_contacts_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: ruebarue_contacts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ruebarue_contacts_id_seq OWNED BY public.ruebarue_contacts.id;
+
+
+--
+-- Name: ruebarue_guests; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ruebarue_guests (
+    id integer NOT NULL,
+    guest_info text NOT NULL,
+    property_info text,
+    door_code text,
+    created_at timestamp without time zone DEFAULT now()
+);
+
+
+--
+-- Name: ruebarue_guests_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ruebarue_guests_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: ruebarue_guests_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ruebarue_guests_id_seq OWNED BY public.ruebarue_guests.id;
+
+
+--
+-- Name: ruebarue_knowledge_base; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ruebarue_knowledge_base (
+    id integer NOT NULL,
+    category character varying(100) NOT NULL,
+    subcategory character varying(100),
+    title text NOT NULL,
+    content text NOT NULL,
+    source character varying(50) NOT NULL,
+    property_name character varying(200),
+    metadata jsonb,
+    created_at timestamp without time zone DEFAULT now(),
+    updated_at timestamp without time zone DEFAULT now()
+);
+
+
+--
+-- Name: ruebarue_knowledge_base_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ruebarue_knowledge_base_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: ruebarue_knowledge_base_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ruebarue_knowledge_base_id_seq OWNED BY public.ruebarue_knowledge_base.id;
+
+
+--
+-- Name: ruebarue_message_templates; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ruebarue_message_templates (
+    id integer NOT NULL,
+    name character varying(200) NOT NULL,
+    type character varying(20) NOT NULL,
+    active boolean DEFAULT true,
+    schedule character varying(200),
+    tags text,
+    booking_source character varying(200),
+    flags text,
+    subject text,
+    message_text text,
+    full_modal_text text,
+    created_at timestamp without time zone DEFAULT now()
+);
+
+
+--
+-- Name: ruebarue_message_templates_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ruebarue_message_templates_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: ruebarue_message_templates_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ruebarue_message_templates_id_seq OWNED BY public.ruebarue_message_templates.id;
+
+
+--
+-- Name: sales_intel; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sales_intel (
+    id integer NOT NULL,
+    signal_type text,
+    cabin_name text,
+    event_type text,
+    check_in date,
+    check_out date,
+    nights integer,
+    guest_count integer,
+    total_quoted numeric(12,2),
+    bedrooms integer,
+    selling_points text[],
+    guest_objections text,
+    conversion_outcome text,
+    competitive_mention text,
+    source_email_id integer,
+    extracted_at timestamp without time zone DEFAULT now()
+);
+
+
+--
+-- Name: sales_intel_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.sales_intel_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: sales_intel_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.sales_intel_id_seq OWNED BY public.sales_intel.id;
+
+
+--
+-- Name: schema_drift_log; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.schema_drift_log (
+    id integer NOT NULL,
+    endpoint text NOT NULL,
+    model_name text NOT NULL,
+    unknown_keys jsonb NOT NULL,
+    sample_values jsonb,
+    record_id text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: schema_drift_log_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.schema_drift_log_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: schema_drift_log_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.schema_drift_log_id_seq OWNED BY public.schema_drift_log.id;
+
+
+--
+-- Name: sender_registry; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sender_registry (
+    id integer NOT NULL,
+    sender_raw text NOT NULL,
+    email_address text,
+    display_name text,
+    domain text,
+    status character varying(20) DEFAULT 'REVIEW'::character varying,
+    division character varying(50),
+    total_volume integer DEFAULT 0,
+    mined_count integer DEFAULT 0,
+    empty_extraction_count integer DEFAULT 0,
+    last_seen timestamp without time zone,
+    signal_ratio double precision GENERATED ALWAYS AS (
+CASE
+    WHEN (total_volume = 0) THEN (0)::double precision
+    ELSE ((mined_count)::double precision / (total_volume)::double precision)
+END) STORED,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: sender_registry_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.sender_registry_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: sender_registry_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.sender_registry_id_seq OWNED BY public.sender_registry.id;
+
+
+--
+-- Name: sentinel_alerts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sentinel_alerts (
+    id integer NOT NULL,
+    source text NOT NULL,
+    name text NOT NULL,
+    priority text NOT NULL,
+    message text NOT NULL,
+    arm64 boolean DEFAULT false,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: sentinel_alerts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.sentinel_alerts_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: sentinel_alerts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.sentinel_alerts_id_seq OWNED BY public.sentinel_alerts.id;
+
+
+--
+-- Name: sentinel_state; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sentinel_state (
+    key text NOT NULL,
+    value text NOT NULL,
+    source text DEFAULT 'unknown'::text NOT NULL,
+    priority text DEFAULT 'MEDIUM'::text NOT NULL,
+    note text DEFAULT ''::text,
     updated_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 
 --
--- Name: taylor_quote_requests; Type: TABLE; Schema: public; Owner: -
+-- Name: sms_providers; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.taylor_quote_requests (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    guest_email character varying(320) NOT NULL,
-    check_in date NOT NULL,
-    check_out date NOT NULL,
-    nights integer NOT NULL,
-    adults integer DEFAULT 2 NOT NULL,
-    children integer DEFAULT 0 NOT NULL,
-    pets integer DEFAULT 0 NOT NULL,
-    status character varying(30) DEFAULT 'pending_approval'::character varying NOT NULL,
-    property_options jsonb DEFAULT '[]'::jsonb NOT NULL,
-    approved_by character varying(320),
-    sent_at timestamp with time zone,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
+CREATE TABLE public.sms_providers (
+    id integer NOT NULL,
+    name character varying(50) NOT NULL,
+    account_sid character varying(255),
+    auth_token_encrypted text,
+    phone_numbers text[],
+    supports_mms boolean DEFAULT false,
+    supports_unicode boolean DEFAULT true,
+    max_message_length integer DEFAULT 160,
+    priority integer DEFAULT 100,
+    enabled boolean DEFAULT true,
+    cost_per_message numeric(6,4),
+    cost_per_segment numeric(6,4),
+    monthly_fee numeric(8,2),
+    total_messages_sent integer DEFAULT 0,
+    success_rate numeric(5,4),
+    avg_delivery_time_seconds integer,
+    last_failure_at timestamp without time zone,
+    consecutive_failures integer DEFAULT 0,
+    rate_limit_per_second integer,
+    rate_limit_per_minute integer,
+    rate_limit_per_hour integer,
+    created_at timestamp without time zone DEFAULT now(),
+    updated_at timestamp without time zone DEFAULT now()
 );
 
 
 --
--- Name: trust_accounts; Type: TABLE; Schema: public; Owner: -
+-- Name: sms_providers_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.trust_accounts (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    name character varying(255) NOT NULL,
-    type character varying(9) NOT NULL,
-    CONSTRAINT trust_account_type CHECK (((type)::text = ANY ((ARRAY['asset'::character varying, 'liability'::character varying])::text[])))
+CREATE SEQUENCE public.sms_providers_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: sms_providers_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.sms_providers_id_seq OWNED BY public.sms_providers.id;
+
+
+--
+-- Name: sovereign_cycles; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sovereign_cycles (
+    id integer NOT NULL,
+    cycle_id integer NOT NULL,
+    "timestamp" timestamp with time zone DEFAULT now() NOT NULL,
+    health_status text NOT NULL,
+    health_score real,
+    directives jsonb DEFAULT '[]'::jsonb,
+    optimization_triggers jsonb DEFAULT '[]'::jsonb,
+    division_a_summary jsonb,
+    division_b_summary jsonb,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
 );
+
+
+--
+-- Name: sovereign_cycles_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.sovereign_cycles_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: sovereign_cycles_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.sovereign_cycles_id_seq OWNED BY public.sovereign_cycles.id;
+
+
+--
+-- Name: starred_responses; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.starred_responses (
+    id integer NOT NULL,
+    message_body text NOT NULL,
+    embedding public.vector(768),
+    intent character varying(100),
+    cabin_name character varying(200),
+    guest_name character varying(200),
+    phone_number_hash character varying(64),
+    loyalty_tier character varying(50),
+    response_type character varying(20) DEFAULT 'approved'::character varying NOT NULL,
+    quality_grade integer,
+    queue_id bigint,
+    ai_model character varying(100),
+    original_draft text,
+    edit_distance_pct numeric(5,2),
+    created_at timestamp with time zone DEFAULT now()
+);
+
+
+--
+-- Name: starred_responses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.starred_responses_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: starred_responses_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.starred_responses_id_seq OWNED BY public.starred_responses.id;
+
+
+--
+-- Name: sys_api_credentials; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sys_api_credentials (
+    service_name character varying(255) NOT NULL,
+    token_key character varying(255) NOT NULL,
+    token_secret character varying(255) NOT NULL,
+    expiration_date timestamp with time zone,
+    last_updated timestamp with time zone DEFAULT now()
+);
+
+
+--
+-- Name: system_directives; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.system_directives (
+    id bigint NOT NULL,
+    directive_text text NOT NULL,
+    source_failure_cluster character varying(512),
+    embedding_metadata jsonb DEFAULT '{}'::jsonb,
+    active boolean DEFAULT true NOT NULL,
+    version smallint DEFAULT '1'::smallint NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: system_directives_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.system_directives_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: system_directives_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.system_directives_id_seq OWNED BY public.system_directives.id;
+
+
+--
+-- Name: system_drift_alerts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.system_drift_alerts (
+    id integer NOT NULL,
+    run_id text NOT NULL,
+    intent text NOT NULL,
+    metric text NOT NULL,
+    current_value numeric NOT NULL,
+    threshold numeric NOT NULL,
+    sample_count integer NOT NULL,
+    detail text,
+    created_at timestamp with time zone DEFAULT now()
+);
+
+
+--
+-- Name: system_drift_alerts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.system_drift_alerts_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: system_drift_alerts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.system_drift_alerts_id_seq OWNED BY public.system_drift_alerts.id;
+
+
+--
+-- Name: system_post_mortems; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.system_post_mortems (
+    id integer NOT NULL,
+    occurred_at timestamp with time zone DEFAULT now() NOT NULL,
+    sector character varying(10) NOT NULL,
+    severity character varying(10) NOT NULL,
+    component text NOT NULL,
+    error_summary text NOT NULL,
+    root_cause text,
+    remediation text,
+    status character varying(20) DEFAULT 'open'::character varying,
+    resolved_by character varying(50),
+    resolved_at timestamp with time zone
+);
+
+
+--
+-- Name: system_post_mortems_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.system_post_mortems_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: system_post_mortems_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.system_post_mortems_id_seq OWNED BY public.system_post_mortems.id;
+
+
+--
+-- Name: system_telemetry; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.system_telemetry (
+    id integer NOT NULL,
+    hostname text,
+    cpu_usage real,
+    ram_usage real,
+    disk_usage real,
+    recorded_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: system_telemetry_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.system_telemetry_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: system_telemetry_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.system_telemetry_id_seq OWNED BY public.system_telemetry.id;
 
 
 --
@@ -3640,13 +6362,14 @@ CREATE TABLE public.trust_accounts (
 --
 
 CREATE TABLE public.trust_balance (
-    id bigint NOT NULL,
-    property_id character varying(100) NOT NULL,
-    owner_funds numeric(12,2) DEFAULT 0 NOT NULL,
-    operating_funds numeric(12,2) DEFAULT 0 NOT NULL,
-    escrow_funds numeric(12,2) DEFAULT 0 NOT NULL,
-    security_deps numeric(12,2) DEFAULT 0 NOT NULL,
-    last_updated timestamp with time zone DEFAULT now() NOT NULL
+    id integer NOT NULL,
+    property_id text NOT NULL,
+    owner_funds numeric(15,2) DEFAULT 0 NOT NULL,
+    operating_funds numeric(15,2) DEFAULT 0 NOT NULL,
+    escrow_funds numeric(15,2) DEFAULT 0 NOT NULL,
+    security_deps numeric(15,2) DEFAULT 0 NOT NULL,
+    last_entry_id integer,
+    last_updated timestamp without time zone DEFAULT CURRENT_TIMESTAMP
 );
 
 
@@ -3655,6 +6378,7 @@ CREATE TABLE public.trust_balance (
 --
 
 CREATE SEQUENCE public.trust_balance_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3670,304 +6394,722 @@ ALTER SEQUENCE public.trust_balance_id_seq OWNED BY public.trust_balance.id;
 
 
 --
--- Name: trust_decisions; Type: TABLE; Schema: public; Owner: -
+-- Name: v_property_lifecycle; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE TABLE public.trust_decisions (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    run_id uuid NOT NULL,
-    proposed_payload jsonb NOT NULL,
-    deterministic_score double precision NOT NULL,
-    policy_evaluation jsonb NOT NULL,
-    status character varying(13) NOT NULL,
-    CONSTRAINT ck_trust_decisions_deterministic_score_nonnegative CHECK ((deterministic_score >= (0)::double precision)),
-    CONSTRAINT trust_decision_status CHECK (((status)::text = ANY ((ARRAY['auto_approved'::character varying, 'escalated'::character varying, 'blocked'::character varying])::text[])))
+CREATE VIEW public.v_property_lifecycle AS
+ SELECT op.property_id,
+    op.name AS display_name,
+    op.bedrooms,
+    op.max_occupants,
+    op.city,
+    op.streamline_id,
+    op.status_name AS ops_status,
+    p.management_status,
+    p.launch_date,
+    p.cost_basis,
+    p.current_value,
+        CASE
+            WHEN ((p.management_status)::text = 'retired'::text) THEN 'RETIRED'::text
+            WHEN (op.status_name = 'Retired'::text) THEN 'ORPHAN'::text
+            WHEN ((p.launch_date IS NOT NULL) AND (p.launch_date > (CURRENT_DATE - '90 days'::interval))) THEN 'RAMP_UP'::text
+            ELSE 'MATURE'::text
+        END AS lifecycle_stage,
+    (COALESCE(r.forecast_revenue, (0)::numeric))::numeric(12,2) AS forecast_revenue,
+    (COALESCE(r.avg_nightly, (0)::numeric))::numeric(10,2) AS avg_nightly_rate,
+    COALESCE(r.entry_count, (0)::bigint) AS rate_entries,
+    COALESCE(t.open_tasks, (0)::bigint) AS open_tasks,
+    COALESCE(t.urgent_tasks, (0)::bigint) AS urgent_tasks,
+    COALESCE(t.overdue_tasks, (0)::bigint) AS overdue_tasks,
+    t.next_deadline
+   FROM (((public.ops_properties op
+     LEFT JOIN public.properties p ON ((p.streamline_id = op.streamline_id)))
+     LEFT JOIN ( SELECT revenue_ledger.cabin_name,
+            sum(revenue_ledger.adjusted_rate) AS forecast_revenue,
+            avg(revenue_ledger.adjusted_rate) AS avg_nightly,
+            count(*) AS entry_count
+           FROM public.revenue_ledger
+          GROUP BY revenue_ledger.cabin_name) r ON ((r.cabin_name = (op.property_id)::text)))
+     LEFT JOIN ( SELECT ops_tasks.property_id,
+            count(*) AS open_tasks,
+            count(*) FILTER (WHERE ((ops_tasks.priority)::text = 'URGENT'::text)) AS urgent_tasks,
+            count(*) FILTER (WHERE (ops_tasks.deadline < now())) AS overdue_tasks,
+            min(ops_tasks.deadline) AS next_deadline
+           FROM public.ops_tasks
+          WHERE ((ops_tasks.status)::text = 'OPEN'::text)
+          GROUP BY ops_tasks.property_id) t ON (((t.property_id)::text = (op.property_id)::text)));
+
+
+--
+-- Name: v_comp_dashboard; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.v_comp_dashboard AS
+ SELECT ( SELECT (COALESCE(sum(rl.adjusted_rate), (0)::numeric))::numeric(12,2) AS "coalesce"
+           FROM public.revenue_ledger rl
+          WHERE (EXISTS ( SELECT 1
+                   FROM public.ops_properties op
+                  WHERE (((op.property_id)::text = rl.cabin_name) AND (op.status_name = 'Active'::text))))) AS forecast_revenue,
+    ( SELECT (avg(rl.adjusted_rate))::numeric(10,2) AS avg
+           FROM public.revenue_ledger rl
+          WHERE (EXISTS ( SELECT 1
+                   FROM public.ops_properties op
+                  WHERE (((op.property_id)::text = rl.cabin_name) AND (op.status_name = 'Active'::text))))) AS avg_nightly_rate,
+    ( SELECT count(DISTINCT rl.cabin_name) AS count
+           FROM public.revenue_ledger rl
+          WHERE (EXISTS ( SELECT 1
+                   FROM public.ops_properties op
+                  WHERE (((op.property_id)::text = rl.cabin_name) AND (op.status_name = 'Active'::text))))) AS active_cabins,
+    ( SELECT count(*) AS count
+           FROM public.v_property_lifecycle
+          WHERE (v_property_lifecycle.lifecycle_stage = 'RAMP_UP'::text)) AS cabins_in_ramp_up,
+    ( SELECT (COALESCE(sum(fi.amount), (0)::numeric))::numeric(14,2) AS "coalesce"
+           FROM (public.finance_invoices fi
+             JOIN finance.vendor_classifications vc ON ((fi.vendor ~~ vc.vendor_pattern)))
+          WHERE (vc.classification = 'REAL_BUSINESS'::text)) AS real_business_expenses,
+    ( SELECT (COALESCE(sum(fi.amount), (0)::numeric))::numeric(14,2) AS "coalesce"
+           FROM (public.finance_invoices fi
+             JOIN finance.vendor_classifications vc ON ((fi.vendor ~~ vc.vendor_pattern)))
+          WHERE (vc.classification = ANY (ARRAY['NOISE'::text, 'FAMILY_INTERNAL'::text, 'CROG_INTERNAL'::text]))) AS excluded_noise_total,
+    ( SELECT (COALESCE(sum(fi.amount), (0)::numeric))::numeric(14,2) AS "coalesce"
+           FROM (public.finance_invoices fi
+             LEFT JOIN finance.vendor_classifications vc ON ((fi.vendor ~~ vc.vendor_pattern)))
+          WHERE (vc.classification IS NULL)) AS unclassified_total,
+    ( SELECT (COALESCE(sum(
+                CASE
+                    WHEN (transactions.amount > (0)::numeric) THEN transactions.amount
+                    ELSE (0)::numeric
+                END), (0)::numeric))::numeric(12,2) AS "coalesce"
+           FROM division_a.transactions) AS ledger_credits,
+    ( SELECT (COALESCE(sum(
+                CASE
+                    WHEN (transactions.amount < (0)::numeric) THEN abs(transactions.amount)
+                    ELSE (0)::numeric
+                END), (0)::numeric))::numeric(12,2) AS "coalesce"
+           FROM division_a.transactions) AS ledger_debits,
+    (( SELECT (COALESCE(sum(rl.adjusted_rate), (0)::numeric))::numeric(12,2) AS "coalesce"
+           FROM public.revenue_ledger rl
+          WHERE (EXISTS ( SELECT 1
+                   FROM public.ops_properties op
+                  WHERE (((op.property_id)::text = rl.cabin_name) AND (op.status_name = 'Active'::text))))) + ( SELECT (COALESCE(sum(transactions.amount), (0)::numeric))::numeric(12,2) AS "coalesce"
+           FROM division_a.transactions)) AS corrected_revenue,
+    ( SELECT (COALESCE(sum(rl.adjusted_rate), (0)::numeric))::numeric(12,2) AS "coalesce"
+           FROM public.revenue_ledger rl
+          WHERE (NOT (EXISTS ( SELECT 1
+                   FROM public.ops_properties op
+                  WHERE (((op.property_id)::text = rl.cabin_name) AND (op.status_name = 'Active'::text)))))) AS excluded_retired_revenue,
+    now() AS report_timestamp,
+    'TITAN-R1-671B v2 (2026-02-13)'::text AS classified_by;
+
+
+--
+-- Name: v_financial_summary; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.v_financial_summary AS
+ WITH forecast AS (
+         SELECT 'FORECAST'::text AS source,
+            revenue_ledger.cabin_name AS entity,
+            revenue_ledger.target_date AS entry_date,
+            revenue_ledger.adjusted_rate AS amount,
+            revenue_ledger.trading_signal AS category,
+            revenue_ledger.run_id AS reference,
+            'Pricing engine forecast rate'::text AS description
+           FROM public.revenue_ledger
+        ), invoices AS (
+         SELECT 'INVOICE'::text AS source,
+            fi.vendor AS entity,
+            fi.date AS entry_date,
+            fi.amount,
+            COALESCE(fi.category, 'Uncategorized'::text) AS category,
+            ('INV-'::text || (fi.id)::text) AS reference,
+                CASE
+                    WHEN (vc.classification IS NOT NULL) THEN (('['::text || vc.classification) || '] Email-extracted invoice'::text)
+                    ELSE 'Email-extracted invoice (UNCLASSIFIED)'::text
+                END AS description
+           FROM (public.finance_invoices fi
+             LEFT JOIN finance.vendor_classifications vc ON ((fi.vendor ~~ vc.vendor_pattern)))
+          WHERE ((vc.classification IS NULL) OR (vc.classification = 'REAL_BUSINESS'::text) OR (vc.classification = 'UNKNOWN'::text))
+        ), transactions AS (
+         SELECT 'LEDGER'::text AS source,
+            transactions.vendor AS entity,
+            transactions.date AS entry_date,
+            transactions.amount,
+            COALESCE(transactions.category, 'Uncategorized'::text) AS category,
+            ('TXN-'::text || (transactions.id)::text) AS reference,
+            COALESCE(transactions.reasoning, 'Double-entry transaction'::text) AS description
+           FROM division_a.transactions
+        )
+ SELECT forecast.source,
+    forecast.entity,
+    forecast.entry_date,
+    forecast.amount,
+    forecast.category,
+    forecast.reference,
+    forecast.description
+   FROM forecast
+UNION ALL
+ SELECT invoices.source,
+    invoices.entity,
+    invoices.entry_date,
+    invoices.amount,
+    invoices.category,
+    invoices.reference,
+    invoices.description
+   FROM invoices
+UNION ALL
+ SELECT transactions.source,
+    transactions.entity,
+    transactions.entry_date,
+    transactions.amount,
+    transactions.category,
+    transactions.reference,
+    transactions.description
+   FROM transactions;
+
+
+--
+-- Name: v_journal_detail; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.v_journal_detail AS
+ SELECT je.id AS entry_id,
+    je.entry_date,
+    je.description,
+    je.reference_id,
+    je.reference_type,
+    je.property_id,
+    je.posted_by,
+    je.source_system,
+    je.is_void,
+    jli.id AS line_id,
+    a.code AS account_code,
+    a.name AS account_name,
+    a.account_type,
+    jli.debit,
+    jli.credit,
+    jli.memo,
+    je.created_at
+   FROM ((public.journal_entries je
+     JOIN public.journal_line_items jli ON ((jli.journal_entry_id = je.id)))
+     JOIN public.accounts a ON ((a.id = jli.account_id)))
+  ORDER BY je.entry_date DESC, je.id, jli.id;
+
+
+--
+-- Name: v_trial_balance; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.v_trial_balance AS
+ SELECT a.id AS account_id,
+    a.code,
+    a.name AS account_name,
+    a.account_type,
+    a.normal_balance,
+    COALESCE(sum(jli.debit), (0)::numeric) AS total_debits,
+    COALESCE(sum(jli.credit), (0)::numeric) AS total_credits,
+    (COALESCE(sum(jli.debit), (0)::numeric) - COALESCE(sum(jli.credit), (0)::numeric)) AS net_balance
+   FROM ((public.accounts a
+     LEFT JOIN public.journal_line_items jli ON ((jli.account_id = a.id)))
+     LEFT JOIN public.journal_entries je ON (((je.id = jli.journal_entry_id) AND (je.is_void = false))))
+  WHERE (a.is_active = true)
+  GROUP BY a.id, a.code, a.name, a.account_type, a.normal_balance
+  ORDER BY a.code;
+
+
+--
+-- Name: v_trust_summary; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.v_trust_summary AS
+ SELECT property_id,
+    owner_funds,
+    operating_funds,
+    escrow_funds,
+    security_deps,
+    (((owner_funds + operating_funds) + escrow_funds) + security_deps) AS total_funds,
+    last_updated
+   FROM public.trust_balance
+  ORDER BY property_id;
+
+
+--
+-- Name: vault_alpha_state_law; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.vault_alpha_state_law (
+    id integer NOT NULL,
+    code_section text NOT NULL,
+    statute_text text NOT NULL,
+    embedding public.vector(768),
+    text_search tsvector GENERATED ALWAYS AS (to_tsvector('english'::regconfig, statute_text)) STORED,
+    title text,
+    metadata jsonb DEFAULT '{}'::jsonb,
+    inserted_at timestamp with time zone DEFAULT now()
 );
 
 
 --
--- Name: trust_ledger_entries; Type: TABLE; Schema: public; Owner: -
+-- Name: vault_alpha_state_law_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.trust_ledger_entries (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    transaction_id uuid NOT NULL,
-    account_id uuid NOT NULL,
-    amount_cents integer NOT NULL,
-    entry_type character varying(6) NOT NULL,
-    CONSTRAINT ck_trust_ledger_entries_amount_positive CHECK ((amount_cents > 0)),
-    CONSTRAINT trust_ledger_entry_type CHECK (((entry_type)::text = ANY ((ARRAY['debit'::character varying, 'credit'::character varying])::text[])))
+CREATE SEQUENCE public.vault_alpha_state_law_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: vault_alpha_state_law_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.vault_alpha_state_law_id_seq OWNED BY public.vault_alpha_state_law.id;
+
+
+--
+-- Name: vault_beta_federal_law; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.vault_beta_federal_law (
+    id integer NOT NULL,
+    title_chapter_section text NOT NULL,
+    statute_text text NOT NULL,
+    embedding public.vector(768),
+    text_search tsvector GENERATED ALWAYS AS (to_tsvector('english'::regconfig, statute_text)) STORED,
+    title text,
+    metadata jsonb DEFAULT '{}'::jsonb,
+    inserted_at timestamp with time zone DEFAULT now()
 );
 
 
 --
--- Name: trust_transactions; Type: TABLE; Schema: public; Owner: -
+-- Name: vault_beta_federal_law_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.trust_transactions (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    streamline_event_id character varying(255) NOT NULL,
-    decision_id uuid,
-    "timestamp" timestamp with time zone DEFAULT now() NOT NULL,
-    signature character varying(64),
-    previous_signature character varying(64)
+CREATE SEQUENCE public.vault_beta_federal_law_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: vault_beta_federal_law_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.vault_beta_federal_law_id_seq OWNED BY public.vault_beta_federal_law.id;
+
+
+--
+-- Name: vault_delta; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.vault_delta (
+    id integer NOT NULL,
+    citation character varying(100) NOT NULL,
+    case_name text NOT NULL,
+    court character varying(150),
+    date_decided date,
+    docket_number character varying(100),
+    opinion_type character varying(30),
+    author character varying(150),
+    chunk_index integer NOT NULL,
+    chunk_text text NOT NULL,
+    embedding public.vector(768),
+    source_file character varying(255),
+    topics text[],
+    created_at timestamp without time zone DEFAULT now(),
+    text_search tsvector GENERATED ALWAYS AS (to_tsvector('english'::regconfig, ((((COALESCE(chunk_text, ''::text) || ' '::text) || COALESCE(case_name, ''::text)) || ' '::text) || (COALESCE(citation, ''::character varying))::text))) STORED
 );
 
 
 --
--- Name: utility_readings; Type: TABLE; Schema: public; Owner: -
+-- Name: vault_delta_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.utility_readings (
-    id uuid NOT NULL,
-    utility_id uuid NOT NULL,
-    reading_date date NOT NULL,
-    cost numeric(10,2) NOT NULL,
-    usage_amount numeric(12,4),
-    usage_unit character varying(30),
-    notes text,
-    created_at timestamp without time zone
+CREATE SEQUENCE public.vault_delta_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: vault_delta_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.vault_delta_id_seq OWNED BY public.vault_delta.id;
+
+
+--
+-- Name: vault_gamma_evidence; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.vault_gamma_evidence (
+    id integer NOT NULL,
+    file_hash text NOT NULL,
+    file_path text NOT NULL,
+    metadata jsonb,
+    raw_text text NOT NULL,
+    embedding public.vector(768),
+    text_search tsvector GENERATED ALWAYS AS (to_tsvector('english'::regconfig, raw_text)) STORED,
+    doc_type text,
+    parties text[],
+    date_authored date,
+    inserted_at timestamp with time zone DEFAULT now()
 );
 
 
 --
--- Name: v_labeling_stats; Type: VIEW; Schema: public; Owner: -
+-- Name: vault_gamma_evidence_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE VIEW public.v_labeling_stats AS
- SELECT date((created_at AT TIME ZONE 'America/New_York'::text)) AS label_date,
-    task_type,
-    count(*) AS total_labeled,
-    count(*) FILTER (WHERE ((godhead_decision)::text = 'confident'::text)) AS confident_count,
-    count(*) FILTER (WHERE ((godhead_decision)::text = 'uncertain'::text)) AS uncertain_count,
-    count(*) FILTER (WHERE ((godhead_decision)::text = 'escalate'::text)) AS escalate_count,
-    count(*) FILTER (WHERE ((godhead_decision)::text = 'skip'::text)) AS skip_count,
-    COALESCE(sum(godhead_cost_usd), (0)::numeric) AS total_cost_usd,
-    count(*) FILTER (WHERE (qc_sampled = true)) AS qc_sampled_count,
-    count(*) FILTER (WHERE (qc_reviewed_at IS NOT NULL)) AS qc_reviewed_count
-   FROM public.capture_labels
-  GROUP BY (date((created_at AT TIME ZONE 'America/New_York'::text))), task_type;
+CREATE SEQUENCE public.vault_gamma_evidence_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
 
 
 --
--- Name: v_qc_queue; Type: VIEW; Schema: public; Owner: -
+-- Name: vault_gamma_evidence_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE VIEW public.v_qc_queue AS
- SELECT id,
-    created_at,
-    task_type,
-    capture_table,
-    godhead_model,
-    godhead_decision,
-    godhead_reasoning,
-    godhead_cost_usd,
-    COALESCE(( SELECT tc.user_prompt
-           FROM public.llm_training_captures tc
-          WHERE (tc.id = cl.capture_id)), ( SELECT rc.prompt
-           FROM public.restricted_captures rc
-          WHERE (rc.id = cl.capture_id))) AS user_prompt,
-    COALESCE(( SELECT tc.assistant_resp
-           FROM public.llm_training_captures tc
-          WHERE (tc.id = cl.capture_id)), ( SELECT rc.response
-           FROM public.restricted_captures rc
-          WHERE (rc.id = cl.capture_id))) AS assistant_resp,
-    COALESCE(( SELECT tc.source_module
-           FROM public.llm_training_captures tc
-          WHERE (tc.id = cl.capture_id)), ( SELECT rc.source_module
-           FROM public.restricted_captures rc
-          WHERE (rc.id = cl.capture_id))) AS source_module
-   FROM public.capture_labels cl
-  WHERE ((qc_sampled = true) AND (qc_reviewed_at IS NULL))
-  ORDER BY created_at DESC;
+ALTER SEQUENCE public.vault_gamma_evidence_id_seq OWNED BY public.vault_gamma_evidence.id;
 
 
 --
--- Name: vault_audit_logs; Type: TABLE; Schema: public; Owner: -
+-- Name: vision_runs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.vault_audit_logs (
-    id uuid NOT NULL,
-    user_id character varying(255) NOT NULL,
-    user_email character varying(255),
-    action character varying(50) NOT NULL,
-    query_text text NOT NULL,
-    filters_applied jsonb NOT NULL,
-    result_count integer NOT NULL,
-    top_score character varying(10),
-    ip_address character varying(45),
-    user_agent text,
-    created_at timestamp without time zone NOT NULL
+CREATE TABLE public.vision_runs (
+    run_id integer NOT NULL,
+    scan_path text NOT NULL,
+    model_used character varying(100),
+    images_found integer DEFAULT 0,
+    images_processed integer DEFAULT 0,
+    images_failed integer DEFAULT 0,
+    images_skipped integer DEFAULT 0,
+    started_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    completed_at timestamp without time zone,
+    status character varying(20) DEFAULT 'RUNNING'::character varying
 );
 
 
 --
--- Name: vendors; Type: TABLE; Schema: public; Owner: -
+-- Name: vision_runs_run_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.vendors (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    name character varying(200) NOT NULL,
-    trade character varying(80),
-    phone character varying(40),
-    email character varying(255),
-    insurance_expiry date,
-    active boolean DEFAULT true NOT NULL,
-    hourly_rate numeric(8,2),
-    regions jsonb DEFAULT '[]'::jsonb NOT NULL,
-    notes text,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
-);
+CREATE SEQUENCE public.vision_runs_run_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
 
 
 --
--- Name: vrs_add_ons; Type: TABLE; Schema: public; Owner: -
+-- Name: vision_runs_run_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE public.vrs_add_ons (
-    id uuid NOT NULL,
-    name character varying(255) NOT NULL,
-    description text NOT NULL,
-    price numeric(12,2) NOT NULL,
-    pricing_model character varying(9) NOT NULL,
-    is_active boolean NOT NULL,
-    scope character varying(17) NOT NULL,
-    property_id uuid,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL,
-    CONSTRAINT ck_vrs_add_ons_price_nonnegative CHECK ((price >= (0)::numeric)),
-    CONSTRAINT ck_vrs_add_ons_scope_property_consistency CHECK (((((scope)::text = 'global'::text) AND (property_id IS NULL)) OR (((scope)::text = 'property_specific'::text) AND (property_id IS NOT NULL)))),
-    CONSTRAINT vrs_add_on_pricing_model CHECK (((pricing_model)::text = ANY ((ARRAY['flat_fee'::character varying, 'per_night'::character varying, 'per_guest'::character varying])::text[]))),
-    CONSTRAINT vrs_add_on_scope CHECK (((scope)::text = ANY ((ARRAY['global'::character varying, 'property_specific'::character varying])::text[])))
-);
+ALTER SEQUENCE public.vision_runs_run_id_seq OWNED BY public.vision_runs.run_id;
 
 
 --
--- Name: vrs_automation_events; Type: TABLE; Schema: public; Owner: -
+-- Name: account_mappings id; Type: DEFAULT; Schema: division_a; Owner: -
 --
 
-CREATE TABLE public.vrs_automation_events (
-    id uuid NOT NULL,
-    rule_id uuid,
-    entity_type character varying(50) NOT NULL,
-    entity_id character varying(100) NOT NULL,
-    event_type character varying(50) NOT NULL,
-    previous_state jsonb DEFAULT '{}'::jsonb NOT NULL,
-    current_state jsonb DEFAULT '{}'::jsonb NOT NULL,
-    action_result character varying(20),
-    error_detail text,
-    created_at timestamp without time zone
-);
+ALTER TABLE ONLY division_a.account_mappings ALTER COLUMN id SET DEFAULT nextval('division_a.account_mappings_id_seq'::regclass);
 
 
 --
--- Name: vrs_automations; Type: TABLE; Schema: public; Owner: -
+-- Name: audit_log id; Type: DEFAULT; Schema: division_a; Owner: -
 --
 
-CREATE TABLE public.vrs_automations (
-    id uuid NOT NULL,
-    name character varying(255) NOT NULL,
-    target_entity character varying(50) NOT NULL,
-    trigger_event character varying(50) NOT NULL,
-    conditions jsonb DEFAULT '{}'::jsonb NOT NULL,
-    action_type character varying(50) NOT NULL,
-    action_payload jsonb DEFAULT '{}'::jsonb NOT NULL,
-    is_active boolean DEFAULT true NOT NULL,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone
-);
+ALTER TABLE ONLY division_a.audit_log ALTER COLUMN id SET DEFAULT nextval('division_a.audit_log_id_seq'::regclass);
 
 
 --
--- Name: work_orders; Type: TABLE; Schema: public; Owner: -
+-- Name: chart_of_accounts id; Type: DEFAULT; Schema: division_a; Owner: -
 --
 
-CREATE TABLE public.work_orders (
-    id uuid NOT NULL,
-    ticket_number character varying(50) NOT NULL,
-    property_id uuid NOT NULL,
-    reservation_id uuid,
-    guest_id uuid,
-    reported_via_message_id uuid,
-    title character varying(255) NOT NULL,
-    description text NOT NULL,
-    category character varying(50) NOT NULL,
-    priority character varying(20) NOT NULL,
-    status character varying(50) NOT NULL,
-    assigned_to character varying(255),
-    assigned_at timestamp without time zone,
-    resolved_at timestamp without time zone,
-    resolution_notes text,
-    cost_amount numeric(10,2),
-    photo_urls character varying[],
-    qdrant_point_id uuid,
-    created_by character varying(100),
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone,
-    legacy_assigned_to character varying(255),
-    assigned_vendor_id uuid
-);
+ALTER TABLE ONLY division_a.chart_of_accounts ALTER COLUMN id SET DEFAULT nextval('division_a.chart_of_accounts_id_seq'::regclass);
 
 
 --
--- Name: yield_overrides; Type: TABLE; Schema: public; Owner: -
+-- Name: general_ledger id; Type: DEFAULT; Schema: division_a; Owner: -
 --
 
-CREATE TABLE public.yield_overrides (
-    id uuid NOT NULL,
-    property_id uuid NOT NULL,
-    reason character varying(255) NOT NULL,
-    override_payload jsonb NOT NULL,
-    created_by character varying(120) NOT NULL,
-    created_at timestamp without time zone NOT NULL
-);
+ALTER TABLE ONLY division_a.general_ledger ALTER COLUMN id SET DEFAULT nextval('division_a.general_ledger_id_seq'::regclass);
 
 
 --
--- Name: yield_simulations; Type: TABLE; Schema: public; Owner: -
+-- Name: journal_entries id; Type: DEFAULT; Schema: division_a; Owner: -
 --
 
-CREATE TABLE public.yield_simulations (
-    id uuid NOT NULL,
-    property_id uuid NOT NULL,
-    assumptions jsonb NOT NULL,
-    simulated_revenue numeric(12,2) NOT NULL,
-    simulated_margin numeric(12,2) NOT NULL,
-    created_at timestamp without time zone NOT NULL
-);
+ALTER TABLE ONLY division_a.journal_entries ALTER COLUMN id SET DEFAULT nextval('division_a.journal_entries_id_seq'::regclass);
 
 
 --
--- Name: products; Type: TABLE; Schema: verses_schema; Owner: -
+-- Name: predictions id; Type: DEFAULT; Schema: division_a; Owner: -
 --
 
-CREATE TABLE verses_schema.products (
-    id uuid NOT NULL,
-    sku character varying(50) NOT NULL,
-    title character varying(255) NOT NULL,
-    seo_description text,
-    typography_metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
-    image_metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
-    stock_level integer,
-    status character varying(30),
-    created_at timestamp with time zone DEFAULT now(),
-    updated_at timestamp with time zone DEFAULT now()
-);
+ALTER TABLE ONLY division_a.predictions ALTER COLUMN id SET DEFAULT nextval('division_a.predictions_id_seq'::regclass);
 
 
 --
--- Name: ai_audit_ledger id; Type: DEFAULT; Schema: legal; Owner: -
+-- Name: transactions id; Type: DEFAULT; Schema: division_a; Owner: -
 --
 
-ALTER TABLE ONLY legal.ai_audit_ledger ALTER COLUMN id SET DEFAULT nextval('legal.ai_audit_ledger_id_seq'::regclass);
+ALTER TABLE ONLY division_a.transactions ALTER COLUMN id SET DEFAULT nextval('division_a.transactions_id_seq'::regclass);
 
 
 --
--- Name: case_statements id; Type: DEFAULT; Schema: legal; Owner: -
+-- Name: account_mappings id; Type: DEFAULT; Schema: division_b; Owner: -
 --
 
-ALTER TABLE ONLY legal.case_statements ALTER COLUMN id SET DEFAULT nextval('legal.case_statements_id_seq'::regclass);
+ALTER TABLE ONLY division_b.account_mappings ALTER COLUMN id SET DEFAULT nextval('division_b.account_mappings_id_seq'::regclass);
+
+
+--
+-- Name: chart_of_accounts id; Type: DEFAULT; Schema: division_b; Owner: -
+--
+
+ALTER TABLE ONLY division_b.chart_of_accounts ALTER COLUMN id SET DEFAULT nextval('division_b.chart_of_accounts_id_seq'::regclass);
+
+
+--
+-- Name: escrow id; Type: DEFAULT; Schema: division_b; Owner: -
+--
+
+ALTER TABLE ONLY division_b.escrow ALTER COLUMN id SET DEFAULT nextval('division_b.escrow_id_seq'::regclass);
+
+
+--
+-- Name: general_ledger id; Type: DEFAULT; Schema: division_b; Owner: -
+--
+
+ALTER TABLE ONLY division_b.general_ledger ALTER COLUMN id SET DEFAULT nextval('division_b.general_ledger_id_seq'::regclass);
+
+
+--
+-- Name: journal_entries id; Type: DEFAULT; Schema: division_b; Owner: -
+--
+
+ALTER TABLE ONLY division_b.journal_entries ALTER COLUMN id SET DEFAULT nextval('division_b.journal_entries_id_seq'::regclass);
+
+
+--
+-- Name: predictions id; Type: DEFAULT; Schema: division_b; Owner: -
+--
+
+ALTER TABLE ONLY division_b.predictions ALTER COLUMN id SET DEFAULT nextval('division_b.predictions_id_seq'::regclass);
+
+
+--
+-- Name: transactions id; Type: DEFAULT; Schema: division_b; Owner: -
+--
+
+ALTER TABLE ONLY division_b.transactions ALTER COLUMN id SET DEFAULT nextval('division_b.transactions_id_seq'::regclass);
+
+
+--
+-- Name: trust_ledger id; Type: DEFAULT; Schema: division_b; Owner: -
+--
+
+ALTER TABLE ONLY division_b.trust_ledger ALTER COLUMN id SET DEFAULT nextval('division_b.trust_ledger_id_seq'::regclass);
+
+
+--
+-- Name: vendor_payouts id; Type: DEFAULT; Schema: division_b; Owner: -
+--
+
+ALTER TABLE ONLY division_b.vendor_payouts ALTER COLUMN id SET DEFAULT nextval('division_b.vendor_payouts_id_seq'::regclass);
+
+
+--
+-- Name: change_orders id; Type: DEFAULT; Schema: engineering; Owner: -
+--
+
+ALTER TABLE ONLY engineering.change_orders ALTER COLUMN id SET DEFAULT nextval('engineering.change_orders_id_seq'::regclass);
+
+
+--
+-- Name: compliance_log id; Type: DEFAULT; Schema: engineering; Owner: -
+--
+
+ALTER TABLE ONLY engineering.compliance_log ALTER COLUMN id SET DEFAULT nextval('engineering.compliance_log_id_seq'::regclass);
+
+
+--
+-- Name: cost_estimates id; Type: DEFAULT; Schema: engineering; Owner: -
+--
+
+ALTER TABLE ONLY engineering.cost_estimates ALTER COLUMN id SET DEFAULT nextval('engineering.cost_estimates_id_seq'::regclass);
+
+
+--
+-- Name: drawings id; Type: DEFAULT; Schema: engineering; Owner: -
+--
+
+ALTER TABLE ONLY engineering.drawings ALTER COLUMN id SET DEFAULT nextval('engineering.drawings_id_seq'::regclass);
+
+
+--
+-- Name: inspections id; Type: DEFAULT; Schema: engineering; Owner: -
+--
+
+ALTER TABLE ONLY engineering.inspections ALTER COLUMN id SET DEFAULT nextval('engineering.inspections_id_seq'::regclass);
+
+
+--
+-- Name: mep_systems id; Type: DEFAULT; Schema: engineering; Owner: -
+--
+
+ALTER TABLE ONLY engineering.mep_systems ALTER COLUMN id SET DEFAULT nextval('engineering.mep_systems_id_seq'::regclass);
+
+
+--
+-- Name: permits id; Type: DEFAULT; Schema: engineering; Owner: -
+--
+
+ALTER TABLE ONLY engineering.permits ALTER COLUMN id SET DEFAULT nextval('engineering.permits_id_seq'::regclass);
+
+
+--
+-- Name: projects id; Type: DEFAULT; Schema: engineering; Owner: -
+--
+
+ALTER TABLE ONLY engineering.projects ALTER COLUMN id SET DEFAULT nextval('engineering.projects_id_seq'::regclass);
+
+
+--
+-- Name: punch_items id; Type: DEFAULT; Schema: engineering; Owner: -
+--
+
+ALTER TABLE ONLY engineering.punch_items ALTER COLUMN id SET DEFAULT nextval('engineering.punch_items_id_seq'::regclass);
+
+
+--
+-- Name: rfis id; Type: DEFAULT; Schema: engineering; Owner: -
+--
+
+ALTER TABLE ONLY engineering.rfis ALTER COLUMN id SET DEFAULT nextval('engineering.rfis_id_seq'::regclass);
+
+
+--
+-- Name: submittals id; Type: DEFAULT; Schema: engineering; Owner: -
+--
+
+ALTER TABLE ONLY engineering.submittals ALTER COLUMN id SET DEFAULT nextval('engineering.submittals_id_seq'::regclass);
+
+
+--
+-- Name: classification_rules id; Type: DEFAULT; Schema: finance; Owner: -
+--
+
+ALTER TABLE ONLY finance.classification_rules ALTER COLUMN id SET DEFAULT nextval('finance.classification_rules_id_seq'::regclass);
+
+
+--
+-- Name: vendor_classifications id; Type: DEFAULT; Schema: finance; Owner: -
+--
+
+ALTER TABLE ONLY finance.vendor_classifications ALTER COLUMN id SET DEFAULT nextval('finance.vendor_classifications_id_seq'::regclass);
+
+
+--
+-- Name: active_strategies id; Type: DEFAULT; Schema: hedge_fund; Owner: -
+--
+
+ALTER TABLE ONLY hedge_fund.active_strategies ALTER COLUMN id SET DEFAULT nextval('hedge_fund.active_strategies_id_seq'::regclass);
+
+
+--
+-- Name: extraction_log id; Type: DEFAULT; Schema: hedge_fund; Owner: -
+--
+
+ALTER TABLE ONLY hedge_fund.extraction_log ALTER COLUMN id SET DEFAULT nextval('hedge_fund.extraction_log_id_seq'::regclass);
+
+
+--
+-- Name: market_signals id; Type: DEFAULT; Schema: hedge_fund; Owner: -
+--
+
+ALTER TABLE ONLY hedge_fund.market_signals ALTER COLUMN id SET DEFAULT nextval('hedge_fund.market_signals_id_seq'::regclass);
+
+
+--
+-- Name: watchlist id; Type: DEFAULT; Schema: hedge_fund; Owner: -
+--
+
+ALTER TABLE ONLY hedge_fund.watchlist ALTER COLUMN id SET DEFAULT nextval('hedge_fund.watchlist_id_seq'::regclass);
+
+
+--
+-- Name: entities id; Type: DEFAULT; Schema: intelligence; Owner: -
+--
+
+ALTER TABLE ONLY intelligence.entities ALTER COLUMN id SET DEFAULT nextval('intelligence.entities_id_seq'::regclass);
+
+
+--
+-- Name: golden_reasoning id; Type: DEFAULT; Schema: intelligence; Owner: -
+--
+
+ALTER TABLE ONLY intelligence.golden_reasoning ALTER COLUMN id SET DEFAULT nextval('intelligence.golden_reasoning_id_seq'::regclass);
+
+
+--
+-- Name: relationships id; Type: DEFAULT; Schema: intelligence; Owner: -
+--
+
+ALTER TABLE ONLY intelligence.relationships ALTER COLUMN id SET DEFAULT nextval('intelligence.relationships_id_seq'::regclass);
+
+
+--
+-- Name: titan_traces id; Type: DEFAULT; Schema: intelligence; Owner: -
+--
+
+ALTER TABLE ONLY intelligence.titan_traces ALTER COLUMN id SET DEFAULT nextval('intelligence.titan_traces_id_seq'::regclass);
+
+
+--
+-- Name: case_actions id; Type: DEFAULT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.case_actions ALTER COLUMN id SET DEFAULT nextval('legal.case_actions_id_seq'::regclass);
+
+
+--
+-- Name: case_evidence id; Type: DEFAULT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.case_evidence ALTER COLUMN id SET DEFAULT nextval('legal.case_evidence_id_seq'::regclass);
+
+
+--
+-- Name: case_precedents id; Type: DEFAULT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.case_precedents ALTER COLUMN id SET DEFAULT nextval('legal.case_precedents_id_seq'::regclass);
+
+
+--
+-- Name: case_watchdog id; Type: DEFAULT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.case_watchdog ALTER COLUMN id SET DEFAULT nextval('legal.case_watchdog_id_seq'::regclass);
 
 
 --
@@ -3978,10 +7120,73 @@ ALTER TABLE ONLY legal.cases ALTER COLUMN id SET DEFAULT nextval('legal.cases_id
 
 
 --
--- Name: vault_documents id; Type: DEFAULT; Schema: legal; Owner: -
+-- Name: correspondence id; Type: DEFAULT; Schema: legal; Owner: -
 --
 
-ALTER TABLE ONLY legal.vault_documents ALTER COLUMN id SET DEFAULT nextval('legal.vault_documents_id_seq'::regclass);
+ALTER TABLE ONLY legal.correspondence ALTER COLUMN id SET DEFAULT nextval('legal.correspondence_id_seq'::regclass);
+
+
+--
+-- Name: deadlines id; Type: DEFAULT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.deadlines ALTER COLUMN id SET DEFAULT nextval('legal.deadlines_id_seq'::regclass);
+
+
+--
+-- Name: email_intake_queue id; Type: DEFAULT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.email_intake_queue ALTER COLUMN id SET DEFAULT nextval('legal.email_intake_queue_id_seq'::regclass);
+
+
+--
+-- Name: expense_intake id; Type: DEFAULT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.expense_intake ALTER COLUMN id SET DEFAULT nextval('legal.expense_intake_id_seq'::regclass);
+
+
+--
+-- Name: filings id; Type: DEFAULT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.filings ALTER COLUMN id SET DEFAULT nextval('legal.filings_id_seq'::regclass);
+
+
+--
+-- Name: timeline_events id; Type: DEFAULT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.timeline_events ALTER COLUMN id SET DEFAULT nextval('legal.timeline_events_id_seq'::regclass);
+
+
+--
+-- Name: uploads id; Type: DEFAULT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.uploads ALTER COLUMN id SET DEFAULT nextval('legal.uploads_id_seq'::regclass);
+
+
+--
+-- Name: attorney_scoring id; Type: DEFAULT; Schema: legal_cmd; Owner: -
+--
+
+ALTER TABLE ONLY legal_cmd.attorney_scoring ALTER COLUMN id SET DEFAULT nextval('legal_cmd.attorney_scoring_id_seq'::regclass);
+
+
+--
+-- Name: ab_test_observations id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ab_test_observations ALTER COLUMN id SET DEFAULT nextval('public.ab_test_observations_id_seq'::regclass);
+
+
+--
+-- Name: ab_tests id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ab_tests ALTER COLUMN id SET DEFAULT nextval('public.ab_tests_id_seq'::regclass);
 
 
 --
@@ -3992,10 +7197,87 @@ ALTER TABLE ONLY public.accounts ALTER COLUMN id SET DEFAULT nextval('public.acc
 
 
 --
--- Name: capex_staging id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: active_learning_queue id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.capex_staging ALTER COLUMN id SET DEFAULT nextval('public.capex_staging_id_seq'::regclass);
+ALTER TABLE ONLY public.active_learning_queue ALTER COLUMN id SET DEFAULT nextval('public.active_learning_queue_id_seq'::regclass);
+
+
+--
+-- Name: agent_learning_log id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agent_learning_log ALTER COLUMN id SET DEFAULT nextval('public.agent_learning_log_id_seq'::regclass);
+
+
+--
+-- Name: agent_memory id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agent_memory ALTER COLUMN id SET DEFAULT nextval('public.agent_memory_id_seq'::regclass);
+
+
+--
+-- Name: agent_performance_log id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agent_performance_log ALTER COLUMN id SET DEFAULT nextval('public.agent_performance_log_id_seq'::regclass);
+
+
+--
+-- Name: agent_response_queue id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agent_response_queue ALTER COLUMN id SET DEFAULT nextval('public.agent_response_queue_id_seq'::regclass);
+
+
+--
+-- Name: agent_telemetry id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agent_telemetry ALTER COLUMN id SET DEFAULT nextval('public.agent_telemetry_id_seq'::regclass);
+
+
+--
+-- Name: ai_training_labels id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ai_training_labels ALTER COLUMN id SET DEFAULT nextval('public.ai_training_labels_id_seq'::regclass);
+
+
+--
+-- Name: anomaly_flags id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.anomaly_flags ALTER COLUMN id SET DEFAULT nextval('public.anomaly_flags_id_seq'::regclass);
+
+
+--
+-- Name: api_key_vault id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.api_key_vault ALTER COLUMN id SET DEFAULT nextval('public.api_key_vault_id_seq'::regclass);
+
+
+--
+-- Name: asset_docs id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.asset_docs ALTER COLUMN id SET DEFAULT nextval('public.asset_docs_id_seq'::regclass);
+
+
+--
+-- Name: conversation_threads id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.conversation_threads ALTER COLUMN id SET DEFAULT nextval('public.conversation_threads_id_seq'::regclass);
+
+
+--
+-- Name: data_sanitizer_log id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.data_sanitizer_log ALTER COLUMN id SET DEFAULT nextval('public.data_sanitizer_log_id_seq'::regclass);
 
 
 --
@@ -4003,6 +7285,139 @@ ALTER TABLE ONLY public.capex_staging ALTER COLUMN id SET DEFAULT nextval('publi
 --
 
 ALTER TABLE ONLY public.deferred_api_writes ALTER COLUMN id SET DEFAULT nextval('public.deferred_api_writes_id_seq'::regclass);
+
+
+--
+-- Name: email_archive id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_archive ALTER COLUMN id SET DEFAULT nextval('public.email_archive_id_seq'::regclass);
+
+
+--
+-- Name: email_classification_rules id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_classification_rules ALTER COLUMN id SET DEFAULT nextval('public.email_classification_rules_id_seq'::regclass);
+
+
+--
+-- Name: email_dead_letter_queue id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_dead_letter_queue ALTER COLUMN id SET DEFAULT nextval('public.email_dead_letter_queue_id_seq'::regclass);
+
+
+--
+-- Name: email_escalation_queue id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_escalation_queue ALTER COLUMN id SET DEFAULT nextval('public.email_escalation_queue_id_seq'::regclass);
+
+
+--
+-- Name: email_escalation_rules id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_escalation_rules ALTER COLUMN id SET DEFAULT nextval('public.email_escalation_rules_id_seq'::regclass);
+
+
+--
+-- Name: email_intake_review_log id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_intake_review_log ALTER COLUMN id SET DEFAULT nextval('public.email_intake_review_log_id_seq'::regclass);
+
+
+--
+-- Name: email_quarantine id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_quarantine ALTER COLUMN id SET DEFAULT nextval('public.email_quarantine_id_seq'::regclass);
+
+
+--
+-- Name: email_routing_rules id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_routing_rules ALTER COLUMN id SET DEFAULT nextval('public.email_routing_rules_id_seq'::regclass);
+
+
+--
+-- Name: email_triage_precedents id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_triage_precedents ALTER COLUMN id SET DEFAULT nextval('public.email_triage_precedents_id_seq'::regclass);
+
+
+--
+-- Name: fin_revenue_snapshots snapshot_id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.fin_revenue_snapshots ALTER COLUMN snapshot_id SET DEFAULT nextval('public.fin_revenue_snapshots_snapshot_id_seq'::regclass);
+
+
+--
+-- Name: finance_invoices id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.finance_invoices ALTER COLUMN id SET DEFAULT nextval('public.finance_invoices_id_seq'::regclass);
+
+
+--
+-- Name: fortress_api_keys id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.fortress_api_keys ALTER COLUMN id SET DEFAULT nextval('public.fortress_api_keys_id_seq'::regclass);
+
+
+--
+-- Name: fortress_users id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.fortress_users ALTER COLUMN id SET DEFAULT nextval('public.fortress_users_id_seq'::regclass);
+
+
+--
+-- Name: general_ledger id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.general_ledger ALTER COLUMN id SET DEFAULT nextval('public.general_ledger_id_seq'::regclass);
+
+
+--
+-- Name: godhead_query_log id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.godhead_query_log ALTER COLUMN id SET DEFAULT nextval('public.godhead_query_log_id_seq'::regclass);
+
+
+--
+-- Name: guest_leads id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.guest_leads ALTER COLUMN id SET DEFAULT nextval('public.guest_leads_id_seq'::regclass);
+
+
+--
+-- Name: guest_profiles id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.guest_profiles ALTER COLUMN id SET DEFAULT nextval('public.guest_profiles_id_seq'::regclass);
+
+
+--
+-- Name: images id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.images ALTER COLUMN id SET DEFAULT nextval('public.images_id_seq'::regclass);
+
+
+--
+-- Name: ingestion_dlq id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ingestion_dlq ALTER COLUMN id SET DEFAULT nextval('public.ingestion_dlq_id_seq'::regclass);
 
 
 --
@@ -4020,87 +7435,325 @@ ALTER TABLE ONLY public.journal_line_items ALTER COLUMN id SET DEFAULT nextval('
 
 
 --
--- Name: management_splits id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: learning_judgments id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.management_splits ALTER COLUMN id SET DEFAULT nextval('public.management_splits_id_seq'::regclass);
-
-
---
--- Name: marketing_attribution id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.marketing_attribution ALTER COLUMN id SET DEFAULT nextval('public.marketing_attribution_id_seq'::regclass);
+ALTER TABLE ONLY public.learning_judgments ALTER COLUMN id SET DEFAULT nextval('public.learning_judgments_id_seq'::regclass);
 
 
 --
--- Name: owner_balance_periods id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: learning_optimizations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.owner_balance_periods ALTER COLUMN id SET DEFAULT nextval('public.owner_balance_periods_id_seq'::regclass);
-
-
---
--- Name: owner_charges id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.owner_charges ALTER COLUMN id SET DEFAULT nextval('public.owner_charges_id_seq'::regclass);
+ALTER TABLE ONLY public.learning_optimizations ALTER COLUMN id SET DEFAULT nextval('public.learning_optimizations_id_seq'::regclass);
 
 
 --
--- Name: owner_magic_tokens id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: legacy_cdc_event_queue id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.owner_magic_tokens ALTER COLUMN id SET DEFAULT nextval('public.owner_magic_tokens_id_seq'::regclass);
-
-
---
--- Name: owner_marketing_preferences id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.owner_marketing_preferences ALTER COLUMN id SET DEFAULT nextval('public.owner_marketing_preferences_id_seq'::regclass);
+ALTER TABLE ONLY public.legacy_cdc_event_queue ALTER COLUMN id SET DEFAULT nextval('public.legacy_cdc_event_queue_id_seq'::regclass);
 
 
 --
--- Name: owner_markup_rules id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: legal_clients client_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.owner_markup_rules ALTER COLUMN id SET DEFAULT nextval('public.owner_markup_rules_id_seq'::regclass);
-
-
---
--- Name: owner_payout_accounts id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.owner_payout_accounts ALTER COLUMN id SET DEFAULT nextval('public.owner_payout_accounts_id_seq'::regclass);
+ALTER TABLE ONLY public.legal_clients ALTER COLUMN client_id SET DEFAULT nextval('public.legal_clients_client_id_seq'::regclass);
 
 
 --
--- Name: owner_property_map id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: legal_docket doc_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.owner_property_map ALTER COLUMN id SET DEFAULT nextval('public.owner_property_map_id_seq'::regclass);
-
-
---
--- Name: owner_statement_sends id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.owner_statement_sends ALTER COLUMN id SET DEFAULT nextval('public.owner_statement_sends_id_seq'::regclass);
+ALTER TABLE ONLY public.legal_docket ALTER COLUMN doc_id SET DEFAULT nextval('public.legal_docket_doc_id_seq'::regclass);
 
 
 --
--- Name: payout_ledger id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: legal_intel id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.payout_ledger ALTER COLUMN id SET DEFAULT nextval('public.payout_ledger_id_seq'::regclass);
+ALTER TABLE ONLY public.legal_intel ALTER COLUMN id SET DEFAULT nextval('public.legal_intel_id_seq'::regclass);
 
 
 --
--- Name: stripe_connect_events id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: legal_matter_notes note_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.stripe_connect_events ALTER COLUMN id SET DEFAULT nextval('public.stripe_connect_events_id_seq'::regclass);
+ALTER TABLE ONLY public.legal_matter_notes ALTER COLUMN note_id SET DEFAULT nextval('public.legal_matter_notes_note_id_seq'::regclass);
+
+
+--
+-- Name: maintenance_log id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.maintenance_log ALTER COLUMN id SET DEFAULT nextval('public.maintenance_log_id_seq'::regclass);
+
+
+--
+-- Name: market_intel id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.market_intel ALTER COLUMN id SET DEFAULT nextval('public.market_intel_id_seq'::regclass);
+
+
+--
+-- Name: market_signals id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.market_signals ALTER COLUMN id SET DEFAULT nextval('public.market_signals_id_seq'::regclass);
+
+
+--
+-- Name: message_analytics id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.message_analytics ALTER COLUMN id SET DEFAULT nextval('public.message_analytics_id_seq'::regclass);
+
+
+--
+-- Name: message_archive id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.message_archive ALTER COLUMN id SET DEFAULT nextval('public.message_archive_id_seq'::regclass);
+
+
+--
+-- Name: model_telemetry id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.model_telemetry ALTER COLUMN id SET DEFAULT nextval('public.model_telemetry_id_seq'::regclass);
+
+
+--
+-- Name: nim_arm64_probe_results id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.nim_arm64_probe_results ALTER COLUMN id SET DEFAULT nextval('public.nim_arm64_probe_results_id_seq'::regclass);
+
+
+--
+-- Name: ops_crew id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ops_crew ALTER COLUMN id SET DEFAULT nextval('public.ops_crew_id_seq'::regclass);
+
+
+--
+-- Name: ops_historical_guests id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ops_historical_guests ALTER COLUMN id SET DEFAULT nextval('public.ops_historical_guests_id_seq'::regclass);
+
+
+--
+-- Name: ops_log id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ops_log ALTER COLUMN id SET DEFAULT nextval('public.ops_log_id_seq'::regclass);
+
+
+--
+-- Name: ops_overrides id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ops_overrides ALTER COLUMN id SET DEFAULT nextval('public.ops_overrides_id_seq'::regclass);
+
+
+--
+-- Name: ops_tasks id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ops_tasks ALTER COLUMN id SET DEFAULT nextval('public.ops_tasks_id_seq'::regclass);
+
+
+--
+-- Name: ops_turnovers id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ops_turnovers ALTER COLUMN id SET DEFAULT nextval('public.ops_turnovers_id_seq'::regclass);
+
+
+--
+-- Name: ops_visuals image_id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ops_visuals ALTER COLUMN image_id SET DEFAULT nextval('public.ops_visuals_image_id_seq'::regclass);
+
+
+--
+-- Name: pages id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pages ALTER COLUMN id SET DEFAULT nextval('public.pages_id_seq'::regclass);
+
+
+--
+-- Name: properties id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.properties ALTER COLUMN id SET DEFAULT nextval('public.properties_id_seq'::regclass);
+
+
+--
+-- Name: property_events id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.property_events ALTER COLUMN id SET DEFAULT nextval('public.property_events_id_seq'::regclass);
+
+
+--
+-- Name: property_sms_config id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.property_sms_config ALTER COLUMN id SET DEFAULT nextval('public.property_sms_config_id_seq'::regclass);
+
+
+--
+-- Name: quarantine_inbox id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quarantine_inbox ALTER COLUMN id SET DEFAULT nextval('public.quarantine_inbox_id_seq'::regclass);
+
+
+--
+-- Name: rag_query_feedback id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rag_query_feedback ALTER COLUMN id SET DEFAULT nextval('public.rag_query_feedback_id_seq'::regclass);
+
+
+--
+-- Name: real_estate_intel id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.real_estate_intel ALTER COLUMN id SET DEFAULT nextval('public.real_estate_intel_id_seq'::regclass);
+
+
+--
+-- Name: recursive_trace_log id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.recursive_trace_log ALTER COLUMN id SET DEFAULT nextval('public.recursive_trace_log_id_seq'::regclass);
+
+
+--
+-- Name: revenue_ledger id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.revenue_ledger ALTER COLUMN id SET DEFAULT nextval('public.revenue_ledger_id_seq'::regclass);
+
+
+--
+-- Name: ruebarue_area_guide id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ruebarue_area_guide ALTER COLUMN id SET DEFAULT nextval('public.ruebarue_area_guide_id_seq'::regclass);
+
+
+--
+-- Name: ruebarue_contacts id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ruebarue_contacts ALTER COLUMN id SET DEFAULT nextval('public.ruebarue_contacts_id_seq'::regclass);
+
+
+--
+-- Name: ruebarue_guests id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ruebarue_guests ALTER COLUMN id SET DEFAULT nextval('public.ruebarue_guests_id_seq'::regclass);
+
+
+--
+-- Name: ruebarue_knowledge_base id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ruebarue_knowledge_base ALTER COLUMN id SET DEFAULT nextval('public.ruebarue_knowledge_base_id_seq'::regclass);
+
+
+--
+-- Name: ruebarue_message_templates id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ruebarue_message_templates ALTER COLUMN id SET DEFAULT nextval('public.ruebarue_message_templates_id_seq'::regclass);
+
+
+--
+-- Name: sales_intel id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sales_intel ALTER COLUMN id SET DEFAULT nextval('public.sales_intel_id_seq'::regclass);
+
+
+--
+-- Name: schema_drift_log id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.schema_drift_log ALTER COLUMN id SET DEFAULT nextval('public.schema_drift_log_id_seq'::regclass);
+
+
+--
+-- Name: sender_registry id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sender_registry ALTER COLUMN id SET DEFAULT nextval('public.sender_registry_id_seq'::regclass);
+
+
+--
+-- Name: sentinel_alerts id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sentinel_alerts ALTER COLUMN id SET DEFAULT nextval('public.sentinel_alerts_id_seq'::regclass);
+
+
+--
+-- Name: sms_providers id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sms_providers ALTER COLUMN id SET DEFAULT nextval('public.sms_providers_id_seq'::regclass);
+
+
+--
+-- Name: sovereign_cycles id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sovereign_cycles ALTER COLUMN id SET DEFAULT nextval('public.sovereign_cycles_id_seq'::regclass);
+
+
+--
+-- Name: starred_responses id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.starred_responses ALTER COLUMN id SET DEFAULT nextval('public.starred_responses_id_seq'::regclass);
+
+
+--
+-- Name: system_directives id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.system_directives ALTER COLUMN id SET DEFAULT nextval('public.system_directives_id_seq'::regclass);
+
+
+--
+-- Name: system_drift_alerts id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.system_drift_alerts ALTER COLUMN id SET DEFAULT nextval('public.system_drift_alerts_id_seq'::regclass);
+
+
+--
+-- Name: system_post_mortems id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.system_post_mortems ALTER COLUMN id SET DEFAULT nextval('public.system_post_mortems_id_seq'::regclass);
+
+
+--
+-- Name: system_telemetry id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.system_telemetry ALTER COLUMN id SET DEFAULT nextval('public.system_telemetry_id_seq'::regclass);
 
 
 --
@@ -4111,187 +7764,470 @@ ALTER TABLE ONLY public.trust_balance ALTER COLUMN id SET DEFAULT nextval('publi
 
 
 --
--- Name: deliberation_logs deliberation_logs_pkey; Type: CONSTRAINT; Schema: core; Owner: -
+-- Name: vault_alpha_state_law id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY core.deliberation_logs
-    ADD CONSTRAINT deliberation_logs_pkey PRIMARY KEY (id);
-
-
---
--- Name: acquisition_documents acquisition_documents_pkey; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
---
-
-ALTER TABLE ONLY crog_acquisition.acquisition_documents
-    ADD CONSTRAINT acquisition_documents_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.vault_alpha_state_law ALTER COLUMN id SET DEFAULT nextval('public.vault_alpha_state_law_id_seq'::regclass);
 
 
 --
--- Name: acquisition_pipeline acquisition_pipeline_pkey; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
+-- Name: vault_beta_federal_law id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY crog_acquisition.acquisition_pipeline
-    ADD CONSTRAINT acquisition_pipeline_pkey PRIMARY KEY (id);
-
-
---
--- Name: due_diligence due_diligence_pkey; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
---
-
-ALTER TABLE ONLY crog_acquisition.due_diligence
-    ADD CONSTRAINT due_diligence_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.vault_beta_federal_law ALTER COLUMN id SET DEFAULT nextval('public.vault_beta_federal_law_id_seq'::regclass);
 
 
 --
--- Name: intel_events intel_events_pkey; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
+-- Name: vault_delta id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY crog_acquisition.intel_events
-    ADD CONSTRAINT intel_events_pkey PRIMARY KEY (id);
-
-
---
--- Name: owner_contacts owner_contacts_pkey; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
---
-
-ALTER TABLE ONLY crog_acquisition.owner_contacts
-    ADD CONSTRAINT owner_contacts_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.vault_delta ALTER COLUMN id SET DEFAULT nextval('public.vault_delta_id_seq'::regclass);
 
 
 --
--- Name: owners owners_pkey; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
+-- Name: vault_gamma_evidence id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY crog_acquisition.owners
-    ADD CONSTRAINT owners_pkey PRIMARY KEY (id);
-
-
---
--- Name: parcels parcels_pkey; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
---
-
-ALTER TABLE ONLY crog_acquisition.parcels
-    ADD CONSTRAINT parcels_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.vault_gamma_evidence ALTER COLUMN id SET DEFAULT nextval('public.vault_gamma_evidence_id_seq'::regclass);
 
 
 --
--- Name: properties properties_airbnb_listing_id_key; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
+-- Name: vision_runs run_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY crog_acquisition.properties
-    ADD CONSTRAINT properties_airbnb_listing_id_key UNIQUE (airbnb_listing_id);
-
-
---
--- Name: properties properties_blue_ridge_str_permit_key; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
---
-
-ALTER TABLE ONLY crog_acquisition.properties
-    ADD CONSTRAINT properties_blue_ridge_str_permit_key UNIQUE (blue_ridge_str_permit);
+ALTER TABLE ONLY public.vision_runs ALTER COLUMN run_id SET DEFAULT nextval('public.vision_runs_run_id_seq'::regclass);
 
 
 --
--- Name: properties properties_fannin_str_cert_id_key; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
+-- Name: account_mappings account_mappings_pkey; Type: CONSTRAINT; Schema: division_a; Owner: -
 --
 
-ALTER TABLE ONLY crog_acquisition.properties
-    ADD CONSTRAINT properties_fannin_str_cert_id_key UNIQUE (fannin_str_cert_id);
-
-
---
--- Name: properties properties_google_place_id_key; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
---
-
-ALTER TABLE ONLY crog_acquisition.properties
-    ADD CONSTRAINT properties_google_place_id_key UNIQUE (google_place_id);
+ALTER TABLE ONLY division_a.account_mappings
+    ADD CONSTRAINT account_mappings_pkey PRIMARY KEY (id);
 
 
 --
--- Name: properties properties_pkey; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
+-- Name: audit_log audit_log_pkey; Type: CONSTRAINT; Schema: division_a; Owner: -
 --
 
-ALTER TABLE ONLY crog_acquisition.properties
-    ADD CONSTRAINT properties_pkey PRIMARY KEY (id);
-
-
---
--- Name: properties properties_vrbo_listing_id_key; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
---
-
-ALTER TABLE ONLY crog_acquisition.properties
-    ADD CONSTRAINT properties_vrbo_listing_id_key UNIQUE (vrbo_listing_id);
+ALTER TABLE ONLY division_a.audit_log
+    ADD CONSTRAINT audit_log_pkey PRIMARY KEY (id);
 
 
 --
--- Name: properties properties_zillow_zpid_key; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
+-- Name: chart_of_accounts chart_of_accounts_code_key; Type: CONSTRAINT; Schema: division_a; Owner: -
 --
 
-ALTER TABLE ONLY crog_acquisition.properties
-    ADD CONSTRAINT properties_zillow_zpid_key UNIQUE (zillow_zpid);
-
-
---
--- Name: str_signals str_signals_pkey; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
---
-
-ALTER TABLE ONLY crog_acquisition.str_signals
-    ADD CONSTRAINT str_signals_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY division_a.chart_of_accounts
+    ADD CONSTRAINT chart_of_accounts_code_key UNIQUE (code);
 
 
 --
--- Name: owner_contacts uq_acquisition_owner_contacts_owner_value; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
+-- Name: chart_of_accounts chart_of_accounts_pkey; Type: CONSTRAINT; Schema: division_a; Owner: -
 --
 
-ALTER TABLE ONLY crog_acquisition.owner_contacts
-    ADD CONSTRAINT uq_acquisition_owner_contacts_owner_value UNIQUE (owner_id, contact_value);
-
-
---
--- Name: parcels uq_acquisition_parcels_parcel_id; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
---
-
-ALTER TABLE ONLY crog_acquisition.parcels
-    ADD CONSTRAINT uq_acquisition_parcels_parcel_id UNIQUE (parcel_id);
+ALTER TABLE ONLY division_a.chart_of_accounts
+    ADD CONSTRAINT chart_of_accounts_pkey PRIMARY KEY (id);
 
 
 --
--- Name: acquisition_pipeline uq_acquisition_pipeline_property_id; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
+-- Name: general_ledger general_ledger_pkey; Type: CONSTRAINT; Schema: division_a; Owner: -
 --
 
-ALTER TABLE ONLY crog_acquisition.acquisition_pipeline
-    ADD CONSTRAINT uq_acquisition_pipeline_property_id UNIQUE (property_id);
-
-
---
--- Name: due_diligence uq_dd_pipeline_item; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
---
-
-ALTER TABLE ONLY crog_acquisition.due_diligence
-    ADD CONSTRAINT uq_dd_pipeline_item UNIQUE (pipeline_id, item_key);
+ALTER TABLE ONLY division_a.general_ledger
+    ADD CONSTRAINT general_ledger_pkey PRIMARY KEY (id);
 
 
 --
--- Name: device_events device_events_pkey; Type: CONSTRAINT; Schema: iot_schema; Owner: -
+-- Name: journal_entries journal_entries_entry_id_key; Type: CONSTRAINT; Schema: division_a; Owner: -
 --
 
-ALTER TABLE ONLY iot_schema.device_events
-    ADD CONSTRAINT device_events_pkey PRIMARY KEY (id);
-
-
---
--- Name: digital_twins digital_twins_pkey; Type: CONSTRAINT; Schema: iot_schema; Owner: -
---
-
-ALTER TABLE ONLY iot_schema.digital_twins
-    ADD CONSTRAINT digital_twins_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY division_a.journal_entries
+    ADD CONSTRAINT journal_entries_entry_id_key UNIQUE (entry_id);
 
 
 --
--- Name: ai_audit_ledger ai_audit_ledger_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
+-- Name: journal_entries journal_entries_pkey; Type: CONSTRAINT; Schema: division_a; Owner: -
 --
 
-ALTER TABLE ONLY legal.ai_audit_ledger
-    ADD CONSTRAINT ai_audit_ledger_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY division_a.journal_entries
+    ADD CONSTRAINT journal_entries_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: predictions predictions_pkey; Type: CONSTRAINT; Schema: division_a; Owner: -
+--
+
+ALTER TABLE ONLY division_a.predictions
+    ADD CONSTRAINT predictions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: transactions transactions_pkey; Type: CONSTRAINT; Schema: division_a; Owner: -
+--
+
+ALTER TABLE ONLY division_a.transactions
+    ADD CONSTRAINT transactions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: transactions transactions_plaid_txn_id_key; Type: CONSTRAINT; Schema: division_a; Owner: -
+--
+
+ALTER TABLE ONLY division_a.transactions
+    ADD CONSTRAINT transactions_plaid_txn_id_key UNIQUE (plaid_txn_id);
+
+
+--
+-- Name: account_mappings unique_vendor_mapping; Type: CONSTRAINT; Schema: division_a; Owner: -
+--
+
+ALTER TABLE ONLY division_a.account_mappings
+    ADD CONSTRAINT unique_vendor_mapping UNIQUE (vendor_name);
+
+
+--
+-- Name: account_mappings account_mappings_pkey; Type: CONSTRAINT; Schema: division_b; Owner: -
+--
+
+ALTER TABLE ONLY division_b.account_mappings
+    ADD CONSTRAINT account_mappings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: chart_of_accounts chart_of_accounts_code_key; Type: CONSTRAINT; Schema: division_b; Owner: -
+--
+
+ALTER TABLE ONLY division_b.chart_of_accounts
+    ADD CONSTRAINT chart_of_accounts_code_key UNIQUE (code);
+
+
+--
+-- Name: chart_of_accounts chart_of_accounts_pkey; Type: CONSTRAINT; Schema: division_b; Owner: -
+--
+
+ALTER TABLE ONLY division_b.chart_of_accounts
+    ADD CONSTRAINT chart_of_accounts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: escrow escrow_pkey; Type: CONSTRAINT; Schema: division_b; Owner: -
+--
+
+ALTER TABLE ONLY division_b.escrow
+    ADD CONSTRAINT escrow_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: escrow escrow_reservation_id_key; Type: CONSTRAINT; Schema: division_b; Owner: -
+--
+
+ALTER TABLE ONLY division_b.escrow
+    ADD CONSTRAINT escrow_reservation_id_key UNIQUE (reservation_id);
+
+
+--
+-- Name: general_ledger general_ledger_pkey; Type: CONSTRAINT; Schema: division_b; Owner: -
+--
+
+ALTER TABLE ONLY division_b.general_ledger
+    ADD CONSTRAINT general_ledger_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: journal_entries journal_entries_entry_id_key; Type: CONSTRAINT; Schema: division_b; Owner: -
+--
+
+ALTER TABLE ONLY division_b.journal_entries
+    ADD CONSTRAINT journal_entries_entry_id_key UNIQUE (entry_id);
+
+
+--
+-- Name: journal_entries journal_entries_pkey; Type: CONSTRAINT; Schema: division_b; Owner: -
+--
+
+ALTER TABLE ONLY division_b.journal_entries
+    ADD CONSTRAINT journal_entries_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: predictions predictions_pkey; Type: CONSTRAINT; Schema: division_b; Owner: -
+--
+
+ALTER TABLE ONLY division_b.predictions
+    ADD CONSTRAINT predictions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: transactions transactions_pkey; Type: CONSTRAINT; Schema: division_b; Owner: -
+--
+
+ALTER TABLE ONLY division_b.transactions
+    ADD CONSTRAINT transactions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: transactions transactions_plaid_txn_id_key; Type: CONSTRAINT; Schema: division_b; Owner: -
+--
+
+ALTER TABLE ONLY division_b.transactions
+    ADD CONSTRAINT transactions_plaid_txn_id_key UNIQUE (plaid_txn_id);
+
+
+--
+-- Name: trust_ledger trust_ledger_pkey; Type: CONSTRAINT; Schema: division_b; Owner: -
+--
+
+ALTER TABLE ONLY division_b.trust_ledger
+    ADD CONSTRAINT trust_ledger_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: account_mappings unique_vendor_mapping; Type: CONSTRAINT; Schema: division_b; Owner: -
+--
+
+ALTER TABLE ONLY division_b.account_mappings
+    ADD CONSTRAINT unique_vendor_mapping UNIQUE (vendor_name);
+
+
+--
+-- Name: vendor_payouts vendor_payouts_pkey; Type: CONSTRAINT; Schema: division_b; Owner: -
+--
+
+ALTER TABLE ONLY division_b.vendor_payouts
+    ADD CONSTRAINT vendor_payouts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: change_orders change_orders_pkey; Type: CONSTRAINT; Schema: engineering; Owner: -
+--
+
+ALTER TABLE ONLY engineering.change_orders
+    ADD CONSTRAINT change_orders_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: compliance_log compliance_log_pkey; Type: CONSTRAINT; Schema: engineering; Owner: -
+--
+
+ALTER TABLE ONLY engineering.compliance_log
+    ADD CONSTRAINT compliance_log_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: cost_estimates cost_estimates_pkey; Type: CONSTRAINT; Schema: engineering; Owner: -
+--
+
+ALTER TABLE ONLY engineering.cost_estimates
+    ADD CONSTRAINT cost_estimates_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: drawings drawings_file_path_key; Type: CONSTRAINT; Schema: engineering; Owner: -
+--
+
+ALTER TABLE ONLY engineering.drawings
+    ADD CONSTRAINT drawings_file_path_key UNIQUE (file_path);
+
+
+--
+-- Name: drawings drawings_pkey; Type: CONSTRAINT; Schema: engineering; Owner: -
+--
+
+ALTER TABLE ONLY engineering.drawings
+    ADD CONSTRAINT drawings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: inspections inspections_pkey; Type: CONSTRAINT; Schema: engineering; Owner: -
+--
+
+ALTER TABLE ONLY engineering.inspections
+    ADD CONSTRAINT inspections_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: mep_systems mep_systems_pkey; Type: CONSTRAINT; Schema: engineering; Owner: -
+--
+
+ALTER TABLE ONLY engineering.mep_systems
+    ADD CONSTRAINT mep_systems_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: permits permits_permit_number_key; Type: CONSTRAINT; Schema: engineering; Owner: -
+--
+
+ALTER TABLE ONLY engineering.permits
+    ADD CONSTRAINT permits_permit_number_key UNIQUE (permit_number);
+
+
+--
+-- Name: permits permits_pkey; Type: CONSTRAINT; Schema: engineering; Owner: -
+--
+
+ALTER TABLE ONLY engineering.permits
+    ADD CONSTRAINT permits_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: projects projects_pkey; Type: CONSTRAINT; Schema: engineering; Owner: -
+--
+
+ALTER TABLE ONLY engineering.projects
+    ADD CONSTRAINT projects_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: projects projects_project_code_key; Type: CONSTRAINT; Schema: engineering; Owner: -
+--
+
+ALTER TABLE ONLY engineering.projects
+    ADD CONSTRAINT projects_project_code_key UNIQUE (project_code);
+
+
+--
+-- Name: punch_items punch_items_pkey; Type: CONSTRAINT; Schema: engineering; Owner: -
+--
+
+ALTER TABLE ONLY engineering.punch_items
+    ADD CONSTRAINT punch_items_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: rfis rfis_pkey; Type: CONSTRAINT; Schema: engineering; Owner: -
+--
+
+ALTER TABLE ONLY engineering.rfis
+    ADD CONSTRAINT rfis_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: submittals submittals_pkey; Type: CONSTRAINT; Schema: engineering; Owner: -
+--
+
+ALTER TABLE ONLY engineering.submittals
+    ADD CONSTRAINT submittals_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: classification_rules classification_rules_pkey; Type: CONSTRAINT; Schema: finance; Owner: -
+--
+
+ALTER TABLE ONLY finance.classification_rules
+    ADD CONSTRAINT classification_rules_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: vendor_classifications vendor_classifications_pkey; Type: CONSTRAINT; Schema: finance; Owner: -
+--
+
+ALTER TABLE ONLY finance.vendor_classifications
+    ADD CONSTRAINT vendor_classifications_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: vendor_classifications vendor_classifications_vendor_pattern_key; Type: CONSTRAINT; Schema: finance; Owner: -
+--
+
+ALTER TABLE ONLY finance.vendor_classifications
+    ADD CONSTRAINT vendor_classifications_vendor_pattern_key UNIQUE (vendor_pattern);
+
+
+--
+-- Name: active_strategies active_strategies_pkey; Type: CONSTRAINT; Schema: hedge_fund; Owner: -
+--
+
+ALTER TABLE ONLY hedge_fund.active_strategies
+    ADD CONSTRAINT active_strategies_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: extraction_log extraction_log_pkey; Type: CONSTRAINT; Schema: hedge_fund; Owner: -
+--
+
+ALTER TABLE ONLY hedge_fund.extraction_log
+    ADD CONSTRAINT extraction_log_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: market_signals market_signals_pkey; Type: CONSTRAINT; Schema: hedge_fund; Owner: -
+--
+
+ALTER TABLE ONLY hedge_fund.market_signals
+    ADD CONSTRAINT market_signals_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: watchlist watchlist_pkey; Type: CONSTRAINT; Schema: hedge_fund; Owner: -
+--
+
+ALTER TABLE ONLY hedge_fund.watchlist
+    ADD CONSTRAINT watchlist_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: watchlist watchlist_ticker_key; Type: CONSTRAINT; Schema: hedge_fund; Owner: -
+--
+
+ALTER TABLE ONLY hedge_fund.watchlist
+    ADD CONSTRAINT watchlist_ticker_key UNIQUE (ticker);
+
+
+--
+-- Name: entities entities_entity_key_key; Type: CONSTRAINT; Schema: intelligence; Owner: -
+--
+
+ALTER TABLE ONLY intelligence.entities
+    ADD CONSTRAINT entities_entity_key_key UNIQUE (entity_key);
+
+
+--
+-- Name: entities entities_pkey; Type: CONSTRAINT; Schema: intelligence; Owner: -
+--
+
+ALTER TABLE ONLY intelligence.entities
+    ADD CONSTRAINT entities_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: golden_reasoning golden_reasoning_pkey; Type: CONSTRAINT; Schema: intelligence; Owner: -
+--
+
+ALTER TABLE ONLY intelligence.golden_reasoning
+    ADD CONSTRAINT golden_reasoning_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: relationships relationships_from_entity_id_to_entity_id_relationship_type_key; Type: CONSTRAINT; Schema: intelligence; Owner: -
+--
+
+ALTER TABLE ONLY intelligence.relationships
+    ADD CONSTRAINT relationships_from_entity_id_to_entity_id_relationship_type_key UNIQUE (from_entity_id, to_entity_id, relationship_type);
+
+
+--
+-- Name: relationships relationships_pkey; Type: CONSTRAINT; Schema: intelligence; Owner: -
+--
+
+ALTER TABLE ONLY intelligence.relationships
+    ADD CONSTRAINT relationships_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: titan_traces titan_traces_pkey; Type: CONSTRAINT; Schema: intelligence; Owner: -
+--
+
+ALTER TABLE ONLY intelligence.titan_traces
+    ADD CONSTRAINT titan_traces_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: case_actions case_actions_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.case_actions
+    ADD CONSTRAINT case_actions_pkey PRIMARY KEY (id);
 
 
 --
@@ -4303,51 +8239,19 @@ ALTER TABLE ONLY legal.case_evidence
 
 
 --
--- Name: case_graph_edges case_graph_edges_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
+-- Name: case_precedents case_precedents_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
 --
 
-ALTER TABLE ONLY legal.case_graph_edges
-    ADD CONSTRAINT case_graph_edges_pkey PRIMARY KEY (id);
-
-
---
--- Name: case_graph_edges_v2 case_graph_edges_v2_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.case_graph_edges_v2
-    ADD CONSTRAINT case_graph_edges_v2_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY legal.case_precedents
+    ADD CONSTRAINT case_precedents_pkey PRIMARY KEY (id);
 
 
 --
--- Name: case_graph_nodes case_graph_nodes_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
+-- Name: case_watchdog case_watchdog_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
 --
 
-ALTER TABLE ONLY legal.case_graph_nodes
-    ADD CONSTRAINT case_graph_nodes_pkey PRIMARY KEY (id);
-
-
---
--- Name: case_graph_nodes_v2 case_graph_nodes_v2_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.case_graph_nodes_v2
-    ADD CONSTRAINT case_graph_nodes_v2_pkey PRIMARY KEY (id);
-
-
---
--- Name: case_statements case_statements_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.case_statements
-    ADD CONSTRAINT case_statements_pkey PRIMARY KEY (id);
-
-
---
--- Name: case_statements_v2 case_statements_v2_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.case_statements_v2
-    ADD CONSTRAINT case_statements_v2_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY legal.case_watchdog
+    ADD CONSTRAINT case_watchdog_pkey PRIMARY KEY (id);
 
 
 --
@@ -4367,83 +8271,59 @@ ALTER TABLE ONLY legal.cases
 
 
 --
--- Name: deposition_kill_sheets_v2 deposition_kill_sheets_v2_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
+-- Name: correspondence correspondence_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
 --
 
-ALTER TABLE ONLY legal.deposition_kill_sheets_v2
-    ADD CONSTRAINT deposition_kill_sheets_v2_pkey PRIMARY KEY (id);
-
-
---
--- Name: discovery_draft_items_v2 discovery_draft_items_v2_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.discovery_draft_items_v2
-    ADD CONSTRAINT discovery_draft_items_v2_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY legal.correspondence
+    ADD CONSTRAINT correspondence_pkey PRIMARY KEY (id);
 
 
 --
--- Name: discovery_draft_packs_v2 discovery_draft_packs_v2_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
+-- Name: deadlines deadlines_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
 --
 
-ALTER TABLE ONLY legal.discovery_draft_packs_v2
-    ADD CONSTRAINT discovery_draft_packs_v2_pkey PRIMARY KEY (id);
-
-
---
--- Name: distillation_memory distillation_memory_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.distillation_memory
-    ADD CONSTRAINT distillation_memory_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY legal.deadlines
+    ADD CONSTRAINT deadlines_pkey PRIMARY KEY (id);
 
 
 --
--- Name: entities entities_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
+-- Name: email_intake_queue email_intake_queue_message_uid_key; Type: CONSTRAINT; Schema: legal; Owner: -
 --
 
-ALTER TABLE ONLY legal.entities
-    ADD CONSTRAINT entities_pkey PRIMARY KEY (id);
-
-
---
--- Name: legal_cases legal_cases_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.legal_cases
-    ADD CONSTRAINT legal_cases_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY legal.email_intake_queue
+    ADD CONSTRAINT email_intake_queue_message_uid_key UNIQUE (message_uid);
 
 
 --
--- Name: legal_cases legal_cases_slug_key; Type: CONSTRAINT; Schema: legal; Owner: -
+-- Name: email_intake_queue email_intake_queue_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
 --
 
-ALTER TABLE ONLY legal.legal_cases
-    ADD CONSTRAINT legal_cases_slug_key UNIQUE (slug);
-
-
---
--- Name: legal_exemplars legal_exemplars_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.legal_exemplars
-    ADD CONSTRAINT legal_exemplars_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY legal.email_intake_queue
+    ADD CONSTRAINT email_intake_queue_pkey PRIMARY KEY (id);
 
 
 --
--- Name: sanctions_alerts_v2 sanctions_alerts_v2_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
+-- Name: expense_intake expense_intake_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
 --
 
-ALTER TABLE ONLY legal.sanctions_alerts_v2
-    ADD CONSTRAINT sanctions_alerts_v2_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY legal.expense_intake
+    ADD CONSTRAINT expense_intake_pkey PRIMARY KEY (id);
 
 
 --
--- Name: sanctions_tripwire_runs_v2 sanctions_tripwire_runs_v2_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
+-- Name: filings filings_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
 --
 
-ALTER TABLE ONLY legal.sanctions_tripwire_runs_v2
-    ADD CONSTRAINT sanctions_tripwire_runs_v2_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY legal.filings
+    ADD CONSTRAINT filings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ingest_runs ingest_runs_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.ingest_runs
+    ADD CONSTRAINT ingest_runs_pkey PRIMARY KEY (id);
 
 
 --
@@ -4455,11 +8335,123 @@ ALTER TABLE ONLY legal.timeline_events
 
 
 --
+-- Name: uploads uploads_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.uploads
+    ADD CONSTRAINT uploads_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: vault_documents uq_vault_documents_case_hash; Type: CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.vault_documents
+    ADD CONSTRAINT uq_vault_documents_case_hash UNIQUE (case_slug, file_hash);
+
+
+--
 -- Name: vault_documents vault_documents_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
 --
 
 ALTER TABLE ONLY legal.vault_documents
     ADD CONSTRAINT vault_documents_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: attorney_scoring attorney_scoring_pkey; Type: CONSTRAINT; Schema: legal_cmd; Owner: -
+--
+
+ALTER TABLE ONLY legal_cmd.attorney_scoring
+    ADD CONSTRAINT attorney_scoring_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: attorneys attorneys_pkey; Type: CONSTRAINT; Schema: legal_cmd; Owner: -
+--
+
+ALTER TABLE ONLY legal_cmd.attorneys
+    ADD CONSTRAINT attorneys_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: deliberation_events deliberation_events_pkey; Type: CONSTRAINT; Schema: legal_cmd; Owner: -
+--
+
+ALTER TABLE ONLY legal_cmd.deliberation_events
+    ADD CONSTRAINT deliberation_events_pkey PRIMARY KEY (event_id);
+
+
+--
+-- Name: deliberation_events deliberation_events_sha256_signature_key; Type: CONSTRAINT; Schema: legal_cmd; Owner: -
+--
+
+ALTER TABLE ONLY legal_cmd.deliberation_events
+    ADD CONSTRAINT deliberation_events_sha256_signature_key UNIQUE (sha256_signature);
+
+
+--
+-- Name: documents documents_pkey; Type: CONSTRAINT; Schema: legal_cmd; Owner: -
+--
+
+ALTER TABLE ONLY legal_cmd.documents
+    ADD CONSTRAINT documents_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: matters matters_pkey; Type: CONSTRAINT; Schema: legal_cmd; Owner: -
+--
+
+ALTER TABLE ONLY legal_cmd.matters
+    ADD CONSTRAINT matters_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: matters matters_reference_code_key; Type: CONSTRAINT; Schema: legal_cmd; Owner: -
+--
+
+ALTER TABLE ONLY legal_cmd.matters
+    ADD CONSTRAINT matters_reference_code_key UNIQUE (reference_code);
+
+
+--
+-- Name: meetings meetings_pkey; Type: CONSTRAINT; Schema: legal_cmd; Owner: -
+--
+
+ALTER TABLE ONLY legal_cmd.meetings
+    ADD CONSTRAINT meetings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: timeline timeline_pkey; Type: CONSTRAINT; Schema: legal_cmd; Owner: -
+--
+
+ALTER TABLE ONLY legal_cmd.timeline
+    ADD CONSTRAINT timeline_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ab_test_observations ab_test_observations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ab_test_observations
+    ADD CONSTRAINT ab_test_observations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ab_tests ab_tests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ab_tests
+    ADD CONSTRAINT ab_tests_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: accounts accounts_code_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.accounts
+    ADD CONSTRAINT accounts_code_key UNIQUE (code);
 
 
 --
@@ -4471,27 +8463,35 @@ ALTER TABLE ONLY public.accounts
 
 
 --
--- Name: activities activities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: active_learning_queue active_learning_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.activities
-    ADD CONSTRAINT activities_pkey PRIMARY KEY (id);
-
-
---
--- Name: agent_queue agent_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.agent_queue
-    ADD CONSTRAINT agent_queue_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.active_learning_queue
+    ADD CONSTRAINT active_learning_queue_pkey PRIMARY KEY (id);
 
 
 --
--- Name: agent_registry agent_registry_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: agent_learning_log agent_learning_log_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.agent_registry
-    ADD CONSTRAINT agent_registry_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.agent_learning_log
+    ADD CONSTRAINT agent_learning_log_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: agent_memory agent_memory_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agent_memory
+    ADD CONSTRAINT agent_memory_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: agent_performance_log agent_performance_log_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agent_performance_log
+    ADD CONSTRAINT agent_performance_log_pkey PRIMARY KEY (id);
 
 
 --
@@ -4503,27 +8503,19 @@ ALTER TABLE ONLY public.agent_response_queue
 
 
 --
--- Name: agent_runs agent_runs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: agent_telemetry agent_telemetry_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.agent_runs
-    ADD CONSTRAINT agent_runs_pkey PRIMARY KEY (id);
-
-
---
--- Name: agreement_templates agreement_templates_name_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.agreement_templates
-    ADD CONSTRAINT agreement_templates_name_key UNIQUE (name);
+ALTER TABLE ONLY public.agent_telemetry
+    ADD CONSTRAINT agent_telemetry_pkey PRIMARY KEY (id);
 
 
 --
--- Name: agreement_templates agreement_templates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: ai_training_labels ai_training_labels_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.agreement_templates
-    ADD CONSTRAINT agreement_templates_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.ai_training_labels
+    ADD CONSTRAINT ai_training_labels_pkey PRIMARY KEY (id);
 
 
 --
@@ -4535,115 +8527,75 @@ ALTER TABLE ONLY public.alembic_version
 
 
 --
--- Name: analytics_events analytics_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: anomaly_flags anomaly_flags_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.analytics_events
-    ADD CONSTRAINT analytics_events_pkey PRIMARY KEY (id);
-
-
---
--- Name: async_job_runs async_job_runs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.async_job_runs
-    ADD CONSTRAINT async_job_runs_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.anomaly_flags
+    ADD CONSTRAINT anomaly_flags_pkey PRIMARY KEY (id);
 
 
 --
--- Name: blocked_days blocked_days_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: api_key_vault api_key_vault_key_name_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.blocked_days
-    ADD CONSTRAINT blocked_days_pkey PRIMARY KEY (id);
-
-
---
--- Name: blogs blogs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.blogs
-    ADD CONSTRAINT blogs_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.api_key_vault
+    ADD CONSTRAINT api_key_vault_key_name_key UNIQUE (key_name);
 
 
 --
--- Name: capex_staging capex_staging_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: api_key_vault api_key_vault_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.capex_staging
-    ADD CONSTRAINT capex_staging_pkey PRIMARY KEY (id);
-
-
---
--- Name: capture_labels capture_labels_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.capture_labels
-    ADD CONSTRAINT capture_labels_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.api_key_vault
+    ADD CONSTRAINT api_key_vault_pkey PRIMARY KEY (id);
 
 
 --
--- Name: channel_mappings channel_mappings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: asset_docs asset_docs_file_path_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.channel_mappings
-    ADD CONSTRAINT channel_mappings_pkey PRIMARY KEY (id);
-
-
---
--- Name: citation_records citation_records_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.citation_records
-    ADD CONSTRAINT citation_records_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.asset_docs
+    ADD CONSTRAINT asset_docs_file_path_key UNIQUE (file_path);
 
 
 --
--- Name: cleaners cleaners_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: asset_docs asset_docs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.cleaners
-    ADD CONSTRAINT cleaners_pkey PRIMARY KEY (id);
-
-
---
--- Name: competitor_listings competitor_listings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.competitor_listings
-    ADD CONSTRAINT competitor_listings_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.asset_docs
+    ADD CONSTRAINT asset_docs_pkey PRIMARY KEY (id);
 
 
 --
--- Name: concierge_queue concierge_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: conversation_threads conversation_threads_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.concierge_queue
-    ADD CONSTRAINT concierge_queue_pkey PRIMARY KEY (id);
-
-
---
--- Name: concierge_recovery_dispatches concierge_recovery_dispatches_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.concierge_recovery_dispatches
-    ADD CONSTRAINT concierge_recovery_dispatches_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.conversation_threads
+    ADD CONSTRAINT conversation_threads_pkey PRIMARY KEY (id);
 
 
 --
--- Name: damage_claims damage_claims_claim_number_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: conversation_threads conversation_threads_thread_hash_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.damage_claims
-    ADD CONSTRAINT damage_claims_claim_number_key UNIQUE (claim_number);
+ALTER TABLE ONLY public.conversation_threads
+    ADD CONSTRAINT conversation_threads_thread_hash_key UNIQUE (thread_hash);
 
 
 --
--- Name: damage_claims damage_claims_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: council_votes council_votes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.damage_claims
-    ADD CONSTRAINT damage_claims_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.council_votes
+    ADD CONSTRAINT council_votes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: data_sanitizer_log data_sanitizer_log_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.data_sanitizer_log
+    ADD CONSTRAINT data_sanitizer_log_pkey PRIMARY KEY (id);
 
 
 --
@@ -4655,171 +8607,243 @@ ALTER TABLE ONLY public.deferred_api_writes
 
 
 --
--- Name: distillation_queue distillation_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: document_oracle_manifest document_oracle_manifest_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.distillation_queue
-    ADD CONSTRAINT distillation_queue_pkey PRIMARY KEY (id);
-
-
---
--- Name: email_inquirers email_inquirers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.email_inquirers
-    ADD CONSTRAINT email_inquirers_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.document_oracle_manifest
+    ADD CONSTRAINT document_oracle_manifest_pkey PRIMARY KEY (file_path);
 
 
 --
--- Name: email_messages email_messages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: email_archive email_archive_file_path_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.email_messages
-    ADD CONSTRAINT email_messages_pkey PRIMARY KEY (id);
-
-
---
--- Name: email_templates email_templates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.email_templates
-    ADD CONSTRAINT email_templates_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.email_archive
+    ADD CONSTRAINT email_archive_file_path_key UNIQUE (file_path);
 
 
 --
--- Name: extra_orders extra_orders_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: email_archive email_archive_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.extra_orders
-    ADD CONSTRAINT extra_orders_pkey PRIMARY KEY (id);
-
-
---
--- Name: extras extras_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.extras
-    ADD CONSTRAINT extras_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.email_archive
+    ADD CONSTRAINT email_archive_pkey PRIMARY KEY (id);
 
 
 --
--- Name: fees fees_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: email_classification_rules email_classification_rules_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.fees
-    ADD CONSTRAINT fees_pkey PRIMARY KEY (id);
-
-
---
--- Name: financial_approvals financial_approvals_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.financial_approvals
-    ADD CONSTRAINT financial_approvals_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.email_classification_rules
+    ADD CONSTRAINT email_classification_rules_pkey PRIMARY KEY (id);
 
 
 --
--- Name: functional_nodes functional_nodes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: email_dead_letter_queue email_dead_letter_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.functional_nodes
-    ADD CONSTRAINT functional_nodes_pkey PRIMARY KEY (id);
-
-
---
--- Name: guest_activities guest_activities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.guest_activities
-    ADD CONSTRAINT guest_activities_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.email_dead_letter_queue
+    ADD CONSTRAINT email_dead_letter_queue_pkey PRIMARY KEY (id);
 
 
 --
--- Name: guest_quotes guest_quotes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: email_escalation_queue email_escalation_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.guest_quotes
-    ADD CONSTRAINT guest_quotes_pkey PRIMARY KEY (id);
-
-
---
--- Name: guest_reviews guest_reviews_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.guest_reviews
-    ADD CONSTRAINT guest_reviews_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.email_escalation_queue
+    ADD CONSTRAINT email_escalation_queue_pkey PRIMARY KEY (id);
 
 
 --
--- Name: guest_surveys guest_surveys_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: email_escalation_rules email_escalation_rules_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.guest_surveys
-    ADD CONSTRAINT guest_surveys_pkey PRIMARY KEY (id);
-
-
---
--- Name: guest_verifications guest_verifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.guest_verifications
-    ADD CONSTRAINT guest_verifications_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.email_escalation_rules
+    ADD CONSTRAINT email_escalation_rules_pkey PRIMARY KEY (id);
 
 
 --
--- Name: guestbook_guides guestbook_guides_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: email_intake_review_log email_intake_review_log_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.guestbook_guides
-    ADD CONSTRAINT guestbook_guides_pkey PRIMARY KEY (id);
-
-
---
--- Name: guests guests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.guests
-    ADD CONSTRAINT guests_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.email_intake_review_log
+    ADD CONSTRAINT email_intake_review_log_pkey PRIMARY KEY (id);
 
 
 --
--- Name: housekeeping_tasks housekeeping_tasks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: email_quarantine email_quarantine_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.housekeeping_tasks
-    ADD CONSTRAINT housekeeping_tasks_pkey PRIMARY KEY (id);
-
-
---
--- Name: hunter_queue hunter_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.hunter_queue
-    ADD CONSTRAINT hunter_queue_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.email_quarantine
+    ADD CONSTRAINT email_quarantine_pkey PRIMARY KEY (id);
 
 
 --
--- Name: hunter_recovery_ops hunter_recovery_ops_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: email_routing_rules email_routing_rules_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.hunter_recovery_ops
-    ADD CONSTRAINT hunter_recovery_ops_pkey PRIMARY KEY (id);
-
-
---
--- Name: hunter_runs hunter_runs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.hunter_runs
-    ADD CONSTRAINT hunter_runs_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.email_routing_rules
+    ADD CONSTRAINT email_routing_rules_pkey PRIMARY KEY (id);
 
 
 --
--- Name: intelligence_ledger intelligence_ledger_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: email_sensors email_sensors_email_address_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.intelligence_ledger
-    ADD CONSTRAINT intelligence_ledger_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.email_sensors
+    ADD CONSTRAINT email_sensors_email_address_key UNIQUE (email_address);
+
+
+--
+-- Name: email_sensors email_sensors_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_sensors
+    ADD CONSTRAINT email_sensors_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: email_triage_precedents email_triage_precedents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_triage_precedents
+    ADD CONSTRAINT email_triage_precedents_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: fin_owner_balances fin_owner_balances_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.fin_owner_balances
+    ADD CONSTRAINT fin_owner_balances_pkey PRIMARY KEY (property_id);
+
+
+--
+-- Name: fin_reservations fin_reservations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.fin_reservations
+    ADD CONSTRAINT fin_reservations_pkey PRIMARY KEY (res_id);
+
+
+--
+-- Name: fin_revenue_snapshots fin_revenue_snapshots_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.fin_revenue_snapshots
+    ADD CONSTRAINT fin_revenue_snapshots_pkey PRIMARY KEY (snapshot_id);
+
+
+--
+-- Name: finance_invoices finance_invoices_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.finance_invoices
+    ADD CONSTRAINT finance_invoices_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: fortress_api_keys fortress_api_keys_key_hash_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.fortress_api_keys
+    ADD CONSTRAINT fortress_api_keys_key_hash_key UNIQUE (key_hash);
+
+
+--
+-- Name: fortress_api_keys fortress_api_keys_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.fortress_api_keys
+    ADD CONSTRAINT fortress_api_keys_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: fortress_users fortress_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.fortress_users
+    ADD CONSTRAINT fortress_users_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: fortress_users fortress_users_username_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.fortress_users
+    ADD CONSTRAINT fortress_users_username_key UNIQUE (username);
+
+
+--
+-- Name: general_ledger general_ledger_filepath_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.general_ledger
+    ADD CONSTRAINT general_ledger_filepath_key UNIQUE (filepath);
+
+
+--
+-- Name: general_ledger general_ledger_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.general_ledger
+    ADD CONSTRAINT general_ledger_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: godhead_query_log godhead_query_log_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.godhead_query_log
+    ADD CONSTRAINT godhead_query_log_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: guest_leads guest_leads_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.guest_leads
+    ADD CONSTRAINT guest_leads_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: guest_profiles guest_profiles_phone_number_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.guest_profiles
+    ADD CONSTRAINT guest_profiles_phone_number_key UNIQUE (phone_number);
+
+
+--
+-- Name: guest_profiles guest_profiles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.guest_profiles
+    ADD CONSTRAINT guest_profiles_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: images images_filename_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.images
+    ADD CONSTRAINT images_filename_key UNIQUE (filename);
+
+
+--
+-- Name: images images_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.images
+    ADD CONSTRAINT images_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ingestion_dlq ingestion_dlq_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ingestion_dlq
+    ADD CONSTRAINT ingestion_dlq_pkey PRIMARY KEY (id);
 
 
 --
@@ -4839,235 +8863,283 @@ ALTER TABLE ONLY public.journal_line_items
 
 
 --
--- Name: knowledge_base_entries knowledge_base_entries_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: learning_judgments learning_judgments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.knowledge_base_entries
-    ADD CONSTRAINT knowledge_base_entries_pkey PRIMARY KEY (id);
-
-
---
--- Name: leads leads_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.leads
-    ADD CONSTRAINT leads_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.learning_judgments
+    ADD CONSTRAINT learning_judgments_pkey PRIMARY KEY (id);
 
 
 --
--- Name: learned_rules learned_rules_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: learning_optimizations learning_optimizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.learned_rules
-    ADD CONSTRAINT learned_rules_pkey PRIMARY KEY (id);
-
-
---
--- Name: legacy_pages legacy_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.legacy_pages
-    ADD CONSTRAINT legacy_pages_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.learning_optimizations
+    ADD CONSTRAINT learning_optimizations_pkey PRIMARY KEY (id);
 
 
 --
--- Name: legal_case_statements legal_case_statements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: legacy_cdc_checkpoints legacy_cdc_checkpoints_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.legal_case_statements
-    ADD CONSTRAINT legal_case_statements_pkey PRIMARY KEY (id);
-
-
---
--- Name: legal_hive_mind_feedback_events legal_hive_mind_feedback_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.legal_hive_mind_feedback_events
-    ADD CONSTRAINT legal_hive_mind_feedback_events_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.legacy_cdc_checkpoints
+    ADD CONSTRAINT legacy_cdc_checkpoints_pkey PRIMARY KEY (stream_name);
 
 
 --
--- Name: llm_training_captures llm_training_captures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: legacy_cdc_event_queue legacy_cdc_event_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.llm_training_captures
-    ADD CONSTRAINT llm_training_captures_pkey PRIMARY KEY (id);
-
-
---
--- Name: management_splits management_splits_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.management_splits
-    ADD CONSTRAINT management_splits_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.legacy_cdc_event_queue
+    ADD CONSTRAINT legacy_cdc_event_queue_pkey PRIMARY KEY (id);
 
 
 --
--- Name: marketing_articles marketing_articles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: legacy_cdc_row_state legacy_cdc_row_state_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.marketing_articles
-    ADD CONSTRAINT marketing_articles_pkey PRIMARY KEY (id);
-
-
---
--- Name: marketing_attribution marketing_attribution_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.marketing_attribution
-    ADD CONSTRAINT marketing_attribution_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.legacy_cdc_row_state
+    ADD CONSTRAINT legacy_cdc_row_state_pkey PRIMARY KEY (source_table, primary_key_hash);
 
 
 --
--- Name: message_queue message_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: legal_clients legal_clients_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.message_queue
-    ADD CONSTRAINT message_queue_pkey PRIMARY KEY (id);
-
-
---
--- Name: message_templates message_templates_name_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.message_templates
-    ADD CONSTRAINT message_templates_name_key UNIQUE (name);
+ALTER TABLE ONLY public.legal_clients
+    ADD CONSTRAINT legal_clients_pkey PRIMARY KEY (client_id);
 
 
 --
--- Name: message_templates message_templates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: legal_docket legal_docket_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.message_templates
-    ADD CONSTRAINT message_templates_pkey PRIMARY KEY (id);
-
-
---
--- Name: messages messages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.messages
-    ADD CONSTRAINT messages_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.legal_docket
+    ADD CONSTRAINT legal_docket_pkey PRIMARY KEY (doc_id);
 
 
 --
--- Name: openshell_audit_logs openshell_audit_logs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: legal_intel legal_intel_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.openshell_audit_logs
-    ADD CONSTRAINT openshell_audit_logs_pkey PRIMARY KEY (id);
-
-
---
--- Name: operator_overrides operator_overrides_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.operator_overrides
-    ADD CONSTRAINT operator_overrides_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.legal_intel
+    ADD CONSTRAINT legal_intel_pkey PRIMARY KEY (id);
 
 
 --
--- Name: ota_micro_updates ota_micro_updates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: legal_matter_notes legal_matter_notes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ota_micro_updates
-    ADD CONSTRAINT ota_micro_updates_pkey PRIMARY KEY (id);
-
-
---
--- Name: owner_balance_periods owner_balance_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.owner_balance_periods
-    ADD CONSTRAINT owner_balance_periods_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.legal_matter_notes
+    ADD CONSTRAINT legal_matter_notes_pkey PRIMARY KEY (note_id);
 
 
 --
--- Name: owner_charges owner_charges_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: legal_matters legal_matters_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.owner_charges
-    ADD CONSTRAINT owner_charges_pkey PRIMARY KEY (id);
-
-
---
--- Name: owner_magic_tokens owner_magic_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.owner_magic_tokens
-    ADD CONSTRAINT owner_magic_tokens_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.legal_matters
+    ADD CONSTRAINT legal_matters_pkey PRIMARY KEY (matter_id);
 
 
 --
--- Name: owner_marketing_preferences owner_marketing_preferences_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: maintenance_log maintenance_log_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.owner_marketing_preferences
-    ADD CONSTRAINT owner_marketing_preferences_pkey PRIMARY KEY (id);
-
-
---
--- Name: owner_markup_rules owner_markup_rules_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.owner_markup_rules
-    ADD CONSTRAINT owner_markup_rules_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.maintenance_log
+    ADD CONSTRAINT maintenance_log_pkey PRIMARY KEY (id);
 
 
 --
--- Name: owner_payout_accounts owner_payout_accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: market_intel market_intel_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.owner_payout_accounts
-    ADD CONSTRAINT owner_payout_accounts_pkey PRIMARY KEY (id);
-
-
---
--- Name: owner_property_map owner_property_map_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.owner_property_map
-    ADD CONSTRAINT owner_property_map_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.market_intel
+    ADD CONSTRAINT market_intel_pkey PRIMARY KEY (id);
 
 
 --
--- Name: owner_statement_sends owner_statement_sends_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: market_signals market_signals_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.owner_statement_sends
-    ADD CONSTRAINT owner_statement_sends_pkey PRIMARY KEY (id);
-
-
---
--- Name: parity_audits parity_audits_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.parity_audits
-    ADD CONSTRAINT parity_audits_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.market_signals
+    ADD CONSTRAINT market_signals_pkey PRIMARY KEY (id);
 
 
 --
--- Name: payout_ledger payout_ledger_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: message_analytics message_analytics_date_hour_property_id_source_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.payout_ledger
-    ADD CONSTRAINT payout_ledger_pkey PRIMARY KEY (id);
-
-
---
--- Name: pending_sync pending_sync_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.pending_sync
-    ADD CONSTRAINT pending_sync_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.message_analytics
+    ADD CONSTRAINT message_analytics_date_hour_property_id_source_key UNIQUE (date, hour, property_id, source);
 
 
 --
--- Name: pricing_overrides pricing_overrides_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: message_analytics message_analytics_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.pricing_overrides
-    ADD CONSTRAINT pricing_overrides_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.message_analytics
+    ADD CONSTRAINT message_analytics_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: message_archive message_archive_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.message_archive
+    ADD CONSTRAINT message_archive_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: model_telemetry model_telemetry_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.model_telemetry
+    ADD CONSTRAINT model_telemetry_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: nas_legal_vault nas_legal_vault_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.nas_legal_vault
+    ADD CONSTRAINT nas_legal_vault_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: nas_legal_vault nas_legal_vault_source_file_chunk_index_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.nas_legal_vault
+    ADD CONSTRAINT nas_legal_vault_source_file_chunk_index_key UNIQUE (source_file, chunk_index);
+
+
+--
+-- Name: nim_arm64_probe_results nim_arm64_probe_results_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.nim_arm64_probe_results
+    ADD CONSTRAINT nim_arm64_probe_results_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: nim_arm64_probe_results nim_arm64_probe_results_probe_date_image_path_tag_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.nim_arm64_probe_results
+    ADD CONSTRAINT nim_arm64_probe_results_probe_date_image_path_tag_key UNIQUE (probe_date, image_path, tag);
+
+
+--
+-- Name: ops_crew ops_crew_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ops_crew
+    ADD CONSTRAINT ops_crew_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ops_historical_guests ops_historical_guests_guest_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ops_historical_guests
+    ADD CONSTRAINT ops_historical_guests_guest_id_key UNIQUE (guest_id);
+
+
+--
+-- Name: ops_historical_guests ops_historical_guests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ops_historical_guests
+    ADD CONSTRAINT ops_historical_guests_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ops_log ops_log_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ops_log
+    ADD CONSTRAINT ops_log_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ops_overrides ops_overrides_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ops_overrides
+    ADD CONSTRAINT ops_overrides_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ops_properties ops_properties_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ops_properties
+    ADD CONSTRAINT ops_properties_pkey PRIMARY KEY (property_id);
+
+
+--
+-- Name: ops_properties ops_properties_streamline_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ops_properties
+    ADD CONSTRAINT ops_properties_streamline_id_key UNIQUE (streamline_id);
+
+
+--
+-- Name: ops_tasks ops_tasks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ops_tasks
+    ADD CONSTRAINT ops_tasks_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ops_turnovers ops_turnovers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ops_turnovers
+    ADD CONSTRAINT ops_turnovers_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ops_visuals ops_visuals_file_path_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ops_visuals
+    ADD CONSTRAINT ops_visuals_file_path_key UNIQUE (file_path);
+
+
+--
+-- Name: ops_visuals ops_visuals_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ops_visuals
+    ADD CONSTRAINT ops_visuals_pkey PRIMARY KEY (image_id);
+
+
+--
+-- Name: pages pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pages
+    ADD CONSTRAINT pages_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: pages pages_url_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pages
+    ADD CONSTRAINT pages_url_key UNIQUE (url);
+
+
+--
+-- Name: persona_scores persona_scores_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.persona_scores
+    ADD CONSTRAINT persona_scores_pkey PRIMARY KEY (persona_slug);
 
 
 --
@@ -5087,299 +9159,227 @@ ALTER TABLE ONLY public.properties
 
 
 --
--- Name: property_fees property_fees_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: properties properties_streamline_id_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.property_fees
-    ADD CONSTRAINT property_fees_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.properties
+    ADD CONSTRAINT properties_streamline_id_key UNIQUE (streamline_id);
 
 
 --
--- Name: property_images property_images_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: property_events property_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.property_images
-    ADD CONSTRAINT property_images_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.property_events
+    ADD CONSTRAINT property_events_pkey PRIMARY KEY (id);
 
 
 --
--- Name: property_knowledge_chunks property_knowledge_chunks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: property_sms_config property_sms_config_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.property_knowledge_chunks
-    ADD CONSTRAINT property_knowledge_chunks_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.property_sms_config
+    ADD CONSTRAINT property_sms_config_pkey PRIMARY KEY (id);
 
 
 --
--- Name: property_knowledge property_knowledge_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: property_sms_config property_sms_config_property_id_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.property_knowledge
-    ADD CONSTRAINT property_knowledge_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.property_sms_config
+    ADD CONSTRAINT property_sms_config_property_id_key UNIQUE (property_id);
 
 
 --
--- Name: property_stay_restrictions property_stay_restrictions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: quarantine_inbox quarantine_inbox_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.property_stay_restrictions
-    ADD CONSTRAINT property_stay_restrictions_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.quarantine_inbox
+    ADD CONSTRAINT quarantine_inbox_pkey PRIMARY KEY (id);
 
 
 --
--- Name: property_taxes property_taxes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: rag_query_feedback rag_query_feedback_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.property_taxes
-    ADD CONSTRAINT property_taxes_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.rag_query_feedback
+    ADD CONSTRAINT rag_query_feedback_pkey PRIMARY KEY (id);
 
 
 --
--- Name: property_utilities property_utilities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: real_estate_intel real_estate_intel_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.property_utilities
-    ADD CONSTRAINT property_utilities_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.real_estate_intel
+    ADD CONSTRAINT real_estate_intel_pkey PRIMARY KEY (id);
 
 
 --
--- Name: quote_options quote_options_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: recursive_trace_log recursive_trace_log_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quote_options
-    ADD CONSTRAINT quote_options_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.recursive_trace_log
+    ADD CONSTRAINT recursive_trace_log_pkey PRIMARY KEY (id);
 
 
 --
--- Name: quotes quotes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: revenue_ledger revenue_ledger_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quotes
-    ADD CONSTRAINT quotes_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.revenue_ledger
+    ADD CONSTRAINT revenue_ledger_pkey PRIMARY KEY (id);
 
 
 --
--- Name: recovery_parity_comparisons recovery_parity_comparisons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: ruebarue_area_guide ruebarue_area_guide_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.recovery_parity_comparisons
-    ADD CONSTRAINT recovery_parity_comparisons_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.ruebarue_area_guide
+    ADD CONSTRAINT ruebarue_area_guide_pkey PRIMARY KEY (id);
 
 
 --
--- Name: rental_agreements rental_agreements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: ruebarue_contacts ruebarue_contacts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.rental_agreements
-    ADD CONSTRAINT rental_agreements_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.ruebarue_contacts
+    ADD CONSTRAINT ruebarue_contacts_pkey PRIMARY KEY (id);
 
 
 --
--- Name: reservation_holds reservation_holds_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: ruebarue_guests ruebarue_guests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.reservation_holds
-    ADD CONSTRAINT reservation_holds_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.ruebarue_guests
+    ADD CONSTRAINT ruebarue_guests_pkey PRIMARY KEY (id);
 
 
 --
--- Name: reservations reservations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: ruebarue_knowledge_base ruebarue_knowledge_base_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.reservations
-    ADD CONSTRAINT reservations_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.ruebarue_knowledge_base
+    ADD CONSTRAINT ruebarue_knowledge_base_pkey PRIMARY KEY (id);
 
 
 --
--- Name: restricted_captures restricted_captures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: ruebarue_message_templates ruebarue_message_templates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.restricted_captures
-    ADD CONSTRAINT restricted_captures_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.ruebarue_message_templates
+    ADD CONSTRAINT ruebarue_message_templates_pkey PRIMARY KEY (id);
 
 
 --
--- Name: rue_bar_rue_legacy_recovery_templates rue_bar_rue_legacy_recovery_templates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: sales_intel sales_intel_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.rue_bar_rue_legacy_recovery_templates
-    ADD CONSTRAINT rue_bar_rue_legacy_recovery_templates_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.sales_intel
+    ADD CONSTRAINT sales_intel_pkey PRIMARY KEY (id);
 
 
 --
--- Name: scheduled_messages scheduled_messages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: schema_drift_log schema_drift_log_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.scheduled_messages
-    ADD CONSTRAINT scheduled_messages_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.schema_drift_log
+    ADD CONSTRAINT schema_drift_log_pkey PRIMARY KEY (id);
 
 
 --
--- Name: seo_patch_queue seo_patch_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: sender_registry sender_registry_raw_unique; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.seo_patch_queue
-    ADD CONSTRAINT seo_patch_queue_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.sender_registry
+    ADD CONSTRAINT sender_registry_raw_unique UNIQUE (sender_raw);
 
 
 --
--- Name: seo_patches seo_patches_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: sentinel_alerts sentinel_alerts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.seo_patches
-    ADD CONSTRAINT seo_patches_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.sentinel_alerts
+    ADD CONSTRAINT sentinel_alerts_pkey PRIMARY KEY (id);
 
 
 --
--- Name: seo_rank_snapshots seo_rank_snapshots_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: sentinel_state sentinel_state_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.seo_rank_snapshots
-    ADD CONSTRAINT seo_rank_snapshots_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.sentinel_state
+    ADD CONSTRAINT sentinel_state_pkey PRIMARY KEY (key);
 
 
 --
--- Name: seo_redirect_remap_queue seo_redirect_remap_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: sms_providers sms_providers_name_account_sid_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.seo_redirect_remap_queue
-    ADD CONSTRAINT seo_redirect_remap_queue_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.sms_providers
+    ADD CONSTRAINT sms_providers_name_account_sid_key UNIQUE (name, account_sid);
 
 
 --
--- Name: seo_redirects seo_redirects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: sms_providers sms_providers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.seo_redirects
-    ADD CONSTRAINT seo_redirects_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.sms_providers
+    ADD CONSTRAINT sms_providers_pkey PRIMARY KEY (id);
 
 
 --
--- Name: seo_rubrics seo_rubrics_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: sovereign_cycles sovereign_cycles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.seo_rubrics
-    ADD CONSTRAINT seo_rubrics_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.sovereign_cycles
+    ADD CONSTRAINT sovereign_cycles_pkey PRIMARY KEY (id);
 
 
 --
--- Name: shadow_discrepancies shadow_discrepancies_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: starred_responses starred_responses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.shadow_discrepancies
-    ADD CONSTRAINT shadow_discrepancies_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.starred_responses
+    ADD CONSTRAINT starred_responses_pkey PRIMARY KEY (id);
 
 
 --
--- Name: staff_invites staff_invites_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: sys_api_credentials sys_api_credentials_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.staff_invites
-    ADD CONSTRAINT staff_invites_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.sys_api_credentials
+    ADD CONSTRAINT sys_api_credentials_pkey PRIMARY KEY (service_name);
 
 
 --
--- Name: staff_users staff_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: system_directives system_directives_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.staff_users
-    ADD CONSTRAINT staff_users_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.system_directives
+    ADD CONSTRAINT system_directives_pkey PRIMARY KEY (id);
 
 
 --
--- Name: storefront_intent_events storefront_intent_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: system_drift_alerts system_drift_alerts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.storefront_intent_events
-    ADD CONSTRAINT storefront_intent_events_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.system_drift_alerts
+    ADD CONSTRAINT system_drift_alerts_pkey PRIMARY KEY (id);
 
 
 --
--- Name: storefront_session_guest_links storefront_session_guest_links_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: system_post_mortems system_post_mortems_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.storefront_session_guest_links
-    ADD CONSTRAINT storefront_session_guest_links_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.system_post_mortems
+    ADD CONSTRAINT system_post_mortems_pkey PRIMARY KEY (id);
 
 
 --
--- Name: streamline_payload_vault streamline_payload_vault_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: system_telemetry system_telemetry_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.streamline_payload_vault
-    ADD CONSTRAINT streamline_payload_vault_pkey PRIMARY KEY (id);
-
-
---
--- Name: stripe_connect_events stripe_connect_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.stripe_connect_events
-    ADD CONSTRAINT stripe_connect_events_pkey PRIMARY KEY (id);
-
-
---
--- Name: survey_templates survey_templates_name_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.survey_templates
-    ADD CONSTRAINT survey_templates_name_key UNIQUE (name);
-
-
---
--- Name: survey_templates survey_templates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.survey_templates
-    ADD CONSTRAINT survey_templates_pkey PRIMARY KEY (id);
-
-
---
--- Name: swarm_escalations swarm_escalations_decision_id_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.swarm_escalations
-    ADD CONSTRAINT swarm_escalations_decision_id_key UNIQUE (decision_id);
-
-
---
--- Name: swarm_escalations swarm_escalations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.swarm_escalations
-    ADD CONSTRAINT swarm_escalations_pkey PRIMARY KEY (id);
-
-
---
--- Name: taxes taxes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.taxes
-    ADD CONSTRAINT taxes_pkey PRIMARY KEY (id);
-
-
---
--- Name: taxonomy_categories taxonomy_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.taxonomy_categories
-    ADD CONSTRAINT taxonomy_categories_pkey PRIMARY KEY (id);
-
-
---
--- Name: taylor_quote_requests taylor_quote_requests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.taylor_quote_requests
-    ADD CONSTRAINT taylor_quote_requests_pkey PRIMARY KEY (id);
-
-
---
--- Name: trust_accounts trust_accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.trust_accounts
-    ADD CONSTRAINT trust_accounts_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.system_telemetry
+    ADD CONSTRAINT system_telemetry_pkey PRIMARY KEY (id);
 
 
 --
@@ -5391,4200 +9391,3023 @@ ALTER TABLE ONLY public.trust_balance
 
 
 --
--- Name: trust_decisions trust_decisions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.trust_decisions
-    ADD CONSTRAINT trust_decisions_pkey PRIMARY KEY (id);
-
-
---
--- Name: trust_ledger_entries trust_ledger_entries_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.trust_ledger_entries
-    ADD CONSTRAINT trust_ledger_entries_pkey PRIMARY KEY (id);
-
-
---
--- Name: trust_transactions trust_transactions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.trust_transactions
-    ADD CONSTRAINT trust_transactions_pkey PRIMARY KEY (id);
-
-
---
--- Name: accounts uq_accounts_code; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.accounts
-    ADD CONSTRAINT uq_accounts_code UNIQUE (code);
-
-
---
--- Name: agent_registry uq_agent_registry_name; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.agent_registry
-    ADD CONSTRAINT uq_agent_registry_name UNIQUE (name);
-
-
---
--- Name: blocked_days uq_blocked_days_prop_dates_type; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.blocked_days
-    ADD CONSTRAINT uq_blocked_days_prop_dates_type UNIQUE (property_id, start_date, end_date, block_type);
-
-
---
--- Name: capture_labels uq_capture_labels_capture; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.capture_labels
-    ADD CONSTRAINT uq_capture_labels_capture UNIQUE (capture_id, capture_table);
-
-
---
--- Name: channel_mappings uq_channel_mappings_property_channel; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.channel_mappings
-    ADD CONSTRAINT uq_channel_mappings_property_channel UNIQUE (property_id, channel);
-
-
---
--- Name: competitor_listings uq_competitor_listings_dedupe_hash; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.competitor_listings
-    ADD CONSTRAINT uq_competitor_listings_dedupe_hash UNIQUE (dedupe_hash);
-
-
---
--- Name: email_inquirers uq_email_inquirers_email; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.email_inquirers
-    ADD CONSTRAINT uq_email_inquirers_email UNIQUE (email);
-
-
---
--- Name: hunter_queue uq_hunter_queue_session_fp; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.hunter_queue
-    ADD CONSTRAINT uq_hunter_queue_session_fp UNIQUE (session_fp);
-
-
---
--- Name: intelligence_ledger uq_intelligence_ledger_dedupe_hash; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.intelligence_ledger
-    ADD CONSTRAINT uq_intelligence_ledger_dedupe_hash UNIQUE (dedupe_hash);
-
-
---
--- Name: management_splits uq_management_splits_property_id; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.management_splits
-    ADD CONSTRAINT uq_management_splits_property_id UNIQUE (property_id);
-
-
---
--- Name: marketing_attribution uq_marketing_attribution_property_period; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.marketing_attribution
-    ADD CONSTRAINT uq_marketing_attribution_property_period UNIQUE (property_id, period_start, period_end);
-
-
---
--- Name: message_queue uq_message_queue_quote_template; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.message_queue
-    ADD CONSTRAINT uq_message_queue_quote_template UNIQUE (quote_id, template_id);
-
-
---
--- Name: owner_balance_periods uq_obp_owner_period; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.owner_balance_periods
-    ADD CONSTRAINT uq_obp_owner_period UNIQUE (owner_payout_account_id, period_start, period_end);
-
-
---
--- Name: owner_magic_tokens uq_owner_magic_tokens_token_hash; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.owner_magic_tokens
-    ADD CONSTRAINT uq_owner_magic_tokens_token_hash UNIQUE (token_hash);
-
-
---
--- Name: owner_marketing_preferences uq_owner_marketing_preferences_property_id; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.owner_marketing_preferences
-    ADD CONSTRAINT uq_owner_marketing_preferences_property_id UNIQUE (property_id);
-
-
---
--- Name: owner_markup_rules uq_owner_markup_rules_property_category; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.owner_markup_rules
-    ADD CONSTRAINT uq_owner_markup_rules_property_category UNIQUE (property_id, expense_category);
-
-
---
--- Name: owner_payout_accounts uq_owner_payout_accounts_property_id; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.owner_payout_accounts
-    ADD CONSTRAINT uq_owner_payout_accounts_property_id UNIQUE (property_id);
-
-
---
--- Name: owner_payout_accounts uq_owner_payout_accounts_stripe_account_id; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.owner_payout_accounts
-    ADD CONSTRAINT uq_owner_payout_accounts_stripe_account_id UNIQUE (stripe_account_id);
-
-
---
--- Name: owner_property_map uq_owner_property_map_owner_unit; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.owner_property_map
-    ADD CONSTRAINT uq_owner_property_map_owner_unit UNIQUE (sl_owner_id, unit_id);
-
-
---
--- Name: property_fees uq_property_fees_property_fee; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.property_fees
-    ADD CONSTRAINT uq_property_fees_property_fee UNIQUE (property_id, fee_id);
-
-
---
--- Name: property_images uq_property_images_property_legacy_url; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.property_images
-    ADD CONSTRAINT uq_property_images_property_legacy_url UNIQUE (property_id, legacy_url);
-
-
---
--- Name: property_taxes uq_property_taxes_property_tax; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.property_taxes
-    ADD CONSTRAINT uq_property_taxes_property_tax UNIQUE (property_id, tax_id);
-
-
---
--- Name: rue_bar_rue_legacy_recovery_templates uq_rbr_legacy_recovery_template_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.rue_bar_rue_legacy_recovery_templates
-    ADD CONSTRAINT uq_rbr_legacy_recovery_template_key UNIQUE (template_key);
-
-
---
--- Name: utility_readings uq_reading_per_day; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.utility_readings
-    ADD CONSTRAINT uq_reading_per_day UNIQUE (utility_id, reading_date);
-
-
---
--- Name: recovery_parity_comparisons uq_recovery_parity_comparisons_dedupe_hash; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.recovery_parity_comparisons
-    ADD CONSTRAINT uq_recovery_parity_comparisons_dedupe_hash UNIQUE (dedupe_hash);
-
-
---
--- Name: seo_patch_queue uq_seo_patch_queue_target_campaign_source; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.seo_patch_queue
-    ADD CONSTRAINT uq_seo_patch_queue_target_campaign_source UNIQUE (target_type, target_slug, campaign, source_hash);
-
-
---
--- Name: seo_redirect_remap_queue uq_seo_redirect_remap_queue_source_campaign_run; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.seo_redirect_remap_queue
-    ADD CONSTRAINT uq_seo_redirect_remap_queue_source_campaign_run UNIQUE (source_path, campaign, proposal_run_id);
-
-
---
--- Name: stripe_connect_events uq_stripe_connect_events_event_id; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.stripe_connect_events
-    ADD CONSTRAINT uq_stripe_connect_events_event_id UNIQUE (stripe_event_id);
-
-
---
--- Name: trust_accounts uq_trust_accounts_name; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.trust_accounts
-    ADD CONSTRAINT uq_trust_accounts_name UNIQUE (name);
-
-
---
--- Name: trust_balance uq_trust_balance_property_id; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: trust_balance uq_trust_property; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.trust_balance
-    ADD CONSTRAINT uq_trust_balance_property_id UNIQUE (property_id);
+    ADD CONSTRAINT uq_trust_property UNIQUE (property_id);
 
 
 --
--- Name: trust_transactions uq_trust_transactions_signature; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: vault_alpha_state_law vault_alpha_state_law_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.trust_transactions
-    ADD CONSTRAINT uq_trust_transactions_signature UNIQUE (signature);
+ALTER TABLE ONLY public.vault_alpha_state_law
+    ADD CONSTRAINT vault_alpha_state_law_pkey PRIMARY KEY (id);
 
 
 --
--- Name: trust_transactions uq_trust_transactions_streamline_event_id; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: vault_beta_federal_law vault_beta_federal_law_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.trust_transactions
-    ADD CONSTRAINT uq_trust_transactions_streamline_event_id UNIQUE (streamline_event_id);
+ALTER TABLE ONLY public.vault_beta_federal_law
+    ADD CONSTRAINT vault_beta_federal_law_pkey PRIMARY KEY (id);
 
 
 --
--- Name: utility_readings utility_readings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: vault_delta vault_delta_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.utility_readings
-    ADD CONSTRAINT utility_readings_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.vault_delta
+    ADD CONSTRAINT vault_delta_pkey PRIMARY KEY (id);
 
 
 --
--- Name: vault_audit_logs vault_audit_logs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: vault_gamma_evidence vault_gamma_evidence_file_hash_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.vault_audit_logs
-    ADD CONSTRAINT vault_audit_logs_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.vault_gamma_evidence
+    ADD CONSTRAINT vault_gamma_evidence_file_hash_key UNIQUE (file_hash);
 
 
 --
--- Name: vendors vendors_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: vault_gamma_evidence vault_gamma_evidence_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.vendors
-    ADD CONSTRAINT vendors_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.vault_gamma_evidence
+    ADD CONSTRAINT vault_gamma_evidence_pkey PRIMARY KEY (id);
 
 
 --
--- Name: vrs_add_ons vrs_add_ons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: vision_runs vision_runs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.vrs_add_ons
-    ADD CONSTRAINT vrs_add_ons_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.vision_runs
+    ADD CONSTRAINT vision_runs_pkey PRIMARY KEY (run_id);
 
 
 --
--- Name: vrs_automation_events vrs_automation_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: idx_div_a_pred_metric; Type: INDEX; Schema: division_a; Owner: -
 --
 
-ALTER TABLE ONLY public.vrs_automation_events
-    ADD CONSTRAINT vrs_automation_events_pkey PRIMARY KEY (id);
+CREATE INDEX idx_div_a_pred_metric ON division_a.predictions USING btree (metric_name);
 
 
 --
--- Name: vrs_automations vrs_automations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: idx_div_a_txn_category; Type: INDEX; Schema: division_a; Owner: -
 --
 
-ALTER TABLE ONLY public.vrs_automations
-    ADD CONSTRAINT vrs_automations_pkey PRIMARY KEY (id);
+CREATE INDEX idx_div_a_txn_category ON division_a.transactions USING btree (category);
 
 
 --
--- Name: work_orders work_orders_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: idx_div_a_txn_date; Type: INDEX; Schema: division_a; Owner: -
 --
 
-ALTER TABLE ONLY public.work_orders
-    ADD CONSTRAINT work_orders_pkey PRIMARY KEY (id);
+CREATE INDEX idx_div_a_txn_date ON division_a.transactions USING btree (date);
 
 
 --
--- Name: work_orders work_orders_ticket_number_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: idx_div_a_txn_vendor; Type: INDEX; Schema: division_a; Owner: -
 --
 
-ALTER TABLE ONLY public.work_orders
-    ADD CONSTRAINT work_orders_ticket_number_key UNIQUE (ticket_number);
+CREATE INDEX idx_div_a_txn_vendor ON division_a.transactions USING btree (vendor);
 
 
 --
--- Name: yield_overrides yield_overrides_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: idx_division_a_am_vendor; Type: INDEX; Schema: division_a; Owner: -
 --
 
-ALTER TABLE ONLY public.yield_overrides
-    ADD CONSTRAINT yield_overrides_pkey PRIMARY KEY (id);
+CREATE INDEX idx_division_a_am_vendor ON division_a.account_mappings USING btree (vendor_name);
 
 
 --
--- Name: yield_simulations yield_simulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: idx_division_a_coa_type; Type: INDEX; Schema: division_a; Owner: -
 --
 
-ALTER TABLE ONLY public.yield_simulations
-    ADD CONSTRAINT yield_simulations_pkey PRIMARY KEY (id);
+CREATE INDEX idx_division_a_coa_type ON division_a.chart_of_accounts USING btree (account_type);
 
 
 --
--- Name: products products_pkey; Type: CONSTRAINT; Schema: verses_schema; Owner: -
+-- Name: idx_division_a_gl_account; Type: INDEX; Schema: division_a; Owner: -
 --
 
-ALTER TABLE ONLY verses_schema.products
-    ADD CONSTRAINT products_pkey PRIMARY KEY (id);
+CREATE INDEX idx_division_a_gl_account ON division_a.general_ledger USING btree (account_code);
 
 
 --
--- Name: ix_core_deliberation_logs_created_at; Type: INDEX; Schema: core; Owner: -
+-- Name: idx_division_a_gl_date; Type: INDEX; Schema: division_a; Owner: -
 --
 
-CREATE INDEX ix_core_deliberation_logs_created_at ON core.deliberation_logs USING btree (created_at);
+CREATE INDEX idx_division_a_gl_date ON division_a.general_ledger USING btree (created_at);
 
 
 --
--- Name: ix_core_deliberation_logs_guest_id; Type: INDEX; Schema: core; Owner: -
+-- Name: idx_division_a_gl_entry; Type: INDEX; Schema: division_a; Owner: -
 --
 
-CREATE INDEX ix_core_deliberation_logs_guest_id ON core.deliberation_logs USING btree (guest_id);
+CREATE INDEX idx_division_a_gl_entry ON division_a.general_ledger USING btree (journal_entry_id);
 
 
 --
--- Name: ix_core_deliberation_logs_message_id; Type: INDEX; Schema: core; Owner: -
+-- Name: idx_division_a_je_date; Type: INDEX; Schema: division_a; Owner: -
 --
 
-CREATE INDEX ix_core_deliberation_logs_message_id ON core.deliberation_logs USING btree (message_id);
+CREATE INDEX idx_division_a_je_date ON division_a.journal_entries USING btree (entry_date);
 
 
 --
--- Name: ix_core_deliberation_logs_property_id; Type: INDEX; Schema: core; Owner: -
+-- Name: idx_division_a_je_source; Type: INDEX; Schema: division_a; Owner: -
 --
 
-CREATE INDEX ix_core_deliberation_logs_property_id ON core.deliberation_logs USING btree (property_id);
+CREATE INDEX idx_division_a_je_source ON division_a.journal_entries USING btree (source_ref);
 
 
 --
--- Name: ix_core_deliberation_logs_reservation_id; Type: INDEX; Schema: core; Owner: -
+-- Name: idx_div_b_escrow_cabin; Type: INDEX; Schema: division_b; Owner: -
 --
 
-CREATE INDEX ix_core_deliberation_logs_reservation_id ON core.deliberation_logs USING btree (reservation_id);
+CREATE INDEX idx_div_b_escrow_cabin ON division_b.escrow USING btree (cabin_id);
 
 
 --
--- Name: ix_core_deliberation_logs_session_id; Type: INDEX; Schema: core; Owner: -
+-- Name: idx_div_b_escrow_status; Type: INDEX; Schema: division_b; Owner: -
 --
 
-CREATE INDEX ix_core_deliberation_logs_session_id ON core.deliberation_logs USING btree (session_id);
+CREATE INDEX idx_div_b_escrow_status ON division_b.escrow USING btree (status);
 
 
 --
--- Name: ix_core_deliberation_logs_verdict_type; Type: INDEX; Schema: core; Owner: -
+-- Name: idx_div_b_txn_date; Type: INDEX; Schema: division_b; Owner: -
 --
 
-CREATE INDEX ix_core_deliberation_logs_verdict_type ON core.deliberation_logs USING btree (verdict_type);
+CREATE INDEX idx_div_b_txn_date ON division_b.transactions USING btree (date);
 
 
 --
--- Name: idx_acquisition_intel_event_type; Type: INDEX; Schema: crog_acquisition; Owner: -
+-- Name: idx_div_b_txn_trust; Type: INDEX; Schema: division_b; Owner: -
 --
 
-CREATE INDEX idx_acquisition_intel_event_type ON crog_acquisition.intel_events USING btree (event_type);
+CREATE INDEX idx_div_b_txn_trust ON division_b.transactions USING btree (trust_related);
 
 
 --
--- Name: idx_acquisition_intel_property_time; Type: INDEX; Schema: crog_acquisition; Owner: -
+-- Name: idx_division_b_am_vendor; Type: INDEX; Schema: division_b; Owner: -
 --
 
-CREATE INDEX idx_acquisition_intel_property_time ON crog_acquisition.intel_events USING btree (property_id, detected_at);
+CREATE INDEX idx_division_b_am_vendor ON division_b.account_mappings USING btree (vendor_name);
 
 
 --
--- Name: idx_acquisition_owner_contacts_owner; Type: INDEX; Schema: crog_acquisition; Owner: -
+-- Name: idx_division_b_coa_type; Type: INDEX; Schema: division_b; Owner: -
 --
 
-CREATE INDEX idx_acquisition_owner_contacts_owner ON crog_acquisition.owner_contacts USING btree (owner_id);
+CREATE INDEX idx_division_b_coa_type ON division_b.chart_of_accounts USING btree (account_type);
 
 
 --
--- Name: idx_acquisition_owners_legal_name; Type: INDEX; Schema: crog_acquisition; Owner: -
+-- Name: idx_division_b_gl_account; Type: INDEX; Schema: division_b; Owner: -
 --
 
-CREATE INDEX idx_acquisition_owners_legal_name ON crog_acquisition.owners USING btree (legal_name);
+CREATE INDEX idx_division_b_gl_account ON division_b.general_ledger USING btree (account_code);
 
 
 --
--- Name: idx_acquisition_parcels_assessed; Type: INDEX; Schema: crog_acquisition; Owner: -
+-- Name: idx_division_b_gl_date; Type: INDEX; Schema: division_b; Owner: -
 --
 
-CREATE INDEX idx_acquisition_parcels_assessed ON crog_acquisition.parcels USING btree (assessed_value);
+CREATE INDEX idx_division_b_gl_date ON division_b.general_ledger USING btree (created_at);
 
 
 --
--- Name: idx_acquisition_parcels_geom; Type: INDEX; Schema: crog_acquisition; Owner: -
+-- Name: idx_division_b_gl_entry; Type: INDEX; Schema: division_b; Owner: -
 --
 
+CREATE INDEX idx_division_b_gl_entry ON division_b.general_ledger USING btree (journal_entry_id);
 
 
 --
--- Name: idx_acquisition_pipeline_next_action_date; Type: INDEX; Schema: crog_acquisition; Owner: -
+-- Name: idx_division_b_je_date; Type: INDEX; Schema: division_b; Owner: -
 --
 
-CREATE INDEX idx_acquisition_pipeline_next_action_date ON crog_acquisition.acquisition_pipeline USING btree (next_action_date);
+CREATE INDEX idx_division_b_je_date ON division_b.journal_entries USING btree (entry_date);
 
 
 --
--- Name: idx_acquisition_pipeline_stage; Type: INDEX; Schema: crog_acquisition; Owner: -
+-- Name: idx_division_b_je_source; Type: INDEX; Schema: division_b; Owner: -
 --
 
-CREATE INDEX idx_acquisition_pipeline_stage ON crog_acquisition.acquisition_pipeline USING btree (stage);
+CREATE INDEX idx_division_b_je_source ON division_b.journal_entries USING btree (source_ref);
 
 
 --
--- Name: idx_acquisition_properties_mgmt; Type: INDEX; Schema: crog_acquisition; Owner: -
+-- Name: idx_eng_co_project; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX idx_acquisition_properties_mgmt ON crog_acquisition.properties USING btree (management_company);
+CREATE INDEX idx_eng_co_project ON engineering.change_orders USING btree (project_id);
 
 
 --
--- Name: idx_acquisition_properties_status; Type: INDEX; Schema: crog_acquisition; Owner: -
+-- Name: idx_eng_co_status; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX idx_acquisition_properties_status ON crog_acquisition.properties USING btree (status);
+CREATE INDEX idx_eng_co_status ON engineering.change_orders USING btree (status);
 
 
 --
--- Name: idx_acquisition_str_signals_detected_at; Type: INDEX; Schema: crog_acquisition; Owner: -
+-- Name: idx_eng_comp_project; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX idx_acquisition_str_signals_detected_at ON crog_acquisition.str_signals USING btree (detected_at);
+CREATE INDEX idx_eng_comp_project ON engineering.compliance_log USING btree (project_id);
 
 
 --
--- Name: idx_acquisition_str_signals_property; Type: INDEX; Schema: crog_acquisition; Owner: -
+-- Name: idx_eng_comp_severity; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX idx_acquisition_str_signals_property ON crog_acquisition.str_signals USING btree (property_id);
+CREATE INDEX idx_eng_comp_severity ON engineering.compliance_log USING btree (severity);
 
 
 --
--- Name: idx_acquisition_str_signals_source; Type: INDEX; Schema: crog_acquisition; Owner: -
+-- Name: idx_eng_comp_status; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX idx_acquisition_str_signals_source ON crog_acquisition.str_signals USING btree (signal_source);
+CREATE INDEX idx_eng_comp_status ON engineering.compliance_log USING btree (status);
 
 
 --
--- Name: ix_acq_docs_pipeline_id; Type: INDEX; Schema: crog_acquisition; Owner: -
+-- Name: idx_eng_cost_project; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_acq_docs_pipeline_id ON crog_acquisition.acquisition_documents USING btree (pipeline_id);
+CREATE INDEX idx_eng_cost_project ON engineering.cost_estimates USING btree (project_id);
 
 
 --
--- Name: ix_crog_acquisition_properties_owner_id; Type: INDEX; Schema: crog_acquisition; Owner: -
+-- Name: idx_eng_cost_type; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_crog_acquisition_properties_owner_id ON crog_acquisition.properties USING btree (owner_id);
+CREATE INDEX idx_eng_cost_type ON engineering.cost_estimates USING btree (estimate_type);
 
 
 --
--- Name: ix_crog_acquisition_properties_parcel_id; Type: INDEX; Schema: crog_acquisition; Owner: -
+-- Name: idx_eng_draw_discipline; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_crog_acquisition_properties_parcel_id ON crog_acquisition.properties USING btree (parcel_id);
+CREATE INDEX idx_eng_draw_discipline ON engineering.drawings USING btree (discipline);
 
 
 --
--- Name: ix_dd_pipeline_id; Type: INDEX; Schema: crog_acquisition; Owner: -
+-- Name: idx_eng_draw_doc_type; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_dd_pipeline_id ON crog_acquisition.due_diligence USING btree (pipeline_id);
+CREATE INDEX idx_eng_draw_doc_type ON engineering.drawings USING btree (doc_type);
 
 
 --
--- Name: ix_dd_status; Type: INDEX; Schema: crog_acquisition; Owner: -
+-- Name: idx_eng_draw_project; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_dd_status ON crog_acquisition.due_diligence USING btree (status);
+CREATE INDEX idx_eng_draw_project ON engineering.drawings USING btree (project_id);
 
 
 --
--- Name: ix_iot_schema_device_events_created_at; Type: INDEX; Schema: iot_schema; Owner: -
+-- Name: idx_eng_draw_property; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_iot_schema_device_events_created_at ON iot_schema.device_events USING btree (created_at);
+CREATE INDEX idx_eng_draw_property ON engineering.drawings USING btree (property_id);
 
 
 --
--- Name: ix_iot_schema_device_events_device_id; Type: INDEX; Schema: iot_schema; Owner: -
+-- Name: idx_eng_insp_project; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_iot_schema_device_events_device_id ON iot_schema.device_events USING btree (device_id);
+CREATE INDEX idx_eng_insp_project ON engineering.inspections USING btree (project_id);
 
 
 --
--- Name: ix_iot_schema_digital_twins_device_id; Type: INDEX; Schema: iot_schema; Owner: -
+-- Name: idx_eng_insp_result; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE UNIQUE INDEX ix_iot_schema_digital_twins_device_id ON iot_schema.digital_twins USING btree (device_id);
+CREATE INDEX idx_eng_insp_result ON engineering.inspections USING btree (result);
 
 
 --
--- Name: ix_iot_schema_digital_twins_property_id; Type: INDEX; Schema: iot_schema; Owner: -
+-- Name: idx_eng_insp_scheduled; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_iot_schema_digital_twins_property_id ON iot_schema.digital_twins USING btree (property_id);
+CREATE INDEX idx_eng_insp_scheduled ON engineering.inspections USING btree (scheduled_date);
 
 
 --
--- Name: ix_ai_audit_ledger_prompt_hash; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_eng_mep_condition; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_ai_audit_ledger_prompt_hash ON legal.ai_audit_ledger USING btree (prompt_hash);
+CREATE INDEX idx_eng_mep_condition ON engineering.mep_systems USING btree (condition);
 
 
 --
--- Name: ix_case_graph_nodes_case_id; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_eng_mep_property; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_case_graph_nodes_case_id ON legal.case_graph_nodes USING btree (case_id);
+CREATE INDEX idx_eng_mep_property ON engineering.mep_systems USING btree (property_id);
 
 
 --
--- Name: ix_case_statements_slug; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_eng_mep_type; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_case_statements_slug ON legal.case_statements USING btree (case_slug);
+CREATE INDEX idx_eng_mep_type ON engineering.mep_systems USING btree (system_type);
 
 
 --
--- Name: ix_legal_case_evidence_case_slug; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_eng_perm_expiration; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_legal_case_evidence_case_slug ON legal.case_evidence USING btree (case_slug);
+CREATE INDEX idx_eng_perm_expiration ON engineering.permits USING btree (expiration_date);
 
 
 --
--- Name: ix_legal_case_evidence_entity_id; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_eng_perm_project; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_legal_case_evidence_entity_id ON legal.case_evidence USING btree (entity_id);
+CREATE INDEX idx_eng_perm_project ON engineering.permits USING btree (project_id);
 
 
 --
--- Name: ix_legal_case_evidence_qdrant_point_id; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_eng_perm_status; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_legal_case_evidence_qdrant_point_id ON legal.case_evidence USING btree (qdrant_point_id);
+CREATE INDEX idx_eng_perm_status ON engineering.permits USING btree (status);
 
 
 --
--- Name: ix_legal_case_evidence_sha256_hash; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_eng_proj_phase; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_legal_case_evidence_sha256_hash ON legal.case_evidence USING btree (sha256_hash);
+CREATE INDEX idx_eng_proj_phase ON engineering.projects USING btree (phase);
 
 
 --
--- Name: ix_legal_case_graph_edges_v2_case_slug; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_eng_proj_property; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_legal_case_graph_edges_v2_case_slug ON legal.case_graph_edges_v2 USING btree (case_slug);
+CREATE INDEX idx_eng_proj_property ON engineering.projects USING btree (property_id);
 
 
 --
--- Name: ix_legal_case_graph_edges_v2_source_evidence_id; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_eng_proj_status; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_legal_case_graph_edges_v2_source_evidence_id ON legal.case_graph_edges_v2 USING btree (source_evidence_id);
+CREATE INDEX idx_eng_proj_status ON engineering.projects USING btree (status);
 
 
 --
--- Name: ix_legal_case_graph_edges_v2_source_node_id; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_eng_punch_project; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_legal_case_graph_edges_v2_source_node_id ON legal.case_graph_edges_v2 USING btree (source_node_id);
+CREATE INDEX idx_eng_punch_project ON engineering.punch_items USING btree (project_id);
 
 
 --
--- Name: ix_legal_case_graph_edges_v2_target_node_id; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_eng_punch_status; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_legal_case_graph_edges_v2_target_node_id ON legal.case_graph_edges_v2 USING btree (target_node_id);
+CREATE INDEX idx_eng_punch_status ON engineering.punch_items USING btree (status);
 
 
 --
--- Name: ix_legal_case_graph_nodes_v2_case_slug; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_eng_rfi_project; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_legal_case_graph_nodes_v2_case_slug ON legal.case_graph_nodes_v2 USING btree (case_slug);
+CREATE INDEX idx_eng_rfi_project ON engineering.rfis USING btree (project_id);
 
 
 --
--- Name: ix_legal_case_graph_nodes_v2_entity_reference_id; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_eng_rfi_status; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_legal_case_graph_nodes_v2_entity_reference_id ON legal.case_graph_nodes_v2 USING btree (entity_reference_id);
+CREATE INDEX idx_eng_rfi_status ON engineering.rfis USING btree (status);
 
 
 --
--- Name: ix_legal_case_graph_nodes_v2_entity_type; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_eng_sub_project; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_legal_case_graph_nodes_v2_entity_type ON legal.case_graph_nodes_v2 USING btree (entity_type);
+CREATE INDEX idx_eng_sub_project ON engineering.submittals USING btree (project_id);
 
 
 --
--- Name: ix_legal_case_statements_v2_case_slug; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_eng_sub_status; Type: INDEX; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_legal_case_statements_v2_case_slug ON legal.case_statements_v2 USING btree (case_slug);
+CREATE INDEX idx_eng_sub_status ON engineering.submittals USING btree (status);
 
 
 --
--- Name: ix_legal_case_statements_v2_doc_id; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_classification_rules_embedding_hnsw; Type: INDEX; Schema: finance; Owner: -
 --
 
-CREATE INDEX ix_legal_case_statements_v2_doc_id ON legal.case_statements_v2 USING btree (doc_id);
+CREATE INDEX idx_classification_rules_embedding_hnsw ON finance.classification_rules USING hnsw (embedding public.vector_cosine_ops) WITH (m='16', ef_construction='64');
 
 
 --
--- Name: ix_legal_case_statements_v2_entity_id; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_rules_category; Type: INDEX; Schema: finance; Owner: -
 --
 
-CREATE INDEX ix_legal_case_statements_v2_entity_id ON legal.case_statements_v2 USING btree (entity_id);
+CREATE INDEX idx_rules_category ON finance.classification_rules USING btree (assigned_category);
 
 
 --
--- Name: ix_legal_case_statements_v2_stated_at; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_rules_embedding_hnsw; Type: INDEX; Schema: finance; Owner: -
 --
 
-CREATE INDEX ix_legal_case_statements_v2_stated_at ON legal.case_statements_v2 USING btree (stated_at);
+CREATE INDEX idx_rules_embedding_hnsw ON finance.classification_rules USING hnsw (embedding public.vector_cosine_ops) WITH (m='16', ef_construction='64');
 
 
 --
--- Name: ix_legal_cases_slug; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_vendor_class_pattern; Type: INDEX; Schema: finance; Owner: -
 --
 
-CREATE INDEX ix_legal_cases_slug ON legal.legal_cases USING btree (slug);
+CREATE INDEX idx_vendor_class_pattern ON finance.vendor_classifications USING btree (vendor_pattern);
 
 
 --
--- Name: ix_legal_deposition_kill_sheets_v2_case_slug; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_hf_extraction_email_unique; Type: INDEX; Schema: hedge_fund; Owner: -
 --
 
-CREATE INDEX ix_legal_deposition_kill_sheets_v2_case_slug ON legal.deposition_kill_sheets_v2 USING btree (case_slug);
+CREATE UNIQUE INDEX idx_hf_extraction_email_unique ON hedge_fund.extraction_log USING btree (email_id);
 
 
 --
--- Name: ix_legal_deposition_kill_sheets_v2_deponent_entity; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_hf_signals_action; Type: INDEX; Schema: hedge_fund; Owner: -
 --
 
-CREATE INDEX ix_legal_deposition_kill_sheets_v2_deponent_entity ON legal.deposition_kill_sheets_v2 USING btree (deponent_entity);
+CREATE INDEX idx_hf_signals_action ON hedge_fund.market_signals USING btree (action);
 
 
 --
--- Name: ix_legal_deposition_kill_sheets_v2_status; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_hf_signals_confidence; Type: INDEX; Schema: hedge_fund; Owner: -
 --
 
-CREATE INDEX ix_legal_deposition_kill_sheets_v2_status ON legal.deposition_kill_sheets_v2 USING btree (status);
+CREATE INDEX idx_hf_signals_confidence ON hedge_fund.market_signals USING btree (confidence_score);
 
 
 --
--- Name: ix_legal_discovery_draft_items_v2_category; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_hf_signals_extracted; Type: INDEX; Schema: hedge_fund; Owner: -
 --
 
-CREATE INDEX ix_legal_discovery_draft_items_v2_category ON legal.discovery_draft_items_v2 USING btree (category);
+CREATE INDEX idx_hf_signals_extracted ON hedge_fund.market_signals USING btree (extracted_at);
 
 
 --
--- Name: ix_legal_discovery_draft_items_v2_pack_id; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_hf_signals_ticker; Type: INDEX; Schema: hedge_fund; Owner: -
 --
 
-CREATE INDEX ix_legal_discovery_draft_items_v2_pack_id ON legal.discovery_draft_items_v2 USING btree (pack_id);
+CREATE INDEX idx_hf_signals_ticker ON hedge_fund.market_signals USING btree (ticker);
 
 
 --
--- Name: ix_legal_discovery_draft_packs_v2_case_slug; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_hf_watchlist_ticker; Type: INDEX; Schema: hedge_fund; Owner: -
 --
 
-CREATE INDEX ix_legal_discovery_draft_packs_v2_case_slug ON legal.discovery_draft_packs_v2 USING btree (case_slug);
+CREATE INDEX idx_hf_watchlist_ticker ON hedge_fund.watchlist USING btree (ticker);
 
 
 --
--- Name: ix_legal_discovery_draft_packs_v2_status; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_entities_key; Type: INDEX; Schema: intelligence; Owner: -
 --
 
-CREATE INDEX ix_legal_discovery_draft_packs_v2_status ON legal.discovery_draft_packs_v2 USING btree (status);
+CREATE INDEX idx_entities_key ON intelligence.entities USING btree (entity_key);
 
 
 --
--- Name: ix_legal_discovery_draft_packs_v2_target_entity; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_entities_type; Type: INDEX; Schema: intelligence; Owner: -
 --
 
-CREATE INDEX ix_legal_discovery_draft_packs_v2_target_entity ON legal.discovery_draft_packs_v2 USING btree (target_entity);
+CREATE INDEX idx_entities_type ON intelligence.entities USING btree (entity_type);
 
 
 --
--- Name: ix_legal_distillation_memory_context_hash; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_golden_entity; Type: INDEX; Schema: intelligence; Owner: -
 --
 
-CREATE UNIQUE INDEX ix_legal_distillation_memory_context_hash ON legal.distillation_memory USING btree (context_hash);
+CREATE INDEX idx_golden_entity ON intelligence.golden_reasoning USING btree (entity_key);
 
 
 --
--- Name: ix_legal_entities_name; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_golden_topic; Type: INDEX; Schema: intelligence; Owner: -
 --
 
-CREATE INDEX ix_legal_entities_name ON legal.entities USING btree (name);
+CREATE INDEX idx_golden_topic ON intelligence.golden_reasoning USING btree (topic);
 
 
 --
--- Name: ix_legal_entities_type; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_rel_from; Type: INDEX; Schema: intelligence; Owner: -
 --
 
-CREATE INDEX ix_legal_entities_type ON legal.entities USING btree (type);
+CREATE INDEX idx_rel_from ON intelligence.relationships USING btree (from_entity_id);
 
 
 --
--- Name: ix_legal_legal_exemplars_category; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_rel_to; Type: INDEX; Schema: intelligence; Owner: -
 --
 
-CREATE INDEX ix_legal_legal_exemplars_category ON legal.legal_exemplars USING btree (category);
+CREATE INDEX idx_rel_to ON intelligence.relationships USING btree (to_entity_id);
 
 
 --
--- Name: ix_legal_sanctions_alerts_v2_alert_type; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_rel_type; Type: INDEX; Schema: intelligence; Owner: -
 --
 
-CREATE INDEX ix_legal_sanctions_alerts_v2_alert_type ON legal.sanctions_alerts_v2 USING btree (alert_type);
+CREATE INDEX idx_rel_type ON intelligence.relationships USING btree (relationship_type);
 
 
 --
--- Name: ix_legal_sanctions_alerts_v2_case_slug; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_traces_created; Type: INDEX; Schema: intelligence; Owner: -
 --
 
-CREATE INDEX ix_legal_sanctions_alerts_v2_case_slug ON legal.sanctions_alerts_v2 USING btree (case_slug);
+CREATE INDEX idx_traces_created ON intelligence.titan_traces USING btree (created_at DESC);
 
 
 --
--- Name: ix_legal_sanctions_alerts_v2_confidence_score; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_traces_session; Type: INDEX; Schema: intelligence; Owner: -
 --
 
-CREATE INDEX ix_legal_sanctions_alerts_v2_confidence_score ON legal.sanctions_alerts_v2 USING btree (confidence_score);
+CREATE INDEX idx_traces_session ON intelligence.titan_traces USING btree (session_type);
 
 
 --
--- Name: ix_legal_sanctions_alerts_v2_status; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_case_actions_case; Type: INDEX; Schema: legal; Owner: -
 --
 
-CREATE INDEX ix_legal_sanctions_alerts_v2_status ON legal.sanctions_alerts_v2 USING btree (status);
+CREATE INDEX idx_case_actions_case ON legal.case_actions USING btree (case_id);
 
 
 --
--- Name: ix_legal_sanctions_tripwire_runs_v2_case_slug; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_case_evidence_case; Type: INDEX; Schema: legal; Owner: -
 --
 
-CREATE INDEX ix_legal_sanctions_tripwire_runs_v2_case_slug ON legal.sanctions_tripwire_runs_v2 USING btree (case_slug);
+CREATE INDEX idx_case_evidence_case ON legal.case_evidence USING btree (case_id);
 
 
 --
--- Name: ix_legal_sanctions_tripwire_runs_v2_status; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_case_precedents_score; Type: INDEX; Schema: legal; Owner: -
 --
 
-CREATE INDEX ix_legal_sanctions_tripwire_runs_v2_status ON legal.sanctions_tripwire_runs_v2 USING btree (status);
+CREATE INDEX idx_case_precedents_score ON legal.case_precedents USING btree (relevance_score DESC);
 
 
 --
--- Name: ix_legal_sanctions_tripwire_runs_v2_trigger_source; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_case_precedents_slug; Type: INDEX; Schema: legal; Owner: -
 --
 
-CREATE INDEX ix_legal_sanctions_tripwire_runs_v2_trigger_source ON legal.sanctions_tripwire_runs_v2 USING btree (trigger_source);
+CREATE INDEX idx_case_precedents_slug ON legal.case_precedents USING btree (case_slug);
 
 
 --
--- Name: ix_legal_timeline_events_case_slug; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_case_slug; Type: INDEX; Schema: legal; Owner: -
 --
 
-CREATE INDEX ix_legal_timeline_events_case_slug ON legal.timeline_events USING btree (case_slug);
+CREATE INDEX idx_case_slug ON legal.cases USING btree (case_slug);
 
 
 --
--- Name: ix_legal_timeline_events_event_date; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_case_watchdog_case; Type: INDEX; Schema: legal; Owner: -
 --
 
-CREATE INDEX ix_legal_timeline_events_event_date ON legal.timeline_events USING btree (event_date);
+CREATE INDEX idx_case_watchdog_case ON legal.case_watchdog USING btree (case_id);
 
 
 --
--- Name: ix_legal_timeline_events_source_evidence_id; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_correspondence_case; Type: INDEX; Schema: legal; Owner: -
 --
 
-CREATE INDEX ix_legal_timeline_events_source_evidence_id ON legal.timeline_events USING btree (source_evidence_id);
+CREATE INDEX idx_correspondence_case ON legal.correspondence USING btree (case_id);
 
 
 --
--- Name: ix_shadow_legal_cases_slug; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_correspondence_status; Type: INDEX; Schema: legal; Owner: -
 --
 
-CREATE INDEX ix_shadow_legal_cases_slug ON legal.cases USING btree (case_slug);
+CREATE INDEX idx_correspondence_status ON legal.correspondence USING btree (status);
 
 
 --
--- Name: ix_vault_documents_slug; Type: INDEX; Schema: legal; Owner: -
+-- Name: idx_deadlines_case; Type: INDEX; Schema: legal; Owner: -
 --
 
-CREATE INDEX ix_vault_documents_slug ON legal.vault_documents USING btree (case_slug);
+CREATE INDEX idx_deadlines_case ON legal.deadlines USING btree (case_id);
 
 
 --
--- Name: idx_cl_capture_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_deadlines_due; Type: INDEX; Schema: legal; Owner: -
 --
 
-CREATE INDEX idx_cl_capture_id ON public.capture_labels USING btree (capture_id);
+CREATE INDEX idx_deadlines_due ON legal.deadlines USING btree (due_date);
 
 
 --
--- Name: idx_cl_created_at; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_deadlines_status; Type: INDEX; Schema: legal; Owner: -
 --
 
-CREATE INDEX idx_cl_created_at ON public.capture_labels USING btree (created_at);
+CREATE INDEX idx_deadlines_status ON legal.deadlines USING btree (status);
 
 
 --
--- Name: idx_cl_godhead_decision; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_filings_case; Type: INDEX; Schema: legal; Owner: -
 --
 
-CREATE INDEX idx_cl_godhead_decision ON public.capture_labels USING btree (godhead_decision);
+CREATE INDEX idx_filings_case ON legal.filings USING btree (case_id);
 
 
 --
--- Name: idx_cl_qc_queue; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ingest_runs_case_slug; Type: INDEX; Schema: legal; Owner: -
 --
 
-CREATE INDEX idx_cl_qc_queue ON public.capture_labels USING btree (created_at DESC) WHERE ((qc_sampled = true) AND (qc_reviewed_at IS NULL));
+CREATE INDEX idx_ingest_runs_case_slug ON legal.ingest_runs USING btree (case_slug);
 
 
 --
--- Name: idx_cl_task_type; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ingest_runs_started_at; Type: INDEX; Schema: legal; Owner: -
 --
 
-CREATE INDEX idx_cl_task_type ON public.capture_labels USING btree (task_type);
+CREATE INDEX idx_ingest_runs_started_at ON legal.ingest_runs USING btree (started_at DESC);
 
 
 --
--- Name: idx_email_inquirers_guest_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ingest_runs_status; Type: INDEX; Schema: legal; Owner: -
 --
 
-CREATE INDEX idx_email_inquirers_guest_id ON public.email_inquirers USING btree (guest_id);
+CREATE INDEX idx_ingest_runs_status ON legal.ingest_runs USING btree (status) WHERE (status = ANY (ARRAY['running'::text, 'error'::text]));
 
 
 --
--- Name: idx_email_messages_imap_uid; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_legalexp_case; Type: INDEX; Schema: legal; Owner: -
 --
 
-CREATE UNIQUE INDEX idx_email_messages_imap_uid ON public.email_messages USING btree (imap_uid) WHERE (imap_uid IS NOT NULL);
+CREATE INDEX idx_legalexp_case ON legal.expense_intake USING btree (case_slug);
 
 
 --
--- Name: idx_email_messages_inquirer; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_uploads_case; Type: INDEX; Schema: legal; Owner: -
 --
 
-CREATE INDEX idx_email_messages_inquirer ON public.email_messages USING btree (inquirer_id, received_at DESC);
+CREATE INDEX idx_uploads_case ON legal.uploads USING btree (case_id);
 
 
 --
--- Name: idx_email_messages_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_uploads_filing; Type: INDEX; Schema: legal; Owner: -
 --
 
-CREATE INDEX idx_email_messages_status ON public.email_messages USING btree (approval_status, received_at DESC);
+CREATE INDEX idx_uploads_filing ON legal.uploads USING btree (filing_id);
 
 
 --
--- Name: idx_email_messages_thread; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_vault_documents_case_slug; Type: INDEX; Schema: legal; Owner: -
 --
 
-CREATE INDEX idx_email_messages_thread ON public.email_messages USING btree (in_reply_to_message_id);
+CREATE INDEX idx_vault_documents_case_slug ON legal.vault_documents USING btree (case_slug);
 
 
 --
--- Name: idx_llm_tc_judge_decision; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_vault_documents_created_at; Type: INDEX; Schema: legal; Owner: -
 --
 
-CREATE INDEX idx_llm_tc_judge_decision ON public.llm_training_captures USING btree (judge_decision);
+CREATE INDEX idx_vault_documents_created_at ON legal.vault_documents USING btree (created_at DESC);
 
 
 --
--- Name: idx_llm_tc_served_by_endpoint; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_vault_documents_file_hash; Type: INDEX; Schema: legal; Owner: -
 --
 
-CREATE INDEX idx_llm_tc_served_by_endpoint ON public.llm_training_captures USING btree (served_by_endpoint);
+CREATE INDEX idx_vault_documents_file_hash ON legal.vault_documents USING btree (file_hash);
 
 
 --
--- Name: idx_llm_tc_task_type; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_vault_documents_status; Type: INDEX; Schema: legal; Owner: -
 --
 
-CREATE INDEX idx_llm_tc_task_type ON public.llm_training_captures USING btree (task_type);
+CREATE INDEX idx_vault_documents_status ON legal.vault_documents USING btree (processing_status) WHERE (processing_status = ANY (ARRAY['pending'::text, 'processing'::text, 'vectorizing'::text, 'error'::text, 'failed'::text, 'ocr_failed'::text]));
 
 
 --
--- Name: idx_llm_tc_teacher_model; Type: INDEX; Schema: public; Owner: -
+-- Name: ix_legal_email_intake_case; Type: INDEX; Schema: legal; Owner: -
 --
 
-CREATE INDEX idx_llm_tc_teacher_model ON public.llm_training_captures USING btree (teacher_model);
+CREATE INDEX ix_legal_email_intake_case ON legal.email_intake_queue USING btree (case_slug);
 
 
 --
--- Name: idx_llm_training_captures_eval_holdout; Type: INDEX; Schema: public; Owner: -
+-- Name: ix_legal_email_intake_rcvd; Type: INDEX; Schema: legal; Owner: -
 --
 
-CREATE INDEX idx_llm_training_captures_eval_holdout ON public.llm_training_captures USING btree (eval_holdout);
+CREATE INDEX ix_legal_email_intake_rcvd ON legal.email_intake_queue USING btree (received_at DESC);
 
 
 --
--- Name: idx_rc_judge_decision; Type: INDEX; Schema: public; Owner: -
+-- Name: ix_legal_email_intake_status; Type: INDEX; Schema: legal; Owner: -
 --
 
-CREATE INDEX idx_rc_judge_decision ON public.restricted_captures USING btree (judge_decision);
+CREATE INDEX ix_legal_email_intake_status ON legal.email_intake_queue USING btree (intake_status);
 
 
 --
--- Name: idx_rc_served_by_endpoint; Type: INDEX; Schema: public; Owner: -
+-- Name: uq_deadlines_content_hash; Type: INDEX; Schema: legal; Owner: -
 --
 
-CREATE INDEX idx_rc_served_by_endpoint ON public.restricted_captures USING btree (served_by_endpoint);
+CREATE UNIQUE INDEX uq_deadlines_content_hash ON legal.deadlines USING btree (content_hash) WHERE (content_hash IS NOT NULL);
 
 
 --
--- Name: idx_rc_task_type; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_attorney_score; Type: INDEX; Schema: legal_cmd; Owner: -
 --
 
-CREATE INDEX idx_rc_task_type ON public.restricted_captures USING btree (task_type);
+CREATE INDEX idx_attorney_score ON legal_cmd.attorney_scoring USING btree (sota_match_score DESC);
 
 
 --
--- Name: idx_rc_teacher_model; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_attorneys_ai_score; Type: INDEX; Schema: legal_cmd; Owner: -
 --
 
-CREATE INDEX idx_rc_teacher_model ON public.restricted_captures USING btree (teacher_model);
+CREATE INDEX idx_attorneys_ai_score ON legal_cmd.attorneys USING btree (ai_score DESC);
 
 
 --
--- Name: idx_restricted_captures_created_at; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_attorneys_outreach; Type: INDEX; Schema: legal_cmd; Owner: -
 --
 
-CREATE INDEX idx_restricted_captures_created_at ON public.restricted_captures USING btree (created_at);
+CREATE INDEX idx_attorneys_outreach ON legal_cmd.attorneys USING btree (outreach_status);
 
 
 --
--- Name: idx_restricted_captures_eval_holdout; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_attorneys_practice; Type: INDEX; Schema: legal_cmd; Owner: -
 --
 
-CREATE INDEX idx_restricted_captures_eval_holdout ON public.restricted_captures USING btree (eval_holdout);
+CREATE INDEX idx_attorneys_practice ON legal_cmd.attorneys USING gin (practice_areas);
 
 
 --
--- Name: idx_restricted_captures_source_persona; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_attorneys_specialty; Type: INDEX; Schema: legal_cmd; Owner: -
 --
 
-CREATE INDEX idx_restricted_captures_source_persona ON public.restricted_captures USING btree (source_persona);
+CREATE INDEX idx_attorneys_specialty ON legal_cmd.attorneys USING btree (specialty);
 
 
 --
--- Name: ix_accounts_code; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_attorneys_status; Type: INDEX; Schema: legal_cmd; Owner: -
 --
 
-CREATE INDEX ix_accounts_code ON public.accounts USING btree (code);
+CREATE INDEX idx_attorneys_status ON legal_cmd.attorneys USING btree (status);
 
 
 --
--- Name: ix_activities_activity_slug; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_delib_case; Type: INDEX; Schema: legal_cmd; Owner: -
 --
 
-CREATE UNIQUE INDEX ix_activities_activity_slug ON public.activities USING btree (activity_slug);
+CREATE INDEX idx_delib_case ON legal_cmd.deliberation_events USING btree (case_slug, "timestamp" DESC);
 
 
 --
--- Name: ix_activities_slug; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_delib_sig; Type: INDEX; Schema: legal_cmd; Owner: -
 --
 
-CREATE UNIQUE INDEX ix_activities_slug ON public.activities USING btree (slug);
+CREATE INDEX idx_delib_sig ON legal_cmd.deliberation_events USING btree (sha256_signature);
 
 
 --
--- Name: ix_agent_queue_guest_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_documents_matter; Type: INDEX; Schema: legal_cmd; Owner: -
 --
 
-CREATE INDEX ix_agent_queue_guest_id ON public.agent_queue USING btree (guest_id);
+CREATE INDEX idx_documents_matter ON legal_cmd.documents USING btree (matter_id);
 
 
 --
--- Name: ix_agent_queue_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_documents_type; Type: INDEX; Schema: legal_cmd; Owner: -
 --
 
-CREATE INDEX ix_agent_queue_property_id ON public.agent_queue USING btree (property_id);
+CREATE INDEX idx_documents_type ON legal_cmd.documents USING btree (doc_type);
 
 
 --
--- Name: ix_agent_queue_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_matters_attorney; Type: INDEX; Schema: legal_cmd; Owner: -
 --
 
-CREATE INDEX ix_agent_queue_status ON public.agent_queue USING btree (status);
+CREATE INDEX idx_matters_attorney ON legal_cmd.matters USING btree (attorney_id);
 
 
 --
--- Name: ix_agent_queue_twilio_sid; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_matters_category; Type: INDEX; Schema: legal_cmd; Owner: -
 --
 
-CREATE INDEX ix_agent_queue_twilio_sid ON public.agent_queue USING btree (twilio_sid);
+CREATE INDEX idx_matters_category ON legal_cmd.matters USING btree (category);
 
 
 --
--- Name: ix_agent_registry_is_active; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_matters_priority; Type: INDEX; Schema: legal_cmd; Owner: -
 --
 
-CREATE INDEX ix_agent_registry_is_active ON public.agent_registry USING btree (is_active);
+CREATE INDEX idx_matters_priority ON legal_cmd.matters USING btree (priority);
 
 
 --
--- Name: ix_agent_registry_name; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_matters_status; Type: INDEX; Schema: legal_cmd; Owner: -
 --
 
-CREATE INDEX ix_agent_registry_name ON public.agent_registry USING btree (name);
+CREATE INDEX idx_matters_status ON legal_cmd.matters USING btree (status);
 
 
 --
--- Name: ix_agent_registry_role; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_meetings_attorney; Type: INDEX; Schema: legal_cmd; Owner: -
 --
 
-CREATE INDEX ix_agent_registry_role ON public.agent_registry USING btree (role);
+CREATE INDEX idx_meetings_attorney ON legal_cmd.meetings USING btree (attorney_id);
 
 
 --
--- Name: ix_agent_response_queue_created_at; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_meetings_date; Type: INDEX; Schema: legal_cmd; Owner: -
 --
 
-CREATE INDEX ix_agent_response_queue_created_at ON public.agent_response_queue USING btree (created_at);
+CREATE INDEX idx_meetings_date ON legal_cmd.meetings USING btree (meeting_date);
 
 
 --
--- Name: ix_agent_response_queue_guest_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_meetings_matter; Type: INDEX; Schema: legal_cmd; Owner: -
 --
 
-CREATE INDEX ix_agent_response_queue_guest_id ON public.agent_response_queue USING btree (guest_id);
+CREATE INDEX idx_meetings_matter ON legal_cmd.meetings USING btree (matter_id);
 
 
 --
--- Name: ix_agent_response_queue_intent; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_timeline_created; Type: INDEX; Schema: legal_cmd; Owner: -
 --
 
-CREATE INDEX ix_agent_response_queue_intent ON public.agent_response_queue USING btree (intent);
+CREATE INDEX idx_timeline_created ON legal_cmd.timeline USING btree (created_at);
 
 
 --
--- Name: ix_agent_response_queue_message_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_timeline_matter; Type: INDEX; Schema: legal_cmd; Owner: -
 --
 
-CREATE INDEX ix_agent_response_queue_message_id ON public.agent_response_queue USING btree (message_id);
+CREATE INDEX idx_timeline_matter ON legal_cmd.timeline USING btree (matter_id);
 
 
 --
--- Name: ix_agent_response_queue_reservation_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_timeline_type; Type: INDEX; Schema: legal_cmd; Owner: -
 --
 
-CREATE INDEX ix_agent_response_queue_reservation_id ON public.agent_response_queue USING btree (reservation_id);
+CREATE INDEX idx_timeline_type ON legal_cmd.timeline USING btree (entry_type);
 
 
 --
--- Name: ix_agent_response_queue_status; Type: INDEX; Schema: public; Owner: -
+-- Name: alpha_gin_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_agent_response_queue_status ON public.agent_response_queue USING btree (status);
+CREATE INDEX alpha_gin_idx ON public.vault_alpha_state_law USING gin (text_search);
 
 
 --
--- Name: ix_agent_runs_agent_status_started; Type: INDEX; Schema: public; Owner: -
+-- Name: alpha_meta_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_agent_runs_agent_status_started ON public.agent_runs USING btree (agent_id, status, started_at);
+CREATE INDEX alpha_meta_idx ON public.vault_alpha_state_law USING gin (metadata);
 
 
 --
--- Name: ix_agent_runs_status; Type: INDEX; Schema: public; Owner: -
+-- Name: alpha_state_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_agent_runs_status ON public.agent_runs USING btree (status);
+CREATE INDEX alpha_state_idx ON public.vault_alpha_state_law USING gin (text_search);
 
 
 --
--- Name: ix_agent_runs_trigger_source; Type: INDEX; Schema: public; Owner: -
+-- Name: beta_federal_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_agent_runs_trigger_source ON public.agent_runs USING btree (trigger_source);
+CREATE INDEX beta_federal_idx ON public.vault_beta_federal_law USING gin (text_search);
 
 
 --
--- Name: ix_agent_runs_trigger_status_started; Type: INDEX; Schema: public; Owner: -
+-- Name: beta_gin_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_agent_runs_trigger_status_started ON public.agent_runs USING btree (trigger_source, status, started_at);
+CREATE INDEX beta_gin_idx ON public.vault_beta_federal_law USING gin (text_search);
 
 
 --
--- Name: ix_agreement_templates_agreement_type; Type: INDEX; Schema: public; Owner: -
+-- Name: beta_meta_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_agreement_templates_agreement_type ON public.agreement_templates USING btree (agreement_type);
+CREATE INDEX beta_meta_idx ON public.vault_beta_federal_law USING gin (metadata);
 
 
 --
--- Name: ix_agreement_templates_is_active; Type: INDEX; Schema: public; Owner: -
+-- Name: council_log_session_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_agreement_templates_is_active ON public.agreement_templates USING btree (is_active);
+CREATE INDEX council_log_session_idx ON public.godhead_query_log USING btree (session_id);
 
 
 --
--- Name: ix_analytics_events_created_at; Type: INDEX; Schema: public; Owner: -
+-- Name: council_log_time_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_analytics_events_created_at ON public.analytics_events USING btree (created_at);
+CREATE INDEX council_log_time_idx ON public.godhead_query_log USING btree (queried_at DESC);
 
 
 --
--- Name: ix_analytics_events_event_type; Type: INDEX; Schema: public; Owner: -
+-- Name: gamma_date_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_analytics_events_event_type ON public.analytics_events USING btree (event_type);
+CREATE INDEX gamma_date_idx ON public.vault_gamma_evidence USING btree (date_authored);
 
 
 --
--- Name: ix_analytics_events_guest_id; Type: INDEX; Schema: public; Owner: -
+-- Name: gamma_hash_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_analytics_events_guest_id ON public.analytics_events USING btree (guest_id);
+CREATE INDEX gamma_hash_idx ON public.vault_gamma_evidence USING btree (file_hash);
 
 
 --
--- Name: ix_analytics_events_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: gamma_metadata_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_analytics_events_property_id ON public.analytics_events USING btree (property_id);
+CREATE INDEX gamma_metadata_idx ON public.vault_gamma_evidence USING gin (metadata);
 
 
 --
--- Name: ix_analytics_events_reservation_id; Type: INDEX; Schema: public; Owner: -
+-- Name: gamma_text_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_analytics_events_reservation_id ON public.analytics_events USING btree (reservation_id);
+CREATE INDEX gamma_text_idx ON public.vault_gamma_evidence USING gin (text_search);
 
 
 --
--- Name: ix_async_job_runs_arq_job_id; Type: INDEX; Schema: public; Owner: -
+-- Name: gamma_type_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX ix_async_job_runs_arq_job_id ON public.async_job_runs USING btree (arq_job_id);
+CREATE INDEX gamma_type_idx ON public.vault_gamma_evidence USING btree (doc_type);
 
 
 --
--- Name: ix_async_job_runs_job_name; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ab_agent; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_async_job_runs_job_name ON public.async_job_runs USING btree (job_name);
+CREATE INDEX idx_ab_agent ON public.ab_tests USING btree (agent_id);
 
 
 --
--- Name: ix_async_job_runs_job_status_created; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ab_status; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_async_job_runs_job_status_created ON public.async_job_runs USING btree (job_name, status, created_at);
+CREATE INDEX idx_ab_status ON public.ab_tests USING btree (status);
 
 
 --
--- Name: ix_async_job_runs_queue_name; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_abo_created; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_async_job_runs_queue_name ON public.async_job_runs USING btree (queue_name);
+CREATE INDEX idx_abo_created ON public.ab_test_observations USING btree (created_at);
 
 
 --
--- Name: ix_async_job_runs_request_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_abo_test; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_async_job_runs_request_id ON public.async_job_runs USING btree (request_id);
+CREATE INDEX idx_abo_test ON public.ab_test_observations USING btree (test_id);
 
 
 --
--- Name: ix_async_job_runs_requested_by; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_abo_variant; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_async_job_runs_requested_by ON public.async_job_runs USING btree (requested_by);
+CREATE INDEX idx_abo_variant ON public.ab_test_observations USING btree (variant);
 
 
 --
--- Name: ix_async_job_runs_requested_by_created; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_acct_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_async_job_runs_requested_by_created ON public.async_job_runs USING btree (requested_by, created_at);
+CREATE INDEX idx_acct_code ON public.accounts USING btree (code);
 
 
 --
--- Name: ix_async_job_runs_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_acct_property; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_async_job_runs_status ON public.async_job_runs USING btree (status);
+CREATE INDEX idx_acct_property ON public.accounts USING btree (property_id);
 
 
 --
--- Name: ix_async_job_runs_status_created; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_acct_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_async_job_runs_status_created ON public.async_job_runs USING btree (status, created_at);
+CREATE INDEX idx_acct_type ON public.accounts USING btree (account_type);
 
 
 --
--- Name: ix_async_job_runs_tenant_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ad_doc_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_async_job_runs_tenant_id ON public.async_job_runs USING btree (tenant_id);
+CREATE INDEX idx_ad_doc_type ON public.asset_docs USING btree (doc_type);
 
 
 --
--- Name: ix_blocked_days_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ad_property_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_blocked_days_property_id ON public.blocked_days USING btree (property_id);
+CREATE INDEX idx_ad_property_id ON public.asset_docs USING btree (property_id);
 
 
 --
--- Name: ix_blogs_slug; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ad_property_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX ix_blogs_slug ON public.blogs USING btree (slug);
+CREATE INDEX idx_ad_property_name ON public.asset_docs USING btree (property_name);
 
 
 --
--- Name: ix_channel_mappings_channel; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_af_entry; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_channel_mappings_channel ON public.channel_mappings USING btree (channel);
+CREATE INDEX idx_af_entry ON public.anomaly_flags USING btree (journal_entry_id);
 
 
 --
--- Name: ix_channel_mappings_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_af_reviewed; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_channel_mappings_property_id ON public.channel_mappings USING btree (property_id);
+CREATE INDEX idx_af_reviewed ON public.anomaly_flags USING btree (reviewed);
 
 
 --
--- Name: ix_citation_records_directory_domain; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_af_severity; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX ix_citation_records_directory_domain ON public.citation_records USING btree (directory_domain);
+CREATE INDEX idx_af_severity ON public.anomaly_flags USING btree (severity);
 
 
 --
--- Name: ix_citation_records_last_audited_at; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_af_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_citation_records_last_audited_at ON public.citation_records USING btree (last_audited_at);
+CREATE INDEX idx_af_type ON public.anomaly_flags USING btree (flag_type);
 
 
 --
--- Name: ix_citation_records_match_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_agent_memory_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_citation_records_match_status ON public.citation_records USING btree (match_status);
+CREATE INDEX idx_agent_memory_created_at ON public.agent_memory USING btree (created_at);
 
 
 --
--- Name: ix_cleaners_active; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_agent_telemetry_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_cleaners_active ON public.cleaners USING btree (active);
+CREATE INDEX idx_agent_telemetry_created_at ON public.agent_telemetry USING btree (created_at);
 
 
 --
--- Name: ix_competitor_listings_dedupe_hash; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_agent_telemetry_success; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_competitor_listings_dedupe_hash ON public.competitor_listings USING btree (dedupe_hash);
+CREATE INDEX idx_agent_telemetry_success ON public.agent_telemetry USING btree (error_class) WHERE (error_class IS NULL);
 
 
 --
--- Name: ix_competitor_listings_last_observed; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_alq_agent; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_competitor_listings_last_observed ON public.competitor_listings USING btree (last_observed);
+CREATE INDEX idx_alq_agent ON public.active_learning_queue USING btree (agent_id);
 
 
 --
--- Name: ix_competitor_listings_platform; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_alq_status; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_competitor_listings_platform ON public.competitor_listings USING btree (platform);
+CREATE INDEX idx_alq_status ON public.active_learning_queue USING btree (status);
 
 
 --
--- Name: ix_competitor_listings_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_analytics_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_competitor_listings_property_id ON public.competitor_listings USING btree (property_id);
+CREATE INDEX idx_analytics_date ON public.message_analytics USING btree (date DESC);
 
 
 --
--- Name: ix_competitor_listings_property_platform_observed; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_analytics_property; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_competitor_listings_property_platform_observed ON public.competitor_listings USING btree (property_id, platform, last_observed);
+CREATE INDEX idx_analytics_property ON public.message_analytics USING btree (property_id);
 
 
 --
--- Name: ix_concierge_queue_guest_phone; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_apl_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_concierge_queue_guest_phone ON public.concierge_queue USING btree (guest_phone);
+CREATE UNIQUE INDEX idx_apl_date ON public.agent_performance_log USING btree (date);
 
 
 --
--- Name: ix_concierge_queue_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_arq_cabin; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_concierge_queue_property_id ON public.concierge_queue USING btree (property_id);
+CREATE INDEX idx_arq_cabin ON public.agent_response_queue USING btree (cabin_name);
 
 
 --
--- Name: ix_concierge_queue_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_arq_created; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_concierge_queue_status ON public.concierge_queue USING btree (status);
+CREATE INDEX idx_arq_created ON public.agent_response_queue USING btree (created_at DESC);
 
 
 --
--- Name: ix_concierge_queue_status_created; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_arq_status; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_concierge_queue_status_created ON public.concierge_queue USING btree (status, created_at);
+CREATE INDEX idx_arq_status ON public.agent_response_queue USING btree (status);
 
 
 --
--- Name: ix_crd_guest_channel_created; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_arq_urgency; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_crd_guest_channel_created ON public.concierge_recovery_dispatches USING btree (guest_id, channel, created_at);
+CREATE INDEX idx_arq_urgency ON public.agent_response_queue USING btree (urgency_level DESC);
 
 
 --
--- Name: ix_crd_session_fp; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_class_rules_active; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_crd_session_fp ON public.concierge_recovery_dispatches USING btree (session_fp);
+CREATE INDEX idx_class_rules_active ON public.email_classification_rules USING btree (division, is_active) WHERE (is_active = true);
 
 
 --
--- Name: ix_damage_claims_guest_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_council_votes_created; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_damage_claims_guest_id ON public.damage_claims USING btree (guest_id);
+CREATE INDEX idx_council_votes_created ON public.council_votes USING btree (created_at DESC);
 
 
 --
--- Name: ix_damage_claims_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_council_votes_resolved; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_damage_claims_property_id ON public.damage_claims USING btree (property_id);
+CREATE INDEX idx_council_votes_resolved ON public.council_votes USING btree (resolved_at) WHERE (resolved_at IS NOT NULL);
 
 
 --
--- Name: ix_damage_claims_reservation_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_deferred_writes_service; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_damage_claims_reservation_id ON public.damage_claims USING btree (reservation_id);
+CREATE INDEX idx_deferred_writes_service ON public.deferred_api_writes USING btree (service, method);
 
 
 --
--- Name: ix_deferred_api_writes_created_at; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_deferred_writes_status; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_deferred_api_writes_created_at ON public.deferred_api_writes USING btree (created_at);
+CREATE INDEX idx_deferred_writes_status ON public.deferred_api_writes USING btree (status, next_retry_at);
 
 
 --
--- Name: ix_deferred_api_writes_service; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_dlq_created; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_deferred_api_writes_service ON public.deferred_api_writes USING btree (service);
+CREATE INDEX idx_dlq_created ON public.ingestion_dlq USING btree (created_at DESC);
 
 
 --
--- Name: ix_deferred_api_writes_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_dlq_source; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_deferred_api_writes_status ON public.deferred_api_writes USING btree (status);
+CREATE INDEX idx_dlq_source ON public.ingestion_dlq USING btree (source, resolved);
 
 
 --
--- Name: ix_distillation_queue_source_intelligence_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_dlq_status_retry; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_distillation_queue_source_intelligence_id ON public.distillation_queue USING btree (source_intelligence_id);
+CREATE INDEX idx_dlq_status_retry ON public.email_dead_letter_queue USING btree (status, next_retry_at);
 
 
 --
--- Name: ix_distillation_queue_source_module; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_docket_matter; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_distillation_queue_source_module ON public.distillation_queue USING btree (source_module);
+CREATE INDEX idx_docket_matter ON public.legal_docket USING btree (matter_id);
 
 
 --
--- Name: ix_distillation_queue_source_ref; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_drift_endpoint; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_distillation_queue_source_ref ON public.distillation_queue USING btree (source_ref);
+CREATE INDEX idx_drift_endpoint ON public.schema_drift_log USING btree (endpoint, created_at DESC);
 
 
 --
--- Name: ix_distillation_queue_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_email_category; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_distillation_queue_status ON public.distillation_queue USING btree (status);
+CREATE INDEX idx_email_category ON public.email_archive USING btree (category);
 
 
 --
--- Name: ix_email_templates_name; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_email_division; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_email_templates_name ON public.email_templates USING btree (name);
+CREATE INDEX idx_email_division ON public.email_archive USING btree (division);
 
 
 --
--- Name: ix_email_templates_trigger_event; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_email_division_null; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_email_templates_trigger_event ON public.email_templates USING btree (trigger_event);
+CREATE INDEX idx_email_division_null ON public.email_archive USING btree (id) WHERE (division IS NULL);
 
 
 --
--- Name: ix_extra_orders_extra_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_email_ingested_from; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_extra_orders_extra_id ON public.extra_orders USING btree (extra_id);
+CREATE INDEX idx_email_ingested_from ON public.email_archive USING btree (ingested_from);
 
 
 --
--- Name: ix_extra_orders_reservation_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_email_message_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_extra_orders_reservation_id ON public.extra_orders USING btree (reservation_id);
+CREATE INDEX idx_email_message_id ON public.email_archive USING btree (message_id);
 
 
 --
--- Name: ix_extra_orders_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_email_mined; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_extra_orders_status ON public.extra_orders USING btree (status);
+CREATE INDEX idx_email_mined ON public.email_archive USING btree (is_mined);
 
 
 --
--- Name: ix_extras_is_available; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_email_to_addr; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_extras_is_available ON public.extras USING btree (is_available);
+CREATE INDEX idx_email_to_addr ON public.email_archive USING btree (to_addresses);
 
 
 --
--- Name: ix_fees_name; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_email_triage_precedents_embedding_hnsw; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX ix_fees_name ON public.fees USING btree (name);
+CREATE INDEX idx_email_triage_precedents_embedding_hnsw ON public.email_triage_precedents USING hnsw (embedding public.vector_cosine_ops) WITH (m='16', ef_construction='64');
 
 
 --
--- Name: ix_financial_approvals_reservation_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_email_ts; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_financial_approvals_reservation_id ON public.financial_approvals USING btree (reservation_id);
+CREATE INDEX idx_email_ts ON public.email_archive USING gin (ts);
 
 
 --
--- Name: ix_financial_approvals_resolution_strategy; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_escalation_pending; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_financial_approvals_resolution_strategy ON public.financial_approvals USING btree (resolution_strategy);
+CREATE INDEX idx_escalation_pending ON public.email_escalation_queue USING btree (status, priority) WHERE ((status)::text = 'pending'::text);
 
 
 --
--- Name: ix_financial_approvals_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_etp_division; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_financial_approvals_status ON public.financial_approvals USING btree (status);
+CREATE INDEX idx_etp_division ON public.email_triage_precedents USING btree (division);
 
 
 --
--- Name: ix_functional_nodes_canonical_path; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_etp_embedding; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX ix_functional_nodes_canonical_path ON public.functional_nodes USING btree (canonical_path);
+CREATE INDEX idx_etp_embedding ON public.email_triage_precedents USING hnsw (embedding public.vector_cosine_ops);
 
 
 --
--- Name: ix_functional_nodes_content_category; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_fin_res_dates; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_functional_nodes_content_category ON public.functional_nodes USING btree (content_category);
+CREATE INDEX idx_fin_res_dates ON public.fin_reservations USING btree (check_in, check_out);
 
 
 --
--- Name: ix_functional_nodes_crawl_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_fin_res_property; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_functional_nodes_crawl_status ON public.functional_nodes USING btree (crawl_status);
+CREATE INDEX idx_fin_res_property ON public.fin_reservations USING btree (property_id);
 
 
 --
--- Name: ix_functional_nodes_cutover_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_fin_res_status; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_functional_nodes_cutover_status ON public.functional_nodes USING btree (cutover_status);
+CREATE INDEX idx_fin_res_status ON public.fin_reservations USING btree (status);
 
 
 --
--- Name: ix_functional_nodes_functional_complexity; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_fin_snap_period; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_functional_nodes_functional_complexity ON public.functional_nodes USING btree (functional_complexity);
+CREATE INDEX idx_fin_snap_period ON public.fin_revenue_snapshots USING btree (period_start, period_end);
 
 
 --
--- Name: ix_functional_nodes_is_published; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_finance_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_functional_nodes_is_published ON public.functional_nodes USING btree (is_published);
+CREATE INDEX idx_finance_date ON public.finance_invoices USING btree (date);
 
 
 --
--- Name: ix_functional_nodes_legacy_node_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_finance_source_email; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_functional_nodes_legacy_node_id ON public.functional_nodes USING btree (legacy_node_id);
+CREATE INDEX idx_finance_source_email ON public.finance_invoices USING btree (source_email_id);
 
 
 --
--- Name: ix_functional_nodes_mirror_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_finance_vendor; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_functional_nodes_mirror_status ON public.functional_nodes USING btree (mirror_status);
+CREATE INDEX idx_finance_vendor ON public.finance_invoices USING btree (vendor);
 
 
 --
--- Name: ix_functional_nodes_node_type; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_gl_business; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_functional_nodes_node_type ON public.functional_nodes USING btree (node_type);
+CREATE INDEX idx_gl_business ON public.general_ledger USING btree (business);
 
 
 --
--- Name: ix_functional_nodes_priority_tier; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_gl_cabin; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_functional_nodes_priority_tier ON public.functional_nodes USING btree (priority_tier);
+CREATE INDEX idx_gl_cabin ON public.general_ledger USING btree (cabin);
 
 
 --
--- Name: ix_functional_nodes_source_path; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_gl_category; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX ix_functional_nodes_source_path ON public.functional_nodes USING btree (source_path);
+CREATE INDEX idx_gl_category ON public.general_ledger USING btree (category);
 
 
 --
--- Name: ix_guest_activities_activity_type; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_gl_checkin; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guest_activities_activity_type ON public.guest_activities USING btree (activity_type);
+CREATE INDEX idx_gl_checkin ON public.guest_leads USING btree (check_in);
 
 
 --
--- Name: ix_guest_activities_category; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_gl_doc_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guest_activities_category ON public.guest_activities USING btree (category);
+CREATE INDEX idx_gl_doc_type ON public.general_ledger USING btree (doc_type);
 
 
 --
--- Name: ix_guest_activities_created_at; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_gl_email; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guest_activities_created_at ON public.guest_activities USING btree (created_at);
+CREATE INDEX idx_gl_email ON public.guest_leads USING btree (source_email_id);
 
 
 --
--- Name: ix_guest_activities_guest_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_gl_event; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guest_activities_guest_id ON public.guest_activities USING btree (guest_id);
+CREATE INDEX idx_gl_event ON public.guest_leads USING btree (event_type);
 
 
 --
--- Name: ix_guest_quotes_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_gl_status; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guest_quotes_property_id ON public.guest_quotes USING btree (property_id);
+CREATE INDEX idx_gl_status ON public.guest_leads USING btree (status);
 
 
 --
--- Name: ix_guest_quotes_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_gl_tax_year; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guest_quotes_status ON public.guest_quotes USING btree (status);
+CREATE INDEX idx_gl_tax_year ON public.general_ledger USING btree (tax_year);
 
 
 --
--- Name: ix_guest_quotes_status_created; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_guest_email; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guest_quotes_status_created ON public.guest_quotes USING btree (status, created_at);
+CREATE INDEX idx_guest_email ON public.guest_profiles USING btree (email);
 
 
 --
--- Name: ix_guest_quotes_target_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_guest_last_contact; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guest_quotes_target_property_id ON public.guest_quotes USING btree (target_property_id);
+CREATE INDEX idx_guest_last_contact ON public.guest_profiles USING btree (last_contact DESC);
 
 
 --
--- Name: ix_guest_reviews_direction; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_guest_phone; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guest_reviews_direction ON public.guest_reviews USING btree (direction);
+CREATE INDEX idx_guest_phone ON public.guest_profiles USING btree (phone_number);
 
 
 --
--- Name: ix_guest_reviews_guest_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_guest_vip; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guest_reviews_guest_id ON public.guest_reviews USING btree (guest_id);
+CREATE INDEX idx_guest_vip ON public.guest_profiles USING btree (vip_guest) WHERE (vip_guest = true);
 
 
 --
--- Name: ix_guest_reviews_is_published; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_je_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guest_reviews_is_published ON public.guest_reviews USING btree (is_published);
+CREATE INDEX idx_je_date ON public.journal_entries USING btree (entry_date);
 
 
 --
--- Name: ix_guest_reviews_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_je_property; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guest_reviews_property_id ON public.guest_reviews USING btree (property_id);
+CREATE INDEX idx_je_property ON public.journal_entries USING btree (property_id);
 
 
 --
--- Name: ix_guest_reviews_reservation_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_je_ref; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guest_reviews_reservation_id ON public.guest_reviews USING btree (reservation_id);
+CREATE INDEX idx_je_ref ON public.journal_entries USING btree (reference_id);
 
 
 --
--- Name: ix_guest_surveys_guest_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_je_ref_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guest_surveys_guest_id ON public.guest_surveys USING btree (guest_id);
+CREATE INDEX idx_je_ref_type ON public.journal_entries USING btree (reference_type);
 
 
 --
--- Name: ix_guest_surveys_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_je_source; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guest_surveys_property_id ON public.guest_surveys USING btree (property_id);
+CREATE INDEX idx_je_source ON public.journal_entries USING btree (source_system);
 
 
 --
--- Name: ix_guest_surveys_reservation_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_je_void; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guest_surveys_reservation_id ON public.guest_surveys USING btree (reservation_id);
+CREATE INDEX idx_je_void ON public.journal_entries USING btree (is_void);
 
 
 --
--- Name: ix_guest_surveys_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_jli_account; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guest_surveys_status ON public.guest_surveys USING btree (status);
+CREATE INDEX idx_jli_account ON public.journal_line_items USING btree (account_id);
 
 
 --
--- Name: ix_guest_surveys_survey_type; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_jli_entry; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guest_surveys_survey_type ON public.guest_surveys USING btree (survey_type);
+CREATE INDEX idx_jli_entry ON public.journal_line_items USING btree (journal_entry_id);
 
 
 --
--- Name: ix_guest_surveys_template_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_lj_agent; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guest_surveys_template_id ON public.guest_surveys USING btree (template_id);
+CREATE INDEX idx_lj_agent ON public.learning_judgments USING btree (agent_id);
 
 
 --
--- Name: ix_guest_verifications_guest_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_lj_created; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guest_verifications_guest_id ON public.guest_verifications USING btree (guest_id);
+CREATE INDEX idx_lj_created ON public.learning_judgments USING btree (created_at);
 
 
 --
--- Name: ix_guest_verifications_reservation_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_lj_metric; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guest_verifications_reservation_id ON public.guest_verifications USING btree (reservation_id);
+CREATE INDEX idx_lj_metric ON public.learning_judgments USING btree (metric_name);
 
 
 --
--- Name: ix_guest_verifications_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_lj_passed; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guest_verifications_status ON public.guest_verifications USING btree (status);
+CREATE INDEX idx_lj_passed ON public.learning_judgments USING btree (passed);
 
 
 --
--- Name: ix_guestbook_guides_guide_type; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_lo_agent; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guestbook_guides_guide_type ON public.guestbook_guides USING btree (guide_type);
+CREATE INDEX idx_lo_agent ON public.learning_optimizations USING btree (agent_id);
 
 
 --
--- Name: ix_guestbook_guides_is_visible; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_lo_created; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guestbook_guides_is_visible ON public.guestbook_guides USING btree (is_visible);
+CREATE INDEX idx_lo_created ON public.learning_optimizations USING btree (created_at);
 
 
 --
--- Name: ix_guestbook_guides_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_lo_method; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guestbook_guides_property_id ON public.guestbook_guides USING btree (property_id);
+CREATE INDEX idx_lo_method ON public.learning_optimizations USING btree (method);
 
 
 --
--- Name: ix_guests_email; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_market_action; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guests_email ON public.guests USING btree (email);
+CREATE INDEX idx_market_action ON public.market_signals USING btree (action);
 
 
 --
--- Name: ix_guests_guest_source; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_market_source_email; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guests_guest_source ON public.guests USING btree (guest_source);
+CREATE INDEX idx_market_source_email ON public.market_signals USING btree (source_email_id);
 
 
 --
--- Name: ix_guests_is_blacklisted; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_market_ticker; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guests_is_blacklisted ON public.guests USING btree (is_blacklisted);
+CREATE INDEX idx_market_ticker ON public.market_signals USING btree (ticker);
 
 
 --
--- Name: ix_guests_is_vip; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_matters_client; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guests_is_vip ON public.guests USING btree (is_vip);
+CREATE INDEX idx_matters_client ON public.legal_matters USING btree (client_id);
 
 
 --
--- Name: ix_guests_loyalty_tier; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_matters_status; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guests_loyalty_tier ON public.guests USING btree (loyalty_tier);
+CREATE INDEX idx_matters_status ON public.legal_matters USING btree (status);
 
 
 --
--- Name: ix_guests_phone; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_message_body_fts; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX ix_guests_phone ON public.guests USING btree (phone);
+CREATE INDEX idx_message_body_fts ON public.message_archive USING gin (to_tsvector('english'::regconfig, message_body));
 
 
 --
--- Name: ix_guests_verification_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_message_direction; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_guests_verification_status ON public.guests USING btree (verification_status);
+CREATE INDEX idx_message_direction ON public.message_archive USING btree (direction);
 
 
 --
--- Name: ix_housekeeping_tasks_cleaner; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_message_external_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_housekeeping_tasks_cleaner ON public.housekeeping_tasks USING btree (assigned_cleaner_id);
+CREATE INDEX idx_message_external_id ON public.message_archive USING btree (external_id);
 
 
 --
--- Name: ix_housekeeping_tasks_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_message_intent; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_housekeeping_tasks_property_id ON public.housekeeping_tasks USING btree (property_id);
+CREATE INDEX idx_message_intent ON public.message_archive USING btree (intent);
 
 
 --
--- Name: ix_housekeeping_tasks_reservation_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_message_phone; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_housekeeping_tasks_reservation_id ON public.housekeeping_tasks USING btree (reservation_id);
+CREATE INDEX idx_message_phone ON public.message_archive USING btree (phone_number);
 
 
 --
--- Name: ix_housekeeping_tasks_scheduled_date; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_message_property; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_housekeeping_tasks_scheduled_date ON public.housekeeping_tasks USING btree (scheduled_date);
+CREATE INDEX idx_message_property ON public.message_archive USING btree (property_id);
 
 
 --
--- Name: ix_housekeeping_tasks_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_message_sent_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_housekeeping_tasks_status ON public.housekeeping_tasks USING btree (status);
+CREATE INDEX idx_message_sent_at ON public.message_archive USING btree (sent_at DESC);
 
 
 --
--- Name: ix_hunter_queue_guest_email; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_message_source; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_hunter_queue_guest_email ON public.hunter_queue USING btree (guest_email);
+CREATE INDEX idx_message_source ON public.message_archive USING btree (source);
 
 
 --
--- Name: ix_hunter_queue_guest_phone; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_message_status; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_hunter_queue_guest_phone ON public.hunter_queue USING btree (guest_phone);
+CREATE INDEX idx_message_status ON public.message_archive USING btree (status);
 
 
 --
--- Name: ix_hunter_queue_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_message_training; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_hunter_queue_property_id ON public.hunter_queue USING btree (property_id);
+CREATE INDEX idx_message_training ON public.message_archive USING btree (used_for_training) WHERE (used_for_training = true);
 
 
 --
--- Name: ix_hunter_queue_reservation_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ml_cabin; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_hunter_queue_reservation_id ON public.hunter_queue USING btree (reservation_id);
+CREATE INDEX idx_ml_cabin ON public.maintenance_log USING btree (cabin_name);
 
 
 --
--- Name: ix_hunter_queue_session_fp; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ml_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX ix_hunter_queue_session_fp ON public.hunter_queue USING btree (session_fp);
+CREATE INDEX idx_ml_date ON public.maintenance_log USING btree (generated_at);
 
 
 --
--- Name: ix_hunter_queue_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ml_room; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_hunter_queue_status ON public.hunter_queue USING btree (status);
+CREATE INDEX idx_ml_room ON public.maintenance_log USING btree (room_type);
 
 
 --
--- Name: ix_hunter_queue_status_created; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ml_run; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_hunter_queue_status_created ON public.hunter_queue USING btree (status, created_at);
+CREATE INDEX idx_ml_run ON public.maintenance_log USING btree (run_id);
 
 
 --
--- Name: ix_hunter_recovery_ops_cart_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ml_verdict; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_hunter_recovery_ops_cart_id ON public.hunter_recovery_ops USING btree (cart_id);
+CREATE INDEX idx_ml_verdict ON public.maintenance_log USING btree (verdict);
 
 
 --
--- Name: ix_hunter_recovery_ops_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_mt_created; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_hunter_recovery_ops_status ON public.hunter_recovery_ops USING btree (status);
+CREATE INDEX idx_mt_created ON public.model_telemetry USING btree (created_at);
 
 
 --
--- Name: ix_hunter_recovery_ops_status_created; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_mt_model; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_hunter_recovery_ops_status_created ON public.hunter_recovery_ops USING btree (status, created_at);
+CREATE INDEX idx_mt_model ON public.model_telemetry USING btree (model_name);
 
 
 --
--- Name: ix_intelligence_ledger_category; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_mt_node; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_intelligence_ledger_category ON public.intelligence_ledger USING btree (category);
+CREATE INDEX idx_mt_node ON public.model_telemetry USING btree (node);
 
 
 --
--- Name: ix_intelligence_ledger_category_discovered; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_mt_op; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_intelligence_ledger_category_discovered ON public.intelligence_ledger USING btree (category, discovered_at);
+CREATE INDEX idx_mt_op ON public.model_telemetry USING btree (operation);
 
 
 --
--- Name: ix_intelligence_ledger_dedupe_hash; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_mt_success; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_intelligence_ledger_dedupe_hash ON public.intelligence_ledger USING btree (dedupe_hash);
+CREATE INDEX idx_mt_success ON public.model_telemetry USING btree (success);
 
 
 --
--- Name: ix_intelligence_ledger_discovered_at; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_nas_vault_case_number; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_intelligence_ledger_discovered_at ON public.intelligence_ledger USING btree (discovered_at);
+CREATE INDEX idx_nas_vault_case_number ON public.nas_legal_vault USING btree (((metadata ->> 'case_number'::text)));
 
 
 --
--- Name: ix_intelligence_ledger_locality; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_nas_vault_deadline; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_intelligence_ledger_locality ON public.intelligence_ledger USING btree (locality);
+CREATE INDEX idx_nas_vault_deadline ON public.nas_legal_vault USING btree (((metadata ->> 'next_deadline'::text)));
 
 
 --
--- Name: ix_intelligence_ledger_market; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_nas_vault_doc_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_intelligence_ledger_market ON public.intelligence_ledger USING btree (market);
+CREATE INDEX idx_nas_vault_doc_type ON public.nas_legal_vault USING btree (((metadata ->> 'doc_type'::text)));
 
 
 --
--- Name: ix_intelligence_ledger_market_discovered; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_nas_vault_embedding; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_intelligence_ledger_market_discovered ON public.intelligence_ledger USING btree (market, discovered_at);
+CREATE INDEX idx_nas_vault_embedding ON public.nas_legal_vault USING hnsw (embedding public.vector_cosine_ops);
 
 
 --
--- Name: ix_intelligence_ledger_query_topic; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_nas_vault_priority; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_intelligence_ledger_query_topic ON public.intelligence_ledger USING btree (query_topic);
+CREATE INDEX idx_nas_vault_priority ON public.nas_legal_vault USING btree (((metadata ->> 'priority'::text)));
 
 
 --
--- Name: ix_intelligence_ledger_scout_run_key; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_nas_vault_source_file; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_intelligence_ledger_scout_run_key ON public.intelligence_ledger USING btree (scout_run_key);
+CREATE INDEX idx_nas_vault_source_file ON public.nas_legal_vault USING btree (source_file);
 
 
 --
--- Name: ix_journal_entries_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_nim_arm64_probe_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_journal_entries_property_id ON public.journal_entries USING btree (property_id);
+CREATE INDEX idx_nim_arm64_probe_date ON public.nim_arm64_probe_results USING btree (probe_date);
 
 
 --
--- Name: ix_journal_entries_reference; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_nim_arm64_probe_image; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_journal_entries_reference ON public.journal_entries USING btree (reference_type, reference_id);
+CREATE INDEX idx_nim_arm64_probe_image ON public.nim_arm64_probe_results USING btree (image_path);
 
 
 --
--- Name: ix_journal_line_items_journal_entry_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_notes_matter; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_journal_line_items_journal_entry_id ON public.journal_line_items USING btree (journal_entry_id);
+CREATE INDEX idx_notes_matter ON public.legal_matter_notes USING btree (matter_id);
 
 
 --
--- Name: ix_knowledge_base_entries_category; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ops_crew_role; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_knowledge_base_entries_category ON public.knowledge_base_entries USING btree (category);
+CREATE INDEX idx_ops_crew_role ON public.ops_crew USING btree (role);
 
 
 --
--- Name: ix_knowledge_base_entries_is_active; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ops_crew_status; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_knowledge_base_entries_is_active ON public.knowledge_base_entries USING btree (is_active);
+CREATE INDEX idx_ops_crew_status ON public.ops_crew USING btree (status);
 
 
 --
--- Name: ix_knowledge_base_entries_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ops_hist_guests_email; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_knowledge_base_entries_property_id ON public.knowledge_base_entries USING btree (property_id);
+CREATE INDEX idx_ops_hist_guests_email ON public.ops_historical_guests USING btree (email);
 
 
 --
--- Name: ix_leads_email; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ops_hist_guests_last_seen; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_leads_email ON public.leads USING btree (email);
+CREATE INDEX idx_ops_hist_guests_last_seen ON public.ops_historical_guests USING btree (last_seen);
 
 
 --
--- Name: ix_leads_source; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ops_hist_guests_phone; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_leads_source ON public.leads USING btree (source);
+CREATE INDEX idx_ops_hist_guests_phone ON public.ops_historical_guests USING btree (phone);
 
 
 --
--- Name: ix_leads_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ops_log_actor; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_leads_status ON public.leads USING btree (status);
+CREATE INDEX idx_ops_log_actor ON public.ops_log USING btree (actor);
 
 
 --
--- Name: ix_leads_streamline_lead_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ops_log_entity; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX ix_leads_streamline_lead_id ON public.leads USING btree (streamline_lead_id);
+CREATE INDEX idx_ops_log_entity ON public.ops_log USING btree (entity_type, entity_id);
 
 
 --
--- Name: ix_learned_rules_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ops_log_time; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_learned_rules_property_id ON public.learned_rules USING btree (property_id);
+CREATE INDEX idx_ops_log_time ON public.ops_log USING btree ("timestamp");
 
 
 --
--- Name: ix_learned_rules_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ops_prop_streamline; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_learned_rules_status ON public.learned_rules USING btree (status);
+CREATE INDEX idx_ops_prop_streamline ON public.ops_properties USING btree (streamline_id);
 
 
 --
--- Name: ix_legacy_pages_slug; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ops_props_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX ix_legacy_pages_slug ON public.legacy_pages USING btree (slug);
+CREATE INDEX idx_ops_props_name ON public.ops_properties USING btree (internal_name);
 
 
 --
--- Name: ix_legal_case_statements_case_slug; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ops_tasks_assignee; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_legal_case_statements_case_slug ON public.legal_case_statements USING btree (case_slug);
+CREATE INDEX idx_ops_tasks_assignee ON public.ops_tasks USING btree (assigned_to);
 
 
 --
--- Name: ix_legal_case_statements_entity_name; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ops_tasks_deadline; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_legal_case_statements_entity_name ON public.legal_case_statements USING btree (entity_name);
+CREATE INDEX idx_ops_tasks_deadline ON public.ops_tasks USING btree (deadline);
 
 
 --
--- Name: ix_legal_case_statements_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ops_tasks_priority; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_legal_case_statements_id ON public.legal_case_statements USING btree (id);
+CREATE INDEX idx_ops_tasks_priority ON public.ops_tasks USING btree (priority);
 
 
 --
--- Name: ix_legal_hive_mind_feedback_events_case_slug; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ops_tasks_property; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_legal_hive_mind_feedback_events_case_slug ON public.legal_hive_mind_feedback_events USING btree (case_slug);
+CREATE INDEX idx_ops_tasks_property ON public.ops_tasks USING btree (property_id);
 
 
 --
--- Name: ix_legal_hive_mind_feedback_events_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ops_tasks_status; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_legal_hive_mind_feedback_events_id ON public.legal_hive_mind_feedback_events USING btree (id);
+CREATE INDEX idx_ops_tasks_status ON public.ops_tasks USING btree (status);
 
 
 --
--- Name: ix_legal_hive_mind_feedback_events_module_type; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ops_tasks_turnover; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_legal_hive_mind_feedback_events_module_type ON public.legal_hive_mind_feedback_events USING btree (module_type);
+CREATE INDEX idx_ops_tasks_turnover ON public.ops_tasks USING btree (turnover_id);
 
 
 --
--- Name: ix_llm_training_captures_module; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ops_tasks_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_llm_training_captures_module ON public.llm_training_captures USING btree (source_module);
+CREATE INDEX idx_ops_tasks_type ON public.ops_tasks USING btree (type);
 
 
 --
--- Name: ix_llm_training_captures_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ops_turn_checkout; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_llm_training_captures_status ON public.llm_training_captures USING btree (status);
+CREATE INDEX idx_ops_turn_checkout ON public.ops_turnovers USING btree (checkout_time);
 
 
 --
--- Name: ix_management_splits_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ops_turn_property; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_management_splits_property_id ON public.management_splits USING btree (property_id);
+CREATE INDEX idx_ops_turn_property ON public.ops_turnovers USING btree (property_id);
 
 
 --
--- Name: ix_marketing_articles_category_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_ops_turn_status; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_marketing_articles_category_id ON public.marketing_articles USING btree (category_id);
+CREATE INDEX idx_ops_turn_status ON public.ops_turnovers USING btree (status);
 
 
 --
--- Name: ix_marketing_articles_published_date; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_overrides_active; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_marketing_articles_published_date ON public.marketing_articles USING btree (published_date);
+CREATE INDEX idx_overrides_active ON public.ops_overrides USING btree (active, entity_type);
 
 
 --
--- Name: ix_marketing_articles_slug; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_overrides_entity; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX ix_marketing_articles_slug ON public.marketing_articles USING btree (slug);
+CREATE INDEX idx_overrides_entity ON public.ops_overrides USING btree (entity_type, entity_id);
 
 
 --
--- Name: ix_message_queue_quote_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_pe_event_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_message_queue_quote_id ON public.message_queue USING btree (quote_id);
+CREATE INDEX idx_pe_event_type ON public.property_events USING btree (event_type);
 
 
 --
--- Name: ix_message_queue_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_pe_property_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_message_queue_status ON public.message_queue USING btree (status);
+CREATE INDEX idx_pe_property_id ON public.property_events USING btree (property_id);
 
 
 --
--- Name: ix_message_queue_template_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_property_ai_enabled; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_message_queue_template_id ON public.message_queue USING btree (template_id);
+CREATE INDEX idx_property_ai_enabled ON public.property_sms_config USING btree (ai_enabled);
 
 
 --
--- Name: ix_message_templates_category; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_property_phone; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_message_templates_category ON public.message_templates USING btree (category);
+CREATE INDEX idx_property_phone ON public.property_sms_config USING btree (assigned_phone_number);
 
 
 --
--- Name: ix_message_templates_is_active; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_provider_enabled; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_message_templates_is_active ON public.message_templates USING btree (is_active);
+CREATE INDEX idx_provider_enabled ON public.sms_providers USING btree (enabled, priority) WHERE (enabled = true);
 
 
 --
--- Name: ix_messages_created_at; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_quarantine_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_messages_created_at ON public.messages USING btree (created_at);
+CREATE INDEX idx_quarantine_at ON public.quarantine_inbox USING btree (quarantined_at);
 
 
 --
--- Name: ix_messages_direction; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_quarantine_sender; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_messages_direction ON public.messages USING btree (direction);
+CREATE INDEX idx_quarantine_sender ON public.quarantine_inbox USING btree (sender);
 
 
 --
--- Name: ix_messages_external_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_quarantine_status; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_messages_external_id ON public.messages USING btree (external_id);
+CREATE INDEX idx_quarantine_status ON public.email_quarantine USING btree (status) WHERE ((status)::text = 'quarantined'::text);
 
 
 --
--- Name: ix_messages_guest_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_queue_attribution; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_messages_guest_id ON public.messages USING btree (guest_id);
+CREATE INDEX idx_queue_attribution ON public.agent_response_queue USING btree (phone_number, intent) WHERE ((intent)::text = 'proactive_sales'::text);
 
 
 --
--- Name: ix_messages_intent; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_rag_section; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_messages_intent ON public.messages USING btree (intent);
+CREATE INDEX idx_rag_section ON public.ruebarue_area_guide USING btree (section);
 
 
 --
--- Name: ix_messages_phone_from; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_review_log_actor; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_messages_phone_from ON public.messages USING btree (phone_from);
+CREATE INDEX idx_review_log_actor ON public.email_intake_review_log USING btree (actor, created_at DESC);
 
 
 --
--- Name: ix_messages_reservation_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_review_log_email; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_messages_reservation_id ON public.messages USING btree (reservation_id);
+CREATE INDEX idx_review_log_email ON public.email_intake_review_log USING btree (email_id);
 
 
 --
--- Name: ix_messages_sentiment; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_review_log_esc; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_messages_sentiment ON public.messages USING btree (sentiment);
+CREATE INDEX idx_review_log_esc ON public.email_intake_review_log USING btree (escalation_id);
 
 
 --
--- Name: ix_obp_owner_period; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_rkb_category; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_obp_owner_period ON public.owner_balance_periods USING btree (owner_payout_account_id, period_start);
+CREATE INDEX idx_rkb_category ON public.ruebarue_knowledge_base USING btree (category);
 
 
 --
--- Name: ix_obp_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_rkb_source; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_obp_status ON public.owner_balance_periods USING btree (status);
+CREATE INDEX idx_rkb_source ON public.ruebarue_knowledge_base USING btree (source);
 
 
 --
--- Name: ix_obp_stripe_transfer_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_rl_cabin; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_obp_stripe_transfer_id ON public.owner_balance_periods USING btree (stripe_transfer_id) WHERE (stripe_transfer_id IS NOT NULL);
+CREATE INDEX idx_rl_cabin ON public.revenue_ledger USING btree (cabin_name);
 
 
 --
--- Name: ix_oc_active; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_rl_cabin_date_run; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_oc_active ON public.owner_charges USING btree (owner_payout_account_id, posting_date) WHERE (voided_at IS NULL);
+CREATE UNIQUE INDEX idx_rl_cabin_date_run ON public.revenue_ledger USING btree (cabin_name, target_date, run_id);
 
 
 --
--- Name: ix_oc_owner_date; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_rl_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_oc_owner_date ON public.owner_charges USING btree (owner_payout_account_id, posting_date);
+CREATE INDEX idx_rl_date ON public.revenue_ledger USING btree (target_date);
 
 
 --
--- Name: ix_oc_transaction_type; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_rl_run; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_oc_transaction_type ON public.owner_charges USING btree (transaction_type);
+CREATE INDEX idx_rl_run ON public.revenue_ledger USING btree (run_id);
 
 
 --
--- Name: ix_opa_streamline_owner_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_rl_signal; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_opa_streamline_owner_id ON public.owner_payout_accounts USING btree (streamline_owner_id);
+CREATE INDEX idx_rl_signal ON public.revenue_ledger USING btree (trading_signal);
 
 
 --
--- Name: ix_openshell_audit_logs_action; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_routing_rules_active; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_openshell_audit_logs_action ON public.openshell_audit_logs USING btree (action);
+CREATE INDEX idx_routing_rules_active ON public.email_routing_rules USING btree (rule_type, is_active) WHERE (is_active = true);
 
 
 --
--- Name: ix_openshell_audit_logs_actor_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_rqf_brain; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_openshell_audit_logs_actor_id ON public.openshell_audit_logs USING btree (actor_id);
+CREATE INDEX idx_rqf_brain ON public.rag_query_feedback USING btree (brain);
 
 
 --
--- Name: ix_openshell_audit_logs_created_at; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_rqf_created; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_openshell_audit_logs_created_at ON public.openshell_audit_logs USING btree (created_at);
+CREATE INDEX idx_rqf_created ON public.rag_query_feedback USING btree (created_at);
 
 
 --
--- Name: ix_openshell_audit_logs_entry_hash; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_rqf_quality; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX ix_openshell_audit_logs_entry_hash ON public.openshell_audit_logs USING btree (entry_hash);
+CREATE INDEX idx_rqf_quality ON public.rag_query_feedback USING btree (response_quality);
 
 
 --
--- Name: ix_openshell_audit_logs_model_route; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_sanitizer_log_run; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_openshell_audit_logs_model_route ON public.openshell_audit_logs USING btree (model_route);
+CREATE INDEX idx_sanitizer_log_run ON public.data_sanitizer_log USING btree (run_id);
 
 
 --
--- Name: ix_openshell_audit_logs_outcome; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_sanitizer_log_table; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_openshell_audit_logs_outcome ON public.openshell_audit_logs USING btree (outcome);
+CREATE INDEX idx_sanitizer_log_table ON public.data_sanitizer_log USING btree (table_name, column_name);
 
 
 --
--- Name: ix_openshell_audit_logs_payload_hash; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_sensors_active; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_openshell_audit_logs_payload_hash ON public.openshell_audit_logs USING btree (payload_hash);
+CREATE INDEX idx_sensors_active ON public.email_sensors USING btree (is_active) WHERE (is_active = true);
 
 
 --
--- Name: ix_openshell_audit_logs_prev_hash; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_sentinel_source; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_openshell_audit_logs_prev_hash ON public.openshell_audit_logs USING btree (prev_hash);
+CREATE INDEX idx_sentinel_source ON public.sentinel_state USING btree (source);
 
 
 --
--- Name: ix_openshell_audit_logs_redaction_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_si_cabin; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_openshell_audit_logs_redaction_status ON public.openshell_audit_logs USING btree (redaction_status);
+CREATE INDEX idx_si_cabin ON public.sales_intel USING btree (cabin_name);
 
 
 --
--- Name: ix_openshell_audit_logs_request_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_si_email; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_openshell_audit_logs_request_id ON public.openshell_audit_logs USING btree (request_id);
+CREATE INDEX idx_si_email ON public.sales_intel USING btree (source_email_id);
 
 
 --
--- Name: ix_openshell_audit_logs_resource_type; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_si_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_openshell_audit_logs_resource_type ON public.openshell_audit_logs USING btree (resource_type);
+CREATE INDEX idx_si_type ON public.sales_intel USING btree (signal_type);
 
 
 --
--- Name: ix_openshell_audit_logs_tool_name; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_sr_domain; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_openshell_audit_logs_tool_name ON public.openshell_audit_logs USING btree (tool_name);
+CREATE INDEX idx_sr_domain ON public.sender_registry USING btree (domain);
 
 
 --
--- Name: ix_operator_overrides_escalation_timestamp; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_sr_email; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_operator_overrides_escalation_timestamp ON public.operator_overrides USING btree (escalation_id, "timestamp");
+CREATE INDEX idx_sr_email ON public.sender_registry USING btree (email_address);
 
 
 --
--- Name: ix_operator_overrides_operator_email; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_sr_signal; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_operator_overrides_operator_email ON public.operator_overrides USING btree (operator_email);
+CREATE INDEX idx_sr_signal ON public.sender_registry USING btree (signal_ratio);
 
 
 --
--- Name: ix_operator_overrides_operator_timestamp; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_sr_status; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_operator_overrides_operator_timestamp ON public.operator_overrides USING btree (operator_email, "timestamp");
+CREATE INDEX idx_sr_status ON public.sender_registry USING btree (status);
 
 
 --
--- Name: ix_operator_overrides_timestamp; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_starred_embedding; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_operator_overrides_timestamp ON public.operator_overrides USING btree ("timestamp");
+CREATE INDEX idx_starred_embedding ON public.starred_responses USING ivfflat (embedding public.vector_cosine_ops) WITH (lists='10');
 
 
 --
--- Name: ix_oss_owner_payout_account_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_starred_intent; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_oss_owner_payout_account_id ON public.owner_statement_sends USING btree (owner_payout_account_id);
+CREATE INDEX idx_starred_intent ON public.starred_responses USING btree (intent);
 
 
 --
--- Name: ix_oss_period; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_system_directives_active_created; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_oss_period ON public.owner_statement_sends USING btree (statement_period_start, statement_period_end);
+CREATE INDEX idx_system_directives_active_created ON public.system_directives USING btree (active, created_at);
 
 
 --
--- Name: ix_oss_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_tb_property; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_oss_property_id ON public.owner_statement_sends USING btree (property_id);
+CREATE INDEX idx_tb_property ON public.trust_balance USING btree (property_id);
 
 
 --
--- Name: ix_oss_sent_at; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_thread_last_message; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_oss_sent_at ON public.owner_statement_sends USING btree (sent_at);
+CREATE INDEX idx_thread_last_message ON public.conversation_threads USING btree (last_message_at DESC);
 
 
 --
--- Name: ix_ota_micro_updates_channel; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_thread_phone; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_ota_micro_updates_channel ON public.ota_micro_updates USING btree (channel);
+CREATE INDEX idx_thread_phone ON public.conversation_threads USING btree (phone_number);
 
 
 --
--- Name: ix_ota_micro_updates_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_thread_property; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_ota_micro_updates_property_id ON public.ota_micro_updates USING btree (property_id);
+CREATE INDEX idx_thread_property ON public.conversation_threads USING btree (property_id);
 
 
 --
--- Name: ix_ota_micro_updates_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_thread_status; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_ota_micro_updates_status ON public.ota_micro_updates USING btree (status);
+CREATE INDEX idx_thread_status ON public.conversation_threads USING btree (status);
 
 
 --
--- Name: ix_owner_charges_vendor_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_trace_created; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_owner_charges_vendor_id ON public.owner_charges USING btree (vendor_id);
+CREATE INDEX idx_trace_created ON public.recursive_trace_log USING btree (created_at);
 
 
 --
--- Name: ix_owner_payout_accounts_owner_email; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_trace_run_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_owner_payout_accounts_owner_email ON public.owner_payout_accounts USING btree (owner_email);
+CREATE INDEX idx_trace_run_id ON public.recursive_trace_log USING btree (run_id);
 
 
 --
--- Name: ix_owner_payout_accounts_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_trace_stage; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_owner_payout_accounts_status ON public.owner_payout_accounts USING btree (account_status);
+CREATE INDEX idx_trace_stage ON public.recursive_trace_log USING btree (stage);
 
 
 --
--- Name: ix_parity_audits_confirmation_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_trace_user; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_parity_audits_confirmation_id ON public.parity_audits USING btree (confirmation_id);
+CREATE INDEX idx_trace_user ON public.recursive_trace_log USING btree (user_id);
 
 
 --
--- Name: ix_parity_audits_reservation_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_training_intent; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_parity_audits_reservation_id ON public.parity_audits USING btree (reservation_id);
+CREATE INDEX idx_training_intent ON public.ai_training_labels USING btree (labeled_intent);
 
 
 --
--- Name: ix_parity_audits_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_training_labeled_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_parity_audits_status ON public.parity_audits USING btree (status);
+CREATE INDEX idx_training_labeled_at ON public.ai_training_labels USING btree (labeled_at DESC);
 
 
 --
--- Name: ix_payout_ledger_confirmation_code; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_training_message; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_payout_ledger_confirmation_code ON public.payout_ledger USING btree (confirmation_code);
+CREATE INDEX idx_training_message ON public.ai_training_labels USING btree (message_id);
 
 
 --
--- Name: ix_payout_ledger_property_created; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_vault_delta_citation; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_payout_ledger_property_created ON public.payout_ledger USING btree (property_id, created_at DESC);
+CREATE INDEX idx_vault_delta_citation ON public.vault_delta USING btree (citation);
 
 
 --
--- Name: ix_payout_ledger_status_created; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_vault_delta_court; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_payout_ledger_status_created ON public.payout_ledger USING btree (status, created_at DESC);
+CREATE INDEX idx_vault_delta_court ON public.vault_delta USING btree (court);
 
 
 --
--- Name: ix_pending_sync_reservation_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_vault_delta_embedding; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_pending_sync_reservation_id ON public.pending_sync USING btree (reservation_id);
+CREATE INDEX idx_vault_delta_embedding ON public.vault_delta USING ivfflat (embedding public.vector_cosine_ops) WITH (lists='100');
 
 
 --
--- Name: ix_pending_sync_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_vault_delta_text_search; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_pending_sync_status ON public.pending_sync USING btree (status);
+CREATE INDEX idx_vault_delta_text_search ON public.vault_delta USING gin (text_search);
 
 
 --
--- Name: ix_pricing_overrides_property_dates; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_vis_ext; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_pricing_overrides_property_dates ON public.pricing_overrides USING btree (property_id, start_date, end_date);
+CREATE INDEX idx_vis_ext ON public.ops_visuals USING btree (file_ext);
 
 
 --
--- Name: ix_pricing_overrides_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_vis_path; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_pricing_overrides_property_id ON public.pricing_overrides USING btree (property_id);
+CREATE INDEX idx_vis_path ON public.ops_visuals USING btree (file_path);
 
 
 --
--- Name: ix_properties_renting_state; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_vis_prop; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_properties_renting_state ON public.properties USING btree (renting_state);
+CREATE INDEX idx_vis_prop ON public.ops_visuals USING btree (property_id);
 
 
 --
--- Name: ix_properties_slug; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_vis_propname; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX ix_properties_slug ON public.properties USING btree (slug);
+CREATE INDEX idx_vis_propname ON public.ops_visuals USING btree (property_name);
 
 
 --
--- Name: ix_properties_streamline_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_vis_room; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_properties_streamline_property_id ON public.properties USING btree (streamline_property_id);
+CREATE INDEX idx_vis_room ON public.ops_visuals USING btree (room_type);
 
 
 --
--- Name: ix_property_fees_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_vis_scanned; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_property_fees_property_id ON public.property_fees USING btree (property_id);
+CREATE INDEX idx_vis_scanned ON public.ops_visuals USING btree (scanned_at);
 
 
 --
--- Name: ix_property_images_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_vis_status; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_property_images_property_id ON public.property_images USING btree (property_id);
+CREATE INDEX idx_vis_status ON public.ops_visuals USING btree (status);
 
 
 --
--- Name: ix_property_images_status; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_visual_hash; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_property_images_status ON public.property_images USING btree (status);
+CREATE INDEX idx_visual_hash ON public.ops_visuals USING btree (visual_hash);
 
 
 --
--- Name: ix_property_knowledge_category; Type: INDEX; Schema: public; Owner: -
+-- Name: ix_agent_memory_model; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_property_knowledge_category ON public.property_knowledge USING btree (category);
+CREATE INDEX ix_agent_memory_model ON public.agent_memory USING btree (model);
 
 
 --
--- Name: ix_property_knowledge_chunks_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: ix_agent_memory_request_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_property_knowledge_chunks_property_id ON public.property_knowledge_chunks USING btree (property_id);
+CREATE INDEX ix_agent_memory_request_id ON public.agent_memory USING btree (request_id);
 
 
 --
--- Name: ix_property_knowledge_prop_cat_updated; Type: INDEX; Schema: public; Owner: -
+-- Name: ix_agent_telemetry_error_class; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_property_knowledge_prop_cat_updated ON public.property_knowledge USING btree (property_id, category, updated_at);
+CREATE INDEX ix_agent_telemetry_error_class ON public.agent_telemetry USING btree (error_class);
 
 
 --
--- Name: ix_property_knowledge_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: ix_agent_telemetry_model; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_property_knowledge_property_id ON public.property_knowledge USING btree (property_id);
+CREATE INDEX ix_agent_telemetry_model ON public.agent_telemetry USING btree (model);
 
 
 --
--- Name: ix_property_knowledge_updated_at; Type: INDEX; Schema: public; Owner: -
+-- Name: ix_agent_telemetry_prompt_hash; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_property_knowledge_updated_at ON public.property_knowledge USING btree (updated_at);
+CREATE INDEX ix_agent_telemetry_prompt_hash ON public.agent_telemetry USING btree (prompt_hash);
 
 
 --
--- Name: ix_property_stay_restrictions_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: ix_agent_telemetry_request_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_property_stay_restrictions_property_id ON public.property_stay_restrictions USING btree (property_id);
+CREATE INDEX ix_agent_telemetry_request_id ON public.agent_telemetry USING btree (request_id);
 
 
 --
--- Name: ix_property_taxes_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: ix_agent_telemetry_user_feedback_signal; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_property_taxes_property_id ON public.property_taxes USING btree (property_id);
+CREATE INDEX ix_agent_telemetry_user_feedback_signal ON public.agent_telemetry USING btree (user_feedback_signal);
 
 
 --
--- Name: ix_property_utilities_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: ix_system_directives_active; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_property_utilities_property_id ON public.property_utilities USING btree (property_id);
+CREATE INDEX ix_system_directives_active ON public.system_directives USING btree (active);
 
 
 --
--- Name: ix_quote_options_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: attorneys trg_attorneys_updated; Type: TRIGGER; Schema: legal_cmd; Owner: -
 --
 
-CREATE INDEX ix_quote_options_property_id ON public.quote_options USING btree (property_id);
+CREATE TRIGGER trg_attorneys_updated BEFORE UPDATE ON legal_cmd.attorneys FOR EACH ROW EXECUTE FUNCTION legal_cmd.update_timestamp();
 
 
 --
--- Name: ix_quote_options_quote_id; Type: INDEX; Schema: public; Owner: -
+-- Name: matters trg_matters_updated; Type: TRIGGER; Schema: legal_cmd; Owner: -
 --
 
-CREATE INDEX ix_quote_options_quote_id ON public.quote_options USING btree (quote_id);
+CREATE TRIGGER trg_matters_updated BEFORE UPDATE ON legal_cmd.matters FOR EACH ROW EXECUTE FUNCTION legal_cmd.update_timestamp();
 
 
 --
--- Name: ix_quotes_lead_id; Type: INDEX; Schema: public; Owner: -
+-- Name: meetings trg_meetings_updated; Type: TRIGGER; Schema: legal_cmd; Owner: -
 --
 
-CREATE INDEX ix_quotes_lead_id ON public.quotes USING btree (lead_id);
+CREATE TRIGGER trg_meetings_updated BEFORE UPDATE ON legal_cmd.meetings FOR EACH ROW EXECUTE FUNCTION legal_cmd.update_timestamp();
 
 
 --
--- Name: ix_quotes_status; Type: INDEX; Schema: public; Owner: -
+-- Name: journal_line_items trg_immutable_line_items; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_quotes_status ON public.quotes USING btree (status);
+CREATE TRIGGER trg_immutable_line_items BEFORE DELETE OR UPDATE ON public.journal_line_items FOR EACH ROW EXECUTE FUNCTION public.enforce_immutable_line_items();
 
 
 --
--- Name: ix_recovery_parity_comparisons_async_job_run_id; Type: INDEX; Schema: public; Owner: -
+-- Name: journal_entries trg_journal_entry_integrity; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_recovery_parity_comparisons_async_job_run_id ON public.recovery_parity_comparisons USING btree (async_job_run_id);
+CREATE TRIGGER trg_journal_entry_integrity BEFORE DELETE OR UPDATE ON public.journal_entries FOR EACH ROW EXECUTE FUNCTION public.enforce_journal_entry_integrity();
 
 
 --
--- Name: ix_recovery_parity_comparisons_created_at; Type: INDEX; Schema: public; Owner: -
+-- Name: journal_line_items trg_verify_balance; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_recovery_parity_comparisons_created_at ON public.recovery_parity_comparisons USING btree (created_at);
+CREATE CONSTRAINT TRIGGER trg_verify_balance AFTER INSERT OR UPDATE ON public.journal_line_items DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION public.verify_journal_balance();
 
 
 --
--- Name: ix_recovery_parity_comparisons_dedupe_hash; Type: INDEX; Schema: public; Owner: -
+-- Name: conversation_threads update_conversation_threads_updated_at; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_recovery_parity_comparisons_dedupe_hash ON public.recovery_parity_comparisons USING btree (dedupe_hash);
+CREATE TRIGGER update_conversation_threads_updated_at BEFORE UPDATE ON public.conversation_threads FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
 
 
 --
--- Name: ix_recovery_parity_comparisons_guest_id; Type: INDEX; Schema: public; Owner: -
+-- Name: guest_profiles update_guest_profiles_updated_at; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_recovery_parity_comparisons_guest_id ON public.recovery_parity_comparisons USING btree (guest_id);
+CREATE TRIGGER update_guest_profiles_updated_at BEFORE UPDATE ON public.guest_profiles FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
 
 
 --
--- Name: ix_recovery_parity_comparisons_session_fp; Type: INDEX; Schema: public; Owner: -
+-- Name: message_archive update_message_archive_updated_at; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE INDEX ix_recovery_parity_comparisons_session_fp ON public.recovery_parity_comparisons USING btree (session_fp);
+CREATE TRIGGER update_message_archive_updated_at BEFORE UPDATE ON public.message_archive FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
 
 
 --
--- Name: ix_recovery_parity_guest_created; Type: INDEX; Schema: public; Owner: -
+-- Name: account_mappings account_mappings_credit_account_fkey; Type: FK CONSTRAINT; Schema: division_a; Owner: -
 --
 
-CREATE INDEX ix_recovery_parity_guest_created ON public.recovery_parity_comparisons USING btree (guest_id, created_at);
+ALTER TABLE ONLY division_a.account_mappings
+    ADD CONSTRAINT account_mappings_credit_account_fkey FOREIGN KEY (credit_account) REFERENCES division_a.chart_of_accounts(code);
 
 
 --
--- Name: ix_recovery_parity_session_fp_created; Type: INDEX; Schema: public; Owner: -
+-- Name: account_mappings account_mappings_debit_account_fkey; Type: FK CONSTRAINT; Schema: division_a; Owner: -
 --
 
-CREATE INDEX ix_recovery_parity_session_fp_created ON public.recovery_parity_comparisons USING btree (session_fp, created_at);
+ALTER TABLE ONLY division_a.account_mappings
+    ADD CONSTRAINT account_mappings_debit_account_fkey FOREIGN KEY (debit_account) REFERENCES division_a.chart_of_accounts(code);
 
 
 --
--- Name: ix_rental_agreements_guest_id; Type: INDEX; Schema: public; Owner: -
+-- Name: general_ledger general_ledger_account_code_fkey; Type: FK CONSTRAINT; Schema: division_a; Owner: -
 --
 
-CREATE INDEX ix_rental_agreements_guest_id ON public.rental_agreements USING btree (guest_id);
+ALTER TABLE ONLY division_a.general_ledger
+    ADD CONSTRAINT general_ledger_account_code_fkey FOREIGN KEY (account_code) REFERENCES division_a.chart_of_accounts(code);
 
 
 --
--- Name: ix_rental_agreements_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: general_ledger general_ledger_journal_entry_id_fkey; Type: FK CONSTRAINT; Schema: division_a; Owner: -
 --
 
-CREATE INDEX ix_rental_agreements_property_id ON public.rental_agreements USING btree (property_id);
+ALTER TABLE ONLY division_a.general_ledger
+    ADD CONSTRAINT general_ledger_journal_entry_id_fkey FOREIGN KEY (journal_entry_id) REFERENCES division_a.journal_entries(entry_id);
 
 
 --
--- Name: ix_rental_agreements_reservation_id; Type: INDEX; Schema: public; Owner: -
+-- Name: account_mappings account_mappings_credit_account_fkey; Type: FK CONSTRAINT; Schema: division_b; Owner: -
 --
 
-CREATE INDEX ix_rental_agreements_reservation_id ON public.rental_agreements USING btree (reservation_id);
+ALTER TABLE ONLY division_b.account_mappings
+    ADD CONSTRAINT account_mappings_credit_account_fkey FOREIGN KEY (credit_account) REFERENCES division_b.chart_of_accounts(code);
 
 
 --
--- Name: ix_rental_agreements_status; Type: INDEX; Schema: public; Owner: -
+-- Name: account_mappings account_mappings_debit_account_fkey; Type: FK CONSTRAINT; Schema: division_b; Owner: -
 --
 
-CREATE INDEX ix_rental_agreements_status ON public.rental_agreements USING btree (status);
+ALTER TABLE ONLY division_b.account_mappings
+    ADD CONSTRAINT account_mappings_debit_account_fkey FOREIGN KEY (debit_account) REFERENCES division_b.chart_of_accounts(code);
 
 
 --
--- Name: ix_rental_agreements_template_id; Type: INDEX; Schema: public; Owner: -
+-- Name: general_ledger general_ledger_account_code_fkey; Type: FK CONSTRAINT; Schema: division_b; Owner: -
 --
 
-CREATE INDEX ix_rental_agreements_template_id ON public.rental_agreements USING btree (template_id);
+ALTER TABLE ONLY division_b.general_ledger
+    ADD CONSTRAINT general_ledger_account_code_fkey FOREIGN KEY (account_code) REFERENCES division_b.chart_of_accounts(code);
 
 
 --
--- Name: ix_reservation_holds_converted_reservation_id; Type: INDEX; Schema: public; Owner: -
+-- Name: general_ledger general_ledger_journal_entry_id_fkey; Type: FK CONSTRAINT; Schema: division_b; Owner: -
 --
 
-CREATE INDEX ix_reservation_holds_converted_reservation_id ON public.reservation_holds USING btree (converted_reservation_id);
+ALTER TABLE ONLY division_b.general_ledger
+    ADD CONSTRAINT general_ledger_journal_entry_id_fkey FOREIGN KEY (journal_entry_id) REFERENCES division_b.journal_entries(entry_id);
 
 
 --
--- Name: ix_reservation_holds_guest_id; Type: INDEX; Schema: public; Owner: -
+-- Name: change_orders change_orders_project_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_reservation_holds_guest_id ON public.reservation_holds USING btree (guest_id);
+ALTER TABLE ONLY engineering.change_orders
+    ADD CONSTRAINT change_orders_project_id_fkey FOREIGN KEY (project_id) REFERENCES engineering.projects(id);
 
 
 --
--- Name: ix_reservation_holds_payment_intent_id; Type: INDEX; Schema: public; Owner: -
+-- Name: compliance_log compliance_log_drawing_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_reservation_holds_payment_intent_id ON public.reservation_holds USING btree (payment_intent_id);
+ALTER TABLE ONLY engineering.compliance_log
+    ADD CONSTRAINT compliance_log_drawing_id_fkey FOREIGN KEY (drawing_id) REFERENCES engineering.drawings(id);
 
 
 --
--- Name: ix_reservation_holds_property_dates; Type: INDEX; Schema: public; Owner: -
+-- Name: compliance_log compliance_log_project_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_reservation_holds_property_dates ON public.reservation_holds USING btree (property_id, check_in_date, check_out_date);
+ALTER TABLE ONLY engineering.compliance_log
+    ADD CONSTRAINT compliance_log_project_id_fkey FOREIGN KEY (project_id) REFERENCES engineering.projects(id);
 
 
 --
--- Name: ix_reservation_holds_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: compliance_log compliance_log_property_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_reservation_holds_property_id ON public.reservation_holds USING btree (property_id);
+ALTER TABLE ONLY engineering.compliance_log
+    ADD CONSTRAINT compliance_log_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id);
 
 
 --
--- Name: ix_reservation_holds_session_id; Type: INDEX; Schema: public; Owner: -
+-- Name: cost_estimates cost_estimates_project_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_reservation_holds_session_id ON public.reservation_holds USING btree (session_id);
+ALTER TABLE ONLY engineering.cost_estimates
+    ADD CONSTRAINT cost_estimates_project_id_fkey FOREIGN KEY (project_id) REFERENCES engineering.projects(id);
 
 
 --
--- Name: ix_reservation_holds_status; Type: INDEX; Schema: public; Owner: -
+-- Name: drawings drawings_project_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_reservation_holds_status ON public.reservation_holds USING btree (status);
+ALTER TABLE ONLY engineering.drawings
+    ADD CONSTRAINT drawings_project_id_fkey FOREIGN KEY (project_id) REFERENCES engineering.projects(id);
 
 
 --
--- Name: ix_reservation_holds_status_expires; Type: INDEX; Schema: public; Owner: -
+-- Name: drawings drawings_property_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_reservation_holds_status_expires ON public.reservation_holds USING btree (status, expires_at);
+ALTER TABLE ONLY engineering.drawings
+    ADD CONSTRAINT drawings_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id);
 
 
 --
--- Name: ix_reservations_check_in_date; Type: INDEX; Schema: public; Owner: -
+-- Name: inspections inspections_permit_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_reservations_check_in_date ON public.reservations USING btree (check_in_date);
+ALTER TABLE ONLY engineering.inspections
+    ADD CONSTRAINT inspections_permit_id_fkey FOREIGN KEY (permit_id) REFERENCES engineering.permits(id);
 
 
 --
--- Name: ix_reservations_check_out_date; Type: INDEX; Schema: public; Owner: -
+-- Name: inspections inspections_project_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_reservations_check_out_date ON public.reservations USING btree (check_out_date);
+ALTER TABLE ONLY engineering.inspections
+    ADD CONSTRAINT inspections_project_id_fkey FOREIGN KEY (project_id) REFERENCES engineering.projects(id);
 
 
 --
--- Name: ix_reservations_confirmation_code; Type: INDEX; Schema: public; Owner: -
+-- Name: inspections inspections_property_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
 --
 
-CREATE UNIQUE INDEX ix_reservations_confirmation_code ON public.reservations USING btree (confirmation_code);
+ALTER TABLE ONLY engineering.inspections
+    ADD CONSTRAINT inspections_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id);
 
 
 --
--- Name: ix_reservations_guest_email; Type: INDEX; Schema: public; Owner: -
+-- Name: mep_systems mep_systems_property_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_reservations_guest_email ON public.reservations USING btree (guest_email);
+ALTER TABLE ONLY engineering.mep_systems
+    ADD CONSTRAINT mep_systems_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id);
 
 
 --
--- Name: ix_reservations_guest_id; Type: INDEX; Schema: public; Owner: -
+-- Name: permits permits_project_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_reservations_guest_id ON public.reservations USING btree (guest_id);
+ALTER TABLE ONLY engineering.permits
+    ADD CONSTRAINT permits_project_id_fkey FOREIGN KEY (project_id) REFERENCES engineering.projects(id);
 
 
 --
--- Name: ix_reservations_is_owner_booking; Type: INDEX; Schema: public; Owner: -
+-- Name: permits permits_property_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_reservations_is_owner_booking ON public.reservations USING btree (is_owner_booking);
+ALTER TABLE ONLY engineering.permits
+    ADD CONSTRAINT permits_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id);
 
 
 --
--- Name: ix_reservations_property_id; Type: INDEX; Schema: public; Owner: -
+-- Name: projects projects_property_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_reservations_property_id ON public.reservations USING btree (property_id);
+ALTER TABLE ONLY engineering.projects
+    ADD CONSTRAINT projects_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id);
 
 
 --
--- Name: ix_reservations_status; Type: INDEX; Schema: public; Owner: -
+-- Name: punch_items punch_items_inspection_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_reservations_status ON public.reservations USING btree (status);
+ALTER TABLE ONLY engineering.punch_items
+    ADD CONSTRAINT punch_items_inspection_id_fkey FOREIGN KEY (inspection_id) REFERENCES engineering.inspections(id);
 
 
 --
--- Name: ix_rue_bar_rue_legacy_recovery_templates_audience_rule; Type: INDEX; Schema: public; Owner: -
+-- Name: punch_items punch_items_project_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_rue_bar_rue_legacy_recovery_templates_audience_rule ON public.rue_bar_rue_legacy_recovery_templates USING btree (audience_rule);
+ALTER TABLE ONLY engineering.punch_items
+    ADD CONSTRAINT punch_items_project_id_fkey FOREIGN KEY (project_id) REFERENCES engineering.projects(id);
 
 
 --
--- Name: ix_rue_bar_rue_legacy_recovery_templates_channel; Type: INDEX; Schema: public; Owner: -
+-- Name: rfis rfis_project_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_rue_bar_rue_legacy_recovery_templates_channel ON public.rue_bar_rue_legacy_recovery_templates USING btree (channel);
+ALTER TABLE ONLY engineering.rfis
+    ADD CONSTRAINT rfis_project_id_fkey FOREIGN KEY (project_id) REFERENCES engineering.projects(id);
 
 
 --
--- Name: ix_rue_bar_rue_legacy_recovery_templates_template_key; Type: INDEX; Schema: public; Owner: -
+-- Name: submittals submittals_project_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
 --
 
-CREATE INDEX ix_rue_bar_rue_legacy_recovery_templates_template_key ON public.rue_bar_rue_legacy_recovery_templates USING btree (template_key);
+ALTER TABLE ONLY engineering.submittals
+    ADD CONSTRAINT submittals_project_id_fkey FOREIGN KEY (project_id) REFERENCES engineering.projects(id);
 
 
 --
--- Name: ix_scheduled_messages_guest_id; Type: INDEX; Schema: public; Owner: -
+-- Name: classification_rules classification_rules_source_vendor_id_fkey; Type: FK CONSTRAINT; Schema: finance; Owner: -
 --
 
-CREATE INDEX ix_scheduled_messages_guest_id ON public.scheduled_messages USING btree (guest_id);
+ALTER TABLE ONLY finance.classification_rules
+    ADD CONSTRAINT classification_rules_source_vendor_id_fkey FOREIGN KEY (source_vendor_id) REFERENCES finance.vendor_classifications(id);
 
 
 --
--- Name: ix_scheduled_messages_reservation_id; Type: INDEX; Schema: public; Owner: -
+-- Name: extraction_log extraction_log_email_id_fkey; Type: FK CONSTRAINT; Schema: hedge_fund; Owner: -
 --
 
-CREATE INDEX ix_scheduled_messages_reservation_id ON public.scheduled_messages USING btree (reservation_id);
+ALTER TABLE ONLY hedge_fund.extraction_log
+    ADD CONSTRAINT extraction_log_email_id_fkey FOREIGN KEY (email_id) REFERENCES public.email_archive(id) ON DELETE SET NULL;
 
 
 --
--- Name: ix_scheduled_messages_scheduled_for; Type: INDEX; Schema: public; Owner: -
+-- Name: market_signals market_signals_source_email_id_fkey; Type: FK CONSTRAINT; Schema: hedge_fund; Owner: -
 --
 
-CREATE INDEX ix_scheduled_messages_scheduled_for ON public.scheduled_messages USING btree (scheduled_for);
+ALTER TABLE ONLY hedge_fund.market_signals
+    ADD CONSTRAINT market_signals_source_email_id_fkey FOREIGN KEY (source_email_id) REFERENCES public.email_archive(id) ON DELETE SET NULL;
 
 
 --
--- Name: ix_scheduled_messages_status; Type: INDEX; Schema: public; Owner: -
+-- Name: relationships relationships_from_entity_id_fkey; Type: FK CONSTRAINT; Schema: intelligence; Owner: -
 --
 
-CREATE INDEX ix_scheduled_messages_status ON public.scheduled_messages USING btree (status);
+ALTER TABLE ONLY intelligence.relationships
+    ADD CONSTRAINT relationships_from_entity_id_fkey FOREIGN KEY (from_entity_id) REFERENCES intelligence.entities(id) ON DELETE CASCADE;
 
 
 --
--- Name: ix_scheduled_messages_template_id; Type: INDEX; Schema: public; Owner: -
+-- Name: relationships relationships_to_entity_id_fkey; Type: FK CONSTRAINT; Schema: intelligence; Owner: -
 --
 
-CREATE INDEX ix_scheduled_messages_template_id ON public.scheduled_messages USING btree (template_id);
+ALTER TABLE ONLY intelligence.relationships
+    ADD CONSTRAINT relationships_to_entity_id_fkey FOREIGN KEY (to_entity_id) REFERENCES intelligence.entities(id) ON DELETE CASCADE;
 
 
 --
--- Name: ix_seo_patch_queue_campaign; Type: INDEX; Schema: public; Owner: -
+-- Name: case_actions case_actions_case_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
 --
 
-CREATE INDEX ix_seo_patch_queue_campaign ON public.seo_patch_queue USING btree (campaign);
+ALTER TABLE ONLY legal.case_actions
+    ADD CONSTRAINT case_actions_case_id_fkey FOREIGN KEY (case_id) REFERENCES legal.cases(id);
 
 
 --
--- Name: ix_seo_patch_queue_created_at; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_patch_queue_created_at ON public.seo_patch_queue USING btree (created_at);
-
-
---
--- Name: ix_seo_patch_queue_property_approved; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_patch_queue_property_approved ON public.seo_patch_queue USING btree (property_id, approved_at);
-
-
---
--- Name: ix_seo_patch_queue_property_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_patch_queue_property_id ON public.seo_patch_queue USING btree (property_id);
-
-
---
--- Name: ix_seo_patch_queue_status; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_patch_queue_status ON public.seo_patch_queue USING btree (status);
-
-
---
--- Name: ix_seo_patch_queue_status_created; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_patch_queue_status_created ON public.seo_patch_queue USING btree (status, created_at);
-
-
---
--- Name: ix_seo_patch_queue_target_approved; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_patch_queue_target_approved ON public.seo_patch_queue USING btree (target_type, target_slug, approved_at);
-
-
---
--- Name: ix_seo_patch_queue_target_slug; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_patch_queue_target_slug ON public.seo_patch_queue USING btree (target_slug);
-
-
---
--- Name: ix_seo_patch_queue_target_type; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_patch_queue_target_type ON public.seo_patch_queue USING btree (target_type);
-
-
---
--- Name: ix_seo_patches_deploy_acknowledged_at; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_patches_deploy_acknowledged_at ON public.seo_patches USING btree (deploy_acknowledged_at);
-
-
---
--- Name: ix_seo_patches_deploy_status; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_patches_deploy_status ON public.seo_patches USING btree (deploy_status);
-
-
---
--- Name: ix_seo_patches_deployed_at; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_patches_deployed_at ON public.seo_patches USING btree (deployed_at);
-
-
---
--- Name: ix_seo_patches_page_path; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_patches_page_path ON public.seo_patches USING btree (page_path);
-
-
---
--- Name: ix_seo_patches_property_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_patches_property_id ON public.seo_patches USING btree (property_id);
-
-
---
--- Name: ix_seo_patches_rubric_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_patches_rubric_id ON public.seo_patches USING btree (rubric_id);
-
-
---
--- Name: ix_seo_patches_source_agent; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_patches_source_agent ON public.seo_patches USING btree (source_agent);
-
-
---
--- Name: ix_seo_patches_source_intelligence_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_patches_source_intelligence_id ON public.seo_patches USING btree (source_intelligence_id);
-
-
---
--- Name: ix_seo_patches_status; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_patches_status ON public.seo_patches USING btree (status);
-
-
---
--- Name: ix_seo_rank_snapshots_keyword; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_rank_snapshots_keyword ON public.seo_rank_snapshots USING btree (keyword);
-
-
---
--- Name: ix_seo_rank_snapshots_property_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_rank_snapshots_property_id ON public.seo_rank_snapshots USING btree (property_id);
-
-
---
--- Name: ix_seo_rank_snapshots_snapshot_date; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_rank_snapshots_snapshot_date ON public.seo_rank_snapshots USING btree (snapshot_date);
-
-
---
--- Name: ix_seo_redirect_remap_queue_campaign; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_redirect_remap_queue_campaign ON public.seo_redirect_remap_queue USING btree (campaign);
-
-
---
--- Name: ix_seo_redirect_remap_queue_created_at; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_redirect_remap_queue_created_at ON public.seo_redirect_remap_queue USING btree (created_at);
-
-
---
--- Name: ix_seo_redirect_remap_queue_proposal_run_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_redirect_remap_queue_proposal_run_id ON public.seo_redirect_remap_queue USING btree (proposal_run_id);
-
-
---
--- Name: ix_seo_redirect_remap_queue_source_path; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_redirect_remap_queue_source_path ON public.seo_redirect_remap_queue USING btree (source_path);
-
-
---
--- Name: ix_seo_redirect_remap_queue_status; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_redirect_remap_queue_status ON public.seo_redirect_remap_queue USING btree (status);
-
-
---
--- Name: ix_seo_redirect_remap_queue_status_created; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_redirect_remap_queue_status_created ON public.seo_redirect_remap_queue USING btree (status, created_at);
-
-
---
--- Name: ix_seo_redirects_created_at; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_redirects_created_at ON public.seo_redirects USING btree (created_at);
-
-
---
--- Name: ix_seo_redirects_is_active; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_redirects_is_active ON public.seo_redirects USING btree (is_active);
-
-
---
--- Name: ix_seo_redirects_source_path; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX ix_seo_redirects_source_path ON public.seo_redirects USING btree (source_path);
-
-
---
--- Name: ix_seo_rubrics_keyword_cluster; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_rubrics_keyword_cluster ON public.seo_rubrics USING btree (keyword_cluster);
-
-
---
--- Name: ix_seo_rubrics_status; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_seo_rubrics_status ON public.seo_rubrics USING btree (status);
-
-
---
--- Name: ix_shadow_discrepancies_property_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_shadow_discrepancies_property_id ON public.shadow_discrepancies USING btree (property_id);
-
-
---
--- Name: ix_shadow_discrepancies_status; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_shadow_discrepancies_status ON public.shadow_discrepancies USING btree (status);
-
-
---
--- Name: ix_ssgl_guest_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_ssgl_guest_id ON public.storefront_session_guest_links USING btree (guest_id);
-
-
---
--- Name: ix_ssgl_session_fp; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_ssgl_session_fp ON public.storefront_session_guest_links USING btree (session_fp);
-
-
---
--- Name: ix_ssgl_session_fp_created; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_ssgl_session_fp_created ON public.storefront_session_guest_links USING btree (session_fp, created_at);
-
-
---
--- Name: ix_staff_invites_email; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_staff_invites_email ON public.staff_invites USING btree (email);
-
-
---
--- Name: ix_staff_invites_token; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX ix_staff_invites_token ON public.staff_invites USING btree (token);
-
-
---
--- Name: ix_staff_users_email; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX ix_staff_users_email ON public.staff_users USING btree (email);
-
-
---
--- Name: ix_staff_users_role; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_staff_users_role ON public.staff_users USING btree (role);
-
-
---
--- Name: ix_storefront_intent_created; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_storefront_intent_created ON public.storefront_intent_events USING btree (created_at);
-
-
---
--- Name: ix_storefront_intent_events_session_fp; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_storefront_intent_events_session_fp ON public.storefront_intent_events USING btree (session_fp);
-
-
---
--- Name: ix_storefront_intent_session_created; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_storefront_intent_session_created ON public.storefront_intent_events USING btree (session_fp, created_at);
-
-
---
--- Name: ix_streamline_payload_vault_event_type; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_streamline_payload_vault_event_type ON public.streamline_payload_vault USING btree (event_type);
-
-
---
--- Name: ix_streamline_payload_vault_reservation_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_streamline_payload_vault_reservation_id ON public.streamline_payload_vault USING btree (reservation_id);
-
-
---
--- Name: ix_stripe_connect_events_account_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_stripe_connect_events_account_id ON public.stripe_connect_events USING btree (account_id);
-
-
---
--- Name: ix_stripe_connect_events_event_type; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_stripe_connect_events_event_type ON public.stripe_connect_events USING btree (event_type);
-
-
---
--- Name: ix_stripe_connect_events_payout_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_stripe_connect_events_payout_id ON public.stripe_connect_events USING btree (payout_id);
-
-
---
--- Name: ix_stripe_connect_events_transfer_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_stripe_connect_events_transfer_id ON public.stripe_connect_events USING btree (transfer_id);
-
-
---
--- Name: ix_survey_templates_is_active; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_survey_templates_is_active ON public.survey_templates USING btree (is_active);
-
-
---
--- Name: ix_survey_templates_survey_type; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_survey_templates_survey_type ON public.survey_templates USING btree (survey_type);
-
-
---
--- Name: ix_swarm_escalations_reason_code; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_swarm_escalations_reason_code ON public.swarm_escalations USING btree (reason_code);
-
-
---
--- Name: ix_swarm_escalations_status; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_swarm_escalations_status ON public.swarm_escalations USING btree (status);
-
-
---
--- Name: ix_swarm_escalations_status_reason; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_swarm_escalations_status_reason ON public.swarm_escalations USING btree (status, reason_code);
-
-
---
--- Name: ix_taxes_name; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX ix_taxes_name ON public.taxes USING btree (name);
-
-
---
--- Name: ix_taxonomy_categories_slug; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX ix_taxonomy_categories_slug ON public.taxonomy_categories USING btree (slug);
-
-
---
--- Name: ix_taylor_quote_requests_created_at; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_taylor_quote_requests_created_at ON public.taylor_quote_requests USING btree (created_at DESC);
-
-
---
--- Name: ix_taylor_quote_requests_guest_email; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_taylor_quote_requests_guest_email ON public.taylor_quote_requests USING btree (guest_email);
-
-
---
--- Name: ix_taylor_quote_requests_status; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_taylor_quote_requests_status ON public.taylor_quote_requests USING btree (status);
-
-
---
--- Name: ix_trust_accounts_name; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_trust_accounts_name ON public.trust_accounts USING btree (name);
-
-
---
--- Name: ix_trust_accounts_type; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_trust_accounts_type ON public.trust_accounts USING btree (type);
-
-
---
--- Name: ix_trust_accounts_type_name; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_trust_accounts_type_name ON public.trust_accounts USING btree (type, name);
-
-
---
--- Name: ix_trust_decisions_run_status; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_trust_decisions_run_status ON public.trust_decisions USING btree (run_id, status);
-
-
---
--- Name: ix_trust_decisions_status; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_trust_decisions_status ON public.trust_decisions USING btree (status);
-
-
---
--- Name: ix_trust_ledger_entries_account_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_trust_ledger_entries_account_id ON public.trust_ledger_entries USING btree (account_id);
-
-
---
--- Name: ix_trust_ledger_entries_entry_type; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_trust_ledger_entries_entry_type ON public.trust_ledger_entries USING btree (entry_type);
-
-
---
--- Name: ix_trust_ledger_entries_transaction_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_trust_ledger_entries_transaction_id ON public.trust_ledger_entries USING btree (transaction_id);
-
-
---
--- Name: ix_trust_transactions_decision_timestamp; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_trust_transactions_decision_timestamp ON public.trust_transactions USING btree (decision_id, "timestamp");
-
-
---
--- Name: ix_trust_transactions_previous_signature; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_trust_transactions_previous_signature ON public.trust_transactions USING btree (previous_signature);
-
-
---
--- Name: ix_trust_transactions_timestamp; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_trust_transactions_timestamp ON public.trust_transactions USING btree ("timestamp");
-
-
---
--- Name: ix_utility_readings_utility_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_utility_readings_utility_id ON public.utility_readings USING btree (utility_id);
-
-
---
--- Name: ix_vault_audit_logs_action; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_vault_audit_logs_action ON public.vault_audit_logs USING btree (action);
-
-
---
--- Name: ix_vault_audit_logs_created_at; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_vault_audit_logs_created_at ON public.vault_audit_logs USING btree (created_at);
-
-
---
--- Name: ix_vault_audit_logs_user_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_vault_audit_logs_user_id ON public.vault_audit_logs USING btree (user_id);
-
-
---
--- Name: ix_vendors_active; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_vendors_active ON public.vendors USING btree (active);
-
-
---
--- Name: ix_vendors_trade; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_vendors_trade ON public.vendors USING btree (trade);
-
-
---
--- Name: ix_vrs_add_ons_active_scope_property; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_vrs_add_ons_active_scope_property ON public.vrs_add_ons USING btree (is_active, scope, property_id);
-
-
---
--- Name: ix_vrs_add_ons_is_active; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_vrs_add_ons_is_active ON public.vrs_add_ons USING btree (is_active);
-
-
---
--- Name: ix_vrs_add_ons_property_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_vrs_add_ons_property_id ON public.vrs_add_ons USING btree (property_id);
-
-
---
--- Name: ix_vrs_add_ons_scope; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_vrs_add_ons_scope ON public.vrs_add_ons USING btree (scope);
-
-
---
--- Name: ix_vrs_automation_events_entity_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_vrs_automation_events_entity_id ON public.vrs_automation_events USING btree (entity_id);
-
-
---
--- Name: ix_vrs_automation_events_entity_type; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_vrs_automation_events_entity_type ON public.vrs_automation_events USING btree (entity_type);
-
-
---
--- Name: ix_vrs_automation_events_event_type; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_vrs_automation_events_event_type ON public.vrs_automation_events USING btree (event_type);
-
-
---
--- Name: ix_vrs_automation_events_rule_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_vrs_automation_events_rule_id ON public.vrs_automation_events USING btree (rule_id);
-
-
---
--- Name: ix_vrs_automations_name; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_vrs_automations_name ON public.vrs_automations USING btree (name);
-
-
---
--- Name: ix_vrs_automations_target_entity; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_vrs_automations_target_entity ON public.vrs_automations USING btree (target_entity);
-
-
---
--- Name: ix_vrs_automations_trigger_event; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_vrs_automations_trigger_event ON public.vrs_automations USING btree (trigger_event);
-
-
---
--- Name: ix_work_orders_created_at; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_work_orders_created_at ON public.work_orders USING btree (created_at);
-
-
---
--- Name: ix_work_orders_guest_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_work_orders_guest_id ON public.work_orders USING btree (guest_id);
-
-
---
--- Name: ix_work_orders_priority; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_work_orders_priority ON public.work_orders USING btree (priority);
-
-
---
--- Name: ix_work_orders_property_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_work_orders_property_id ON public.work_orders USING btree (property_id);
-
-
---
--- Name: ix_work_orders_reservation_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_work_orders_reservation_id ON public.work_orders USING btree (reservation_id);
-
-
---
--- Name: ix_work_orders_status; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_work_orders_status ON public.work_orders USING btree (status);
-
-
---
--- Name: ix_work_orders_vendor; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_work_orders_vendor ON public.work_orders USING btree (assigned_vendor_id);
-
-
---
--- Name: ix_yield_overrides_property_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_yield_overrides_property_id ON public.yield_overrides USING btree (property_id);
-
-
---
--- Name: ix_yield_simulations_property_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_yield_simulations_property_id ON public.yield_simulations USING btree (property_id);
-
-
---
--- Name: uq_payout_ledger_stripe_transfer_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX uq_payout_ledger_stripe_transfer_id ON public.payout_ledger USING btree (stripe_transfer_id) WHERE (stripe_transfer_id IS NOT NULL);
-
-
---
--- Name: ix_verses_schema_products_sku; Type: INDEX; Schema: verses_schema; Owner: -
---
-
-CREATE UNIQUE INDEX ix_verses_schema_products_sku ON verses_schema.products USING btree (sku);
-
-
---
--- Name: streamline_payload_vault trg_immutable_streamline_payload_vault; Type: TRIGGER; Schema: public; Owner: -
---
-
-CREATE TRIGGER trg_immutable_streamline_payload_vault BEFORE DELETE OR UPDATE ON public.streamline_payload_vault FOR EACH ROW EXECUTE FUNCTION public.prevent_mutation();
-
-
---
--- Name: trust_ledger_entries trg_immutable_trust_ledger_entries; Type: TRIGGER; Schema: public; Owner: -
---
-
-CREATE TRIGGER trg_immutable_trust_ledger_entries BEFORE DELETE OR UPDATE ON public.trust_ledger_entries FOR EACH ROW EXECUTE FUNCTION public.prevent_mutation();
-
-
---
--- Name: trust_transactions trg_immutable_trust_transactions; Type: TRIGGER; Schema: public; Owner: -
---
-
-CREATE TRIGGER trg_immutable_trust_transactions BEFORE DELETE OR UPDATE ON public.trust_transactions FOR EACH ROW EXECUTE FUNCTION public.prevent_mutation();
-
-
---
--- Name: acquisition_documents acquisition_documents_pipeline_id_fkey; Type: FK CONSTRAINT; Schema: crog_acquisition; Owner: -
---
-
-ALTER TABLE ONLY crog_acquisition.acquisition_documents
-    ADD CONSTRAINT acquisition_documents_pipeline_id_fkey FOREIGN KEY (pipeline_id) REFERENCES crog_acquisition.acquisition_pipeline(id) ON DELETE CASCADE;
-
-
---
--- Name: acquisition_pipeline acquisition_pipeline_property_id_fkey; Type: FK CONSTRAINT; Schema: crog_acquisition; Owner: -
---
-
-ALTER TABLE ONLY crog_acquisition.acquisition_pipeline
-    ADD CONSTRAINT acquisition_pipeline_property_id_fkey FOREIGN KEY (property_id) REFERENCES crog_acquisition.properties(id) ON DELETE CASCADE;
-
-
---
--- Name: due_diligence due_diligence_pipeline_id_fkey; Type: FK CONSTRAINT; Schema: crog_acquisition; Owner: -
---
-
-ALTER TABLE ONLY crog_acquisition.due_diligence
-    ADD CONSTRAINT due_diligence_pipeline_id_fkey FOREIGN KEY (pipeline_id) REFERENCES crog_acquisition.acquisition_pipeline(id) ON DELETE CASCADE;
-
-
---
--- Name: intel_events intel_events_property_id_fkey; Type: FK CONSTRAINT; Schema: crog_acquisition; Owner: -
---
-
-ALTER TABLE ONLY crog_acquisition.intel_events
-    ADD CONSTRAINT intel_events_property_id_fkey FOREIGN KEY (property_id) REFERENCES crog_acquisition.properties(id) ON DELETE CASCADE;
-
-
---
--- Name: owner_contacts owner_contacts_owner_id_fkey; Type: FK CONSTRAINT; Schema: crog_acquisition; Owner: -
---
-
-ALTER TABLE ONLY crog_acquisition.owner_contacts
-    ADD CONSTRAINT owner_contacts_owner_id_fkey FOREIGN KEY (owner_id) REFERENCES crog_acquisition.owners(id) ON DELETE CASCADE;
-
-
---
--- Name: properties properties_owner_id_fkey; Type: FK CONSTRAINT; Schema: crog_acquisition; Owner: -
---
-
-ALTER TABLE ONLY crog_acquisition.properties
-    ADD CONSTRAINT properties_owner_id_fkey FOREIGN KEY (owner_id) REFERENCES crog_acquisition.owners(id) ON DELETE SET NULL;
-
-
---
--- Name: properties properties_parcel_id_fkey; Type: FK CONSTRAINT; Schema: crog_acquisition; Owner: -
---
-
-ALTER TABLE ONLY crog_acquisition.properties
-    ADD CONSTRAINT properties_parcel_id_fkey FOREIGN KEY (parcel_id) REFERENCES crog_acquisition.parcels(id) ON DELETE CASCADE;
-
-
---
--- Name: str_signals str_signals_property_id_fkey; Type: FK CONSTRAINT; Schema: crog_acquisition; Owner: -
---
-
-ALTER TABLE ONLY crog_acquisition.str_signals
-    ADD CONSTRAINT str_signals_property_id_fkey FOREIGN KEY (property_id) REFERENCES crog_acquisition.properties(id) ON DELETE CASCADE;
-
-
---
--- Name: case_evidence case_evidence_entity_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
+-- Name: case_evidence case_evidence_case_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
 --
 
 ALTER TABLE ONLY legal.case_evidence
-    ADD CONSTRAINT case_evidence_entity_id_fkey FOREIGN KEY (entity_id) REFERENCES legal.entities(id) ON DELETE SET NULL;
+    ADD CONSTRAINT case_evidence_case_id_fkey FOREIGN KEY (case_id) REFERENCES legal.cases(id);
 
 
 --
--- Name: case_graph_edges case_graph_edges_case_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
+-- Name: case_watchdog case_watchdog_case_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
 --
 
-ALTER TABLE ONLY legal.case_graph_edges
-    ADD CONSTRAINT case_graph_edges_case_id_fkey FOREIGN KEY (case_id) REFERENCES legal.legal_cases(id) ON DELETE CASCADE;
-
-
---
--- Name: case_graph_edges case_graph_edges_source_node_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.case_graph_edges
-    ADD CONSTRAINT case_graph_edges_source_node_id_fkey FOREIGN KEY (source_node_id) REFERENCES legal.case_graph_nodes(id) ON DELETE CASCADE;
+ALTER TABLE ONLY legal.case_watchdog
+    ADD CONSTRAINT case_watchdog_case_id_fkey FOREIGN KEY (case_id) REFERENCES legal.cases(id);
 
 
 --
--- Name: case_graph_edges case_graph_edges_target_node_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
+-- Name: correspondence correspondence_case_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
 --
 
-ALTER TABLE ONLY legal.case_graph_edges
-    ADD CONSTRAINT case_graph_edges_target_node_id_fkey FOREIGN KEY (target_node_id) REFERENCES legal.case_graph_nodes(id) ON DELETE CASCADE;
-
-
---
--- Name: case_graph_edges_v2 case_graph_edges_v2_source_node_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.case_graph_edges_v2
-    ADD CONSTRAINT case_graph_edges_v2_source_node_id_fkey FOREIGN KEY (source_node_id) REFERENCES legal.case_graph_nodes_v2(id) ON DELETE CASCADE;
+ALTER TABLE ONLY legal.correspondence
+    ADD CONSTRAINT correspondence_case_id_fkey FOREIGN KEY (case_id) REFERENCES legal.cases(id);
 
 
 --
--- Name: case_graph_edges_v2 case_graph_edges_v2_target_node_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
+-- Name: deadlines deadlines_case_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
 --
 
-ALTER TABLE ONLY legal.case_graph_edges_v2
-    ADD CONSTRAINT case_graph_edges_v2_target_node_id_fkey FOREIGN KEY (target_node_id) REFERENCES legal.case_graph_nodes_v2(id) ON DELETE CASCADE;
-
-
---
--- Name: case_graph_nodes case_graph_nodes_case_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.case_graph_nodes
-    ADD CONSTRAINT case_graph_nodes_case_id_fkey FOREIGN KEY (case_id) REFERENCES legal.legal_cases(id) ON DELETE CASCADE;
+ALTER TABLE ONLY legal.deadlines
+    ADD CONSTRAINT deadlines_case_id_fkey FOREIGN KEY (case_id) REFERENCES legal.cases(id);
 
 
 --
--- Name: discovery_draft_items_v2 discovery_draft_items_v2_pack_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
+-- Name: filings filings_case_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
 --
 
-ALTER TABLE ONLY legal.discovery_draft_items_v2
-    ADD CONSTRAINT discovery_draft_items_v2_pack_id_fkey FOREIGN KEY (pack_id) REFERENCES legal.discovery_draft_packs_v2(id) ON DELETE CASCADE;
-
-
---
--- Name: timeline_events timeline_events_source_evidence_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.timeline_events
-    ADD CONSTRAINT timeline_events_source_evidence_id_fkey FOREIGN KEY (source_evidence_id) REFERENCES legal.case_evidence(id) ON DELETE SET NULL;
+ALTER TABLE ONLY legal.filings
+    ADD CONSTRAINT filings_case_id_fkey FOREIGN KEY (case_id) REFERENCES legal.cases(id);
 
 
 --
--- Name: agent_queue agent_queue_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: ingest_runs fk_ingest_runs_case_slug; Type: FK CONSTRAINT; Schema: legal; Owner: -
 --
 
-ALTER TABLE ONLY public.agent_queue
-    ADD CONSTRAINT agent_queue_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE SET NULL;
-
-
---
--- Name: agent_queue agent_queue_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.agent_queue
-    ADD CONSTRAINT agent_queue_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE SET NULL;
+ALTER TABLE ONLY legal.ingest_runs
+    ADD CONSTRAINT fk_ingest_runs_case_slug FOREIGN KEY (case_slug) REFERENCES legal.cases(case_slug) ON DELETE CASCADE;
 
 
 --
--- Name: agent_response_queue agent_response_queue_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: case_precedents fk_precedent_case_slug; Type: FK CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.case_precedents
+    ADD CONSTRAINT fk_precedent_case_slug FOREIGN KEY (case_slug) REFERENCES legal.cases(case_slug);
+
+
+--
+-- Name: vault_documents fk_vault_documents_case_slug; Type: FK CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.vault_documents
+    ADD CONSTRAINT fk_vault_documents_case_slug FOREIGN KEY (case_slug) REFERENCES legal.cases(case_slug) ON DELETE CASCADE;
+
+
+--
+-- Name: uploads uploads_case_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.uploads
+    ADD CONSTRAINT uploads_case_id_fkey FOREIGN KEY (case_id) REFERENCES legal.cases(id);
+
+
+--
+-- Name: uploads uploads_filing_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.uploads
+    ADD CONSTRAINT uploads_filing_id_fkey FOREIGN KEY (filing_id) REFERENCES legal.filings(id);
+
+
+--
+-- Name: attorney_scoring attorney_scoring_attorney_id_fkey; Type: FK CONSTRAINT; Schema: legal_cmd; Owner: -
+--
+
+ALTER TABLE ONLY legal_cmd.attorney_scoring
+    ADD CONSTRAINT attorney_scoring_attorney_id_fkey FOREIGN KEY (attorney_id) REFERENCES legal_cmd.attorneys(id) ON DELETE CASCADE;
+
+
+--
+-- Name: documents documents_matter_id_fkey; Type: FK CONSTRAINT; Schema: legal_cmd; Owner: -
+--
+
+ALTER TABLE ONLY legal_cmd.documents
+    ADD CONSTRAINT documents_matter_id_fkey FOREIGN KEY (matter_id) REFERENCES legal_cmd.matters(id);
+
+
+--
+-- Name: matters matters_attorney_id_fkey; Type: FK CONSTRAINT; Schema: legal_cmd; Owner: -
+--
+
+ALTER TABLE ONLY legal_cmd.matters
+    ADD CONSTRAINT matters_attorney_id_fkey FOREIGN KEY (attorney_id) REFERENCES legal_cmd.attorneys(id);
+
+
+--
+-- Name: meetings meetings_attorney_id_fkey; Type: FK CONSTRAINT; Schema: legal_cmd; Owner: -
+--
+
+ALTER TABLE ONLY legal_cmd.meetings
+    ADD CONSTRAINT meetings_attorney_id_fkey FOREIGN KEY (attorney_id) REFERENCES legal_cmd.attorneys(id);
+
+
+--
+-- Name: meetings meetings_matter_id_fkey; Type: FK CONSTRAINT; Schema: legal_cmd; Owner: -
+--
+
+ALTER TABLE ONLY legal_cmd.meetings
+    ADD CONSTRAINT meetings_matter_id_fkey FOREIGN KEY (matter_id) REFERENCES legal_cmd.matters(id);
+
+
+--
+-- Name: timeline timeline_matter_id_fkey; Type: FK CONSTRAINT; Schema: legal_cmd; Owner: -
+--
+
+ALTER TABLE ONLY legal_cmd.timeline
+    ADD CONSTRAINT timeline_matter_id_fkey FOREIGN KEY (matter_id) REFERENCES legal_cmd.matters(id);
+
+
+--
+-- Name: timeline timeline_related_attorney_id_fkey; Type: FK CONSTRAINT; Schema: legal_cmd; Owner: -
+--
+
+ALTER TABLE ONLY legal_cmd.timeline
+    ADD CONSTRAINT timeline_related_attorney_id_fkey FOREIGN KEY (related_attorney_id) REFERENCES legal_cmd.attorneys(id);
+
+
+--
+-- Name: timeline timeline_related_meeting_id_fkey; Type: FK CONSTRAINT; Schema: legal_cmd; Owner: -
+--
+
+ALTER TABLE ONLY legal_cmd.timeline
+    ADD CONSTRAINT timeline_related_meeting_id_fkey FOREIGN KEY (related_meeting_id) REFERENCES legal_cmd.meetings(id);
+
+
+--
+-- Name: ab_test_observations ab_test_observations_test_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ab_test_observations
+    ADD CONSTRAINT ab_test_observations_test_id_fkey FOREIGN KEY (test_id) REFERENCES public.ab_tests(id);
+
+
+--
+-- Name: accounts accounts_parent_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.accounts
+    ADD CONSTRAINT accounts_parent_id_fkey FOREIGN KEY (parent_id) REFERENCES public.accounts(id);
+
+
+--
+-- Name: active_learning_queue active_learning_queue_judgment_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.active_learning_queue
+    ADD CONSTRAINT active_learning_queue_judgment_id_fkey FOREIGN KEY (judgment_id) REFERENCES public.learning_judgments(id);
+
+
+--
+-- Name: agent_learning_log agent_learning_log_queue_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agent_learning_log
+    ADD CONSTRAINT agent_learning_log_queue_id_fkey FOREIGN KEY (queue_id) REFERENCES public.agent_response_queue(id);
+
+
+--
+-- Name: agent_response_queue agent_response_queue_inbound_message_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.agent_response_queue
-    ADD CONSTRAINT agent_response_queue_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE SET NULL;
+    ADD CONSTRAINT agent_response_queue_inbound_message_id_fkey FOREIGN KEY (inbound_message_id) REFERENCES public.message_archive(id);
 
 
 --
--- Name: agent_response_queue agent_response_queue_message_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: ai_training_labels ai_training_labels_message_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.agent_response_queue
-    ADD CONSTRAINT agent_response_queue_message_id_fkey FOREIGN KEY (message_id) REFERENCES public.messages(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.ai_training_labels
+    ADD CONSTRAINT ai_training_labels_message_id_fkey FOREIGN KEY (message_id) REFERENCES public.message_archive(id);
 
 
 --
--- Name: agent_response_queue agent_response_queue_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: anomaly_flags anomaly_flags_account_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.agent_response_queue
-    ADD CONSTRAINT agent_response_queue_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE SET NULL;
+ALTER TABLE ONLY public.anomaly_flags
+    ADD CONSTRAINT anomaly_flags_account_id_fkey FOREIGN KEY (account_id) REFERENCES public.accounts(id);
 
 
 --
--- Name: agent_response_queue agent_response_queue_sent_message_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: anomaly_flags anomaly_flags_journal_entry_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.agent_response_queue
-    ADD CONSTRAINT agent_response_queue_sent_message_id_fkey FOREIGN KEY (sent_message_id) REFERENCES public.messages(id) ON DELETE SET NULL;
+ALTER TABLE ONLY public.anomaly_flags
+    ADD CONSTRAINT anomaly_flags_journal_entry_id_fkey FOREIGN KEY (journal_entry_id) REFERENCES public.journal_entries(id);
 
 
 --
--- Name: agent_runs agent_runs_agent_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: asset_docs asset_docs_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.agent_runs
-    ADD CONSTRAINT agent_runs_agent_id_fkey FOREIGN KEY (agent_id) REFERENCES public.agent_registry(id) ON DELETE RESTRICT;
+ALTER TABLE ONLY public.asset_docs
+    ADD CONSTRAINT asset_docs_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id);
 
 
 --
--- Name: analytics_events analytics_events_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: email_escalation_queue email_escalation_queue_email_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.analytics_events
-    ADD CONSTRAINT analytics_events_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE SET NULL;
+ALTER TABLE ONLY public.email_escalation_queue
+    ADD CONSTRAINT email_escalation_queue_email_id_fkey FOREIGN KEY (email_id) REFERENCES public.email_archive(id);
 
 
 --
--- Name: analytics_events analytics_events_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: email_intake_review_log email_intake_review_log_email_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.analytics_events
-    ADD CONSTRAINT analytics_events_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE SET NULL;
+ALTER TABLE ONLY public.email_intake_review_log
+    ADD CONSTRAINT email_intake_review_log_email_id_fkey FOREIGN KEY (email_id) REFERENCES public.email_archive(id);
 
 
 --
--- Name: analytics_events analytics_events_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: email_intake_review_log email_intake_review_log_escalation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.analytics_events
-    ADD CONSTRAINT analytics_events_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE SET NULL;
+ALTER TABLE ONLY public.email_intake_review_log
+    ADD CONSTRAINT email_intake_review_log_escalation_id_fkey FOREIGN KEY (escalation_id) REFERENCES public.email_escalation_queue(id);
 
 
 --
--- Name: blocked_days blocked_days_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: email_quarantine email_quarantine_rule_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.blocked_days
-    ADD CONSTRAINT blocked_days_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.email_quarantine
+    ADD CONSTRAINT email_quarantine_rule_id_fkey FOREIGN KEY (rule_id) REFERENCES public.email_routing_rules(id);
 
 
 --
--- Name: channel_mappings channel_mappings_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: finance_invoices finance_invoices_source_email_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.channel_mappings
-    ADD CONSTRAINT channel_mappings_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.finance_invoices
+    ADD CONSTRAINT finance_invoices_source_email_id_fkey FOREIGN KEY (source_email_id) REFERENCES public.email_archive(id) ON DELETE CASCADE;
 
 
 --
--- Name: competitor_listings competitor_listings_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fortress_api_keys fortress_api_keys_owner_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.competitor_listings
-    ADD CONSTRAINT competitor_listings_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.fortress_api_keys
+    ADD CONSTRAINT fortress_api_keys_owner_id_fkey FOREIGN KEY (owner_id) REFERENCES public.fortress_users(id);
 
 
 --
--- Name: concierge_queue concierge_queue_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: guest_leads guest_leads_source_email_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.concierge_queue
-    ADD CONSTRAINT concierge_queue_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE SET NULL;
-
-
---
--- Name: concierge_recovery_dispatches concierge_recovery_dispatches_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.concierge_recovery_dispatches
-    ADD CONSTRAINT concierge_recovery_dispatches_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE CASCADE;
-
-
---
--- Name: damage_claims damage_claims_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.damage_claims
-    ADD CONSTRAINT damage_claims_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE CASCADE;
-
-
---
--- Name: damage_claims damage_claims_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.damage_claims
-    ADD CONSTRAINT damage_claims_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
-
-
---
--- Name: damage_claims damage_claims_rental_agreement_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.damage_claims
-    ADD CONSTRAINT damage_claims_rental_agreement_id_fkey FOREIGN KEY (rental_agreement_id) REFERENCES public.rental_agreements(id) ON DELETE SET NULL;
-
-
---
--- Name: damage_claims damage_claims_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.damage_claims
-    ADD CONSTRAINT damage_claims_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE CASCADE;
-
-
---
--- Name: distillation_queue distillation_queue_source_intelligence_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.distillation_queue
-    ADD CONSTRAINT distillation_queue_source_intelligence_id_fkey FOREIGN KEY (source_intelligence_id) REFERENCES public.intelligence_ledger(id) ON DELETE SET NULL;
-
-
---
--- Name: email_inquirers email_inquirers_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.email_inquirers
-    ADD CONSTRAINT email_inquirers_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE SET NULL;
-
-
---
--- Name: email_messages email_messages_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.email_messages
-    ADD CONSTRAINT email_messages_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE SET NULL;
-
-
---
--- Name: email_messages email_messages_human_reviewed_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.email_messages
-    ADD CONSTRAINT email_messages_human_reviewed_by_fkey FOREIGN KEY (human_reviewed_by) REFERENCES public.staff_users(id) ON DELETE SET NULL;
-
-
---
--- Name: email_messages email_messages_inquirer_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.email_messages
-    ADD CONSTRAINT email_messages_inquirer_id_fkey FOREIGN KEY (inquirer_id) REFERENCES public.email_inquirers(id) ON DELETE CASCADE;
-
-
---
--- Name: email_messages email_messages_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.email_messages
-    ADD CONSTRAINT email_messages_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE SET NULL;
-
-
---
--- Name: extra_orders extra_orders_extra_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.extra_orders
-    ADD CONSTRAINT extra_orders_extra_id_fkey FOREIGN KEY (extra_id) REFERENCES public.extras(id) ON DELETE CASCADE;
-
-
---
--- Name: extra_orders extra_orders_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.extra_orders
-    ADD CONSTRAINT extra_orders_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE CASCADE;
-
-
---
--- Name: email_messages fk_email_messages_reply_to; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.email_messages
-    ADD CONSTRAINT fk_email_messages_reply_to FOREIGN KEY (in_reply_to_message_id) REFERENCES public.email_messages(id) ON DELETE SET NULL;
-
-
---
--- Name: guest_activities guest_activities_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.guest_activities
-    ADD CONSTRAINT guest_activities_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE CASCADE;
-
-
---
--- Name: guest_activities guest_activities_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.guest_activities
-    ADD CONSTRAINT guest_activities_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE SET NULL;
-
-
---
--- Name: guest_activities guest_activities_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.guest_activities
-    ADD CONSTRAINT guest_activities_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE SET NULL;
-
-
---
--- Name: guest_quotes guest_quotes_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.guest_quotes
-    ADD CONSTRAINT guest_quotes_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE SET NULL;
-
-
---
--- Name: guest_reviews guest_reviews_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.guest_reviews
-    ADD CONSTRAINT guest_reviews_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE CASCADE;
-
-
---
--- Name: guest_reviews guest_reviews_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.guest_reviews
-    ADD CONSTRAINT guest_reviews_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
-
-
---
--- Name: guest_reviews guest_reviews_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.guest_reviews
-    ADD CONSTRAINT guest_reviews_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE SET NULL;
-
-
---
--- Name: guest_surveys guest_surveys_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.guest_surveys
-    ADD CONSTRAINT guest_surveys_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE CASCADE;
-
-
---
--- Name: guest_surveys guest_surveys_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.guest_surveys
-    ADD CONSTRAINT guest_surveys_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE SET NULL;
-
-
---
--- Name: guest_surveys guest_surveys_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.guest_surveys
-    ADD CONSTRAINT guest_surveys_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE SET NULL;
-
-
---
--- Name: guest_surveys guest_surveys_template_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.guest_surveys
-    ADD CONSTRAINT guest_surveys_template_id_fkey FOREIGN KEY (template_id) REFERENCES public.survey_templates(id) ON DELETE SET NULL;
-
-
---
--- Name: guest_verifications guest_verifications_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.guest_verifications
-    ADD CONSTRAINT guest_verifications_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE CASCADE;
-
-
---
--- Name: guest_verifications guest_verifications_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.guest_verifications
-    ADD CONSTRAINT guest_verifications_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE SET NULL;
-
-
---
--- Name: guestbook_guides guestbook_guides_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.guestbook_guides
-    ADD CONSTRAINT guestbook_guides_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
-
-
---
--- Name: housekeeping_tasks housekeeping_tasks_assigned_cleaner_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.housekeeping_tasks
-    ADD CONSTRAINT housekeeping_tasks_assigned_cleaner_id_fkey FOREIGN KEY (assigned_cleaner_id) REFERENCES public.cleaners(id) ON DELETE SET NULL;
-
-
---
--- Name: housekeeping_tasks housekeeping_tasks_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.housekeeping_tasks
-    ADD CONSTRAINT housekeeping_tasks_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
-
-
---
--- Name: housekeeping_tasks housekeeping_tasks_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.housekeeping_tasks
-    ADD CONSTRAINT housekeeping_tasks_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE SET NULL;
-
-
---
--- Name: hunter_queue hunter_queue_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.hunter_queue
-    ADD CONSTRAINT hunter_queue_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE SET NULL;
-
-
---
--- Name: hunter_queue hunter_queue_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.hunter_queue
-    ADD CONSTRAINT hunter_queue_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE SET NULL;
+ALTER TABLE ONLY public.guest_leads
+    ADD CONSTRAINT guest_leads_source_email_id_fkey FOREIGN KEY (source_email_id) REFERENCES public.email_archive(id);
 
 
 --
@@ -9592,7 +12415,7 @@ ALTER TABLE ONLY public.hunter_queue
 --
 
 ALTER TABLE ONLY public.journal_line_items
-    ADD CONSTRAINT journal_line_items_account_id_fkey FOREIGN KEY (account_id) REFERENCES public.accounts(id) ON DELETE RESTRICT;
+    ADD CONSTRAINT journal_line_items_account_id_fkey FOREIGN KEY (account_id) REFERENCES public.accounts(id);
 
 
 --
@@ -9604,519 +12427,103 @@ ALTER TABLE ONLY public.journal_line_items
 
 
 --
--- Name: knowledge_base_entries knowledge_base_entries_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: legal_docket legal_docket_matter_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.knowledge_base_entries
-    ADD CONSTRAINT knowledge_base_entries_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.legal_docket
+    ADD CONSTRAINT legal_docket_matter_id_fkey FOREIGN KEY (matter_id) REFERENCES public.legal_matters(matter_id);
 
 
 --
--- Name: marketing_articles marketing_articles_category_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: legal_matter_notes legal_matter_notes_matter_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.marketing_articles
-    ADD CONSTRAINT marketing_articles_category_id_fkey FOREIGN KEY (category_id) REFERENCES public.taxonomy_categories(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.legal_matter_notes
+    ADD CONSTRAINT legal_matter_notes_matter_id_fkey FOREIGN KEY (matter_id) REFERENCES public.legal_matters(matter_id);
 
 
 --
--- Name: message_queue message_queue_quote_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: legal_matters legal_matters_client_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.message_queue
-    ADD CONSTRAINT message_queue_quote_id_fkey FOREIGN KEY (quote_id) REFERENCES public.quotes(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.legal_matters
+    ADD CONSTRAINT legal_matters_client_id_fkey FOREIGN KEY (client_id) REFERENCES public.legal_clients(client_id);
 
 
 --
--- Name: message_queue message_queue_template_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: ops_tasks ops_tasks_assigned_to_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.message_queue
-    ADD CONSTRAINT message_queue_template_id_fkey FOREIGN KEY (template_id) REFERENCES public.email_templates(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.ops_tasks
+    ADD CONSTRAINT ops_tasks_assigned_to_fkey FOREIGN KEY (assigned_to) REFERENCES public.ops_crew(id);
 
 
 --
--- Name: messages messages_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: ops_tasks ops_tasks_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.messages
-    ADD CONSTRAINT messages_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE SET NULL;
+ALTER TABLE ONLY public.ops_tasks
+    ADD CONSTRAINT ops_tasks_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.ops_properties(property_id);
 
 
 --
--- Name: messages messages_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: ops_tasks ops_tasks_turnover_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.messages
-    ADD CONSTRAINT messages_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE SET NULL;
+ALTER TABLE ONLY public.ops_tasks
+    ADD CONSTRAINT ops_tasks_turnover_id_fkey FOREIGN KEY (turnover_id) REFERENCES public.ops_turnovers(id);
 
 
 --
--- Name: operator_overrides operator_overrides_escalation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: ops_turnovers ops_turnovers_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.operator_overrides
-    ADD CONSTRAINT operator_overrides_escalation_id_fkey FOREIGN KEY (escalation_id) REFERENCES public.swarm_escalations(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.ops_turnovers
+    ADD CONSTRAINT ops_turnovers_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.ops_properties(property_id);
 
 
 --
--- Name: ota_micro_updates ota_micro_updates_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: ops_visuals ops_visuals_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ota_micro_updates
-    ADD CONSTRAINT ota_micro_updates_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.ops_visuals
+    ADD CONSTRAINT ops_visuals_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.ops_properties(property_id) ON DELETE SET NULL;
 
 
 --
--- Name: owner_balance_periods owner_balance_periods_owner_payout_account_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: property_events property_events_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.owner_balance_periods
-    ADD CONSTRAINT owner_balance_periods_owner_payout_account_id_fkey FOREIGN KEY (owner_payout_account_id) REFERENCES public.owner_payout_accounts(id) ON DELETE RESTRICT;
+ALTER TABLE ONLY public.property_events
+    ADD CONSTRAINT property_events_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id);
 
 
 --
--- Name: owner_charges owner_charges_owner_payout_account_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: property_sms_config property_sms_config_provider_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.owner_charges
-    ADD CONSTRAINT owner_charges_owner_payout_account_id_fkey FOREIGN KEY (owner_payout_account_id) REFERENCES public.owner_payout_accounts(id) ON DELETE RESTRICT;
+ALTER TABLE ONLY public.property_sms_config
+    ADD CONSTRAINT property_sms_config_provider_id_fkey FOREIGN KEY (provider_id) REFERENCES public.sms_providers(id);
 
 
 --
--- Name: owner_charges owner_charges_vendor_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: sales_intel sales_intel_source_email_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.owner_charges
-    ADD CONSTRAINT owner_charges_vendor_id_fkey FOREIGN KEY (vendor_id) REFERENCES public.vendors(id) ON DELETE SET NULL;
+ALTER TABLE ONLY public.sales_intel
+    ADD CONSTRAINT sales_intel_source_email_id_fkey FOREIGN KEY (source_email_id) REFERENCES public.email_archive(id);
 
 
 --
--- Name: owner_statement_sends owner_statement_sends_owner_payout_account_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: trust_balance trust_balance_last_entry_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.owner_statement_sends
-    ADD CONSTRAINT owner_statement_sends_owner_payout_account_id_fkey FOREIGN KEY (owner_payout_account_id) REFERENCES public.owner_payout_accounts(id) ON DELETE RESTRICT;
-
-
---
--- Name: owner_statement_sends owner_statement_sends_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.owner_statement_sends
-    ADD CONSTRAINT owner_statement_sends_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE RESTRICT;
-
-
---
--- Name: pricing_overrides pricing_overrides_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.pricing_overrides
-    ADD CONSTRAINT pricing_overrides_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
-
-
---
--- Name: properties properties_default_housekeeper_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.properties
-    ADD CONSTRAINT properties_default_housekeeper_id_fkey FOREIGN KEY (default_housekeeper_id) REFERENCES public.staff_users(id) ON DELETE SET NULL;
-
-
---
--- Name: property_fees property_fees_fee_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.property_fees
-    ADD CONSTRAINT property_fees_fee_id_fkey FOREIGN KEY (fee_id) REFERENCES public.fees(id) ON DELETE CASCADE;
-
-
---
--- Name: property_fees property_fees_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.property_fees
-    ADD CONSTRAINT property_fees_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
-
-
---
--- Name: property_images property_images_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.property_images
-    ADD CONSTRAINT property_images_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
-
-
---
--- Name: property_knowledge_chunks property_knowledge_chunks_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.property_knowledge_chunks
-    ADD CONSTRAINT property_knowledge_chunks_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
-
-
---
--- Name: property_knowledge property_knowledge_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.property_knowledge
-    ADD CONSTRAINT property_knowledge_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
-
-
---
--- Name: property_stay_restrictions property_stay_restrictions_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.property_stay_restrictions
-    ADD CONSTRAINT property_stay_restrictions_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
-
-
---
--- Name: property_taxes property_taxes_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.property_taxes
-    ADD CONSTRAINT property_taxes_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
-
-
---
--- Name: property_taxes property_taxes_tax_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.property_taxes
-    ADD CONSTRAINT property_taxes_tax_id_fkey FOREIGN KEY (tax_id) REFERENCES public.taxes(id) ON DELETE CASCADE;
-
-
---
--- Name: property_utilities property_utilities_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.property_utilities
-    ADD CONSTRAINT property_utilities_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
-
-
---
--- Name: quote_options quote_options_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.quote_options
-    ADD CONSTRAINT quote_options_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
-
-
---
--- Name: quote_options quote_options_quote_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.quote_options
-    ADD CONSTRAINT quote_options_quote_id_fkey FOREIGN KEY (quote_id) REFERENCES public.quotes(id) ON DELETE CASCADE;
-
-
---
--- Name: quotes quotes_lead_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.quotes
-    ADD CONSTRAINT quotes_lead_id_fkey FOREIGN KEY (lead_id) REFERENCES public.leads(id) ON DELETE CASCADE;
-
-
---
--- Name: recovery_parity_comparisons recovery_parity_comparisons_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.recovery_parity_comparisons
-    ADD CONSTRAINT recovery_parity_comparisons_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE SET NULL;
-
-
---
--- Name: rental_agreements rental_agreements_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.rental_agreements
-    ADD CONSTRAINT rental_agreements_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE CASCADE;
-
-
---
--- Name: rental_agreements rental_agreements_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.rental_agreements
-    ADD CONSTRAINT rental_agreements_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE SET NULL;
-
-
---
--- Name: rental_agreements rental_agreements_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.rental_agreements
-    ADD CONSTRAINT rental_agreements_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE SET NULL;
-
-
---
--- Name: rental_agreements rental_agreements_template_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.rental_agreements
-    ADD CONSTRAINT rental_agreements_template_id_fkey FOREIGN KEY (template_id) REFERENCES public.agreement_templates(id) ON DELETE SET NULL;
-
-
---
--- Name: reservation_holds reservation_holds_converted_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.reservation_holds
-    ADD CONSTRAINT reservation_holds_converted_reservation_id_fkey FOREIGN KEY (converted_reservation_id) REFERENCES public.reservations(id) ON DELETE SET NULL;
-
-
---
--- Name: reservation_holds reservation_holds_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.reservation_holds
-    ADD CONSTRAINT reservation_holds_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE CASCADE;
-
-
---
--- Name: reservation_holds reservation_holds_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.reservation_holds
-    ADD CONSTRAINT reservation_holds_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
-
-
---
--- Name: reservations reservations_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.reservations
-    ADD CONSTRAINT reservations_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE CASCADE;
-
-
---
--- Name: reservations reservations_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.reservations
-    ADD CONSTRAINT reservations_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
-
-
---
--- Name: scheduled_messages scheduled_messages_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.scheduled_messages
-    ADD CONSTRAINT scheduled_messages_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE CASCADE;
-
-
---
--- Name: scheduled_messages scheduled_messages_message_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.scheduled_messages
-    ADD CONSTRAINT scheduled_messages_message_id_fkey FOREIGN KEY (message_id) REFERENCES public.messages(id) ON DELETE SET NULL;
-
-
---
--- Name: scheduled_messages scheduled_messages_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.scheduled_messages
-    ADD CONSTRAINT scheduled_messages_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE CASCADE;
-
-
---
--- Name: scheduled_messages scheduled_messages_template_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.scheduled_messages
-    ADD CONSTRAINT scheduled_messages_template_id_fkey FOREIGN KEY (template_id) REFERENCES public.message_templates(id) ON DELETE CASCADE;
-
-
---
--- Name: seo_patch_queue seo_patch_queue_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.seo_patch_queue
-    ADD CONSTRAINT seo_patch_queue_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
-
-
---
--- Name: seo_patches seo_patches_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.seo_patches
-    ADD CONSTRAINT seo_patches_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
-
-
---
--- Name: seo_patches seo_patches_rubric_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.seo_patches
-    ADD CONSTRAINT seo_patches_rubric_id_fkey FOREIGN KEY (rubric_id) REFERENCES public.seo_rubrics(id) ON DELETE SET NULL;
-
-
---
--- Name: seo_patches seo_patches_source_intelligence_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.seo_patches
-    ADD CONSTRAINT seo_patches_source_intelligence_id_fkey FOREIGN KEY (source_intelligence_id) REFERENCES public.intelligence_ledger(id) ON DELETE SET NULL;
-
-
---
--- Name: seo_rank_snapshots seo_rank_snapshots_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.seo_rank_snapshots
-    ADD CONSTRAINT seo_rank_snapshots_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
-
-
---
--- Name: staff_invites staff_invites_invited_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.staff_invites
-    ADD CONSTRAINT staff_invites_invited_by_fkey FOREIGN KEY (invited_by) REFERENCES public.staff_users(id);
-
-
---
--- Name: storefront_session_guest_links storefront_session_guest_links_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.storefront_session_guest_links
-    ADD CONSTRAINT storefront_session_guest_links_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE CASCADE;
-
-
---
--- Name: storefront_session_guest_links storefront_session_guest_links_reservation_hold_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.storefront_session_guest_links
-    ADD CONSTRAINT storefront_session_guest_links_reservation_hold_id_fkey FOREIGN KEY (reservation_hold_id) REFERENCES public.reservation_holds(id) ON DELETE SET NULL;
-
-
---
--- Name: swarm_escalations swarm_escalations_decision_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.swarm_escalations
-    ADD CONSTRAINT swarm_escalations_decision_id_fkey FOREIGN KEY (decision_id) REFERENCES public.trust_decisions(id) ON DELETE CASCADE;
-
-
---
--- Name: trust_decisions trust_decisions_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.trust_decisions
-    ADD CONSTRAINT trust_decisions_run_id_fkey FOREIGN KEY (run_id) REFERENCES public.agent_runs(id) ON DELETE CASCADE;
-
-
---
--- Name: trust_ledger_entries trust_ledger_entries_account_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.trust_ledger_entries
-    ADD CONSTRAINT trust_ledger_entries_account_id_fkey FOREIGN KEY (account_id) REFERENCES public.trust_accounts(id) ON DELETE RESTRICT;
-
-
---
--- Name: trust_ledger_entries trust_ledger_entries_transaction_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.trust_ledger_entries
-    ADD CONSTRAINT trust_ledger_entries_transaction_id_fkey FOREIGN KEY (transaction_id) REFERENCES public.trust_transactions(id) ON DELETE CASCADE;
-
-
---
--- Name: trust_transactions trust_transactions_decision_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.trust_transactions
-    ADD CONSTRAINT trust_transactions_decision_id_fkey FOREIGN KEY (decision_id) REFERENCES public.trust_decisions(id) ON DELETE RESTRICT;
-
-
---
--- Name: utility_readings utility_readings_utility_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.utility_readings
-    ADD CONSTRAINT utility_readings_utility_id_fkey FOREIGN KEY (utility_id) REFERENCES public.property_utilities(id) ON DELETE CASCADE;
-
-
---
--- Name: vrs_add_ons vrs_add_ons_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.vrs_add_ons
-    ADD CONSTRAINT vrs_add_ons_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
-
-
---
--- Name: vrs_automation_events vrs_automation_events_rule_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.vrs_automation_events
-    ADD CONSTRAINT vrs_automation_events_rule_id_fkey FOREIGN KEY (rule_id) REFERENCES public.vrs_automations(id) ON DELETE SET NULL;
-
-
---
--- Name: work_orders work_orders_assigned_vendor_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.work_orders
-    ADD CONSTRAINT work_orders_assigned_vendor_id_fkey FOREIGN KEY (assigned_vendor_id) REFERENCES public.vendors(id) ON DELETE SET NULL;
-
-
---
--- Name: work_orders work_orders_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.work_orders
-    ADD CONSTRAINT work_orders_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE SET NULL;
-
-
---
--- Name: work_orders work_orders_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.work_orders
-    ADD CONSTRAINT work_orders_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
-
-
---
--- Name: work_orders work_orders_reported_via_message_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.work_orders
-    ADD CONSTRAINT work_orders_reported_via_message_id_fkey FOREIGN KEY (reported_via_message_id) REFERENCES public.messages(id) ON DELETE SET NULL;
-
-
---
--- Name: work_orders work_orders_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.work_orders
-    ADD CONSTRAINT work_orders_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE SET NULL;
-
-
---
--- Name: yield_overrides yield_overrides_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.yield_overrides
-    ADD CONSTRAINT yield_overrides_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
-
-
---
--- Name: yield_simulations yield_simulations_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.yield_simulations
-    ADD CONSTRAINT yield_simulations_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.trust_balance
+    ADD CONSTRAINT trust_balance_last_entry_id_fkey FOREIGN KEY (last_entry_id) REFERENCES public.journal_entries(id);
 
 
 --
 -- PostgreSQL database dump complete
 --
 
-\unrestrict FdO3Ro8PL5WgXQeaZzwcBMCxYm7tASohFPK6iWWOA4tAqKqVEW35qN3uEPfbMbp
+\unrestrict VUrcdL6h86Va4b8PalMVliVEj9OibDpqKcdRaRctoyg85SNJEnJ3GJKYJj1pYCh

--- a/fortress-guest-platform/ci/schema.sql
+++ b/fortress-guest-platform/ci/schema.sql
@@ -1,8 +1,8 @@
 -- CI schema snapshot for fortress-guest-platform
--- Generated: 2026-04-25T12:12:32Z
--- Source:    fortress_db
--- Commit:    13866efa658ffe2950593d1e8a48dec8ca691608
--- Alembic:   d8e3c1f5b9a6,m8f9a1b2c3d4
+-- Generated: 2026-04-21T02:49:45Z
+-- Source:    fortress_shadow
+-- Commit:    3446e105817985d0c870aad9a782c12f06a5d862
+-- Alembic:   l7e8f1a2b3c4
 -- NOTE: geometry/vector types replaced with text for CI compatibility.
 --       postgis/vector extensions omitted (postgres:16 has pgcrypto/uuid-ossp).
 
@@ -18,7 +18,7 @@ SET ROLE TO fortress_admin;
 -- PostgreSQL database dump
 --
 
-\restrict VUrcdL6h86Va4b8PalMVliVEj9OibDpqKcdRaRctoyg85SNJEnJ3GJKYJj1pYCh
+\restrict FdO3Ro8PL5WgXQeaZzwcBMCxYm7tASohFPK6iWWOA4tAqKqVEW35qN3uEPfbMbp
 
 -- Dumped from database version 16.13 (Ubuntu 16.13-0ubuntu0.24.04.1)
 -- Dumped by pg_dump version 16.13 (Ubuntu 16.13-0ubuntu0.24.04.1)
@@ -35,45 +35,24 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
--- Name: division_a; Type: SCHEMA; Schema: -; Owner: -
+-- Name: core; Type: SCHEMA; Schema: -; Owner: -
 --
 
-CREATE SCHEMA division_a;
-
-
---
--- Name: division_b; Type: SCHEMA; Schema: -; Owner: -
---
-
-CREATE SCHEMA division_b;
+CREATE SCHEMA core;
 
 
 --
--- Name: engineering; Type: SCHEMA; Schema: -; Owner: -
+-- Name: crog_acquisition; Type: SCHEMA; Schema: -; Owner: -
 --
 
-CREATE SCHEMA engineering;
-
-
---
--- Name: finance; Type: SCHEMA; Schema: -; Owner: -
---
-
-CREATE SCHEMA finance;
+CREATE SCHEMA crog_acquisition;
 
 
 --
--- Name: hedge_fund; Type: SCHEMA; Schema: -; Owner: -
+-- Name: iot_schema; Type: SCHEMA; Schema: -; Owner: -
 --
 
-CREATE SCHEMA hedge_fund;
-
-
---
--- Name: intelligence; Type: SCHEMA; Schema: -; Owner: -
---
-
-CREATE SCHEMA intelligence;
+CREATE SCHEMA iot_schema;
 
 
 --
@@ -84,10 +63,17 @@ CREATE SCHEMA legal;
 
 
 --
--- Name: legal_cmd; Type: SCHEMA; Schema: -; Owner: -
+-- Name: verses_schema; Type: SCHEMA; Schema: -; Owner: -
 --
 
-CREATE SCHEMA legal_cmd;
+CREATE SCHEMA verses_schema;
+
+
+--
+-- Name: dblink; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS dblink WITH SCHEMA public;
 
 
 --
@@ -95,6 +81,12 @@ CREATE SCHEMA legal_cmd;
 --
 
 CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
+
+
+--
+-- Name: postgis; Type: EXTENSION; Schema: -; Owner: -
+--
+
 
 
 --
@@ -111,429 +103,364 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA public;
 
 
 --
--- Name: update_timestamp(); Type: FUNCTION; Schema: legal_cmd; Owner: -
+-- Name: funnel_stage; Type: TYPE; Schema: crog_acquisition; Owner: -
 --
 
-CREATE FUNCTION legal_cmd.update_timestamp() RETURNS trigger
+CREATE TYPE crog_acquisition.funnel_stage AS ENUM (
+    'RADAR',
+    'TARGET_LOCKED',
+    'DEPLOYED',
+    'ENGAGED',
+    'ACQUIRED',
+    'REJECTED'
+);
+
+
+--
+-- Name: market_state; Type: TYPE; Schema: crog_acquisition; Owner: -
+--
+
+CREATE TYPE crog_acquisition.market_state AS ENUM (
+    'UNMANAGED',
+    'CROG_MANAGED',
+    'COMPETITOR_MANAGED',
+    'FOR_SALE'
+);
+
+
+--
+-- Name: signal_source; Type: TYPE; Schema: crog_acquisition; Owner: -
+--
+
+CREATE TYPE crog_acquisition.signal_source AS ENUM (
+    'FOIA_CSV',
+    'OTA_FIRECRAWL_HEURISTIC',
+    'AGGREGATOR_API'
+);
+
+
+--
+-- Name: guest_quote_status; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.guest_quote_status AS ENUM (
+    'pending',
+    'accepted',
+    'rejected',
+    'expired'
+);
+
+
+--
+-- Name: hunter_recovery_op_status; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.hunter_recovery_op_status AS ENUM (
+    'QUEUED',
+    'EXECUTING',
+    'DRAFT_READY',
+    'DISPATCHED',
+    'REJECTED'
+);
+
+
+--
+-- Name: owner_charge_type_enum; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.owner_charge_type_enum AS ENUM (
+    'cleaning_fee',
+    'maintenance',
+    'management_fee',
+    'supplies',
+    'landscaping',
+    'linen',
+    'electric_bill',
+    'housekeeper_pay',
+    'advertising_fee',
+    'third_party_ota_commission',
+    'travel_agent_fee',
+    'credit_card_dispute',
+    'federal_tax_withholding',
+    'adjust_owner_revenue',
+    'credit_from_management',
+    'pay_to_old_owner',
+    'misc_guest_charges',
+    'statement_marker',
+    'room_revenue',
+    'hacienda_tax',
+    'charge_expired_owner',
+    'owner_payment_received'
+);
+
+
+--
+-- Name: property_renting_state; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.property_renting_state AS ENUM (
+    'active',
+    'pre_launch',
+    'paused',
+    'offboarded'
+);
+
+
+--
+-- Name: statement_period_status; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.statement_period_status AS ENUM (
+    'draft',
+    'pending_approval',
+    'approved',
+    'paid',
+    'emailed',
+    'voided'
+);
+
+
+--
+-- Name: prevent_mutation(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.prevent_mutation() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN
-    NEW.updated_at = NOW();
-    RETURN NEW;
+    RAISE EXCEPTION 'Immutable table: UPDATE and DELETE are strictly forbidden on %', TG_TABLE_NAME;
+    RETURN NULL;
 END;
 $$;
-
-
---
--- Name: enforce_immutable_line_items(); Type: FUNCTION; Schema: public; Owner: -
---
-
-CREATE FUNCTION public.enforce_immutable_line_items() RETURNS trigger
-    LANGUAGE plpgsql
-    AS $$
-BEGIN
-    RAISE EXCEPTION 'FORTRESS PROTOCOL: journal_line_items is append-only. Issue a reversing journal entry via void_entry() instead.';
-END;
-$$;
-
-
---
--- Name: enforce_journal_entry_integrity(); Type: FUNCTION; Schema: public; Owner: -
---
-
-CREATE FUNCTION public.enforce_journal_entry_integrity() RETURNS trigger
-    LANGUAGE plpgsql
-    AS $$
-BEGIN
-    IF TG_OP = 'DELETE' THEN
-        RAISE EXCEPTION 'FORTRESS PROTOCOL: journal_entries cannot be deleted. Use void_entry() to mark entries as void.';
-    END IF;
-
-    IF TG_OP = 'UPDATE' THEN
-        IF OLD.entry_date IS DISTINCT FROM NEW.entry_date
-           OR OLD.description IS DISTINCT FROM NEW.description
-           OR OLD.reference_id IS DISTINCT FROM NEW.reference_id
-           OR OLD.reference_type IS DISTINCT FROM NEW.reference_type
-           OR OLD.property_id IS DISTINCT FROM NEW.property_id
-           OR OLD.posted_by IS DISTINCT FROM NEW.posted_by
-           OR OLD.source_system IS DISTINCT FROM NEW.source_system THEN
-            RAISE EXCEPTION 'FORTRESS PROTOCOL: Financial columns on journal_entries are immutable. Only void-related fields (is_void, void_reason, voided_at, voided_by) may be updated.';
-        END IF;
-    END IF;
-
-    RETURN NEW;
-END;
-$$;
-
-
---
--- Name: update_updated_at_column(); Type: FUNCTION; Schema: public; Owner: -
---
-
-CREATE FUNCTION public.update_updated_at_column() RETURNS trigger
-    LANGUAGE plpgsql
-    AS $$
-BEGIN
-    NEW.updated_at = NOW();
-    RETURN NEW;
-END;
-$$;
-
-
---
--- Name: verify_journal_balance(); Type: FUNCTION; Schema: public; Owner: -
---
-
-CREATE FUNCTION public.verify_journal_balance() RETURNS trigger
-    LANGUAGE plpgsql
-    AS $_$
-DECLARE
-    total_debits    NUMERIC(15, 2);
-    total_credits   NUMERIC(15, 2);
-BEGIN
-    SELECT
-        COALESCE(SUM(debit), 0),
-        COALESCE(SUM(credit), 0)
-    INTO total_debits, total_credits
-    FROM journal_line_items
-    WHERE journal_entry_id = NEW.journal_entry_id;
-
-    IF total_debits != total_credits THEN
-        RAISE EXCEPTION
-            '[IRON DOME] REJECTED: Entry #% — Debits ($%) != Credits ($%). Delta: $%',
-            NEW.journal_entry_id,
-            total_debits,
-            total_credits,
-            ABS(total_debits - total_credits);
-    END IF;
-
-    RETURN NEW;
-END;
-$_$;
 
 
 SET default_table_access_method = heap;
 
 --
--- Name: account_mappings; Type: TABLE; Schema: division_a; Owner: -
+-- Name: deliberation_logs; Type: TABLE; Schema: core; Owner: -
 --
 
-CREATE TABLE division_a.account_mappings (
-    id integer NOT NULL,
-    vendor_name text NOT NULL,
-    plaid_category text DEFAULT ''::text,
-    debit_account text NOT NULL,
-    credit_account text NOT NULL,
-    confidence numeric(4,3) DEFAULT 0.0,
-    reasoning text DEFAULT ''::text,
-    learned_at timestamp with time zone DEFAULT now(),
-    source text DEFAULT 'llm'::text
+CREATE TABLE core.deliberation_logs (
+    id uuid NOT NULL,
+    verdict_type character varying(64) NOT NULL,
+    session_id character varying(128) NOT NULL,
+    guest_id uuid,
+    reservation_id uuid,
+    property_id uuid,
+    message_id uuid,
+    payload_json jsonb DEFAULT '{}'::jsonb NOT NULL,
+    created_at timestamp without time zone NOT NULL
 );
 
 
 --
--- Name: account_mappings_id_seq; Type: SEQUENCE; Schema: division_a; Owner: -
+-- Name: acquisition_documents; Type: TABLE; Schema: crog_acquisition; Owner: -
 --
 
-CREATE SEQUENCE division_a.account_mappings_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: account_mappings_id_seq; Type: SEQUENCE OWNED BY; Schema: division_a; Owner: -
---
-
-ALTER SEQUENCE division_a.account_mappings_id_seq OWNED BY division_a.account_mappings.id;
+CREATE TABLE crog_acquisition.acquisition_documents (
+    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    pipeline_id uuid NOT NULL,
+    file_name character varying(255) NOT NULL,
+    nfs_path text NOT NULL,
+    mime_type character varying(100) DEFAULT 'application/octet-stream'::character varying NOT NULL,
+    file_hash character varying(64),
+    file_size_bytes integer,
+    doc_type character varying(50) DEFAULT 'general'::character varying NOT NULL,
+    uploaded_by character varying(255),
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
 
 
 --
--- Name: audit_log; Type: TABLE; Schema: division_a; Owner: -
+-- Name: acquisition_pipeline; Type: TABLE; Schema: crog_acquisition; Owner: -
 --
 
-CREATE TABLE division_a.audit_log (
-    id integer NOT NULL,
-    action text NOT NULL,
-    agent text DEFAULT 'division_a.agent'::text,
-    detail jsonb,
+CREATE TABLE crog_acquisition.acquisition_pipeline (
+    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    property_id uuid NOT NULL,
+    stage crog_acquisition.funnel_stage DEFAULT 'RADAR'::crog_acquisition.funnel_stage NOT NULL,
+    llm_viability_score numeric(3,2),
+    lob_mail_sent_at timestamp with time zone,
+    instantly_campaign_id character varying(255),
+    vapi_call_status character varying(100),
+    next_action_date date,
+    rejection_reason text,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: due_diligence; Type: TABLE; Schema: crog_acquisition; Owner: -
+--
+
+CREATE TABLE crog_acquisition.due_diligence (
+    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    pipeline_id uuid NOT NULL,
+    item_key character varying(80) NOT NULL,
+    label character varying(255) NOT NULL,
+    display_order integer DEFAULT 0 NOT NULL,
+    status character varying(20) DEFAULT 'pending'::character varying NOT NULL,
+    notes text,
+    completed_at timestamp with time zone,
+    completed_by character varying(255),
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT chk_dd_status CHECK (((status)::text = ANY ((ARRAY['pending'::character varying, 'passed'::character varying, 'failed'::character varying, 'waived'::character varying])::text[])))
+);
+
+
+--
+-- Name: intel_events; Type: TABLE; Schema: crog_acquisition; Owner: -
+--
+
+CREATE TABLE crog_acquisition.intel_events (
+    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    property_id uuid NOT NULL,
+    event_type character varying(100) NOT NULL,
+    event_description text NOT NULL,
+    raw_source_data jsonb,
+    detected_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: owner_contacts; Type: TABLE; Schema: crog_acquisition; Owner: -
+--
+
+CREATE TABLE crog_acquisition.owner_contacts (
+    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    owner_id uuid NOT NULL,
+    contact_type character varying(50),
+    contact_value character varying(255) NOT NULL,
+    source character varying(100),
+    confidence_score numeric(3,2),
+    is_dnc boolean DEFAULT false NOT NULL,
+    CONSTRAINT ck_acquisition_owner_contacts_confidence_score CHECK (((confidence_score >= 0.00) AND (confidence_score <= 1.00))),
+    CONSTRAINT ck_acquisition_owner_contacts_contact_type CHECK (((contact_type)::text = ANY ((ARRAY['CELL'::character varying, 'LANDLINE'::character varying, 'EMAIL'::character varying])::text[])))
+);
+
+
+--
+-- Name: owners; Type: TABLE; Schema: crog_acquisition; Owner: -
+--
+
+CREATE TABLE crog_acquisition.owners (
+    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    legal_name character varying(255) NOT NULL,
+    tax_mailing_address text NOT NULL,
+    primary_residence_state character varying(2),
+    psychological_profile jsonb,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: parcels; Type: TABLE; Schema: crog_acquisition; Owner: -
+--
+
+CREATE TABLE crog_acquisition.parcels (
+    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    county_name character varying(100) DEFAULT 'Fannin'::character varying NOT NULL,
+    parcel_id character varying(100) NOT NULL,
+    geom text,
+    assessed_value numeric(12,2) NOT NULL,
+    zoning_code character varying(50),
+    is_waterfront boolean DEFAULT false NOT NULL,
+    is_ridgeline boolean DEFAULT false NOT NULL,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: properties; Type: TABLE; Schema: crog_acquisition; Owner: -
+--
+
+CREATE TABLE crog_acquisition.properties (
+    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    parcel_id uuid NOT NULL,
+    owner_id uuid,
+    fannin_str_cert_id character varying(100),
+    blue_ridge_str_permit character varying(100),
+    zillow_zpid character varying(100),
+    google_place_id character varying(255),
+    airbnb_listing_id character varying(100),
+    vrbo_listing_id character varying(100),
+    status crog_acquisition.market_state DEFAULT 'UNMANAGED'::crog_acquisition.market_state NOT NULL,
+    management_company character varying(255),
+    bedrooms integer,
+    bathrooms numeric(3,1),
+    projected_adr numeric(8,2),
+    projected_annual_revenue numeric(10,2),
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: str_signals; Type: TABLE; Schema: crog_acquisition; Owner: -
+--
+
+CREATE TABLE crog_acquisition.str_signals (
+    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    property_id uuid NOT NULL,
+    signal_source crog_acquisition.signal_source NOT NULL,
+    confidence_score numeric(3,2) NOT NULL,
+    raw_payload jsonb DEFAULT '{}'::jsonb NOT NULL,
+    detected_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT ck_acquisition_str_signals_confidence_score CHECK (((confidence_score >= 0.00) AND (confidence_score <= 1.00)))
+);
+
+
+--
+-- Name: device_events; Type: TABLE; Schema: iot_schema; Owner: -
+--
+
+CREATE TABLE iot_schema.device_events (
+    id uuid NOT NULL,
+    device_id character varying(100) NOT NULL,
+    event_type character varying(100) NOT NULL,
+    payload jsonb DEFAULT '{}'::jsonb NOT NULL,
     created_at timestamp with time zone DEFAULT now()
 );
 
 
 --
--- Name: audit_log_id_seq; Type: SEQUENCE; Schema: division_a; Owner: -
+-- Name: digital_twins; Type: TABLE; Schema: iot_schema; Owner: -
 --
 
-CREATE SEQUENCE division_a.audit_log_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: audit_log_id_seq; Type: SEQUENCE OWNED BY; Schema: division_a; Owner: -
---
-
-ALTER SEQUENCE division_a.audit_log_id_seq OWNED BY division_a.audit_log.id;
-
-
---
--- Name: general_ledger; Type: TABLE; Schema: division_a; Owner: -
---
-
-CREATE TABLE division_a.general_ledger (
-    id integer NOT NULL,
-    journal_entry_id text NOT NULL,
-    account_code text NOT NULL,
-    account_name text NOT NULL,
-    debit numeric(14,2) DEFAULT 0.00 NOT NULL,
-    credit numeric(14,2) DEFAULT 0.00 NOT NULL,
-    memo text DEFAULT ''::text,
-    created_at timestamp with time zone DEFAULT now(),
-    CONSTRAINT debit_xor_credit CHECK ((((debit > (0)::numeric) AND (credit = (0)::numeric)) OR ((debit = (0)::numeric) AND (credit > (0)::numeric))))
-);
-
-
---
--- Name: balance_check; Type: VIEW; Schema: division_a; Owner: -
---
-
-CREATE VIEW division_a.balance_check AS
- SELECT sum(debit) AS total_debits,
-    sum(credit) AS total_credits,
-    (sum(debit) - sum(credit)) AS imbalance,
-        CASE
-            WHEN (sum(debit) = sum(credit)) THEN 'BALANCED'::text
-            ELSE 'IMBALANCED'::text
-        END AS status
-   FROM division_a.general_ledger;
-
-
---
--- Name: chart_of_accounts; Type: TABLE; Schema: division_a; Owner: -
---
-
-CREATE TABLE division_a.chart_of_accounts (
-    id integer NOT NULL,
-    code text NOT NULL,
-    name text NOT NULL,
-    account_type text NOT NULL,
-    parent_code text,
-    description text DEFAULT ''::text,
-    is_active boolean DEFAULT true,
-    qbo_id text,
-    qbo_name text,
-    normal_balance text DEFAULT 'debit'::text NOT NULL,
-    created_at timestamp with time zone DEFAULT now(),
-    updated_at timestamp with time zone DEFAULT now(),
-    CONSTRAINT valid_account_type CHECK ((account_type = ANY (ARRAY['asset'::text, 'liability'::text, 'equity'::text, 'revenue'::text, 'expense'::text, 'cogs'::text]))),
-    CONSTRAINT valid_normal_balance CHECK ((normal_balance = ANY (ARRAY['debit'::text, 'credit'::text])))
-);
-
-
---
--- Name: chart_of_accounts_id_seq; Type: SEQUENCE; Schema: division_a; Owner: -
---
-
-CREATE SEQUENCE division_a.chart_of_accounts_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: chart_of_accounts_id_seq; Type: SEQUENCE OWNED BY; Schema: division_a; Owner: -
---
-
-ALTER SEQUENCE division_a.chart_of_accounts_id_seq OWNED BY division_a.chart_of_accounts.id;
-
-
---
--- Name: general_ledger_id_seq; Type: SEQUENCE; Schema: division_a; Owner: -
---
-
-CREATE SEQUENCE division_a.general_ledger_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: general_ledger_id_seq; Type: SEQUENCE OWNED BY; Schema: division_a; Owner: -
---
-
-ALTER SEQUENCE division_a.general_ledger_id_seq OWNED BY division_a.general_ledger.id;
-
-
---
--- Name: journal_entries; Type: TABLE; Schema: division_a; Owner: -
---
-
-CREATE TABLE division_a.journal_entries (
-    id integer NOT NULL,
-    entry_id text NOT NULL,
-    entry_date date NOT NULL,
-    description text NOT NULL,
-    source_type text DEFAULT 'plaid'::text,
-    source_ref text DEFAULT ''::text,
-    memo text DEFAULT ''::text,
-    is_posted boolean DEFAULT false,
-    created_by text DEFAULT 'fortress'::text,
-    created_at timestamp with time zone DEFAULT now(),
-    posted_at timestamp with time zone
-);
-
-
---
--- Name: journal_entries_id_seq; Type: SEQUENCE; Schema: division_a; Owner: -
---
-
-CREATE SEQUENCE division_a.journal_entries_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: journal_entries_id_seq; Type: SEQUENCE OWNED BY; Schema: division_a; Owner: -
---
-
-ALTER SEQUENCE division_a.journal_entries_id_seq OWNED BY division_a.journal_entries.id;
-
-
---
--- Name: predictions; Type: TABLE; Schema: division_a; Owner: -
---
-
-CREATE TABLE division_a.predictions (
-    id integer NOT NULL,
-    metric_name text NOT NULL,
-    predicted_value numeric(14,4),
-    actual_value numeric(14,4),
-    variance_pct numeric(8,4),
-    cycle_id integer,
-    created_at timestamp with time zone DEFAULT now()
-);
-
-
---
--- Name: predictions_id_seq; Type: SEQUENCE; Schema: division_a; Owner: -
---
-
-CREATE SEQUENCE division_a.predictions_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: predictions_id_seq; Type: SEQUENCE OWNED BY; Schema: division_a; Owner: -
---
-
-ALTER SEQUENCE division_a.predictions_id_seq OWNED BY division_a.predictions.id;
-
-
---
--- Name: transactions; Type: TABLE; Schema: division_a; Owner: -
---
-
-CREATE TABLE division_a.transactions (
-    id integer NOT NULL,
-    plaid_txn_id text,
-    date date NOT NULL,
-    vendor text NOT NULL,
-    amount numeric(12,2) NOT NULL,
-    category text DEFAULT 'UNCATEGORIZED'::text NOT NULL,
-    confidence numeric(4,3) DEFAULT 0.0,
-    roi_impact text DEFAULT 'neutral'::text,
-    reasoning text,
-    method text DEFAULT 'manual'::text,
-    account_id text,
+CREATE TABLE iot_schema.digital_twins (
+    id uuid NOT NULL,
+    device_id character varying(100) NOT NULL,
+    property_id character varying(100) NOT NULL,
+    device_type character varying(50) NOT NULL,
+    device_name character varying(255),
+    state_json jsonb DEFAULT '{}'::jsonb NOT NULL,
+    battery_level integer,
+    is_online boolean,
+    last_event_ts timestamp with time zone DEFAULT now(),
     created_at timestamp with time zone DEFAULT now(),
     updated_at timestamp with time zone DEFAULT now()
 );
 
 
 --
--- Name: transactions_id_seq; Type: SEQUENCE; Schema: division_a; Owner: -
+-- Name: ai_audit_ledger; Type: TABLE; Schema: legal; Owner: -
 --
 
-CREATE SEQUENCE division_a.transactions_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: transactions_id_seq; Type: SEQUENCE OWNED BY; Schema: division_a; Owner: -
---
-
-ALTER SEQUENCE division_a.transactions_id_seq OWNED BY division_a.transactions.id;
-
-
---
--- Name: trial_balance; Type: VIEW; Schema: division_a; Owner: -
---
-
-CREATE VIEW division_a.trial_balance AS
- SELECT coa.code,
-    coa.name,
-    coa.account_type,
-    coa.normal_balance,
-    COALESCE(sum(gl.debit), (0)::numeric) AS total_debits,
-    COALESCE(sum(gl.credit), (0)::numeric) AS total_credits,
-    (COALESCE(sum(gl.debit), (0)::numeric) - COALESCE(sum(gl.credit), (0)::numeric)) AS net_balance
-   FROM (division_a.chart_of_accounts coa
-     LEFT JOIN division_a.general_ledger gl ON ((gl.account_code = coa.code)))
-  WHERE (coa.is_active = true)
-  GROUP BY coa.code, coa.name, coa.account_type, coa.normal_balance
-  ORDER BY coa.code;
-
-
---
--- Name: account_mappings; Type: TABLE; Schema: division_b; Owner: -
---
-
-CREATE TABLE division_b.account_mappings (
+CREATE TABLE legal.ai_audit_ledger (
     id integer NOT NULL,
-    vendor_name text NOT NULL,
-    plaid_category text DEFAULT ''::text,
-    debit_account text NOT NULL,
-    credit_account text NOT NULL,
-    confidence numeric(4,3) DEFAULT 0.0,
-    reasoning text DEFAULT ''::text,
-    learned_at timestamp with time zone DEFAULT now(),
-    source text DEFAULT 'llm'::text
+    case_slug text,
+    prompt_hash text,
+    retrieved_vectors jsonb DEFAULT '[]'::jsonb,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 
 --
--- Name: account_mappings_id_seq; Type: SEQUENCE; Schema: division_b; Owner: -
+-- Name: ai_audit_ledger_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
 --
 
-CREATE SEQUENCE division_b.account_mappings_id_seq
+CREATE SEQUENCE legal.ai_audit_ledger_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -543,1292 +470,10 @@ CREATE SEQUENCE division_b.account_mappings_id_seq
 
 
 --
--- Name: account_mappings_id_seq; Type: SEQUENCE OWNED BY; Schema: division_b; Owner: -
+-- Name: ai_audit_ledger_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
 --
 
-ALTER SEQUENCE division_b.account_mappings_id_seq OWNED BY division_b.account_mappings.id;
-
-
---
--- Name: general_ledger; Type: TABLE; Schema: division_b; Owner: -
---
-
-CREATE TABLE division_b.general_ledger (
-    id integer NOT NULL,
-    journal_entry_id text NOT NULL,
-    account_code text NOT NULL,
-    account_name text NOT NULL,
-    debit numeric(14,2) DEFAULT 0.00 NOT NULL,
-    credit numeric(14,2) DEFAULT 0.00 NOT NULL,
-    memo text DEFAULT ''::text,
-    created_at timestamp with time zone DEFAULT now(),
-    CONSTRAINT debit_xor_credit CHECK ((((debit > (0)::numeric) AND (credit = (0)::numeric)) OR ((debit = (0)::numeric) AND (credit > (0)::numeric))))
-);
-
-
---
--- Name: balance_check; Type: VIEW; Schema: division_b; Owner: -
---
-
-CREATE VIEW division_b.balance_check AS
- SELECT sum(debit) AS total_debits,
-    sum(credit) AS total_credits,
-    (sum(debit) - sum(credit)) AS imbalance,
-        CASE
-            WHEN (sum(debit) = sum(credit)) THEN 'BALANCED'::text
-            ELSE 'IMBALANCED'::text
-        END AS status
-   FROM division_b.general_ledger;
-
-
---
--- Name: chart_of_accounts; Type: TABLE; Schema: division_b; Owner: -
---
-
-CREATE TABLE division_b.chart_of_accounts (
-    id integer NOT NULL,
-    code text NOT NULL,
-    name text NOT NULL,
-    account_type text NOT NULL,
-    parent_code text,
-    description text DEFAULT ''::text,
-    is_active boolean DEFAULT true,
-    qbo_id text,
-    qbo_name text,
-    normal_balance text DEFAULT 'debit'::text NOT NULL,
-    created_at timestamp with time zone DEFAULT now(),
-    updated_at timestamp with time zone DEFAULT now(),
-    CONSTRAINT valid_account_type CHECK ((account_type = ANY (ARRAY['asset'::text, 'liability'::text, 'equity'::text, 'revenue'::text, 'expense'::text, 'cogs'::text]))),
-    CONSTRAINT valid_normal_balance CHECK ((normal_balance = ANY (ARRAY['debit'::text, 'credit'::text])))
-);
-
-
---
--- Name: chart_of_accounts_id_seq; Type: SEQUENCE; Schema: division_b; Owner: -
---
-
-CREATE SEQUENCE division_b.chart_of_accounts_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: chart_of_accounts_id_seq; Type: SEQUENCE OWNED BY; Schema: division_b; Owner: -
---
-
-ALTER SEQUENCE division_b.chart_of_accounts_id_seq OWNED BY division_b.chart_of_accounts.id;
-
-
---
--- Name: escrow; Type: TABLE; Schema: division_b; Owner: -
---
-
-CREATE TABLE division_b.escrow (
-    id integer NOT NULL,
-    reservation_id text NOT NULL,
-    guest_name text NOT NULL,
-    cabin_id text NOT NULL,
-    amount numeric(12,2) NOT NULL,
-    deposit_date date NOT NULL,
-    checkout_date date,
-    release_date date,
-    status text DEFAULT 'held'::text,
-    notes text,
-    created_at timestamp with time zone DEFAULT now(),
-    updated_at timestamp with time zone DEFAULT now()
-);
-
-
---
--- Name: escrow_id_seq; Type: SEQUENCE; Schema: division_b; Owner: -
---
-
-CREATE SEQUENCE division_b.escrow_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: escrow_id_seq; Type: SEQUENCE OWNED BY; Schema: division_b; Owner: -
---
-
-ALTER SEQUENCE division_b.escrow_id_seq OWNED BY division_b.escrow.id;
-
-
---
--- Name: general_ledger_id_seq; Type: SEQUENCE; Schema: division_b; Owner: -
---
-
-CREATE SEQUENCE division_b.general_ledger_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: general_ledger_id_seq; Type: SEQUENCE OWNED BY; Schema: division_b; Owner: -
---
-
-ALTER SEQUENCE division_b.general_ledger_id_seq OWNED BY division_b.general_ledger.id;
-
-
---
--- Name: journal_entries; Type: TABLE; Schema: division_b; Owner: -
---
-
-CREATE TABLE division_b.journal_entries (
-    id integer NOT NULL,
-    entry_id text NOT NULL,
-    entry_date date NOT NULL,
-    description text NOT NULL,
-    source_type text DEFAULT 'plaid'::text,
-    source_ref text DEFAULT ''::text,
-    memo text DEFAULT ''::text,
-    is_posted boolean DEFAULT false,
-    created_by text DEFAULT 'fortress'::text,
-    created_at timestamp with time zone DEFAULT now(),
-    posted_at timestamp with time zone
-);
-
-
---
--- Name: journal_entries_id_seq; Type: SEQUENCE; Schema: division_b; Owner: -
---
-
-CREATE SEQUENCE division_b.journal_entries_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: journal_entries_id_seq; Type: SEQUENCE OWNED BY; Schema: division_b; Owner: -
---
-
-ALTER SEQUENCE division_b.journal_entries_id_seq OWNED BY division_b.journal_entries.id;
-
-
---
--- Name: predictions; Type: TABLE; Schema: division_b; Owner: -
---
-
-CREATE TABLE division_b.predictions (
-    id integer NOT NULL,
-    metric_name text NOT NULL,
-    predicted_value numeric(14,4),
-    actual_value numeric(14,4),
-    variance_pct numeric(8,4),
-    cycle_id integer,
-    created_at timestamp with time zone DEFAULT now()
-);
-
-
---
--- Name: predictions_id_seq; Type: SEQUENCE; Schema: division_b; Owner: -
---
-
-CREATE SEQUENCE division_b.predictions_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: predictions_id_seq; Type: SEQUENCE OWNED BY; Schema: division_b; Owner: -
---
-
-ALTER SEQUENCE division_b.predictions_id_seq OWNED BY division_b.predictions.id;
-
-
---
--- Name: transactions; Type: TABLE; Schema: division_b; Owner: -
---
-
-CREATE TABLE division_b.transactions (
-    id integer NOT NULL,
-    plaid_txn_id text,
-    date date NOT NULL,
-    vendor text NOT NULL,
-    amount numeric(12,2) NOT NULL,
-    category text DEFAULT 'UNCATEGORIZED'::text NOT NULL,
-    confidence numeric(4,3) DEFAULT 0.0,
-    trust_related boolean DEFAULT false,
-    reservation_id text,
-    reasoning text,
-    method text DEFAULT 'manual'::text,
-    account_id text,
-    created_at timestamp with time zone DEFAULT now()
-);
-
-
---
--- Name: transactions_id_seq; Type: SEQUENCE; Schema: division_b; Owner: -
---
-
-CREATE SEQUENCE division_b.transactions_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: transactions_id_seq; Type: SEQUENCE OWNED BY; Schema: division_b; Owner: -
---
-
-ALTER SEQUENCE division_b.transactions_id_seq OWNED BY division_b.transactions.id;
-
-
---
--- Name: trial_balance; Type: VIEW; Schema: division_b; Owner: -
---
-
-CREATE VIEW division_b.trial_balance AS
- SELECT coa.code,
-    coa.name,
-    coa.account_type,
-    coa.normal_balance,
-    COALESCE(sum(gl.debit), (0)::numeric) AS total_debits,
-    COALESCE(sum(gl.credit), (0)::numeric) AS total_credits,
-    (COALESCE(sum(gl.debit), (0)::numeric) - COALESCE(sum(gl.credit), (0)::numeric)) AS net_balance
-   FROM (division_b.chart_of_accounts coa
-     LEFT JOIN division_b.general_ledger gl ON ((gl.account_code = coa.code)))
-  WHERE (coa.is_active = true)
-  GROUP BY coa.code, coa.name, coa.account_type, coa.normal_balance
-  ORDER BY coa.code;
-
-
---
--- Name: trust_ledger; Type: TABLE; Schema: division_b; Owner: -
---
-
-CREATE TABLE division_b.trust_ledger (
-    id integer NOT NULL,
-    entry_type text NOT NULL,
-    amount numeric(12,2) NOT NULL,
-    reference_id text,
-    description text,
-    running_balance numeric(14,2),
-    created_at timestamp with time zone DEFAULT now()
-);
-
-
---
--- Name: trust_ledger_id_seq; Type: SEQUENCE; Schema: division_b; Owner: -
---
-
-CREATE SEQUENCE division_b.trust_ledger_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: trust_ledger_id_seq; Type: SEQUENCE OWNED BY; Schema: division_b; Owner: -
---
-
-ALTER SEQUENCE division_b.trust_ledger_id_seq OWNED BY division_b.trust_ledger.id;
-
-
---
--- Name: vendor_payouts; Type: TABLE; Schema: division_b; Owner: -
---
-
-CREATE TABLE division_b.vendor_payouts (
-    id integer NOT NULL,
-    vendor_name text NOT NULL,
-    amount numeric(12,2) NOT NULL,
-    invoice_number text,
-    invoice_date date,
-    cabin_id text,
-    category text DEFAULT 'MAINTENANCE'::text,
-    status text DEFAULT 'pending'::text,
-    approved_by text,
-    plaid_txn_id text,
-    created_at timestamp with time zone DEFAULT now()
-);
-
-
---
--- Name: vendor_payouts_id_seq; Type: SEQUENCE; Schema: division_b; Owner: -
---
-
-CREATE SEQUENCE division_b.vendor_payouts_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: vendor_payouts_id_seq; Type: SEQUENCE OWNED BY; Schema: division_b; Owner: -
---
-
-ALTER SEQUENCE division_b.vendor_payouts_id_seq OWNED BY division_b.vendor_payouts.id;
-
-
---
--- Name: change_orders; Type: TABLE; Schema: engineering; Owner: -
---
-
-CREATE TABLE engineering.change_orders (
-    id integer NOT NULL,
-    project_id integer NOT NULL,
-    co_number character varying(20) NOT NULL,
-    description text NOT NULL,
-    reason character varying(50),
-    discipline character varying(30),
-    cost_impact numeric(12,2),
-    schedule_impact_days integer,
-    status character varying(20) DEFAULT 'proposed'::character varying NOT NULL,
-    submitted_date date,
-    approved_date date,
-    approved_by character varying(100),
-    document_path text,
-    notes text,
-    ai_json jsonb,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
-);
-
-
---
--- Name: change_orders_id_seq; Type: SEQUENCE; Schema: engineering; Owner: -
---
-
-CREATE SEQUENCE engineering.change_orders_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: change_orders_id_seq; Type: SEQUENCE OWNED BY; Schema: engineering; Owner: -
---
-
-ALTER SEQUENCE engineering.change_orders_id_seq OWNED BY engineering.change_orders.id;
-
-
---
--- Name: compliance_log; Type: TABLE; Schema: engineering; Owner: -
---
-
-CREATE TABLE engineering.compliance_log (
-    id integer NOT NULL,
-    project_id integer,
-    property_id integer,
-    drawing_id integer,
-    issue_type character varying(50) NOT NULL,
-    severity character varying(20) DEFAULT 'HIGH'::character varying NOT NULL,
-    discipline character varying(30),
-    code_reference character varying(100),
-    description text NOT NULL,
-    recommended_action text,
-    status character varying(20) DEFAULT 'open'::character varying NOT NULL,
-    resolved_date date,
-    resolution_notes text,
-    resolved_by character varying(100),
-    detected_by character varying(50) DEFAULT 'architect_agent'::character varying,
-    ai_json jsonb,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
-);
-
-
---
--- Name: compliance_log_id_seq; Type: SEQUENCE; Schema: engineering; Owner: -
---
-
-CREATE SEQUENCE engineering.compliance_log_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: compliance_log_id_seq; Type: SEQUENCE OWNED BY; Schema: engineering; Owner: -
---
-
-ALTER SEQUENCE engineering.compliance_log_id_seq OWNED BY engineering.compliance_log.id;
-
-
---
--- Name: cost_estimates; Type: TABLE; Schema: engineering; Owner: -
---
-
-CREATE TABLE engineering.cost_estimates (
-    id integer NOT NULL,
-    project_id integer NOT NULL,
-    estimate_type character varying(30) NOT NULL,
-    version integer DEFAULT 1,
-    architectural_cost numeric(12,2) DEFAULT 0,
-    civil_cost numeric(12,2) DEFAULT 0,
-    structural_cost numeric(12,2) DEFAULT 0,
-    mechanical_cost numeric(12,2) DEFAULT 0,
-    electrical_cost numeric(12,2) DEFAULT 0,
-    plumbing_cost numeric(12,2) DEFAULT 0,
-    fire_protection_cost numeric(12,2) DEFAULT 0,
-    general_conditions numeric(12,2) DEFAULT 0,
-    contingency numeric(12,2) DEFAULT 0,
-    total_estimate numeric(12,2) NOT NULL,
-    cost_per_sqft numeric(8,2),
-    total_sqft numeric(10,2),
-    prepared_by character varying(100),
-    estimate_date date,
-    document_path text,
-    notes text,
-    ai_json jsonb,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
-);
-
-
---
--- Name: cost_estimates_id_seq; Type: SEQUENCE; Schema: engineering; Owner: -
---
-
-CREATE SEQUENCE engineering.cost_estimates_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: cost_estimates_id_seq; Type: SEQUENCE OWNED BY; Schema: engineering; Owner: -
---
-
-ALTER SEQUENCE engineering.cost_estimates_id_seq OWNED BY engineering.cost_estimates.id;
-
-
---
--- Name: drawings; Type: TABLE; Schema: engineering; Owner: -
---
-
-CREATE TABLE engineering.drawings (
-    id integer NOT NULL,
-    property_id integer,
-    project_id integer,
-    discipline character varying(30) DEFAULT 'general'::character varying NOT NULL,
-    doc_type character varying(50) DEFAULT 'Unknown'::character varying NOT NULL,
-    file_path text,
-    filename text,
-    extension character varying(10),
-    file_size bigint,
-    sheet_number character varying(20),
-    title character varying(200),
-    revision character varying(10),
-    revision_date date,
-    scale character varying(30),
-    ocr_text text,
-    confidence character varying(20),
-    ai_json jsonb,
-    phase integer DEFAULT 1,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
-);
-
-
---
--- Name: drawings_id_seq; Type: SEQUENCE; Schema: engineering; Owner: -
---
-
-CREATE SEQUENCE engineering.drawings_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: drawings_id_seq; Type: SEQUENCE OWNED BY; Schema: engineering; Owner: -
---
-
-ALTER SEQUENCE engineering.drawings_id_seq OWNED BY engineering.drawings.id;
-
-
---
--- Name: inspections; Type: TABLE; Schema: engineering; Owner: -
---
-
-CREATE TABLE engineering.inspections (
-    id integer NOT NULL,
-    project_id integer,
-    permit_id integer,
-    property_id integer,
-    inspection_type character varying(50) NOT NULL,
-    discipline character varying(30),
-    scheduled_date date,
-    actual_date date,
-    inspector_name character varying(150),
-    result character varying(20),
-    deficiencies text,
-    corrections_required text,
-    re_inspection_date date,
-    report_path text,
-    notes text,
-    ai_json jsonb,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
-);
-
-
---
--- Name: inspections_id_seq; Type: SEQUENCE; Schema: engineering; Owner: -
---
-
-CREATE SEQUENCE engineering.inspections_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: inspections_id_seq; Type: SEQUENCE OWNED BY; Schema: engineering; Owner: -
---
-
-ALTER SEQUENCE engineering.inspections_id_seq OWNED BY engineering.inspections.id;
-
-
---
--- Name: mep_systems; Type: TABLE; Schema: engineering; Owner: -
---
-
-CREATE TABLE engineering.mep_systems (
-    id integer NOT NULL,
-    property_id integer NOT NULL,
-    property_name character varying(100),
-    system_type character varying(50) NOT NULL,
-    discipline character varying(30),
-    manufacturer character varying(100),
-    model_number character varying(100),
-    serial_number character varying(100),
-    capacity character varying(50),
-    fuel_type character varying(30),
-    install_date date,
-    warranty_expiry date,
-    expected_life_years integer,
-    condition character varying(20) DEFAULT 'good'::character varying,
-    last_service_date date,
-    next_service_due date,
-    location character varying(100),
-    install_cost numeric(10,2),
-    replacement_cost numeric(10,2),
-    notes text,
-    ai_json jsonb,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
-);
-
-
---
--- Name: mep_systems_id_seq; Type: SEQUENCE; Schema: engineering; Owner: -
---
-
-CREATE SEQUENCE engineering.mep_systems_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: mep_systems_id_seq; Type: SEQUENCE OWNED BY; Schema: engineering; Owner: -
---
-
-ALTER SEQUENCE engineering.mep_systems_id_seq OWNED BY engineering.mep_systems.id;
-
-
---
--- Name: permits; Type: TABLE; Schema: engineering; Owner: -
---
-
-CREATE TABLE engineering.permits (
-    id integer NOT NULL,
-    project_id integer,
-    property_id integer,
-    permit_type character varying(50) NOT NULL,
-    permit_number character varying(50),
-    jurisdiction character varying(100) DEFAULT 'Fannin County'::character varying,
-    issuing_authority character varying(150),
-    status character varying(30) DEFAULT 'draft'::character varying NOT NULL,
-    application_date date,
-    approval_date date,
-    expiration_date date,
-    renewal_date date,
-    application_fee numeric(10,2),
-    impact_fee numeric(10,2),
-    conditions text,
-    special_inspections text[],
-    application_doc text,
-    approval_doc text,
-    notes text,
-    ai_json jsonb,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
-);
-
-
---
--- Name: permits_id_seq; Type: SEQUENCE; Schema: engineering; Owner: -
---
-
-CREATE SEQUENCE engineering.permits_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: permits_id_seq; Type: SEQUENCE OWNED BY; Schema: engineering; Owner: -
---
-
-ALTER SEQUENCE engineering.permits_id_seq OWNED BY engineering.permits.id;
-
-
---
--- Name: projects; Type: TABLE; Schema: engineering; Owner: -
---
-
-CREATE TABLE engineering.projects (
-    id integer NOT NULL,
-    project_code character varying(20) NOT NULL,
-    name character varying(200) NOT NULL,
-    description text,
-    property_id integer,
-    property_name character varying(100),
-    phase character varying(30) DEFAULT 'concept'::character varying NOT NULL,
-    status character varying(20) DEFAULT 'active'::character varying NOT NULL,
-    project_type character varying(50),
-    disciplines text[],
-    start_date date,
-    target_completion date,
-    actual_completion date,
-    estimated_cost numeric(12,2),
-    actual_cost numeric(12,2),
-    contingency_pct numeric(5,2) DEFAULT 10.00,
-    architect_of_record character varying(150),
-    engineer_of_record character varying(150),
-    general_contractor character varying(150),
-    project_manager character varying(150),
-    jurisdiction character varying(100) DEFAULT 'Fannin County'::character varying,
-    permit_number character varying(50),
-    notes text,
-    ai_json jsonb,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
-);
-
-
---
--- Name: projects_id_seq; Type: SEQUENCE; Schema: engineering; Owner: -
---
-
-CREATE SEQUENCE engineering.projects_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: projects_id_seq; Type: SEQUENCE OWNED BY; Schema: engineering; Owner: -
---
-
-ALTER SEQUENCE engineering.projects_id_seq OWNED BY engineering.projects.id;
-
-
---
--- Name: punch_items; Type: TABLE; Schema: engineering; Owner: -
---
-
-CREATE TABLE engineering.punch_items (
-    id integer NOT NULL,
-    project_id integer NOT NULL,
-    inspection_id integer,
-    item_number integer NOT NULL,
-    description text NOT NULL,
-    discipline character varying(30),
-    location character varying(100),
-    priority character varying(20) DEFAULT 'normal'::character varying,
-    assigned_to character varying(100),
-    due_date date,
-    status character varying(20) DEFAULT 'open'::character varying NOT NULL,
-    completed_date date,
-    verified_by character varying(100),
-    photo_before text,
-    photo_after text,
-    notes text,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
-);
-
-
---
--- Name: punch_items_id_seq; Type: SEQUENCE; Schema: engineering; Owner: -
---
-
-CREATE SEQUENCE engineering.punch_items_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: punch_items_id_seq; Type: SEQUENCE OWNED BY; Schema: engineering; Owner: -
---
-
-ALTER SEQUENCE engineering.punch_items_id_seq OWNED BY engineering.punch_items.id;
-
-
---
--- Name: rfis; Type: TABLE; Schema: engineering; Owner: -
---
-
-CREATE TABLE engineering.rfis (
-    id integer NOT NULL,
-    project_id integer NOT NULL,
-    rfi_number character varying(20) NOT NULL,
-    subject character varying(200) NOT NULL,
-    question text NOT NULL,
-    discipline character varying(30),
-    drawing_reference character varying(50),
-    response text,
-    responded_by character varying(100),
-    response_date date,
-    cost_impact numeric(12,2),
-    schedule_impact_days integer,
-    status character varying(20) DEFAULT 'open'::character varying NOT NULL,
-    submitted_date date,
-    due_date date,
-    submitted_by character varying(100),
-    notes text,
-    ai_json jsonb,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
-);
-
-
---
--- Name: rfis_id_seq; Type: SEQUENCE; Schema: engineering; Owner: -
---
-
-CREATE SEQUENCE engineering.rfis_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: rfis_id_seq; Type: SEQUENCE OWNED BY; Schema: engineering; Owner: -
---
-
-ALTER SEQUENCE engineering.rfis_id_seq OWNED BY engineering.rfis.id;
-
-
---
--- Name: submittals; Type: TABLE; Schema: engineering; Owner: -
---
-
-CREATE TABLE engineering.submittals (
-    id integer NOT NULL,
-    project_id integer NOT NULL,
-    submittal_number character varying(20) NOT NULL,
-    description character varying(200) NOT NULL,
-    discipline character varying(30),
-    spec_section character varying(20),
-    status character varying(30) DEFAULT 'pending'::character varying NOT NULL,
-    submitted_date date,
-    review_date date,
-    reviewed_by character varying(100),
-    review_comments text,
-    document_path text,
-    notes text,
-    ai_json jsonb,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
-);
-
-
---
--- Name: submittals_id_seq; Type: SEQUENCE; Schema: engineering; Owner: -
---
-
-CREATE SEQUENCE engineering.submittals_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: submittals_id_seq; Type: SEQUENCE OWNED BY; Schema: engineering; Owner: -
---
-
-ALTER SEQUENCE engineering.submittals_id_seq OWNED BY engineering.submittals.id;
-
-
---
--- Name: classification_rules; Type: TABLE; Schema: finance; Owner: -
---
-
-CREATE TABLE finance.classification_rules (
-    id integer NOT NULL,
-    vendor_pattern text NOT NULL,
-    assigned_category text NOT NULL,
-    reasoning text,
-    source_vendor_id integer,
-    embedding public.vector(768),
-    created_at timestamp with time zone DEFAULT now(),
-    created_by text DEFAULT 'CFO-MANUAL'::text
-);
-
-
---
--- Name: classification_rules_id_seq; Type: SEQUENCE; Schema: finance; Owner: -
---
-
-CREATE SEQUENCE finance.classification_rules_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: classification_rules_id_seq; Type: SEQUENCE OWNED BY; Schema: finance; Owner: -
---
-
-ALTER SEQUENCE finance.classification_rules_id_seq OWNED BY finance.classification_rules.id;
-
-
---
--- Name: vendor_classifications; Type: TABLE; Schema: finance; Owner: -
---
-
-CREATE TABLE finance.vendor_classifications (
-    id integer NOT NULL,
-    vendor_pattern text NOT NULL,
-    vendor_label text NOT NULL,
-    classification text NOT NULL,
-    is_revenue boolean DEFAULT false,
-    is_expense boolean DEFAULT false,
-    titan_notes text,
-    classified_at timestamp without time zone DEFAULT now(),
-    classified_by text DEFAULT 'TITAN-R1-671B'::text,
-    CONSTRAINT vendor_classifications_classification_check CHECK ((classification = ANY (ARRAY['OWNER_PRINCIPAL'::text, 'REAL_BUSINESS'::text, 'CONTRACTOR'::text, 'CROG_INTERNAL'::text, 'FAMILY_INTERNAL'::text, 'FINANCIAL_SERVICE'::text, 'PROFESSIONAL_SERVICE'::text, 'LEGAL_SERVICE'::text, 'INSURANCE'::text, 'OPERATIONAL_EXPENSE'::text, 'SUBSCRIPTION'::text, 'MARKETING'::text, 'TENANT_GUEST'::text, 'PERSONAL_EXPENSE'::text, 'GOVERNMENT'::text, 'LITIGATION_RECOVERY'::text, 'NOISE'::text, 'UNKNOWN'::text])))
-);
-
-
---
--- Name: vendor_classifications_id_seq; Type: SEQUENCE; Schema: finance; Owner: -
---
-
-CREATE SEQUENCE finance.vendor_classifications_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: vendor_classifications_id_seq; Type: SEQUENCE OWNED BY; Schema: finance; Owner: -
---
-
-ALTER SEQUENCE finance.vendor_classifications_id_seq OWNED BY finance.vendor_classifications.id;
-
-
---
--- Name: active_strategies; Type: TABLE; Schema: hedge_fund; Owner: -
---
-
-CREATE TABLE hedge_fund.active_strategies (
-    id integer NOT NULL,
-    strategy_name character varying(100) NOT NULL,
-    description text,
-    allocation_limit numeric(12,2),
-    risk_level character varying(20),
-    status character varying(20) DEFAULT 'ACTIVE'::character varying,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
-);
-
-
---
--- Name: active_strategies_id_seq; Type: SEQUENCE; Schema: hedge_fund; Owner: -
---
-
-CREATE SEQUENCE hedge_fund.active_strategies_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: active_strategies_id_seq; Type: SEQUENCE OWNED BY; Schema: hedge_fund; Owner: -
---
-
-ALTER SEQUENCE hedge_fund.active_strategies_id_seq OWNED BY hedge_fund.active_strategies.id;
-
-
---
--- Name: extraction_log; Type: TABLE; Schema: hedge_fund; Owner: -
---
-
-CREATE TABLE hedge_fund.extraction_log (
-    id integer NOT NULL,
-    email_id integer,
-    status character varying(20),
-    signals_found integer DEFAULT 0,
-    model_used character varying(50),
-    latency_ms integer,
-    error_message text,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
-);
-
-
---
--- Name: extraction_log_id_seq; Type: SEQUENCE; Schema: hedge_fund; Owner: -
---
-
-CREATE SEQUENCE hedge_fund.extraction_log_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: extraction_log_id_seq; Type: SEQUENCE OWNED BY; Schema: hedge_fund; Owner: -
---
-
-ALTER SEQUENCE hedge_fund.extraction_log_id_seq OWNED BY hedge_fund.extraction_log.id;
-
-
---
--- Name: market_signals; Type: TABLE; Schema: hedge_fund; Owner: -
---
-
-CREATE TABLE hedge_fund.market_signals (
-    id integer NOT NULL,
-    ticker character varying(10) NOT NULL,
-    signal_type character varying(50),
-    action character varying(20),
-    sentiment_score double precision,
-    confidence_score integer DEFAULT 0,
-    price_target numeric(12,2),
-    source_email_id integer,
-    source_sender text,
-    source_subject text,
-    raw_reasoning text,
-    model_used character varying(50),
-    extracted_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
-);
-
-
---
--- Name: market_signals_id_seq; Type: SEQUENCE; Schema: hedge_fund; Owner: -
---
-
-CREATE SEQUENCE hedge_fund.market_signals_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: market_signals_id_seq; Type: SEQUENCE OWNED BY; Schema: hedge_fund; Owner: -
---
-
-ALTER SEQUENCE hedge_fund.market_signals_id_seq OWNED BY hedge_fund.market_signals.id;
-
-
---
--- Name: watchlist; Type: TABLE; Schema: hedge_fund; Owner: -
---
-
-CREATE TABLE hedge_fund.watchlist (
-    id integer NOT NULL,
-    ticker character varying(10) NOT NULL,
-    sector character varying(50),
-    thesis text,
-    added_by character varying(50) DEFAULT 'system'::character varying,
-    signal_count integer DEFAULT 0,
-    last_signal_at timestamp without time zone,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
-);
-
-
---
--- Name: watchlist_id_seq; Type: SEQUENCE; Schema: hedge_fund; Owner: -
---
-
-CREATE SEQUENCE hedge_fund.watchlist_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: watchlist_id_seq; Type: SEQUENCE OWNED BY; Schema: hedge_fund; Owner: -
---
-
-ALTER SEQUENCE hedge_fund.watchlist_id_seq OWNED BY hedge_fund.watchlist.id;
-
-
---
--- Name: entities; Type: TABLE; Schema: intelligence; Owner: -
---
-
-CREATE TABLE intelligence.entities (
-    id integer NOT NULL,
-    entity_type text NOT NULL,
-    entity_key text NOT NULL,
-    display_name text NOT NULL,
-    metadata jsonb DEFAULT '{}'::jsonb,
-    source_table text,
-    source_id text,
-    created_at timestamp without time zone DEFAULT now(),
-    updated_at timestamp without time zone DEFAULT now()
-);
-
-
---
--- Name: entities_id_seq; Type: SEQUENCE; Schema: intelligence; Owner: -
---
-
-CREATE SEQUENCE intelligence.entities_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: entities_id_seq; Type: SEQUENCE OWNED BY; Schema: intelligence; Owner: -
---
-
-ALTER SEQUENCE intelligence.entities_id_seq OWNED BY intelligence.entities.id;
-
-
---
--- Name: golden_reasoning; Type: TABLE; Schema: intelligence; Owner: -
---
-
-CREATE TABLE intelligence.golden_reasoning (
-    id integer NOT NULL,
-    topic text NOT NULL,
-    entity_key text,
-    bad_reasoning text,
-    correct_reasoning text NOT NULL,
-    correction_type text DEFAULT 'FACTUAL'::text,
-    created_by text DEFAULT 'Gary'::text,
-    created_at timestamp without time zone DEFAULT now(),
-    used_count integer DEFAULT 0,
-    CONSTRAINT golden_reasoning_correction_type_check CHECK ((correction_type = ANY (ARRAY['FACTUAL'::text, 'CLASSIFICATION'::text, 'MISSING_LINK'::text, 'LOGIC_ERROR'::text])))
-);
-
-
---
--- Name: golden_reasoning_id_seq; Type: SEQUENCE; Schema: intelligence; Owner: -
---
-
-CREATE SEQUENCE intelligence.golden_reasoning_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: golden_reasoning_id_seq; Type: SEQUENCE OWNED BY; Schema: intelligence; Owner: -
---
-
-ALTER SEQUENCE intelligence.golden_reasoning_id_seq OWNED BY intelligence.golden_reasoning.id;
-
-
---
--- Name: relationships; Type: TABLE; Schema: intelligence; Owner: -
---
-
-CREATE TABLE intelligence.relationships (
-    id integer NOT NULL,
-    from_entity_id integer NOT NULL,
-    to_entity_id integer NOT NULL,
-    relationship_type text NOT NULL,
-    confidence numeric(3,2) DEFAULT 1.00,
-    metadata jsonb DEFAULT '{}'::jsonb,
-    source text DEFAULT 'SYSTEM'::text,
-    created_at timestamp without time zone DEFAULT now()
-);
-
-
---
--- Name: relationships_id_seq; Type: SEQUENCE; Schema: intelligence; Owner: -
---
-
-CREATE SEQUENCE intelligence.relationships_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: relationships_id_seq; Type: SEQUENCE OWNED BY; Schema: intelligence; Owner: -
---
-
-ALTER SEQUENCE intelligence.relationships_id_seq OWNED BY intelligence.relationships.id;
-
-
---
--- Name: titan_traces; Type: TABLE; Schema: intelligence; Owner: -
---
-
-CREATE TABLE intelligence.titan_traces (
-    id integer NOT NULL,
-    trace_id uuid DEFAULT gen_random_uuid(),
-    session_type text NOT NULL,
-    defcon_mode text DEFAULT 'TITAN'::text,
-    system_prompt text,
-    user_context text,
-    context_chars integer,
-    thinking_trace text,
-    response text,
-    thinking_tokens integer,
-    response_tokens integer,
-    latency_ms integer,
-    model text,
-    corrections jsonb DEFAULT '[]'::jsonb,
-    score integer,
-    score_comment text,
-    created_at timestamp without time zone DEFAULT now()
-);
-
-
---
--- Name: titan_traces_id_seq; Type: SEQUENCE; Schema: intelligence; Owner: -
---
-
-CREATE SEQUENCE intelligence.titan_traces_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: titan_traces_id_seq; Type: SEQUENCE OWNED BY; Schema: intelligence; Owner: -
---
-
-ALTER SEQUENCE intelligence.titan_traces_id_seq OWNED BY intelligence.titan_traces.id;
-
-
---
--- Name: case_actions; Type: TABLE; Schema: legal; Owner: -
---
-
-CREATE TABLE legal.case_actions (
-    id integer NOT NULL,
-    case_id integer,
-    action_type text NOT NULL,
-    action_date timestamp with time zone DEFAULT now(),
-    description text NOT NULL,
-    status text DEFAULT 'pending'::text,
-    tracking_number text,
-    attachments text[],
-    notes text,
-    created_at timestamp with time zone DEFAULT now()
-);
-
-
---
--- Name: case_actions_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
---
-
-CREATE SEQUENCE legal.case_actions_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: case_actions_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
---
-
-ALTER SEQUENCE legal.case_actions_id_seq OWNED BY legal.case_actions.id;
+ALTER SEQUENCE legal.ai_audit_ledger_id_seq OWNED BY legal.ai_audit_ledger.id;
 
 
 --
@@ -1836,59 +481,96 @@ ALTER SEQUENCE legal.case_actions_id_seq OWNED BY legal.case_actions.id;
 --
 
 CREATE TABLE legal.case_evidence (
-    id integer NOT NULL,
-    case_id integer,
-    evidence_type text NOT NULL,
-    email_id integer,
-    file_path text,
-    description text NOT NULL,
-    relevance text,
-    discovered_at timestamp with time zone DEFAULT now(),
-    is_critical boolean DEFAULT false
+    id uuid NOT NULL,
+    case_slug character varying(255) NOT NULL,
+    entity_id uuid,
+    file_name character varying(500) NOT NULL,
+    nas_path text NOT NULL,
+    qdrant_point_id character varying(255),
+    sha256_hash character varying(128) NOT NULL,
+    uploaded_at timestamp with time zone NOT NULL
 );
 
 
 --
--- Name: case_evidence_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
+-- Name: case_graph_edges; Type: TABLE; Schema: legal; Owner: -
 --
 
-CREATE SEQUENCE legal.case_evidence_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: case_evidence_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
---
-
-ALTER SEQUENCE legal.case_evidence_id_seq OWNED BY legal.case_evidence.id;
+CREATE TABLE legal.case_graph_edges (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    case_id uuid NOT NULL,
+    source_node_id uuid NOT NULL,
+    target_node_id uuid NOT NULL,
+    relationship_type character varying(128) NOT NULL,
+    weight double precision DEFAULT 1.0 NOT NULL,
+    source_ref character varying(500),
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
 
 
 --
--- Name: case_precedents; Type: TABLE; Schema: legal; Owner: -
+-- Name: case_graph_edges_v2; Type: TABLE; Schema: legal; Owner: -
 --
 
-CREATE TABLE legal.case_precedents (
+CREATE TABLE legal.case_graph_edges_v2 (
+    id uuid NOT NULL,
+    case_slug character varying(255) NOT NULL,
+    source_node_id uuid NOT NULL,
+    target_node_id uuid NOT NULL,
+    relationship_type character varying(128) NOT NULL,
+    weight double precision NOT NULL,
+    source_evidence_id uuid
+);
+
+
+--
+-- Name: case_graph_nodes; Type: TABLE; Schema: legal; Owner: -
+--
+
+CREATE TABLE legal.case_graph_nodes (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    case_id uuid NOT NULL,
+    entity_type character varying(64) NOT NULL,
+    label character varying(500) NOT NULL,
+    metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: case_graph_nodes_v2; Type: TABLE; Schema: legal; Owner: -
+--
+
+CREATE TABLE legal.case_graph_nodes_v2 (
+    id uuid NOT NULL,
+    case_slug character varying(255) NOT NULL,
+    entity_type character varying(64) NOT NULL,
+    entity_reference_id uuid,
+    label character varying(500) NOT NULL,
+    properties_json jsonb NOT NULL
+);
+
+
+--
+-- Name: case_statements; Type: TABLE; Schema: legal; Owner: -
+--
+
+CREATE TABLE legal.case_statements (
     id integer NOT NULL,
     case_slug text NOT NULL,
-    citation text NOT NULL,
-    url text,
-    relevance_score integer NOT NULL,
-    justification text NOT NULL,
-    extracted_at timestamp with time zone DEFAULT now() NOT NULL,
-    CONSTRAINT case_precedents_relevance_score_check CHECK (((relevance_score >= 0) AND (relevance_score <= 100)))
+    entity_name text,
+    quote_text text,
+    source_ref text,
+    stated_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 
 --
--- Name: case_precedents_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
+-- Name: case_statements_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
 --
 
-CREATE SEQUENCE legal.case_precedents_id_seq
+CREATE SEQUENCE legal.case_statements_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -1898,45 +580,26 @@ CREATE SEQUENCE legal.case_precedents_id_seq
 
 
 --
--- Name: case_precedents_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
+-- Name: case_statements_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
 --
 
-ALTER SEQUENCE legal.case_precedents_id_seq OWNED BY legal.case_precedents.id;
+ALTER SEQUENCE legal.case_statements_id_seq OWNED BY legal.case_statements.id;
 
 
 --
--- Name: case_watchdog; Type: TABLE; Schema: legal; Owner: -
+-- Name: case_statements_v2; Type: TABLE; Schema: legal; Owner: -
 --
 
-CREATE TABLE legal.case_watchdog (
-    id integer NOT NULL,
-    case_id integer,
-    search_type text NOT NULL,
-    search_term text NOT NULL,
-    priority text DEFAULT 'P2'::text,
-    is_active boolean DEFAULT true,
-    created_at timestamp with time zone DEFAULT now()
+CREATE TABLE legal.case_statements_v2 (
+    id uuid NOT NULL,
+    case_slug character varying(255) NOT NULL,
+    entity_id uuid,
+    quote_text text NOT NULL,
+    source_ref text,
+    doc_id character varying(255),
+    stated_at timestamp with time zone,
+    created_at timestamp with time zone NOT NULL
 );
-
-
---
--- Name: case_watchdog_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
---
-
-CREATE SEQUENCE legal.case_watchdog_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: case_watchdog_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
---
-
-ALTER SEQUENCE legal.case_watchdog_id_seq OWNED BY legal.case_watchdog.id;
 
 
 --
@@ -1946,32 +609,16 @@ ALTER SEQUENCE legal.case_watchdog_id_seq OWNED BY legal.case_watchdog.id;
 CREATE TABLE legal.cases (
     id integer NOT NULL,
     case_slug text NOT NULL,
-    case_number text NOT NULL,
-    case_name text NOT NULL,
+    case_number text,
+    case_name text,
     court text,
     judge text,
-    case_type text DEFAULT 'bankruptcy'::text,
+    case_type text DEFAULT 'civil'::text,
     our_role text DEFAULT 'creditor'::text,
     status text DEFAULT 'active'::text,
-    critical_date date,
-    critical_note text,
-    plan_admin text,
-    plan_admin_email text,
-    plan_admin_address text,
-    fiduciary text,
-    opposing_counsel text,
-    our_claim_basis text,
-    petition_date date,
-    notes text,
-    created_at timestamp with time zone DEFAULT now(),
-    updated_at timestamp with time zone DEFAULT now(),
-    risk_score integer,
-    extraction_status text DEFAULT 'none'::text,
     extracted_entities jsonb DEFAULT '{}'::jsonb,
-    active_brief text,
-    active_consensus jsonb,
-    nas_layout jsonb,
-    CONSTRAINT cases_risk_score_check CHECK (((risk_score >= 1) AND (risk_score <= 5)))
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 
@@ -1996,244 +643,135 @@ ALTER SEQUENCE legal.cases_id_seq OWNED BY legal.cases.id;
 
 
 --
--- Name: correspondence; Type: TABLE; Schema: legal; Owner: -
+-- Name: deposition_kill_sheets_v2; Type: TABLE; Schema: legal; Owner: -
 --
 
-CREATE TABLE legal.correspondence (
-    id integer NOT NULL,
-    case_id integer,
-    direction text DEFAULT 'outbound'::text NOT NULL,
-    comm_type text NOT NULL,
-    recipient text,
-    recipient_email text,
-    subject text NOT NULL,
-    body text,
-    status text DEFAULT 'draft'::text,
-    gmail_draft_id text,
-    tracking_number text,
-    file_path text,
-    approved_by text,
-    approved_at timestamp with time zone,
-    sent_at timestamp with time zone,
-    created_at timestamp with time zone DEFAULT now(),
-    risk_score integer,
-    extraction_status text DEFAULT 'none'::text,
-    extracted_entities jsonb DEFAULT '{}'::jsonb,
-    CONSTRAINT correspondence_risk_score_check CHECK (((risk_score >= 1) AND (risk_score <= 5)))
+CREATE TABLE legal.deposition_kill_sheets_v2 (
+    id uuid NOT NULL,
+    case_slug character varying(255) NOT NULL,
+    deponent_entity character varying(255) NOT NULL,
+    status character varying(32) NOT NULL,
+    summary text NOT NULL,
+    high_risk_topics_json jsonb NOT NULL,
+    document_sequence_json jsonb NOT NULL,
+    suggested_questions_json jsonb NOT NULL,
+    created_at timestamp with time zone NOT NULL
 );
 
 
 --
--- Name: correspondence_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
+-- Name: discovery_draft_items_v2; Type: TABLE; Schema: legal; Owner: -
 --
 
-CREATE SEQUENCE legal.correspondence_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: correspondence_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
---
-
-ALTER SEQUENCE legal.correspondence_id_seq OWNED BY legal.correspondence.id;
-
-
---
--- Name: deadlines; Type: TABLE; Schema: legal; Owner: -
---
-
-CREATE TABLE legal.deadlines (
-    id integer NOT NULL,
-    case_id integer,
-    deadline_type text NOT NULL,
-    description text NOT NULL,
-    due_date date NOT NULL,
-    alert_days_before integer DEFAULT 7,
-    status text DEFAULT 'pending'::text,
-    extended_to date,
-    extension_reason text,
-    created_at timestamp with time zone DEFAULT now(),
-    source_document text,
-    auto_extracted boolean DEFAULT false,
-    review_status character varying(20) DEFAULT 'pending_review'::character varying,
-    content_hash character varying(32)
+CREATE TABLE legal.discovery_draft_items_v2 (
+    id uuid NOT NULL,
+    pack_id uuid NOT NULL,
+    category character varying(32) NOT NULL,
+    content text NOT NULL,
+    rationale_from_graph text NOT NULL,
+    sequence_number integer NOT NULL,
+    lethality_score integer,
+    proportionality_score integer,
+    correction_notes character varying(2000)
 );
 
 
 --
--- Name: deadlines_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
+-- Name: discovery_draft_packs_v2; Type: TABLE; Schema: legal; Owner: -
 --
 
-CREATE SEQUENCE legal.deadlines_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: deadlines_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
---
-
-ALTER SEQUENCE legal.deadlines_id_seq OWNED BY legal.deadlines.id;
+CREATE TABLE legal.discovery_draft_packs_v2 (
+    id uuid NOT NULL,
+    case_slug character varying(255) NOT NULL,
+    target_entity character varying(255) NOT NULL,
+    status character varying(32) NOT NULL,
+    created_at timestamp with time zone NOT NULL
+);
 
 
 --
--- Name: email_intake_queue; Type: TABLE; Schema: legal; Owner: -
+-- Name: distillation_memory; Type: TABLE; Schema: legal; Owner: -
 --
 
-CREATE TABLE legal.email_intake_queue (
-    id integer NOT NULL,
-    message_uid text NOT NULL,
-    sender_email text NOT NULL,
-    sender_name text,
-    subject text,
-    body_text text,
-    case_slug text,
-    triage_result jsonb,
-    intake_status text DEFAULT 'pending'::text NOT NULL,
-    attachment_count integer DEFAULT 0,
-    correspondence_id integer,
-    received_at timestamp with time zone DEFAULT now() NOT NULL,
-    processed_at timestamp with time zone,
+CREATE TABLE legal.distillation_memory (
+    id uuid NOT NULL,
+    context_hash character varying(128) NOT NULL,
+    frontier_insight text NOT NULL,
+    local_correction text NOT NULL,
+    created_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: entities; Type: TABLE; Schema: legal; Owner: -
+--
+
+CREATE TABLE legal.entities (
+    id uuid NOT NULL,
+    name character varying(255) NOT NULL,
+    type character varying(100) NOT NULL,
+    role character varying(100)
+);
+
+
+--
+-- Name: legal_cases; Type: TABLE; Schema: legal; Owner: -
+--
+
+CREATE TABLE legal.legal_cases (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    slug character varying(255) NOT NULL,
+    court character varying(255) DEFAULT ''::character varying NOT NULL,
+    jurisdiction character varying(255) DEFAULT ''::character varying NOT NULL,
+    status character varying(64) DEFAULT 'open'::character varying NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 
 --
--- Name: email_intake_queue_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
+-- Name: legal_exemplars; Type: TABLE; Schema: legal; Owner: -
 --
 
-CREATE SEQUENCE legal.email_intake_queue_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: email_intake_queue_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
---
-
-ALTER SEQUENCE legal.email_intake_queue_id_seq OWNED BY legal.email_intake_queue.id;
-
-
---
--- Name: expense_intake; Type: TABLE; Schema: legal; Owner: -
---
-
-CREATE TABLE legal.expense_intake (
-    id integer NOT NULL,
-    case_slug text,
-    vendor text NOT NULL,
-    amount numeric(15,2) DEFAULT 0 NOT NULL,
-    description text,
-    rag_category text,
-    rag_reasoning text,
-    audit_trail jsonb DEFAULT '[]'::jsonb,
-    source_system text DEFAULT 'triage_router'::text,
-    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP
+CREATE TABLE legal.legal_exemplars (
+    id uuid NOT NULL,
+    category character varying(32) NOT NULL,
+    rationale_context text NOT NULL,
+    perfect_output text NOT NULL,
+    source_model character varying(128) NOT NULL,
+    created_at timestamp with time zone NOT NULL
 );
 
 
 --
--- Name: expense_intake_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
+-- Name: sanctions_alerts_v2; Type: TABLE; Schema: legal; Owner: -
 --
 
-CREATE SEQUENCE legal.expense_intake_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: expense_intake_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
---
-
-ALTER SEQUENCE legal.expense_intake_id_seq OWNED BY legal.expense_intake.id;
-
-
---
--- Name: filings; Type: TABLE; Schema: legal; Owner: -
---
-
-CREATE TABLE legal.filings (
-    id integer NOT NULL,
-    case_id integer,
-    filing_type text NOT NULL,
-    title text NOT NULL,
-    filed_date date,
-    filed_by text,
-    filed_with text,
-    filing_location text,
-    status text DEFAULT 'filed'::text,
-    served_on text,
-    served_date date,
-    served_method text,
-    original_path text,
-    stamped_path text,
-    notes text,
-    created_at timestamp with time zone DEFAULT now(),
-    updated_at timestamp with time zone DEFAULT now()
+CREATE TABLE legal.sanctions_alerts_v2 (
+    id uuid NOT NULL,
+    case_slug character varying(255) NOT NULL,
+    alert_type character varying(32) NOT NULL,
+    contradiction_summary text NOT NULL,
+    confidence_score integer NOT NULL,
+    status character varying(32) NOT NULL,
+    created_at timestamp with time zone NOT NULL
 );
 
 
 --
--- Name: filings_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
+-- Name: sanctions_tripwire_runs_v2; Type: TABLE; Schema: legal; Owner: -
 --
 
-CREATE SEQUENCE legal.filings_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: filings_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
---
-
-ALTER SEQUENCE legal.filings_id_seq OWNED BY legal.filings.id;
-
-
---
--- Name: ingest_runs; Type: TABLE; Schema: legal; Owner: -
---
-
-CREATE TABLE legal.ingest_runs (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    case_slug text NOT NULL,
-    script_name text NOT NULL,
-    started_at timestamp with time zone DEFAULT now() NOT NULL,
-    ended_at timestamp with time zone,
-    args jsonb DEFAULT '{}'::jsonb NOT NULL,
-    status text DEFAULT 'running'::text NOT NULL,
-    manifest_path text,
-    total_files integer,
-    processed integer,
-    errored integer,
-    skipped integer,
-    error_summary text,
-    host text,
-    pid integer,
-    runtime_seconds numeric(12,3),
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    CONSTRAINT ingest_runs_status_check CHECK ((status = ANY (ARRAY['running'::text, 'complete'::text, 'error'::text, 'interrupted'::text])))
+CREATE TABLE legal.sanctions_tripwire_runs_v2 (
+    id uuid NOT NULL,
+    case_slug character varying(255) NOT NULL,
+    trigger_source character varying(64) NOT NULL,
+    status character varying(32) NOT NULL,
+    model_used character varying(128),
+    alerts_found integer NOT NULL,
+    alerts_saved integer NOT NULL,
+    error_detail text,
+    started_at timestamp with time zone NOT NULL,
+    completed_at timestamp with time zone
 );
 
 
@@ -2242,73 +780,12 @@ CREATE TABLE legal.ingest_runs (
 --
 
 CREATE TABLE legal.timeline_events (
-    id integer NOT NULL,
-    case_slug text NOT NULL,
-    event_date date DEFAULT CURRENT_DATE NOT NULL,
-    description text,
-    source_evidence_id integer,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
+    id uuid NOT NULL,
+    case_slug character varying(255) NOT NULL,
+    event_date date NOT NULL,
+    description text NOT NULL,
+    source_evidence_id uuid
 );
-
-
---
--- Name: timeline_events_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
---
-
-CREATE SEQUENCE legal.timeline_events_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: timeline_events_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
---
-
-ALTER SEQUENCE legal.timeline_events_id_seq OWNED BY legal.timeline_events.id;
-
-
---
--- Name: uploads; Type: TABLE; Schema: legal; Owner: -
---
-
-CREATE TABLE legal.uploads (
-    id integer NOT NULL,
-    case_id integer,
-    filename text NOT NULL,
-    original_name text NOT NULL,
-    content_type text DEFAULT 'application/pdf'::text,
-    file_size integer,
-    nas_path text NOT NULL,
-    upload_type text DEFAULT 'general'::text,
-    description text,
-    filing_id integer,
-    uploaded_by text DEFAULT 'admin'::text,
-    created_at timestamp with time zone DEFAULT now()
-);
-
-
---
--- Name: uploads_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
---
-
-CREATE SEQUENCE legal.uploads_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: uploads_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
---
-
-ALTER SEQUENCE legal.uploads_id_seq OWNED BY legal.uploads.id;
 
 
 --
@@ -2316,44 +793,22 @@ ALTER SEQUENCE legal.uploads_id_seq OWNED BY legal.uploads.id;
 --
 
 CREATE TABLE legal.vault_documents (
-    id uuid NOT NULL,
+    id integer NOT NULL,
     case_slug text NOT NULL,
-    file_name text NOT NULL,
-    nfs_path text NOT NULL,
-    mime_type text NOT NULL,
-    file_hash text NOT NULL,
-    file_size_bytes bigint NOT NULL,
-    processing_status text DEFAULT 'pending'::text NOT NULL,
+    file_name text,
+    nfs_path text,
+    mime_type text,
     chunk_count integer,
-    error_detail text,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    CONSTRAINT chk_vault_documents_status CHECK ((processing_status = ANY (ARRAY['pending'::text, 'processing'::text, 'vectorizing'::text, 'complete'::text, 'completed'::text, 'ocr_failed'::text, 'error'::text, 'failed'::text, 'locked_privileged'::text])))
+    processing_status text DEFAULT 'pending'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 
 --
--- Name: attorney_scoring; Type: TABLE; Schema: legal_cmd; Owner: -
+-- Name: vault_documents_id_seq; Type: SEQUENCE; Schema: legal; Owner: -
 --
 
-CREATE TABLE legal_cmd.attorney_scoring (
-    id integer NOT NULL,
-    attorney_id uuid,
-    sota_match_score integer,
-    eckles_competency boolean DEFAULT false,
-    commercial_litigation_focus boolean DEFAULT false,
-    fannin_jurisdiction_match boolean DEFAULT false,
-    ai_rationale text,
-    scored_by_model text,
-    scored_at timestamp without time zone DEFAULT now(),
-    CONSTRAINT attorney_scoring_sota_match_score_check CHECK (((sota_match_score >= 0) AND (sota_match_score <= 100)))
-);
-
-
---
--- Name: attorney_scoring_id_seq; Type: SEQUENCE; Schema: legal_cmd; Owner: -
---
-
-CREATE SEQUENCE legal_cmd.attorney_scoring_id_seq
+CREATE SEQUENCE legal.vault_documents_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -2363,238 +818,10 @@ CREATE SEQUENCE legal_cmd.attorney_scoring_id_seq
 
 
 --
--- Name: attorney_scoring_id_seq; Type: SEQUENCE OWNED BY; Schema: legal_cmd; Owner: -
+-- Name: vault_documents_id_seq; Type: SEQUENCE OWNED BY; Schema: legal; Owner: -
 --
 
-ALTER SEQUENCE legal_cmd.attorney_scoring_id_seq OWNED BY legal_cmd.attorney_scoring.id;
-
-
---
--- Name: attorneys; Type: TABLE; Schema: legal_cmd; Owner: -
---
-
-CREATE TABLE legal_cmd.attorneys (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    first_name text NOT NULL,
-    last_name text NOT NULL,
-    firm_name text,
-    specialty text,
-    email text,
-    phone text,
-    address text,
-    website text,
-    bar_number text,
-    bar_state text,
-    hourly_rate numeric(10,2),
-    retainer_amount numeric(10,2),
-    retainer_status text DEFAULT 'none'::text,
-    engagement_date date,
-    status text DEFAULT 'active'::text,
-    rating integer,
-    notes text,
-    tags text[],
-    created_at timestamp with time zone DEFAULT now(),
-    updated_at timestamp with time zone DEFAULT now(),
-    case_id integer,
-    source text,
-    source_url text,
-    ai_score numeric(3,1),
-    ai_score_reasoning text,
-    practice_areas text[],
-    jurisdiction text[],
-    admission_date date,
-    outreach_status text DEFAULT 'prospect'::text,
-    last_contacted_at timestamp with time zone,
-    firm_size character varying(50),
-    CONSTRAINT attorneys_rating_check CHECK (((rating >= 1) AND (rating <= 5)))
-);
-
-
---
--- Name: deliberation_events; Type: TABLE; Schema: legal_cmd; Owner: -
---
-
-CREATE TABLE legal_cmd.deliberation_events (
-    event_id uuid DEFAULT gen_random_uuid() NOT NULL,
-    case_slug character varying(255) NOT NULL,
-    case_number character varying(255),
-    "timestamp" timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
-    trigger_type character varying(50) NOT NULL,
-    qdrant_vector_ids text[],
-    context_chunks text[],
-    user_prompt text NOT NULL,
-    moe_roster_snapshot jsonb NOT NULL,
-    seat_opinions jsonb NOT NULL,
-    counsel_results jsonb NOT NULL,
-    consensus_signal character varying(50),
-    consensus_conviction numeric(4,3),
-    execution_time_ms integer,
-    sha256_signature character varying(64) NOT NULL
-);
-
-
---
--- Name: documents; Type: TABLE; Schema: legal_cmd; Owner: -
---
-
-CREATE TABLE legal_cmd.documents (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    matter_id uuid,
-    title text NOT NULL,
-    doc_type text,
-    file_path text,
-    file_url text,
-    description text,
-    uploaded_by text DEFAULT 'owner'::text,
-    tags text[],
-    created_at timestamp with time zone DEFAULT now()
-);
-
-
---
--- Name: matters; Type: TABLE; Schema: legal_cmd; Owner: -
---
-
-CREATE TABLE legal_cmd.matters (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    title text NOT NULL,
-    reference_code text,
-    category text NOT NULL,
-    status text DEFAULT 'open'::text,
-    priority text DEFAULT 'normal'::text,
-    description text,
-    attorney_id uuid,
-    opposing_party text,
-    opposing_counsel text,
-    amount_at_stake numeric(12,2),
-    outcome text,
-    outcome_date date,
-    next_action text,
-    next_action_date date,
-    tags text[],
-    created_at timestamp with time zone DEFAULT now(),
-    updated_at timestamp with time zone DEFAULT now()
-);
-
-
---
--- Name: meetings; Type: TABLE; Schema: legal_cmd; Owner: -
---
-
-CREATE TABLE legal_cmd.meetings (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    matter_id uuid,
-    attorney_id uuid,
-    title text NOT NULL,
-    meeting_type text DEFAULT 'in_person'::text,
-    meeting_date timestamp with time zone NOT NULL,
-    duration_minutes integer,
-    location text,
-    attendees text,
-    summary text,
-    action_items text,
-    key_decisions text,
-    documents_discussed text,
-    billable boolean DEFAULT false,
-    cost numeric(10,2),
-    follow_up_date date,
-    follow_up_notes text,
-    tags text[],
-    created_at timestamp with time zone DEFAULT now(),
-    updated_at timestamp with time zone DEFAULT now()
-);
-
-
---
--- Name: timeline; Type: TABLE; Schema: legal_cmd; Owner: -
---
-
-CREATE TABLE legal_cmd.timeline (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    matter_id uuid NOT NULL,
-    entry_type text NOT NULL,
-    title text NOT NULL,
-    body text,
-    entered_by text DEFAULT 'owner'::text,
-    importance text DEFAULT 'normal'::text,
-    related_meeting_id uuid,
-    related_attorney_id uuid,
-    document_ref text,
-    tags text[],
-    created_at timestamp with time zone DEFAULT now()
-);
-
-
---
--- Name: ab_test_observations; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.ab_test_observations (
-    id integer NOT NULL,
-    test_id integer,
-    variant text NOT NULL,
-    metric_value numeric(15,4),
-    context jsonb,
-    created_at timestamp without time zone DEFAULT now()
-);
-
-
---
--- Name: ab_test_observations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.ab_test_observations_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: ab_test_observations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.ab_test_observations_id_seq OWNED BY public.ab_test_observations.id;
-
-
---
--- Name: ab_tests; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.ab_tests (
-    id integer NOT NULL,
-    test_name text NOT NULL,
-    agent_id text NOT NULL,
-    variant_a text NOT NULL,
-    variant_b text NOT NULL,
-    metric_name text NOT NULL,
-    status text DEFAULT 'active'::text,
-    winner text,
-    created_at timestamp without time zone DEFAULT now(),
-    concluded_at timestamp without time zone
-);
-
-
---
--- Name: ab_tests_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.ab_tests_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: ab_tests_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.ab_tests_id_seq OWNED BY public.ab_tests.id;
+ALTER SEQUENCE legal.vault_documents_id_seq OWNED BY legal.vault_documents.id;
 
 
 --
@@ -2602,19 +829,9 @@ ALTER SEQUENCE public.ab_tests_id_seq OWNED BY public.ab_tests.id;
 --
 
 CREATE TABLE public.accounts (
-    id integer NOT NULL,
-    code text NOT NULL,
-    name text NOT NULL,
-    account_type text NOT NULL,
-    sub_type text,
-    normal_balance text NOT NULL,
-    parent_id integer,
-    property_id text,
-    is_active boolean DEFAULT true,
-    description text,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT accounts_account_type_check CHECK ((account_type = ANY (ARRAY['Asset'::text, 'Liability'::text, 'Equity'::text, 'Revenue'::text, 'Expense'::text]))),
-    CONSTRAINT accounts_normal_balance_check CHECK ((normal_balance = ANY (ARRAY['debit'::text, 'credit'::text])))
+    id bigint NOT NULL,
+    code character varying(32) NOT NULL,
+    name character varying(255) NOT NULL
 );
 
 
@@ -2623,7 +840,6 @@ CREATE TABLE public.accounts (
 --
 
 CREATE SEQUENCE public.accounts_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2639,45 +855,77 @@ ALTER SEQUENCE public.accounts_id_seq OWNED BY public.accounts.id;
 
 
 --
--- Name: active_learning_queue; Type: TABLE; Schema: public; Owner: -
+-- Name: activities; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.active_learning_queue (
-    id integer NOT NULL,
-    judgment_id integer,
-    agent_id text NOT NULL,
-    metric_name text NOT NULL,
-    predicted_value numeric(15,4),
-    actual_value numeric(15,4),
-    variance_pct numeric(8,4),
-    context jsonb,
-    status text DEFAULT 'pending'::text,
-    reviewer text,
-    review_result text,
-    review_notes text,
-    created_at timestamp without time zone DEFAULT now(),
-    reviewed_at timestamp without time zone
+CREATE TABLE public.activities (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    title character varying(500) NOT NULL,
+    slug character varying(255) NOT NULL,
+    activity_slug character varying(500),
+    body text,
+    body_summary text,
+    address text,
+    activity_type character varying(255),
+    activity_type_tid integer,
+    area character varying(255),
+    area_tid integer,
+    people character varying(255),
+    people_tid integer,
+    difficulty_level character varying(255),
+    difficulty_level_tid integer,
+    season character varying(255),
+    season_tid integer,
+    featured_image_url text,
+    featured_image_alt character varying(500),
+    featured_image_title character varying(500),
+    video_urls jsonb,
+    latitude double precision,
+    longitude double precision,
+    status character varying(50) DEFAULT 'published'::character varying,
+    is_featured boolean DEFAULT false,
+    display_order integer DEFAULT 0,
+    drupal_nid integer,
+    drupal_vid integer,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    published_at timestamp with time zone
 );
 
 
 --
--- Name: active_learning_queue_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: agent_queue; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.active_learning_queue_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
+CREATE TABLE public.agent_queue (
+    id uuid NOT NULL,
+    guest_id uuid,
+    property_id uuid,
+    original_ai_draft text NOT NULL,
+    final_human_message text,
+    status character varying(30) NOT NULL,
+    delivery_channel character varying(20) DEFAULT 'email'::character varying NOT NULL,
+    twilio_sid character varying(128),
+    error_log text,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL,
+    CONSTRAINT ck_agent_queue_status CHECK (((status)::text = ANY ((ARRAY['pending_review'::character varying, 'approved'::character varying, 'edited'::character varying, 'rejected'::character varying, 'sending'::character varying, 'delivered'::character varying, 'failed'::character varying])::text[])))
+);
 
 
 --
--- Name: active_learning_queue_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+-- Name: agent_registry; Type: TABLE; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.active_learning_queue_id_seq OWNED BY public.active_learning_queue.id;
+CREATE TABLE public.agent_registry (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    name character varying(255) NOT NULL,
+    role character varying(100) NOT NULL,
+    is_active boolean DEFAULT true NOT NULL,
+    scope_boundary jsonb NOT NULL,
+    daily_tool_budget integer NOT NULL,
+    CONSTRAINT ck_agent_registry_daily_tool_budget_nonnegative CHECK ((daily_tool_budget >= 0))
+);
 
 
 --
@@ -2685,360 +933,64 @@ ALTER SEQUENCE public.active_learning_queue_id_seq OWNED BY public.active_learni
 --
 
 CREATE TABLE public.agent_response_queue (
-    id bigint NOT NULL,
-    inbound_message_id bigint,
-    phone_number character varying(20) NOT NULL,
-    guest_name character varying(255),
-    cabin_name character varying(100),
-    reservation_id character varying(100),
-    guest_message text NOT NULL,
+    id uuid NOT NULL,
+    message_id uuid NOT NULL,
+    guest_id uuid,
+    reservation_id uuid,
     intent character varying(50),
-    intent_confidence numeric(4,3),
-    sentiment character varying(20),
-    urgency_level integer DEFAULT 1,
-    escalation_required boolean DEFAULT false,
+    sentiment_label character varying(30),
+    sentiment_score double precision,
+    urgency_level integer,
+    proposed_response text NOT NULL,
+    confidence double precision NOT NULL,
+    action character varying(80),
     escalation_reason text,
-    ai_draft text NOT NULL,
-    ai_model character varying(100),
-    ai_duration_ms integer,
-    knowledge_sources jsonb,
-    confidence_score numeric(4,3),
-    status character varying(20) DEFAULT 'pending_review'::character varying NOT NULL,
+    status character varying(30) NOT NULL,
     reviewed_by character varying(100),
     reviewed_at timestamp without time zone,
-    edited_draft text,
-    review_notes text,
-    sent_at timestamp without time zone,
-    sent_via character varying(20),
-    outbound_message_id bigint,
-    delivery_status character varying(20),
-    created_at timestamp without time zone DEFAULT now(),
-    updated_at timestamp without time zone DEFAULT now(),
-    expires_at timestamp without time zone,
-    quality_grade integer,
-    edit_distance_pct numeric(5,2),
-    grade_notes text,
-    guest_tier character varying(20) DEFAULT 'new'::character varying,
-    converted_at timestamp with time zone,
-    revenue_generated numeric(10,2) DEFAULT 0.00,
-    CONSTRAINT agent_response_queue_quality_grade_check CHECK (((quality_grade >= 1) AND (quality_grade <= 5)))
+    final_response text,
+    sent_message_id uuid,
+    decision_metadata jsonb,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
 );
 
 
 --
--- Name: agent_grade_summary; Type: VIEW; Schema: public; Owner: -
+-- Name: agent_runs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE VIEW public.agent_grade_summary AS
- SELECT intent,
-    ai_model,
-    count(*) AS total,
-    count(*) FILTER (WHERE (quality_grade IS NOT NULL)) AS graded,
-    round(avg(quality_grade), 2) AS avg_grade,
-    round(avg(edit_distance_pct), 1) AS avg_edit_pct,
-    count(*) FILTER (WHERE ((status)::text = 'approved'::text)) AS approved_as_is,
-    count(*) FILTER (WHERE ((status)::text = 'edited'::text)) AS needed_edit,
-    count(*) FILTER (WHERE ((status)::text = 'rejected'::text)) AS rejected,
-    round(avg(ai_duration_ms), 0) AS avg_duration_ms
-   FROM public.agent_response_queue
-  GROUP BY intent, ai_model
-  ORDER BY (count(*)) DESC;
-
-
---
--- Name: agent_learning_log; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.agent_learning_log (
-    id bigint NOT NULL,
-    queue_id bigint,
-    pattern_type character varying(50) NOT NULL,
-    intent character varying(50),
-    cabin_name character varying(100),
-    ai_draft text,
-    human_edit text,
-    correction_summary text,
-    quality_grade integer,
-    edit_distance_pct numeric(5,2),
-    learned_at timestamp without time zone DEFAULT now()
+CREATE TABLE public.agent_runs (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    agent_id uuid NOT NULL,
+    trigger_source character varying(100) NOT NULL,
+    status character varying(9) DEFAULT 'queued'::character varying NOT NULL,
+    started_at timestamp with time zone DEFAULT now() NOT NULL,
+    completed_at timestamp with time zone,
+    CONSTRAINT agent_run_status CHECK (((status)::text = ANY ((ARRAY['queued'::character varying, 'running'::character varying, 'completed'::character varying, 'failed'::character varying, 'escalated'::character varying, 'blocked'::character varying])::text[])))
 );
 
 
 --
--- Name: agent_learning_log_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: agreement_templates; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.agent_learning_log_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: agent_learning_log_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.agent_learning_log_id_seq OWNED BY public.agent_learning_log.id;
-
-
---
--- Name: agent_memory; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.agent_memory (
-    id bigint NOT NULL,
-    request_id uuid NOT NULL,
-    model character varying(128) NOT NULL,
-    reasoning_block text,
-    outcome_tags jsonb DEFAULT '[]'::jsonb,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    retained_until timestamp with time zone
+CREATE TABLE public.agreement_templates (
+    id uuid NOT NULL,
+    name character varying(255) NOT NULL,
+    description text,
+    agreement_type character varying(50) NOT NULL,
+    content_markdown text NOT NULL,
+    required_variables jsonb,
+    is_active boolean,
+    requires_signature boolean,
+    requires_initials boolean,
+    auto_send boolean,
+    send_days_before_checkin integer,
+    property_ids jsonb,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
 );
-
-
---
--- Name: agent_memory_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.agent_memory_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: agent_memory_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.agent_memory_id_seq OWNED BY public.agent_memory.id;
-
-
---
--- Name: agent_performance_log; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.agent_performance_log (
-    id bigint NOT NULL,
-    date date DEFAULT CURRENT_DATE NOT NULL,
-    messages_received integer DEFAULT 0,
-    drafts_generated integer DEFAULT 0,
-    drafts_approved integer DEFAULT 0,
-    drafts_edited integer DEFAULT 0,
-    drafts_rejected integer DEFAULT 0,
-    auto_sent integer DEFAULT 0,
-    avg_confidence numeric(4,3),
-    avg_response_time_ms integer,
-    escalation_count integer DEFAULT 0,
-    intent_breakdown jsonb,
-    created_at timestamp without time zone DEFAULT now()
-);
-
-
---
--- Name: agent_performance_log_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.agent_performance_log_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: agent_performance_log_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.agent_performance_log_id_seq OWNED BY public.agent_performance_log.id;
-
-
---
--- Name: agent_response_queue_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.agent_response_queue_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: agent_response_queue_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.agent_response_queue_id_seq OWNED BY public.agent_response_queue.id;
-
-
---
--- Name: agent_telemetry; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.agent_telemetry (
-    id bigint NOT NULL,
-    request_id uuid NOT NULL,
-    prompt_hash character varying(64),
-    model character varying(128) NOT NULL,
-    route character varying(256),
-    latency_ms integer,
-    retries smallint DEFAULT '0'::smallint NOT NULL,
-    error_class character varying(256),
-    user_feedback_signal character varying(32),
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    retained_until timestamp with time zone
-);
-
-
---
--- Name: agent_telemetry_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.agent_telemetry_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: agent_telemetry_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.agent_telemetry_id_seq OWNED BY public.agent_telemetry.id;
-
-
---
--- Name: ai_training_labels; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.ai_training_labels (
-    id bigint NOT NULL,
-    message_id bigint,
-    labeled_intent character varying(50) NOT NULL,
-    labeled_sentiment character varying(20),
-    labeled_urgency integer,
-    requires_human boolean,
-    response_appropriateness integer,
-    response_accuracy integer,
-    response_tone integer,
-    labeled_by character varying(100) NOT NULL,
-    labeled_at timestamp without time zone DEFAULT now(),
-    labeling_confidence integer,
-    notes text,
-    used_in_training_run character varying(100),
-    training_epoch integer,
-    CONSTRAINT valid_accuracy CHECK ((((response_accuracy >= 1) AND (response_accuracy <= 5)) OR (response_accuracy IS NULL))),
-    CONSTRAINT valid_appropriateness CHECK ((((response_appropriateness >= 1) AND (response_appropriateness <= 5)) OR (response_appropriateness IS NULL)))
-);
-
-
---
--- Name: message_archive; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.message_archive (
-    id bigint NOT NULL,
-    source character varying(50) NOT NULL,
-    external_id character varying(255),
-    provider_account character varying(100),
-    phone_number character varying(20),
-    guest_name character varying(255),
-    message_body text NOT NULL,
-    direction character varying(10) NOT NULL,
-    media_url text[],
-    sent_at timestamp without time zone,
-    received_at timestamp without time zone,
-    delivered_at timestamp without time zone,
-    read_at timestamp without time zone,
-    failed_at timestamp without time zone,
-    property_id integer,
-    cabin_name character varying(100),
-    reservation_id character varying(100),
-    reservation_checkin date,
-    reservation_checkout date,
-    intent character varying(50),
-    intent_confidence numeric(4,3),
-    sub_intent character varying(50),
-    sentiment character varying(20),
-    urgency_level integer,
-    contains_question boolean DEFAULT false,
-    requires_human boolean DEFAULT false,
-    response_generated_by character varying(50),
-    response_time_seconds integer,
-    ai_model_used character varying(100),
-    response_quality_score integer,
-    resolution_status character varying(20),
-    used_for_training boolean DEFAULT false,
-    training_label character varying(50),
-    training_split character varying(10),
-    human_reviewed boolean DEFAULT false,
-    human_reviewer character varying(100),
-    review_notes text,
-    approved_for_fine_tuning boolean DEFAULT false,
-    status character varying(50),
-    error_code character varying(50),
-    error_message text,
-    num_segments integer DEFAULT 1,
-    cost_usd numeric(10,6),
-    provider_cost_usd numeric(10,6),
-    created_at timestamp without time zone DEFAULT now(),
-    updated_at timestamp without time zone DEFAULT now(),
-    extracted_at timestamp without time zone,
-    extraction_method character varying(50),
-    channel character varying(20) DEFAULT 'sms'::character varying,
-    sender_email text,
-    CONSTRAINT valid_direction CHECK (((direction)::text = ANY ((ARRAY['inbound'::character varying, 'outbound'::character varying])::text[]))),
-    CONSTRAINT valid_quality CHECK ((((response_quality_score >= 1) AND (response_quality_score <= 5)) OR (response_quality_score IS NULL))),
-    CONSTRAINT valid_sentiment CHECK ((((sentiment)::text = ANY ((ARRAY['positive'::character varying, 'neutral'::character varying, 'negative'::character varying, 'urgent'::character varying])::text[])) OR (sentiment IS NULL))),
-    CONSTRAINT valid_urgency CHECK ((((urgency_level >= 1) AND (urgency_level <= 5)) OR (urgency_level IS NULL)))
-);
-
-
---
--- Name: ai_training_dataset; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public.ai_training_dataset AS
- SELECT ma.id,
-    ma.message_body AS input_text,
-    ma.intent AS intent_label,
-    ma.sentiment AS sentiment_label,
-    ma.direction,
-    atl.labeled_intent,
-    atl.labeled_sentiment,
-    atl.response_appropriateness,
-    ma.phone_number,
-    ma.property_id,
-    ma.sent_at
-   FROM (public.message_archive ma
-     LEFT JOIN public.ai_training_labels atl ON ((ma.id = atl.message_id)))
-  WHERE ((ma.used_for_training = true) AND (ma.human_reviewed = true));
-
-
---
--- Name: ai_training_labels_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.ai_training_labels_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: ai_training_labels_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.ai_training_labels_id_seq OWNED BY public.ai_training_labels.id;
 
 
 --
@@ -3051,286 +1003,112 @@ CREATE TABLE public.alembic_version (
 
 
 --
--- Name: anomaly_flags; Type: TABLE; Schema: public; Owner: -
+-- Name: analytics_events; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.anomaly_flags (
-    id integer NOT NULL,
-    journal_entry_id integer NOT NULL,
-    account_id integer,
-    flag_type text NOT NULL,
-    severity text NOT NULL,
-    deviation_pct numeric(8,2),
-    expected_amount numeric(15,2),
-    actual_amount numeric(15,2),
-    ai_explanation text,
-    reviewed boolean DEFAULT false,
-    reviewed_by text,
-    reviewed_at timestamp without time zone,
-    review_notes text,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT anomaly_flags_flag_type_check CHECK ((flag_type = ANY (ARRAY['amount_deviation'::text, 'unusual_category'::text, 'duplicate_suspect'::text, 'missing_reference'::text, 'trust_imbalance'::text, 'manual_review'::text]))),
-    CONSTRAINT anomaly_flags_severity_check CHECK ((severity = ANY (ARRAY['low'::text, 'medium'::text, 'high'::text, 'critical'::text])))
+CREATE TABLE public.analytics_events (
+    id uuid NOT NULL,
+    event_type character varying(100) NOT NULL,
+    guest_id uuid,
+    reservation_id uuid,
+    property_id uuid,
+    event_data jsonb,
+    session_id uuid,
+    user_agent text,
+    ip_address inet,
+    created_at timestamp without time zone
 );
 
 
 --
--- Name: anomaly_flags_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: async_job_runs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.anomaly_flags_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: anomaly_flags_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.anomaly_flags_id_seq OWNED BY public.anomaly_flags.id;
-
-
---
--- Name: api_key_vault; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.api_key_vault (
-    id integer NOT NULL,
-    key_name character varying(100) NOT NULL,
-    encrypted_value text NOT NULL,
-    label character varying(100),
-    description text,
-    category character varying(50) DEFAULT 'General'::character varying,
-    last_rotated timestamp with time zone DEFAULT now(),
-    created_at timestamp with time zone DEFAULT now(),
-    updated_by character varying(50)
+CREATE TABLE public.async_job_runs (
+    id uuid NOT NULL,
+    job_name character varying(100) NOT NULL,
+    queue_name character varying(100) NOT NULL,
+    status character varying(20) NOT NULL,
+    requested_by character varying(255),
+    tenant_id character varying(100),
+    request_id character varying(100),
+    arq_job_id character varying(100),
+    attempts integer NOT NULL,
+    payload_json jsonb NOT NULL,
+    result_json jsonb NOT NULL,
+    error_text text,
+    created_at timestamp with time zone NOT NULL,
+    started_at timestamp with time zone,
+    finished_at timestamp with time zone,
+    updated_at timestamp with time zone NOT NULL,
+    CONSTRAINT ck_async_job_runs_status CHECK (((status)::text = ANY ((ARRAY['queued'::character varying, 'running'::character varying, 'succeeded'::character varying, 'failed'::character varying, 'cancelled'::character varying])::text[])))
 );
 
 
 --
--- Name: api_key_vault_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: blocked_days; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.api_key_vault_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: api_key_vault_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.api_key_vault_id_seq OWNED BY public.api_key_vault.id;
-
-
---
--- Name: asset_docs; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.asset_docs (
-    id integer NOT NULL,
-    property_id integer,
-    property_name text,
-    doc_type character varying(50),
-    file_path text,
-    filename text,
-    extension text,
-    file_size bigint,
-    ocr_text text,
-    recording_date date,
-    book_page character varying(50),
-    grantor text,
-    grantee text,
-    parcel_id character varying(50),
-    confidence text,
-    ai_json text,
-    phase integer DEFAULT 1,
-    last_updated timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+CREATE TABLE public.blocked_days (
+    id uuid NOT NULL,
+    property_id uuid NOT NULL,
+    start_date date NOT NULL,
+    end_date date NOT NULL,
+    block_type character varying(50),
+    confirmation_code character varying(50),
+    source character varying(20),
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
 );
 
 
 --
--- Name: asset_docs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: blogs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.asset_docs_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: asset_docs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.asset_docs_id_seq OWNED BY public.asset_docs.id;
-
-
---
--- Name: conversation_threads; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.conversation_threads (
-    id bigint NOT NULL,
-    phone_number character varying(20) NOT NULL,
-    property_id integer,
-    thread_hash character varying(64),
-    started_at timestamp without time zone NOT NULL,
-    last_message_at timestamp without time zone NOT NULL,
-    message_count integer DEFAULT 0,
-    inbound_count integer DEFAULT 0,
-    outbound_count integer DEFAULT 0,
-    primary_intent character varying(50),
-    status character varying(20),
-    resolution_time_seconds integer,
-    handled_by_ai boolean DEFAULT false,
-    ai_success boolean,
-    escalated_to_human boolean DEFAULT false,
-    escalation_reason text,
-    guest_satisfaction_score integer,
-    guest_feedback text,
-    reservation_id character varying(100),
-    cabin_name character varying(100),
-    created_at timestamp without time zone DEFAULT now(),
-    updated_at timestamp without time zone DEFAULT now(),
-    CONSTRAINT valid_status CHECK (((status)::text = ANY ((ARRAY['active'::character varying, 'resolved'::character varying, 'escalated'::character varying, 'abandoned'::character varying])::text[])))
-);
-
-
---
--- Name: conversation_threads_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.conversation_threads_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: conversation_threads_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.conversation_threads_id_seq OWNED BY public.conversation_threads.id;
-
-
---
--- Name: council_votes; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.council_votes (
+CREATE TABLE public.blogs (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
-    event text NOT NULL,
-    context text,
-    model_used character varying(100) DEFAULT 'qwen2.5:7b'::character varying NOT NULL,
-    consensus_signal character varying(20) NOT NULL,
-    consensus_conviction double precision NOT NULL,
-    agreement_rate double precision NOT NULL,
-    bullish_count integer DEFAULT 0 NOT NULL,
-    bearish_count integer DEFAULT 0 NOT NULL,
-    neutral_count integer DEFAULT 0 NOT NULL,
-    total_voters integer DEFAULT 9 NOT NULL,
-    opinions jsonb DEFAULT '[]'::jsonb NOT NULL,
-    signal_breakdown jsonb DEFAULT '{}'::jsonb NOT NULL,
-    mode character varying(50),
-    elapsed_seconds double precision,
+    title character varying(500) NOT NULL,
+    slug character varying(255) NOT NULL,
+    body text,
+    author_name character varying(255),
+    status character varying(50) DEFAULT 'published'::character varying,
+    is_promoted boolean DEFAULT false,
+    is_sticky boolean DEFAULT false,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
-    resolved_at timestamp with time zone,
-    actual_outcome character varying(20),
-    resolution_notes text
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    published_at timestamp with time zone
 );
 
 
 --
--- Name: message_analytics; Type: TABLE; Schema: public; Owner: -
+-- Name: capex_staging; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.message_analytics (
+CREATE TABLE public.capex_staging (
     id bigint NOT NULL,
-    date date NOT NULL,
-    hour integer,
-    property_id integer,
-    source character varying(50),
-    total_messages integer DEFAULT 0,
-    inbound_messages integer DEFAULT 0,
-    outbound_messages integer DEFAULT 0,
-    ai_handled_count integer DEFAULT 0,
-    human_handled_count integer DEFAULT 0,
-    escalation_count integer DEFAULT 0,
-    ai_success_rate numeric(5,4),
-    avg_response_time_seconds integer,
-    median_response_time_seconds integer,
-    p95_response_time_seconds integer,
-    intent_distribution jsonb,
-    positive_messages integer DEFAULT 0,
-    neutral_messages integer DEFAULT 0,
-    negative_messages integer DEFAULT 0,
-    urgent_messages integer DEFAULT 0,
-    total_cost_usd numeric(10,2),
-    cost_per_message numeric(6,4),
-    avg_satisfaction_score numeric(3,2),
-    created_at timestamp without time zone DEFAULT now()
+    property_id character varying(100) NOT NULL,
+    vendor character varying(255) NOT NULL,
+    amount numeric(12,2) NOT NULL,
+    total_owner_charge numeric(12,2) NOT NULL,
+    description text,
+    journal_lines jsonb,
+    audit_trail jsonb,
+    compliance_status character varying(64) DEFAULT 'PENDING_CAPEX_APPROVAL'::character varying NOT NULL,
+    approved_by character varying(100),
+    approved_at timestamp with time zone,
+    rejected_by character varying(100),
+    rejected_at timestamp with time zone,
+    rejection_reason text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 
 --
--- Name: daily_performance; Type: VIEW; Schema: public; Owner: -
+-- Name: capex_staging_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE VIEW public.daily_performance AS
- SELECT date,
-    sum(total_messages) AS total_messages,
-    sum(inbound_messages) AS inbound_messages,
-    sum(outbound_messages) AS outbound_messages,
-    avg(ai_success_rate) AS avg_ai_success_rate,
-    avg(avg_response_time_seconds) AS avg_response_time,
-    sum(total_cost_usd) AS total_cost,
-    avg(avg_satisfaction_score) AS avg_satisfaction
-   FROM public.message_analytics
-  WHERE (hour IS NULL)
-  GROUP BY date
-  ORDER BY date DESC;
-
-
---
--- Name: data_sanitizer_log; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.data_sanitizer_log (
-    id integer NOT NULL,
-    run_id uuid NOT NULL,
-    table_name text NOT NULL,
-    column_name text NOT NULL,
-    row_id text NOT NULL,
-    original_value text,
-    sanitized_value text,
-    rule_applied text NOT NULL,
-    anomalies text[],
-    severity character varying(20) NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    CONSTRAINT data_sanitizer_log_severity_check CHECK (((severity)::text = ANY ((ARRAY['auto_fix'::character varying, 'flag'::character varying, 'quarantine'::character varying])::text[])))
-);
-
-
---
--- Name: data_sanitizer_log_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.data_sanitizer_log_id_seq
-    AS integer
+CREATE SEQUENCE public.capex_staging_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3339,10 +1117,193 @@ CREATE SEQUENCE public.data_sanitizer_log_id_seq
 
 
 --
--- Name: data_sanitizer_log_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+-- Name: capex_staging_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.data_sanitizer_log_id_seq OWNED BY public.data_sanitizer_log.id;
+ALTER SEQUENCE public.capex_staging_id_seq OWNED BY public.capex_staging.id;
+
+
+--
+-- Name: capture_labels; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.capture_labels (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    capture_id uuid NOT NULL,
+    capture_table character varying(32) NOT NULL,
+    task_type character varying(64) NOT NULL,
+    godhead_model character varying(128),
+    godhead_decision character varying(16),
+    godhead_reasoning text,
+    godhead_called_at timestamp with time zone,
+    godhead_cost_usd numeric(8,4),
+    qc_sampled boolean DEFAULT false NOT NULL,
+    qc_decision character varying(16),
+    qc_note text,
+    qc_reviewed_at timestamp with time zone,
+    final_decision character varying(16),
+    label_source character varying(16)
+);
+
+
+--
+-- Name: channel_mappings; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.channel_mappings (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    property_id uuid NOT NULL,
+    channel character varying(50) NOT NULL,
+    external_listing_id character varying(255) NOT NULL,
+    sync_status character varying(30) DEFAULT 'active'::character varying NOT NULL,
+    last_synced_at timestamp with time zone,
+    sync_error text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: citation_records; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.citation_records (
+    id uuid NOT NULL,
+    directory_domain character varying(255) NOT NULL,
+    profile_url character varying(1000),
+    found_name character varying(500),
+    found_address character varying(1000),
+    found_phone character varying(100),
+    match_status character varying(30) NOT NULL,
+    last_audited_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: cleaners; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.cleaners (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    name character varying(200) NOT NULL,
+    phone character varying(40),
+    email character varying(255),
+    active boolean DEFAULT true NOT NULL,
+    per_clean_rate numeric(8,2),
+    hourly_rate numeric(8,2),
+    property_ids jsonb DEFAULT '[]'::jsonb NOT NULL,
+    regions jsonb DEFAULT '[]'::jsonb NOT NULL,
+    notes text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: competitor_listings; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.competitor_listings (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    property_id uuid NOT NULL,
+    platform character varying(11) NOT NULL,
+    external_url character varying(500),
+    external_id character varying(100),
+    dedupe_hash character varying(64) NOT NULL,
+    observed_nightly_rate numeric(12,2) NOT NULL,
+    observed_total_before_tax numeric(12,2) NOT NULL,
+    platform_fee numeric(12,2) DEFAULT 0 NOT NULL,
+    cleaning_fee numeric(12,2) DEFAULT 0 NOT NULL,
+    total_after_tax numeric(12,2) NOT NULL,
+    snapshot_payload jsonb NOT NULL,
+    last_observed timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT ota_provider CHECK (((platform)::text = ANY ((ARRAY['airbnb'::character varying, 'vrbo'::character varying, 'booking_com'::character varying])::text[])))
+);
+
+
+--
+-- Name: concierge_queue; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.concierge_queue (
+    id uuid NOT NULL,
+    guest_phone character varying(40) NOT NULL,
+    property_id uuid,
+    inbound_message text NOT NULL,
+    retrieved_context jsonb NOT NULL,
+    ai_draft_reply text,
+    reviewed_by character varying(120),
+    review_note text,
+    sent_at timestamp without time zone,
+    metadata_json jsonb NOT NULL,
+    status character varying(30) NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    CONSTRAINT ck_concierge_queue_status CHECK (((status)::text = ANY ((ARRAY['pending_review'::character varying, 'approved'::character varying, 'rejected'::character varying, 'sent'::character varying, 'failed'::character varying])::text[])))
+);
+
+
+--
+-- Name: concierge_recovery_dispatches; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.concierge_recovery_dispatches (
+    id uuid NOT NULL,
+    session_fp character varying(64),
+    guest_id uuid NOT NULL,
+    channel character varying(16) NOT NULL,
+    template_key character varying(64) DEFAULT 'abandon_cart_v1'::character varying NOT NULL,
+    body_preview text,
+    status character varying(24) DEFAULT 'sent'::character varying NOT NULL,
+    provider_metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: damage_claims; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.damage_claims (
+    id uuid NOT NULL,
+    claim_number character varying(50) NOT NULL,
+    reservation_id uuid NOT NULL,
+    property_id uuid NOT NULL,
+    guest_id uuid NOT NULL,
+    damage_description text NOT NULL,
+    policy_violations text,
+    damage_areas text[],
+    estimated_cost numeric(10,2),
+    photo_urls text[],
+    reported_by character varying(200) NOT NULL,
+    inspection_date date NOT NULL,
+    inspection_notes text,
+    legal_draft text,
+    legal_draft_model character varying(100),
+    legal_draft_at timestamp without time zone,
+    rental_agreement_id uuid,
+    agreement_clauses jsonb,
+    status character varying(30) NOT NULL,
+    reviewed_by character varying(200),
+    reviewed_at timestamp without time zone,
+    final_response text,
+    sent_at timestamp without time zone,
+    sent_via character varying(30),
+    resolution text,
+    resolution_amount numeric(10,2),
+    resolved_at timestamp without time zone,
+    qdrant_point_id uuid,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone,
+    stripe_charge_id character varying(255),
+    amount_charged numeric(10,2),
+    charge_payment_method_id character varying(255),
+    charge_executed_at timestamp with time zone,
+    charge_executed_by character varying(255)
+);
 
 
 --
@@ -3350,18 +1311,15 @@ ALTER SEQUENCE public.data_sanitizer_log_id_seq OWNED BY public.data_sanitizer_l
 --
 
 CREATE TABLE public.deferred_api_writes (
-    id integer NOT NULL,
-    service text NOT NULL,
-    method text NOT NULL,
+    id bigint NOT NULL,
+    service character varying(128) NOT NULL,
+    method character varying(512) NOT NULL,
     payload jsonb NOT NULL,
-    status character varying(20) DEFAULT 'pending'::character varying NOT NULL,
-    attempts integer DEFAULT 0 NOT NULL,
-    max_attempts integer DEFAULT 10 NOT NULL,
-    last_error text,
+    status character varying(64) DEFAULT 'pending'::character varying NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
-    next_retry_at timestamp with time zone DEFAULT now() NOT NULL,
-    completed_at timestamp with time zone,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
+    retry_count integer DEFAULT 0 NOT NULL,
+    last_error text,
+    reconciled_at timestamp with time zone
 );
 
 
@@ -3370,7 +1328,6 @@ CREATE TABLE public.deferred_api_writes (
 --
 
 CREATE SEQUENCE public.deferred_api_writes_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3386,875 +1343,617 @@ ALTER SEQUENCE public.deferred_api_writes_id_seq OWNED BY public.deferred_api_wr
 
 
 --
--- Name: document_oracle_manifest; Type: TABLE; Schema: public; Owner: -
+-- Name: distillation_queue; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.document_oracle_manifest (
-    file_path text NOT NULL,
-    sha256_hash text NOT NULL,
-    chunk_count integer NOT NULL,
-    sector text NOT NULL,
-    ingested_at timestamp with time zone DEFAULT now() NOT NULL
+CREATE TABLE public.distillation_queue (
+    id uuid NOT NULL,
+    source_module character varying(120) NOT NULL,
+    source_ref character varying(255) NOT NULL,
+    source_intelligence_id uuid,
+    input_payload jsonb NOT NULL,
+    output_payload jsonb NOT NULL,
+    status character varying(10) NOT NULL,
+    error text,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
 );
 
 
 --
--- Name: email_archive; Type: TABLE; Schema: public; Owner: -
+-- Name: email_inquirers; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.email_archive (
-    id integer NOT NULL,
-    category text,
-    file_path text,
-    sender text,
-    subject text,
-    content text,
-    sent_at timestamp without time zone,
-    is_mined boolean DEFAULT false,
-    ts tsvector GENERATED ALWAYS AS (to_tsvector('english'::regconfig, ((COALESCE(subject, ''::text) || ' '::text) || COALESCE(content, ''::text)))) STORED,
-    retry_count integer DEFAULT 0,
-    last_error text,
-    division text,
-    division_confidence integer,
-    division_summary text,
-    is_vectorized boolean DEFAULT false,
-    to_addresses text,
-    cc_addresses text,
-    bcc_addresses text,
-    message_id text,
-    ingested_from text
-);
-
-
---
--- Name: email_archive_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.email_archive_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: email_archive_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.email_archive_id_seq OWNED BY public.email_archive.id;
-
-
---
--- Name: email_classification_rules; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.email_classification_rules (
-    id integer NOT NULL,
-    division character varying(30) NOT NULL,
-    match_field character varying(20) NOT NULL,
-    pattern text NOT NULL,
-    weight integer DEFAULT 10,
-    is_regex boolean DEFAULT false,
-    is_active boolean DEFAULT true,
-    hit_count integer DEFAULT 0,
-    notes text,
-    created_at timestamp without time zone DEFAULT now(),
-    CONSTRAINT email_classification_rules_match_field_check CHECK (((match_field)::text = ANY ((ARRAY['sender'::character varying, 'subject'::character varying, 'content'::character varying, 'any'::character varying])::text[]))),
-    CONSTRAINT email_classification_rules_weight_check CHECK (((weight >= 1) AND (weight <= 100)))
-);
-
-
---
--- Name: email_classification_rules_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.email_classification_rules_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: email_classification_rules_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.email_classification_rules_id_seq OWNED BY public.email_classification_rules.id;
-
-
---
--- Name: email_dead_letter_queue; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.email_dead_letter_queue (
-    id integer NOT NULL,
-    fingerprint text NOT NULL,
-    source_tag text,
-    sender text,
-    subject text,
-    raw_payload jsonb NOT NULL,
-    error_message text,
-    error_traceback text,
-    retry_count integer DEFAULT 0,
-    max_retries integer DEFAULT 5,
-    next_retry_at timestamp with time zone,
-    status text DEFAULT 'pending'::text,
-    created_at timestamp with time zone DEFAULT now(),
-    updated_at timestamp with time zone DEFAULT now(),
-    CONSTRAINT email_dead_letter_queue_status_check CHECK ((status = ANY (ARRAY['pending'::text, 'retrying'::text, 'recovered'::text, 'dead'::text, 'manual_review'::text, 'discarded'::text])))
-);
-
-
---
--- Name: email_dead_letter_queue_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.email_dead_letter_queue_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: email_dead_letter_queue_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.email_dead_letter_queue_id_seq OWNED BY public.email_dead_letter_queue.id;
-
-
---
--- Name: email_escalation_queue; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.email_escalation_queue (
-    id bigint NOT NULL,
-    email_id bigint,
-    trigger_type character varying(30) NOT NULL,
-    trigger_detail text,
-    priority character varying(5) DEFAULT 'P2'::character varying,
-    status character varying(20) DEFAULT 'pending'::character varying,
-    seen_by character varying(50),
-    seen_at timestamp without time zone,
-    action_taken text,
-    created_at timestamp without time zone DEFAULT now(),
-    snooze_until timestamp with time zone,
-    CONSTRAINT email_escalation_queue_priority_check CHECK (((priority)::text = ANY ((ARRAY['P0'::character varying, 'P1'::character varying, 'P2'::character varying, 'P3'::character varying])::text[]))),
-    CONSTRAINT email_escalation_queue_status_check CHECK (((status)::text = ANY ((ARRAY['pending'::character varying, 'seen'::character varying, 'actioned'::character varying, 'dismissed'::character varying, 'snoozed'::character varying])::text[]))),
-    CONSTRAINT email_escalation_queue_trigger_type_check CHECK (((trigger_type)::text = ANY ((ARRAY['vip_sender'::character varying, 'high_dollar'::character varying, 'legal_watchdog'::character varying, 'failed_classification'::character varying, 'negative_sentiment'::character varying, 'new_important_domain'::character varying, 'manual'::character varying, 'content_flag'::character varying])::text[])))
-);
-
-
---
--- Name: email_escalation_queue_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.email_escalation_queue_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: email_escalation_queue_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.email_escalation_queue_id_seq OWNED BY public.email_escalation_queue.id;
-
-
---
--- Name: email_escalation_rules; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.email_escalation_rules (
-    id integer NOT NULL,
-    rule_name character varying(100) NOT NULL,
-    trigger_type character varying(30) NOT NULL,
-    match_field character varying(20) NOT NULL,
-    pattern text NOT NULL,
-    priority character varying(5) DEFAULT 'P2'::character varying,
-    is_active boolean DEFAULT true,
-    notes text,
-    created_at timestamp without time zone DEFAULT now(),
-    CONSTRAINT email_escalation_rules_match_field_check CHECK (((match_field)::text = ANY ((ARRAY['sender'::character varying, 'subject'::character varying, 'content'::character varying, 'any'::character varying, 'amount'::character varying])::text[])))
-);
-
-
---
--- Name: email_escalation_rules_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.email_escalation_rules_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: email_escalation_rules_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.email_escalation_rules_id_seq OWNED BY public.email_escalation_rules.id;
-
-
---
--- Name: email_intake_review_log; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.email_intake_review_log (
-    id bigint NOT NULL,
-    escalation_id bigint,
-    email_id bigint,
-    actor character varying(50) NOT NULL,
-    action_type character varying(30) NOT NULL,
-    old_division character varying(30),
-    new_division character varying(30),
-    old_confidence integer,
-    new_confidence integer,
-    review_grade integer,
-    notes text,
-    created_at timestamp without time zone DEFAULT now(),
-    CONSTRAINT email_intake_review_log_action_type_check CHECK (((action_type)::text = ANY ((ARRAY['reclassify'::character varying, 'grade'::character varying, 'dismiss'::character varying, 'escalate'::character varying, 'approve'::character varying, 'add_rule'::character varying, 'bulk_action'::character varying])::text[]))),
-    CONSTRAINT email_intake_review_log_review_grade_check CHECK (((review_grade IS NULL) OR ((review_grade >= 1) AND (review_grade <= 5))))
-);
-
-
---
--- Name: email_intake_review_log_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.email_intake_review_log_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: email_intake_review_log_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.email_intake_review_log_id_seq OWNED BY public.email_intake_review_log.id;
-
-
---
--- Name: email_quarantine; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.email_quarantine (
-    id bigint NOT NULL,
-    sender text,
-    subject text,
-    content_preview text,
-    sent_at timestamp without time zone,
-    fingerprint character varying(64),
-    source_tag character varying(30),
-    rule_id integer,
-    rule_type character varying(30),
-    rule_reason text,
-    status character varying(20) DEFAULT 'quarantined'::character varying,
-    reviewed_by character varying(50),
-    reviewed_at timestamp without time zone,
-    created_at timestamp without time zone DEFAULT now(),
-    CONSTRAINT email_quarantine_status_check CHECK (((status)::text = ANY ((ARRAY['quarantined'::character varying, 'released'::character varying, 'deleted'::character varying, 'reviewed'::character varying])::text[])))
-);
-
-
---
--- Name: email_quarantine_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.email_quarantine_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: email_quarantine_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.email_quarantine_id_seq OWNED BY public.email_quarantine.id;
-
-
---
--- Name: email_routing_rules; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.email_routing_rules (
-    id integer NOT NULL,
-    rule_type character varying(30) NOT NULL,
-    pattern text NOT NULL,
-    action character varying(20) NOT NULL,
-    division character varying(30),
-    reason text,
-    is_active boolean DEFAULT true,
-    hit_count integer DEFAULT 0,
-    created_at timestamp without time zone DEFAULT now(),
-    updated_at timestamp without time zone DEFAULT now(),
-    CONSTRAINT email_routing_rules_action_check CHECK (((action)::text = ANY ((ARRAY['REJECT'::character varying, 'QUARANTINE'::character varying, 'ALLOW'::character varying, 'ESCALATE'::character varying, 'PRIORITY'::character varying])::text[]))),
-    CONSTRAINT email_routing_rules_rule_type_check CHECK (((rule_type)::text = ANY ((ARRAY['sender_block'::character varying, 'sender_vip'::character varying, 'domain_trust'::character varying, 'subject_block'::character varying, 'content_block'::character varying, 'sender_allow'::character varying])::text[])))
-);
-
-
---
--- Name: email_routing_rules_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.email_routing_rules_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: email_routing_rules_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.email_routing_rules_id_seq OWNED BY public.email_routing_rules.id;
-
-
---
--- Name: email_sensors; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.email_sensors (
+CREATE TABLE public.email_inquirers (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
-    email_address text NOT NULL,
-    display_name text,
-    protocol character varying(10) DEFAULT 'pop3'::character varying NOT NULL,
-    server_address text NOT NULL,
-    server_port integer DEFAULT 995 NOT NULL,
-    encrypted_password text NOT NULL,
-    use_ssl boolean DEFAULT true NOT NULL,
+    email character varying(255) NOT NULL,
+    display_name character varying(255),
+    first_name character varying(100),
+    last_name character varying(100),
+    guest_id uuid,
+    inferred_party_size integer,
+    inferred_dates_text text,
+    opt_in_email boolean DEFAULT true NOT NULL,
+    first_seen_at timestamp with time zone DEFAULT now() NOT NULL,
+    last_seen_at timestamp with time zone DEFAULT now() NOT NULL,
+    inquiry_count integer DEFAULT 1 NOT NULL
+);
+
+
+--
+-- Name: email_messages; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.email_messages (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    inquirer_id uuid NOT NULL,
+    guest_id uuid,
+    reservation_id uuid,
+    in_reply_to_message_id uuid,
+    direction character varying(20) NOT NULL,
+    email_from character varying(255) NOT NULL,
+    email_to character varying(255) NOT NULL,
+    email_cc text,
+    subject text,
+    body_text text NOT NULL,
+    body_excerpt text,
+    imap_uid bigint,
+    imap_message_id text,
+    received_at timestamp with time zone,
+    intent character varying(50),
+    sentiment character varying(20),
+    category character varying(50),
+    ai_draft text,
+    ai_confidence numeric(4,3),
+    ai_meta jsonb,
+    approval_status character varying(30) DEFAULT 'pending_approval'::character varying NOT NULL,
+    requires_human_review boolean DEFAULT true NOT NULL,
+    human_reviewed_at timestamp with time zone,
+    human_reviewed_by uuid,
+    human_edited_body text,
+    sent_at timestamp with time zone,
+    smtp_message_id text,
+    error_code character varying(50),
+    error_message text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    extra_data jsonb,
+    CONSTRAINT ck_email_messages_approval_status CHECK (((approval_status)::text = ANY ((ARRAY['pending_approval'::character varying, 'approved'::character varying, 'rejected'::character varying, 'sent'::character varying, 'send_failed'::character varying, 'no_draft_needed'::character varying])::text[]))),
+    CONSTRAINT ck_email_messages_direction CHECK (((direction)::text = ANY ((ARRAY['inbound'::character varying, 'outbound'::character varying])::text[])))
+);
+
+
+--
+-- Name: email_templates; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.email_templates (
+    id uuid NOT NULL,
+    name character varying(255) NOT NULL,
+    trigger_event character varying(100) NOT NULL,
+    subject_template character varying(1000) NOT NULL,
+    body_template text NOT NULL,
     is_active boolean DEFAULT true NOT NULL,
-    last_sweep_at timestamp without time zone,
-    last_sweep_status character varying(20) DEFAULT 'pending'::character varying,
-    last_sweep_error text,
-    emails_ingested_total integer DEFAULT 0,
-    created_at timestamp without time zone DEFAULT now(),
-    updated_at timestamp without time zone DEFAULT now(),
-    CONSTRAINT email_sensors_last_sweep_status_check CHECK (((last_sweep_status)::text = ANY ((ARRAY['green'::character varying, 'red'::character varying, 'pending'::character varying])::text[]))),
-    CONSTRAINT email_sensors_protocol_check CHECK (((protocol)::text = ANY ((ARRAY['pop3'::character varying, 'imap'::character varying, 'gmail_api'::character varying])::text[])))
+    requires_human_approval boolean DEFAULT true NOT NULL,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
 );
 
 
 --
--- Name: email_triage_precedents; Type: TABLE; Schema: public; Owner: -
+-- Name: extra_orders; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.email_triage_precedents (
-    id integer NOT NULL,
-    email_id integer,
-    pattern_text text NOT NULL,
-    division text NOT NULL,
-    priority text DEFAULT 'P2'::text,
-    reasoning text,
-    created_by text DEFAULT 'HUMAN'::text,
-    embedding public.vector(768),
-    created_at timestamp with time zone DEFAULT now()
+CREATE TABLE public.extra_orders (
+    id uuid NOT NULL,
+    reservation_id uuid NOT NULL,
+    extra_id uuid NOT NULL,
+    quantity integer,
+    unit_price numeric(10,2) NOT NULL,
+    total_price numeric(10,2) NOT NULL,
+    status character varying(50) NOT NULL,
+    fulfilled_at timestamp without time zone,
+    notes text,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
 );
 
 
 --
--- Name: email_triage_precedents_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: extras; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.email_triage_precedents_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: email_triage_precedents_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.email_triage_precedents_id_seq OWNED BY public.email_triage_precedents.id;
-
-
---
--- Name: fin_owner_balances; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.fin_owner_balances (
-    property_id character varying(50) NOT NULL,
-    property_name character varying(200),
-    owner_name character varying(100),
-    bedrooms integer,
-    estimated_rate numeric(12,2),
-    total_booked_nights integer DEFAULT 0,
-    gross_revenue numeric(12,2) DEFAULT 0,
-    mgmt_fee_pct numeric(5,2) DEFAULT 25.00,
-    mgmt_fee_amount numeric(12,2) DEFAULT 0,
-    owner_payout numeric(12,2) DEFAULT 0,
-    last_calculated timestamp without time zone,
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+CREATE TABLE public.extras (
+    id uuid NOT NULL,
+    name character varying(255) NOT NULL,
+    description text,
+    category character varying(50),
+    price numeric(10,2) NOT NULL,
+    currency character varying(3),
+    is_available boolean,
+    properties uuid[],
+    image_url text,
+    display_order integer,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
 );
 
 
 --
--- Name: fin_reservations; Type: TABLE; Schema: public; Owner: -
+-- Name: fees; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.fin_reservations (
-    res_id character varying(100) NOT NULL,
-    property_id character varying(50),
-    property_name character varying(200),
-    guest_name character varying(100),
+CREATE TABLE public.fees (
+    id uuid NOT NULL,
+    name character varying(255) NOT NULL,
+    flat_amount numeric(12,2) NOT NULL,
+    is_pet_fee boolean DEFAULT false NOT NULL,
+    is_active boolean DEFAULT true NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL,
+    fee_type character varying(20) DEFAULT 'flat'::character varying NOT NULL,
+    percentage_rate numeric(6,3),
+    is_optional boolean DEFAULT false NOT NULL
+);
+
+
+--
+-- Name: financial_approvals; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.financial_approvals (
+    id uuid NOT NULL,
+    reservation_id character varying(100) NOT NULL,
+    status character varying(30) DEFAULT 'pending'::character varying NOT NULL,
+    discrepancy_type character varying(100) NOT NULL,
+    local_total_cents integer NOT NULL,
+    streamline_total_cents integer NOT NULL,
+    delta_cents integer NOT NULL,
+    context_payload jsonb DEFAULT '{}'::jsonb NOT NULL,
+    resolution_strategy character varying(30),
+    stripe_invoice_id character varying(255),
+    resolved_by character varying(255),
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    resolved_at timestamp with time zone
+);
+
+
+--
+-- Name: functional_nodes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.functional_nodes (
+    id uuid NOT NULL,
+    legacy_node_id integer,
+    source_path character varying(255) NOT NULL,
+    canonical_path character varying(512) NOT NULL,
+    title character varying(255) NOT NULL,
+    node_type character varying(64) NOT NULL,
+    content_category character varying(64) NOT NULL,
+    functional_complexity character varying(64) NOT NULL,
+    crawl_status character varying(32) NOT NULL,
+    mirror_status character varying(32) NOT NULL,
+    cutover_status character varying(32) NOT NULL,
+    priority_tier integer NOT NULL,
+    is_published boolean NOT NULL,
+    http_status integer,
+    body_html text,
+    body_text_preview text,
+    form_fields jsonb NOT NULL,
+    taxonomy_terms jsonb NOT NULL,
+    media_refs jsonb NOT NULL,
+    source_metadata jsonb NOT NULL,
+    mirror_component_path character varying(512),
+    mirror_route_path character varying(512),
+    source_hash character varying(64),
+    last_crawled_at timestamp with time zone,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: guest_activities; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.guest_activities (
+    id uuid NOT NULL,
+    guest_id uuid NOT NULL,
+    activity_type character varying(50) NOT NULL,
+    category character varying(30) NOT NULL,
+    title character varying(255) NOT NULL,
+    description text,
+    reservation_id uuid,
+    property_id uuid,
+    message_id uuid,
+    review_id uuid,
+    survey_id uuid,
+    agreement_id uuid,
+    work_order_id uuid,
+    performed_by character varying(100),
+    performed_by_type character varying(20),
+    metadata jsonb,
+    importance character varying(10),
+    is_visible_to_guest character varying(5),
+    created_at timestamp without time zone
+);
+
+
+--
+-- Name: guest_quotes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.guest_quotes (
+    id uuid NOT NULL,
+    target_property_id character varying(255) NOT NULL,
+    property_id uuid,
+    status public.guest_quote_status NOT NULL,
+    campaign character varying(100) NOT NULL,
+    target_keyword character varying(255),
+    guest_name character varying(255),
+    guest_email character varying(255),
+    guest_phone character varying(40),
     check_in date,
     check_out date,
     nights integer,
-    nightly_rate numeric(12,2),
-    base_rent numeric(12,2),
-    taxes numeric(12,2) DEFAULT 0,
-    fees numeric(12,2) DEFAULT 0,
-    total_revenue numeric(12,2),
-    status character varying(50) DEFAULT 'Shadow-Booked'::character varying,
-    source character varying(50) DEFAULT 'shadow'::character varying,
-    is_estimation boolean DEFAULT true,
-    confidence character varying(20) DEFAULT 'medium'::character varying,
-    notes text,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+    adults integer NOT NULL,
+    children integer NOT NULL,
+    pets integer NOT NULL,
+    currency character varying(10) NOT NULL,
+    base_rent numeric(12,2) NOT NULL,
+    taxes numeric(12,2) NOT NULL,
+    fees numeric(12,2) NOT NULL,
+    total_amount numeric(12,2) NOT NULL,
+    base_price double precision NOT NULL,
+    ai_adjusted_price double precision NOT NULL,
+    sovereign_narrative text NOT NULL,
+    quote_breakdown jsonb NOT NULL,
+    source_snapshot jsonb NOT NULL,
+    stripe_payment_link_url character varying(1024),
+    stripe_payment_link_id character varying(255),
+    note text,
+    expires_at timestamp without time zone NOT NULL,
+    accepted_at timestamp without time zone,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
 );
 
 
 --
--- Name: fin_revenue_snapshots; Type: TABLE; Schema: public; Owner: -
+-- Name: guest_reviews; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.fin_revenue_snapshots (
-    snapshot_id integer NOT NULL,
-    period_start date,
-    period_end date,
-    total_properties integer,
-    total_nights integer,
-    gross_revenue numeric(12,2),
-    est_taxes numeric(12,2),
-    est_mgmt_fees numeric(12,2),
-    est_owner_payout numeric(12,2),
-    source character varying(50) DEFAULT 'shadow'::character varying,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+CREATE TABLE public.guest_reviews (
+    id uuid NOT NULL,
+    guest_id uuid NOT NULL,
+    reservation_id uuid,
+    property_id uuid NOT NULL,
+    direction character varying(30) NOT NULL,
+    overall_rating integer NOT NULL,
+    cleanliness_rating integer,
+    accuracy_rating integer,
+    communication_rating integer,
+    location_rating integer,
+    checkin_rating integer,
+    value_rating integer,
+    amenities_rating integer,
+    house_rules_rating integer,
+    cleanliness_left_rating integer,
+    communication_guest_rating integer,
+    respect_rating integer,
+    noise_rating integer,
+    checkout_compliance_rating integer,
+    title character varying(255),
+    body text,
+    response_body text,
+    response_by character varying(100),
+    response_at timestamp without time zone,
+    sentiment character varying(20),
+    sentiment_score numeric(4,3),
+    key_phrases jsonb,
+    improvement_suggestions jsonb,
+    is_published boolean,
+    published_at timestamp without time zone,
+    publish_to_website boolean,
+    publish_to_airbnb boolean,
+    publish_to_google boolean,
+    external_review_urls jsonb,
+    is_flagged boolean,
+    flag_reason character varying(255),
+    moderated_by character varying(100),
+    moderated_at timestamp without time zone,
+    solicitation_sent_at timestamp without time zone,
+    solicitation_method character varying(20),
+    solicitation_template_id uuid,
+    submitted_via character varying(30),
+    streamline_feedback_id character varying(100),
+    source character varying(50),
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
 );
 
 
 --
--- Name: fin_revenue_snapshots_snapshot_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: guest_surveys; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.fin_revenue_snapshots_snapshot_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: fin_revenue_snapshots_snapshot_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.fin_revenue_snapshots_snapshot_id_seq OWNED BY public.fin_revenue_snapshots.snapshot_id;
-
-
---
--- Name: finance_invoices; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.finance_invoices (
-    id integer NOT NULL,
-    vendor text NOT NULL,
-    amount numeric(10,2) NOT NULL,
-    date date NOT NULL,
-    category text,
-    source_email_id integer,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+CREATE TABLE public.guest_surveys (
+    id uuid NOT NULL,
+    guest_id uuid NOT NULL,
+    reservation_id uuid,
+    property_id uuid,
+    template_id uuid,
+    survey_type character varying(50) NOT NULL,
+    responses jsonb NOT NULL,
+    overall_score numeric(4,2),
+    nps_score integer,
+    nps_category character varying(20),
+    housekeeping_score integer,
+    maintenance_score integer,
+    communication_score integer,
+    amenities_score integer,
+    sentiment character varying(20),
+    key_themes jsonb,
+    action_items jsonb,
+    status character varying(30) NOT NULL,
+    sent_at timestamp without time zone,
+    started_at timestamp without time zone,
+    completed_at timestamp without time zone,
+    send_method character varying(20),
+    survey_url text,
+    follow_up_required boolean,
+    follow_up_notes text,
+    follow_up_completed_at timestamp without time zone,
+    follow_up_by character varying(100),
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
 );
 
 
 --
--- Name: finance_invoices_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: guest_verifications; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.finance_invoices_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: finance_invoices_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.finance_invoices_id_seq OWNED BY public.finance_invoices.id;
-
-
---
--- Name: fortress_api_keys; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.fortress_api_keys (
-    id integer NOT NULL,
-    key_prefix character varying(12) NOT NULL,
-    key_hash character varying(255) NOT NULL,
-    name character varying(100) NOT NULL,
-    scopes text[] DEFAULT '{}'::text[],
-    owner_id integer,
-    is_active boolean DEFAULT true,
-    created_at timestamp without time zone DEFAULT now(),
-    last_used timestamp without time zone
+CREATE TABLE public.guest_verifications (
+    id uuid NOT NULL,
+    guest_id uuid NOT NULL,
+    reservation_id uuid,
+    verification_type character varying(50) NOT NULL,
+    status character varying(30) NOT NULL,
+    document_type character varying(50),
+    document_number_hash character varying(255),
+    document_country character varying(2),
+    document_state character varying(5),
+    document_expiration date,
+    document_front_url text,
+    document_back_url text,
+    selfie_url text,
+    confidence_score numeric(4,3),
+    match_details jsonb,
+    reviewed_by character varying(100),
+    reviewed_at timestamp without time zone,
+    rejection_reason text,
+    external_verification_id character varying(255),
+    provider character varying(50),
+    ip_address character varying(45),
+    user_agent text,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone,
+    expires_at timestamp without time zone
 );
 
 
 --
--- Name: fortress_api_keys_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: guestbook_guides; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.fortress_api_keys_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
+CREATE TABLE public.guestbook_guides (
+    id uuid NOT NULL,
+    property_id uuid,
+    title character varying(255) NOT NULL,
+    slug character varying(255) NOT NULL,
+    guide_type character varying(50) NOT NULL,
+    category character varying(50),
+    content text NOT NULL,
+    icon character varying(50),
+    display_order integer,
+    is_visible boolean,
+    visibility_rules jsonb,
+    view_count integer,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
+);
 
 
 --
--- Name: fortress_api_keys_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+-- Name: guests; Type: TABLE; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.fortress_api_keys_id_seq OWNED BY public.fortress_api_keys.id;
-
-
---
--- Name: fortress_users; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.fortress_users (
-    id integer NOT NULL,
-    username character varying(50) NOT NULL,
+CREATE TABLE public.guests (
+    id uuid NOT NULL,
+    phone character varying(20) NOT NULL,
+    phone_number_secondary character varying(20),
     email character varying(255),
-    password character varying(255) NOT NULL,
-    role character varying(20) DEFAULT 'viewer'::character varying NOT NULL,
-    is_active boolean DEFAULT true,
-    created_at timestamp without time zone DEFAULT now(),
-    last_login timestamp without time zone,
-    full_name character varying(100),
-    web_ui_access boolean DEFAULT false NOT NULL,
-    vrs_access boolean DEFAULT false NOT NULL,
-    CONSTRAINT fortress_users_role_check CHECK (((role)::text = ANY ((ARRAY['admin'::character varying, 'operator'::character varying, 'viewer'::character varying])::text[])))
-);
-
-
---
--- Name: fortress_users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.fortress_users_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: fortress_users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.fortress_users_id_seq OWNED BY public.fortress_users.id;
-
-
---
--- Name: general_ledger; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.general_ledger (
-    id integer NOT NULL,
-    filepath text,
-    filename text,
-    extension text,
-    file_size bigint,
-    doc_type text,
-    category text,
-    vendor text,
-    client_name text,
-    date_detected text,
-    amount numeric(15,2),
-    tax_year text,
-    cabin text,
-    business text,
-    confidence text,
-    raw_text text,
-    ai_json text,
-    processed_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    phase integer DEFAULT 1
-);
-
-
---
--- Name: general_ledger_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.general_ledger_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: general_ledger_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.general_ledger_id_seq OWNED BY public.general_ledger.id;
-
-
---
--- Name: godhead_query_log; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.godhead_query_log (
-    id bigint NOT NULL,
-    session_id uuid DEFAULT gen_random_uuid(),
-    prompt text NOT NULL,
-    vaults_queried text[],
-    models_called text[],
-    synthesis text,
-    confidence numeric(4,3),
-    metadata jsonb DEFAULT '{}'::jsonb,
-    queried_at timestamp with time zone DEFAULT now()
-);
-
-
---
--- Name: godhead_query_log_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.godhead_query_log_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: godhead_query_log_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.godhead_query_log_id_seq OWNED BY public.godhead_query_log.id;
-
-
---
--- Name: guest_leads; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.guest_leads (
-    id integer NOT NULL,
-    guest_name text,
-    guest_email text,
-    guest_phone text,
-    event_type text,
-    cabin_names text[],
-    check_in date,
-    check_out date,
-    nights integer,
-    guest_count integer,
-    quoted_total numeric(12,2),
-    status text DEFAULT 'inquiry'::text,
-    source_email_id integer,
-    email_direction text,
-    thread_subject text,
-    taylor_response_summary text,
-    amenities_highlighted text[],
-    notes text,
-    extracted_at timestamp without time zone DEFAULT now()
-);
-
-
---
--- Name: guest_leads_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.guest_leads_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: guest_leads_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.guest_leads_id_seq OWNED BY public.guest_leads.id;
-
-
---
--- Name: guest_profiles; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.guest_profiles (
-    id bigint NOT NULL,
-    phone_number character varying(20) NOT NULL,
-    name character varying(255),
-    email character varying(255),
-    alternate_phones character varying(20)[],
-    total_messages integer DEFAULT 0,
-    total_conversations integer DEFAULT 0,
-    avg_response_time_seconds integer,
-    preferred_contact_time character varying(20),
-    typical_response_length character varying(20),
-    common_intents text[],
-    frequently_asked_questions text[],
-    overall_sentiment character varying(20),
-    sentiment_trend character varying(20),
-    positive_interaction_ratio numeric(3,2),
-    avg_satisfaction_score numeric(3,2),
-    total_stays integer DEFAULT 0,
-    favorite_cabins text[],
-    lifetime_value numeric(10,2),
+    email_secondary character varying(255),
+    first_name character varying(100),
+    last_name character varying(100),
+    address_line1 character varying(255),
+    address_line2 character varying(255),
+    city character varying(100),
+    state character varying(50),
+    postal_code character varying(20),
+    country character varying(2),
+    date_of_birth date,
+    emergency_contact_name character varying(200),
+    emergency_contact_phone character varying(20),
+    emergency_contact_relationship character varying(50),
+    vehicle_make character varying(50),
+    vehicle_model character varying(50),
+    vehicle_color character varying(30),
+    vehicle_plate character varying(20),
+    vehicle_state character varying(5),
+    language_preference character varying(10),
+    opt_in_marketing boolean,
+    opt_in_sms boolean,
+    opt_in_email boolean,
+    preferred_contact_method character varying(20),
+    quiet_hours_start character varying(5),
+    quiet_hours_end character varying(5),
+    timezone character varying(50),
+    verification_status character varying(20),
+    verification_method character varying(50),
+    verified_at timestamp without time zone,
+    id_document_type character varying(50),
+    id_expiration_date date,
+    loyalty_tier character varying(20),
+    loyalty_points integer,
+    loyalty_enrolled_at timestamp without time zone,
+    lifetime_stays integer,
+    lifetime_nights integer,
+    lifetime_revenue numeric(12,2),
+    value_score integer,
+    risk_score integer,
+    satisfaction_score integer,
+    preferences jsonb,
+    special_requests text,
+    internal_notes text,
+    staff_notes text,
+    is_vip boolean,
+    is_blacklisted boolean,
+    blacklist_reason text,
+    blacklisted_at timestamp without time zone,
+    blacklisted_by character varying(100),
+    is_do_not_contact boolean,
+    requires_supervision boolean,
+    guest_source character varying(50),
+    referral_source character varying(255),
+    first_booking_source character varying(50),
+    acquisition_campaign character varying(100),
+    total_stays integer,
+    total_messages_sent integer,
+    total_messages_received integer,
+    average_rating numeric(3,2),
     last_stay_date date,
-    next_booking_date date,
-    communication_style character varying(50),
-    language_preference character varying(10) DEFAULT 'en'::character varying,
-    accessibility_needs text[],
-    special_requests text[],
-    vip_guest boolean DEFAULT false,
-    requires_human_touch boolean DEFAULT false,
-    do_not_contact boolean DEFAULT false,
-    opted_out_at timestamp without time zone,
-    first_contact timestamp without time zone,
-    last_contact timestamp without time zone,
-    days_since_last_contact integer,
-    created_at timestamp without time zone DEFAULT now(),
-    updated_at timestamp without time zone DEFAULT now(),
-    CONSTRAINT valid_overall_sentiment CHECK ((((overall_sentiment)::text = ANY ((ARRAY['positive'::character varying, 'neutral'::character varying, 'negative'::character varying, 'urgent'::character varying])::text[])) OR (overall_sentiment IS NULL)))
+    streamline_guest_id character varying(100),
+    airbnb_guest_id character varying(100),
+    vrbo_guest_id character varying(100),
+    booking_com_guest_id character varying(100),
+    stripe_customer_id character varying(100),
+    tags character varying[],
+    notes text,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone,
+    last_contacted_at timestamp without time zone,
+    last_activity_at timestamp without time zone
 );
 
 
 --
--- Name: guest_profiles_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: housekeeping_tasks; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.guest_profiles_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: guest_profiles_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.guest_profiles_id_seq OWNED BY public.guest_profiles.id;
-
-
---
--- Name: images; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.images (
-    id integer NOT NULL,
-    filename text,
-    path text,
-    alt_text text,
-    ai_description text,
-    processed boolean DEFAULT false
+CREATE TABLE public.housekeeping_tasks (
+    id uuid NOT NULL,
+    property_id uuid NOT NULL,
+    reservation_id uuid,
+    scheduled_date date NOT NULL,
+    scheduled_time time without time zone,
+    status character varying(20) NOT NULL,
+    assigned_to character varying(255),
+    cleaning_type character varying(20) NOT NULL,
+    estimated_minutes integer,
+    actual_minutes integer,
+    notes text,
+    completed_at timestamp without time zone,
+    streamline_source jsonb,
+    streamline_synced_at timestamp without time zone,
+    streamline_checklist_id character varying(100),
+    dispatched_by character varying(50),
+    dispatch_payload jsonb,
+    created_at timestamp without time zone,
+    legacy_assigned_to character varying(255),
+    assigned_cleaner_id uuid
 );
 
 
 --
--- Name: images_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: hunter_queue; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.images_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: images_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.images_id_seq OWNED BY public.images.id;
-
-
---
--- Name: ingestion_dlq; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.ingestion_dlq (
-    id integer NOT NULL,
-    source text NOT NULL,
-    endpoint text,
-    record_id text,
+CREATE TABLE public.hunter_queue (
+    id uuid NOT NULL,
+    session_fp character varying(128) NOT NULL,
+    property_id uuid,
+    reservation_id uuid,
+    guest_phone character varying(40),
+    guest_email character varying(255),
+    campaign character varying(120) NOT NULL,
     payload jsonb NOT NULL,
-    error_reason text NOT NULL,
-    field_errors jsonb,
-    resolved boolean DEFAULT false NOT NULL,
-    resolved_at timestamp with time zone,
-    resolved_by text,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
+    score integer NOT NULL,
+    status character varying(30) NOT NULL,
+    last_error text,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    CONSTRAINT ck_hunter_queue_status CHECK (((status)::text = ANY ((ARRAY['queued'::character varying, 'processing'::character varying, 'sent'::character varying, 'failed'::character varying, 'cancelled'::character varying])::text[])))
 );
 
 
 --
--- Name: ingestion_dlq_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: hunter_recovery_ops; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.ingestion_dlq_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
+CREATE TABLE public.hunter_recovery_ops (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    cart_id character varying(255) NOT NULL,
+    guest_name character varying(255),
+    cabin_name character varying(255),
+    cart_value numeric(10,2),
+    status public.hunter_recovery_op_status DEFAULT 'QUEUED'::public.hunter_recovery_op_status NOT NULL,
+    ai_draft_body text,
+    assigned_worker character varying(32),
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
 
 
 --
--- Name: ingestion_dlq_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+-- Name: hunter_runs; Type: TABLE; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.ingestion_dlq_id_seq OWNED BY public.ingestion_dlq.id;
+CREATE TABLE public.hunter_runs (
+    id uuid NOT NULL,
+    trigger character varying(120) NOT NULL,
+    campaign character varying(120) NOT NULL,
+    stats jsonb NOT NULL,
+    started_at timestamp without time zone NOT NULL,
+    completed_at timestamp without time zone
+);
+
+
+--
+-- Name: intelligence_ledger; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.intelligence_ledger (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    category character varying(64) NOT NULL,
+    title character varying(255) NOT NULL,
+    summary text NOT NULL,
+    market character varying(128) NOT NULL,
+    locality character varying(128),
+    dedupe_hash character varying(64) NOT NULL,
+    confidence_score double precision,
+    query_topic character varying(120),
+    scout_query text,
+    scout_run_key character varying(120),
+    target_property_ids jsonb NOT NULL,
+    target_tags jsonb NOT NULL,
+    source_urls jsonb NOT NULL,
+    grounding_payload jsonb NOT NULL,
+    finding_payload jsonb NOT NULL,
+    discovered_at timestamp with time zone NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
 
 
 --
@@ -4262,21 +1961,16 @@ ALTER SEQUENCE public.ingestion_dlq_id_seq OWNED BY public.ingestion_dlq.id;
 --
 
 CREATE TABLE public.journal_entries (
-    id integer NOT NULL,
-    entry_date date NOT NULL,
-    description text NOT NULL,
-    reference_id text,
-    reference_type text,
-    property_id text,
-    posted_by text DEFAULT 'system'::text,
-    source_system text DEFAULT 'fortress'::text,
-    is_void boolean DEFAULT false,
-    void_reason text,
-    voided_at timestamp without time zone,
-    voided_by text,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT journal_entries_reference_type_check CHECK ((reference_type = ANY (ARRAY['booking'::text, 'invoice'::text, 'payout'::text, 'adjustment'::text, 'cleaning_fee'::text, 'tax_remittance'::text, 'owner_draw'::text, 'security_deposit'::text, 'import'::text, 'manual'::text, NULL::text])))
+    id bigint NOT NULL,
+    property_id character varying(100) NOT NULL,
+    entry_date date DEFAULT CURRENT_DATE NOT NULL,
+    description text,
+    reference_type character varying(64) NOT NULL,
+    reference_id character varying(255) NOT NULL,
+    is_void boolean DEFAULT false NOT NULL,
+    posted_by character varying(100),
+    source_system character varying(64),
+    created_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 
@@ -4285,7 +1979,6 @@ CREATE TABLE public.journal_entries (
 --
 
 CREATE SEQUENCE public.journal_entries_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4305,15 +1998,11 @@ ALTER SEQUENCE public.journal_entries_id_seq OWNED BY public.journal_entries.id;
 --
 
 CREATE TABLE public.journal_line_items (
-    id integer NOT NULL,
-    journal_entry_id integer NOT NULL,
-    account_id integer NOT NULL,
-    debit numeric(15,2) DEFAULT 0 NOT NULL,
-    credit numeric(15,2) DEFAULT 0 NOT NULL,
-    memo text,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT chk_non_negative CHECK (((debit >= (0)::numeric) AND (credit >= (0)::numeric))),
-    CONSTRAINT chk_single_side CHECK ((((debit > (0)::numeric) AND (credit = (0)::numeric)) OR ((debit = (0)::numeric) AND (credit > (0)::numeric))))
+    id bigint NOT NULL,
+    journal_entry_id bigint NOT NULL,
+    account_id bigint NOT NULL,
+    debit numeric(18,2) DEFAULT '0'::numeric NOT NULL,
+    credit numeric(18,2) DEFAULT '0'::numeric NOT NULL
 );
 
 
@@ -4322,7 +2011,6 @@ CREATE TABLE public.journal_line_items (
 --
 
 CREATE SEQUENCE public.journal_line_items_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4338,723 +2026,162 @@ ALTER SEQUENCE public.journal_line_items_id_seq OWNED BY public.journal_line_ite
 
 
 --
--- Name: learning_judgments; Type: TABLE; Schema: public; Owner: -
+-- Name: knowledge_base_entries; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.learning_judgments (
-    id integer NOT NULL,
-    agent_id text NOT NULL,
-    metric_name text NOT NULL,
-    predicted_value numeric(15,4),
-    actual_value numeric(15,4),
-    variance_pct numeric(8,4),
-    passed boolean,
-    action_taken text,
-    context jsonb,
-    created_at timestamp without time zone DEFAULT now()
-);
-
-
---
--- Name: learning_judgments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.learning_judgments_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: learning_judgments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.learning_judgments_id_seq OWNED BY public.learning_judgments.id;
-
-
---
--- Name: learning_optimizations; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.learning_optimizations (
-    id integer NOT NULL,
-    agent_id text NOT NULL,
-    method text,
-    old_prompt_hash text,
-    new_prompt_hash text,
-    reasoning text,
-    failure_count integer,
-    created_at timestamp without time zone DEFAULT now()
-);
-
-
---
--- Name: learning_optimizations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.learning_optimizations_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: learning_optimizations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.learning_optimizations_id_seq OWNED BY public.learning_optimizations.id;
-
-
---
--- Name: legacy_cdc_checkpoints; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.legacy_cdc_checkpoints (
-    stream_name text NOT NULL,
-    log_file text,
-    log_pos bigint,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
---
--- Name: legacy_cdc_event_queue; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.legacy_cdc_event_queue (
-    id bigint NOT NULL,
-    stream_name text NOT NULL,
-    source_schema text,
-    source_table text NOT NULL,
-    operation text NOT NULL,
-    primary_key jsonb NOT NULL,
-    row_data jsonb,
-    binlog_file text,
-    binlog_pos bigint,
-    event_time timestamp with time zone DEFAULT now() NOT NULL,
-    state text DEFAULT 'queued'::text NOT NULL,
-    attempts integer DEFAULT 0 NOT NULL,
-    last_error text,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    applied_at timestamp with time zone
-);
-
-
---
--- Name: legacy_cdc_event_queue_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.legacy_cdc_event_queue_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: legacy_cdc_event_queue_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.legacy_cdc_event_queue_id_seq OWNED BY public.legacy_cdc_event_queue.id;
-
-
---
--- Name: legacy_cdc_row_state; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.legacy_cdc_row_state (
-    source_schema text,
-    source_table text NOT NULL,
-    primary_key_hash text NOT NULL,
-    primary_key jsonb NOT NULL,
-    row_data jsonb,
-    deleted boolean DEFAULT false NOT NULL,
-    last_event_id bigint,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
---
--- Name: legal_clients; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.legal_clients (
-    client_id integer NOT NULL,
-    name character varying(200) NOT NULL,
-    industry character varying(100),
-    contact_name character varying(200),
-    contact_email character varying(200),
-    notes text,
-    status character varying(50) DEFAULT 'Active'::character varying,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
-);
-
-
---
--- Name: legal_clients_client_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.legal_clients_client_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: legal_clients_client_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.legal_clients_client_id_seq OWNED BY public.legal_clients.client_id;
-
-
---
--- Name: legal_docket; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.legal_docket (
-    doc_id integer NOT NULL,
-    matter_id character varying(50),
-    doc_type character varying(50),
-    title character varying(200) NOT NULL,
-    content text,
-    version integer DEFAULT 1,
-    status character varying(50) DEFAULT 'Draft'::character varying,
-    created_by character varying(100) DEFAULT 'system'::character varying,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
-);
-
-
---
--- Name: legal_docket_doc_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.legal_docket_doc_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: legal_docket_doc_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.legal_docket_doc_id_seq OWNED BY public.legal_docket.doc_id;
-
-
---
--- Name: legal_intel; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.legal_intel (
-    id integer NOT NULL,
-    case_name character varying(255),
-    case_number character varying(100),
-    court character varying(255),
-    status character varying(100),
-    priority character varying(50),
-    next_deadline date,
-    source_email_id integer,
-    content text,
+CREATE TABLE public.knowledge_base_entries (
+    id uuid NOT NULL,
+    category character varying(100) NOT NULL,
+    question text,
+    answer text NOT NULL,
+    keywords character varying[],
+    property_id uuid,
+    qdrant_point_id uuid,
+    usage_count integer,
+    helpful_count integer,
+    not_helpful_count integer,
+    last_used_at timestamp without time zone,
+    is_active boolean,
+    source character varying(100),
     created_at timestamp without time zone,
-    enriched_at timestamp without time zone
+    updated_at timestamp without time zone
 );
 
 
 --
--- Name: legal_intel_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: leads; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.legal_intel_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: legal_intel_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.legal_intel_id_seq OWNED BY public.legal_intel.id;
-
-
---
--- Name: legal_matter_notes; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.legal_matter_notes (
-    note_id integer NOT NULL,
-    matter_id character varying(50),
-    agent character varying(50) DEFAULT 'user'::character varying,
-    content text NOT NULL,
-    note_type character varying(50) DEFAULT 'note'::character varying,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
-);
-
-
---
--- Name: legal_matter_notes_note_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.legal_matter_notes_note_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: legal_matter_notes_note_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.legal_matter_notes_note_id_seq OWNED BY public.legal_matter_notes.note_id;
-
-
---
--- Name: legal_matters; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.legal_matters (
-    matter_id character varying(50) NOT NULL,
-    client_id integer,
-    title character varying(255) NOT NULL,
-    practice_area character varying(100),
-    description text,
-    opposing_counsel character varying(200),
-    jurisdiction character varying(100),
-    status character varying(50) DEFAULT 'Open'::character varying,
-    priority character varying(20) DEFAULT 'Normal'::character varying,
-    strategy_notes text,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
-);
-
-
---
--- Name: maintenance_log; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.maintenance_log (
-    id integer NOT NULL,
-    run_id text NOT NULL,
-    cabin_name text NOT NULL,
-    room_type text NOT NULL,
-    room_display text,
-    image_path text,
-    image_hash text,
-    image_size_bytes bigint,
-    overall_score numeric(5,1),
-    verdict text NOT NULL,
-    pass_threshold integer DEFAULT 80,
-    items_passed integer,
-    items_failed integer,
-    items_total integer,
-    ai_confidence_score numeric(5,4),
-    detected_by text,
-    json_parsed boolean DEFAULT false,
-    issues_found text,
-    checklist_json text,
-    overall_impression text,
-    raw_analysis text,
-    inspector_id text,
-    inference_time_s real,
-    engine_version text DEFAULT '1.0.0'::text,
-    generated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
-);
-
-
---
--- Name: maintenance_log_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.maintenance_log_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: maintenance_log_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.maintenance_log_id_seq OWNED BY public.maintenance_log.id;
-
-
---
--- Name: market_intel; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.market_intel (
-    id integer NOT NULL,
-    ticker text,
-    asset_class text,
-    content text,
-    signal_strength real,
-    sent_at timestamp without time zone,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    source_file text,
-    chunk_index integer,
-    sender text,
-    subject_line text,
-    signal_direction text,
-    broker text,
-    action text,
-    price numeric(15,4),
-    source_email_id integer,
-    enriched_at timestamp without time zone
-);
-
-
---
--- Name: market_intel_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.market_intel_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: market_intel_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.market_intel_id_seq OWNED BY public.market_intel.id;
-
-
---
--- Name: market_signals; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.market_signals (
-    id integer NOT NULL,
-    symbol text,
-    price real,
-    sentiment_score real,
-    source text,
-    "timestamp" timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    ticker text,
-    action text,
-    confidence_score numeric(3,2),
-    source_email_id integer,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
-);
-
-
---
--- Name: market_signals_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.market_signals_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: market_signals_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.market_signals_id_seq OWNED BY public.market_signals.id;
-
-
---
--- Name: message_analytics_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.message_analytics_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: message_analytics_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.message_analytics_id_seq OWNED BY public.message_analytics.id;
-
-
---
--- Name: message_archive_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.message_archive_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: message_archive_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.message_archive_id_seq OWNED BY public.message_archive.id;
-
-
---
--- Name: model_telemetry; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.model_telemetry (
-    id integer NOT NULL,
-    model_name text NOT NULL,
-    node text,
-    operation text,
-    success boolean,
-    latency_ms integer,
-    input_tokens integer,
-    output_tokens integer,
-    error_message text,
-    created_at timestamp without time zone DEFAULT now()
-);
-
-
---
--- Name: model_telemetry_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.model_telemetry_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: model_telemetry_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.model_telemetry_id_seq OWNED BY public.model_telemetry.id;
-
-
---
--- Name: nas_legal_vault; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.nas_legal_vault (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    source_file text NOT NULL,
-    chunk_index integer NOT NULL,
-    chunk_text text NOT NULL,
-    metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
-    embedding public.vector(768),
-    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP
-);
-
-
---
--- Name: nim_arm64_probe_results; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.nim_arm64_probe_results (
-    id integer NOT NULL,
-    probe_date date NOT NULL,
-    image_path text NOT NULL,
-    tag text NOT NULL,
-    stage1_arm64 boolean,
-    arm64_digest text,
-    amd64_digest text,
-    arm64_manifest_bytes integer,
-    amd64_manifest_bytes integer,
-    possible_mismatch boolean,
-    verdict text,
-    probe_notes text,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
---
--- Name: nim_arm64_probe_results_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.nim_arm64_probe_results_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: nim_arm64_probe_results_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.nim_arm64_probe_results_id_seq OWNED BY public.nim_arm64_probe_results.id;
-
-
---
--- Name: ops_crew; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.ops_crew (
-    id integer NOT NULL,
-    name character varying(100) NOT NULL,
-    role character varying(50) NOT NULL,
+CREATE TABLE public.leads (
+    id uuid NOT NULL,
+    streamline_lead_id character varying(100),
+    guest_name character varying(255),
+    email character varying(255),
     phone character varying(20),
-    email character varying(100),
-    status character varying(20) DEFAULT 'ACTIVE'::character varying,
-    current_location character varying(100),
-    skills jsonb DEFAULT '{}'::jsonb,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+    guest_message text,
+    status character varying(20) NOT NULL,
+    ai_score integer,
+    source character varying(50),
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
 );
 
 
 --
--- Name: ops_crew_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: learned_rules; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.ops_crew_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: ops_crew_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.ops_crew_id_seq OWNED BY public.ops_crew.id;
-
-
---
--- Name: ops_historical_guests; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.ops_historical_guests (
-    id bigint NOT NULL,
-    guest_id text NOT NULL,
-    full_name text,
-    email text,
-    phone text,
-    address text,
-    reservation_history jsonb DEFAULT '[]'::jsonb NOT NULL,
-    total_spend numeric(14,2) DEFAULT 0 NOT NULL,
-    first_seen date,
-    last_seen date,
-    raw_json jsonb DEFAULT '{}'::jsonb NOT NULL,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
-);
-
-
---
--- Name: ops_historical_guests_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.ops_historical_guests_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: ops_historical_guests_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.ops_historical_guests_id_seq OWNED BY public.ops_historical_guests.id;
-
-
---
--- Name: ops_log; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.ops_log (
-    id integer NOT NULL,
-    "timestamp" timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    actor character varying(100),
-    action text NOT NULL,
-    entity_type character varying(50),
-    entity_id integer,
-    metadata jsonb
-);
-
-
---
--- Name: ops_log_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.ops_log_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: ops_log_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.ops_log_id_seq OWNED BY public.ops_log.id;
-
-
---
--- Name: ops_overrides; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.ops_overrides (
-    id integer NOT NULL,
-    entity_type character varying(50) NOT NULL,
-    entity_id character varying(100) NOT NULL,
-    override_type character varying(50) NOT NULL,
-    reason text,
-    issued_by character varying(100) DEFAULT '''commander'''::character varying,
-    effective_until timestamp without time zone,
-    active boolean DEFAULT true,
-    created_at timestamp without time zone DEFAULT now(),
+CREATE TABLE public.learned_rules (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    property_id uuid,
+    rule_name character varying(255) NOT NULL,
+    trigger_condition jsonb NOT NULL,
+    adjustment_type character varying(20) NOT NULL,
+    adjustment_value double precision NOT NULL,
+    confidence_score double precision DEFAULT 0.0 NOT NULL,
+    status character varying(30) DEFAULT 'pending_approval'::character varying NOT NULL,
+    created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now()
 );
 
 
 --
--- Name: ops_overrides_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: legacy_pages; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.ops_overrides_id_seq
-    AS integer
+CREATE TABLE public.legacy_pages (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    slug character varying(255) NOT NULL,
+    title character varying(500) NOT NULL,
+    body_value text,
+    body_summary text,
+    body_format character varying(50) DEFAULT 'full_html'::character varying,
+    entity_type character varying(50) DEFAULT 'node'::character varying,
+    bundle character varying(100) DEFAULT 'page'::character varying,
+    language character varying(10) DEFAULT 'en'::character varying,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: legal_case_statements; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.legal_case_statements (
+    id character varying NOT NULL,
+    case_slug character varying NOT NULL,
+    entity_name character varying NOT NULL,
+    quote_text character varying NOT NULL,
+    source_ref character varying NOT NULL,
+    stated_at timestamp without time zone,
+    created_at timestamp without time zone
+);
+
+
+--
+-- Name: legal_hive_mind_feedback_events; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.legal_hive_mind_feedback_events (
+    id character varying NOT NULL,
+    case_slug character varying NOT NULL,
+    module_type character varying NOT NULL,
+    original_swarm_text character varying NOT NULL,
+    human_edited_text character varying NOT NULL,
+    accepted boolean,
+    user_id character varying,
+    created_at timestamp without time zone
+);
+
+
+--
+-- Name: llm_training_captures; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.llm_training_captures (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    source_module character varying(120) NOT NULL,
+    model_used character varying(120) NOT NULL,
+    user_prompt text NOT NULL,
+    assistant_resp text NOT NULL,
+    quality_score double precision,
+    status character varying(20) DEFAULT 'pending'::character varying NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    eval_holdout boolean DEFAULT false NOT NULL,
+    served_by_endpoint character varying(256),
+    served_vector_store character varying(64),
+    escalated_from character varying(256),
+    sovereign_attempt text,
+    teacher_endpoint character varying(256),
+    teacher_model character varying(128),
+    task_type character varying(64),
+    judge_decision character varying(16),
+    judge_reasoning text,
+    capture_metadata jsonb
+);
+
+
+--
+-- Name: management_splits; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.management_splits (
+    id bigint NOT NULL,
+    property_id character varying(100) NOT NULL,
+    owner_pct numeric(6,2) NOT NULL,
+    pm_pct numeric(6,2) NOT NULL,
+    effective_date date NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: management_splits_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.management_splits_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5063,92 +2190,55 @@ CREATE SEQUENCE public.ops_overrides_id_seq
 
 
 --
--- Name: ops_overrides_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+-- Name: management_splits_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.ops_overrides_id_seq OWNED BY public.ops_overrides.id;
+ALTER SEQUENCE public.management_splits_id_seq OWNED BY public.management_splits.id;
 
 
 --
--- Name: ops_properties; Type: TABLE; Schema: public; Owner: -
+-- Name: marketing_articles; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.ops_properties (
-    property_id character varying(50) NOT NULL,
-    internal_name character varying(100),
-    address text,
-    access_code_wifi character varying(50),
-    access_code_door character varying(50),
-    trash_pickup_day character varying(20),
-    cleaning_sla_minutes integer DEFAULT 240,
-    hvac_filter_size character varying(20),
-    hot_tub_gallons integer,
-    config_yaml text,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    streamline_id integer,
-    name text,
-    unit_code text,
-    status_name text DEFAULT 'Active'::text,
-    status_id integer DEFAULT 1,
-    address2 text,
-    city text,
-    state_name text,
-    zip text,
-    country_name text,
-    latitude numeric(10,7),
-    longitude numeric(11,7),
-    location_area_name text,
-    resort_area_name text,
-    view_name text,
-    bedrooms numeric(4,1),
-    bathrooms numeric(4,1),
-    max_occupants integer,
-    max_adults integer,
-    max_pets integer,
-    lodging_type_id integer,
-    square_feet integer,
-    company_id integer,
-    owning_type_id integer,
-    seo_title text,
-    flyer_url text,
-    default_image_url text,
-    description_short text,
-    streamline_created timestamp without time zone,
-    last_reservation timestamp without time zone,
-    last_synced timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    raw_json jsonb
+CREATE TABLE public.marketing_articles (
+    id uuid NOT NULL,
+    title character varying(255) NOT NULL,
+    slug character varying(255) NOT NULL,
+    content_body_html text NOT NULL,
+    author character varying(255),
+    published_date timestamp with time zone,
+    category_id uuid NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 
 --
--- Name: ops_tasks; Type: TABLE; Schema: public; Owner: -
+-- Name: marketing_attribution; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.ops_tasks (
-    id integer NOT NULL,
-    type character varying(50) NOT NULL,
-    priority character varying(20) DEFAULT 'NORMAL'::character varying,
-    property_id character varying(50),
-    assigned_to integer,
-    turnover_id integer,
-    description text,
-    deadline timestamp without time zone,
-    started_at timestamp without time zone,
-    completed_at timestamp without time zone,
-    status character varying(50) DEFAULT 'OPEN'::character varying,
-    evidence_photos jsonb,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+CREATE TABLE public.marketing_attribution (
+    id bigint NOT NULL,
+    property_id character varying(100) NOT NULL,
+    period_start date NOT NULL,
+    period_end date NOT NULL,
+    ad_spend numeric(12,2) DEFAULT 0 NOT NULL,
+    impressions integer DEFAULT 0 NOT NULL,
+    clicks integer DEFAULT 0 NOT NULL,
+    direct_bookings integer DEFAULT 0 NOT NULL,
+    gross_revenue numeric(12,2) DEFAULT 0 NOT NULL,
+    roas numeric(12,2) DEFAULT 0 NOT NULL,
+    campaign_notes text,
+    entered_by character varying(100),
+    created_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 
 --
--- Name: ops_tasks_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: marketing_attribution_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.ops_tasks_id_seq
-    AS integer
+CREATE SEQUENCE public.marketing_attribution_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5157,86 +2247,182 @@ CREATE SEQUENCE public.ops_tasks_id_seq
 
 
 --
--- Name: ops_tasks_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+-- Name: marketing_attribution_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.ops_tasks_id_seq OWNED BY public.ops_tasks.id;
+ALTER SEQUENCE public.marketing_attribution_id_seq OWNED BY public.marketing_attribution.id;
 
 
 --
--- Name: ops_turnovers; Type: TABLE; Schema: public; Owner: -
+-- Name: message_queue; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.ops_turnovers (
-    id integer NOT NULL,
-    property_id character varying(50),
-    reservation_id_out character varying(50),
-    reservation_id_in character varying(50),
-    checkout_time timestamp without time zone NOT NULL,
-    checkin_time timestamp without time zone NOT NULL,
-    window_hours numeric(5,2),
-    status character varying(50) DEFAULT 'PENDING'::character varying,
-    cleanliness_score integer,
-    notes text,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+CREATE TABLE public.message_queue (
+    id uuid NOT NULL,
+    quote_id uuid NOT NULL,
+    template_id uuid NOT NULL,
+    status character varying(20) NOT NULL,
+    rendered_subject character varying(1000) NOT NULL,
+    rendered_body text NOT NULL,
+    created_at timestamp without time zone
 );
 
 
 --
--- Name: ops_turnovers_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: message_templates; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.ops_turnovers_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
+CREATE TABLE public.message_templates (
+    id uuid NOT NULL,
+    name character varying(255) NOT NULL,
+    category character varying(50) NOT NULL,
+    subject character varying(255),
+    body text NOT NULL,
+    variables character varying[],
+    trigger_type character varying(50),
+    trigger_offset_days integer,
+    trigger_time time without time zone,
+    is_active boolean,
+    send_priority integer,
+    language character varying(10),
+    usage_count integer,
+    last_used_at timestamp without time zone,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
+);
 
 
 --
--- Name: ops_turnovers_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+-- Name: messages; Type: TABLE; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.ops_turnovers_id_seq OWNED BY public.ops_turnovers.id;
-
-
---
--- Name: ops_visuals; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.ops_visuals (
-    image_id integer NOT NULL,
-    file_path text NOT NULL,
-    file_name character varying(255),
-    file_size_bytes bigint,
-    file_ext character varying(10),
-    property_id character varying(50),
-    property_name character varying(200),
-    description text,
-    features jsonb DEFAULT '{}'::jsonb,
-    room_type character varying(50),
-    quality_score numeric(5,2),
-    embedding_id character varying(100),
-    collection_name character varying(100) DEFAULT 'fortress_docs'::character varying,
-    model_used character varying(100),
-    inference_time_s real,
-    status character varying(20) DEFAULT 'PENDING'::character varying,
+CREATE TABLE public.messages (
+    id uuid NOT NULL,
+    external_id character varying(255),
+    guest_id uuid,
+    reservation_id uuid,
+    direction character varying(20) NOT NULL,
+    phone_from character varying(20) NOT NULL,
+    phone_to character varying(20) NOT NULL,
+    body text NOT NULL,
+    intent character varying(50),
+    sentiment character varying(20),
+    category character varying(50),
+    status character varying(50) NOT NULL,
+    is_auto_response boolean,
+    ai_confidence numeric(4,3),
+    requires_human_review boolean,
+    human_reviewed_at timestamp without time zone,
+    human_reviewed_by character varying(100),
+    sent_at timestamp without time zone,
+    delivered_at timestamp without time zone,
+    read_at timestamp without time zone,
+    error_code character varying(50),
     error_message text,
-    scanned_at timestamp without time zone,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    visual_hash character varying(64)
+    provider character varying(50),
+    cost_amount numeric(8,4),
+    num_segments integer,
+    trace_id uuid,
+    metadata jsonb,
+    created_at timestamp without time zone
 );
 
 
 --
--- Name: ops_visuals_image_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: openshell_audit_logs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.ops_visuals_image_id_seq
-    AS integer
+CREATE TABLE public.openshell_audit_logs (
+    id uuid NOT NULL,
+    actor_id character varying(255),
+    actor_email character varying(255),
+    action character varying(120) NOT NULL,
+    resource_type character varying(120) NOT NULL,
+    resource_id character varying(255),
+    purpose character varying(255),
+    tool_name character varying(120),
+    redaction_status character varying(50) NOT NULL,
+    model_route character varying(120),
+    outcome character varying(50) NOT NULL,
+    request_id character varying(100),
+    metadata_json jsonb NOT NULL,
+    payload_hash character varying(128) NOT NULL,
+    prev_hash character varying(128),
+    entry_hash character varying(128) NOT NULL,
+    signature text NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: operator_overrides; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.operator_overrides (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    escalation_id uuid NOT NULL,
+    operator_email character varying(255) NOT NULL,
+    override_action character varying(7) NOT NULL,
+    final_payload jsonb NOT NULL,
+    "timestamp" timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT operator_override_action CHECK (((override_action)::text = ANY ((ARRAY['approve'::character varying, 'reject'::character varying, 'modify'::character varying])::text[])))
+);
+
+
+--
+-- Name: ota_micro_updates; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ota_micro_updates (
+    id uuid NOT NULL,
+    property_id uuid,
+    channel character varying(80) NOT NULL,
+    patch_payload jsonb NOT NULL,
+    status character varying(30) NOT NULL,
+    error text,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: owner_balance_periods; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.owner_balance_periods (
+    id bigint NOT NULL,
+    owner_payout_account_id bigint NOT NULL,
+    period_start date NOT NULL,
+    period_end date NOT NULL,
+    opening_balance numeric(12,2) NOT NULL,
+    closing_balance numeric(12,2) NOT NULL,
+    total_revenue numeric(12,2) DEFAULT 0 NOT NULL,
+    total_commission numeric(12,2) DEFAULT 0 NOT NULL,
+    total_charges numeric(12,2) DEFAULT 0 NOT NULL,
+    total_payments numeric(12,2) DEFAULT 0 NOT NULL,
+    total_owner_income numeric(12,2) DEFAULT 0 NOT NULL,
+    status public.statement_period_status DEFAULT 'draft'::public.statement_period_status NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    approved_at timestamp with time zone,
+    approved_by character varying(255),
+    paid_at timestamp with time zone,
+    emailed_at timestamp with time zone,
+    notes text,
+    voided_at timestamp with time zone,
+    voided_by character varying(255),
+    paid_by character varying(255),
+    stripe_transfer_id character varying(100),
+    paid_amount numeric(12,2),
+    CONSTRAINT chk_obp_ledger_equation CHECK ((closing_balance = (((((opening_balance + total_revenue) - total_commission) - total_charges) - total_payments) + total_owner_income))),
+    CONSTRAINT chk_obp_period_order CHECK ((period_end > period_start))
+);
+
+
+--
+-- Name: owner_balance_periods_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.owner_balance_periods_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5245,31 +2431,44 @@ CREATE SEQUENCE public.ops_visuals_image_id_seq
 
 
 --
--- Name: ops_visuals_image_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+-- Name: owner_balance_periods_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.ops_visuals_image_id_seq OWNED BY public.ops_visuals.image_id;
+ALTER SEQUENCE public.owner_balance_periods_id_seq OWNED BY public.owner_balance_periods.id;
 
 
 --
--- Name: pages; Type: TABLE; Schema: public; Owner: -
+-- Name: owner_charges; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.pages (
-    id integer NOT NULL,
-    url text,
-    title text,
-    content text,
-    last_scraped timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+CREATE TABLE public.owner_charges (
+    id bigint NOT NULL,
+    owner_payout_account_id bigint NOT NULL,
+    posting_date date NOT NULL,
+    transaction_type public.owner_charge_type_enum NOT NULL,
+    description character varying(500) NOT NULL,
+    amount numeric(12,2) NOT NULL,
+    reference_id character varying(100),
+    originating_work_order_id bigint,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_by character varying(255) NOT NULL,
+    voided_at timestamp with time zone,
+    voided_by character varying(255),
+    void_reason text,
+    vendor_id uuid,
+    markup_percentage numeric(5,2) DEFAULT 0.00 NOT NULL,
+    vendor_amount numeric(12,2),
+    CONSTRAINT chk_oc_amount_not_zero CHECK ((amount <> (0)::numeric)),
+    CONSTRAINT chk_oc_description_not_empty CHECK (((description)::text <> ''::text)),
+    CONSTRAINT chk_oc_void_pair CHECK ((((voided_at IS NULL) AND (voided_by IS NULL)) OR ((voided_at IS NOT NULL) AND (voided_by IS NOT NULL))))
 );
 
 
 --
--- Name: pages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: owner_charges_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.pages_id_seq
-    AS integer
+CREATE SEQUENCE public.owner_charges_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5278,56 +2477,346 @@ CREATE SEQUENCE public.pages_id_seq
 
 
 --
--- Name: pages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+-- Name: owner_charges_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.pages_id_seq OWNED BY public.pages.id;
-
-
---
--- Name: pending_reviews; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public.pending_reviews AS
- SELECT arq.id,
-    arq.phone_number,
-    arq.guest_name,
-    arq.cabin_name,
-    arq.guest_message,
-    arq.intent,
-    arq.sentiment,
-    arq.urgency_level,
-    arq.escalation_required,
-    arq.ai_draft,
-    arq.confidence_score,
-    arq.ai_model,
-    arq.created_at,
-    arq.expires_at,
-    gp.communication_style,
-    gp.total_stays,
-    gp.vip_guest,
-    gp.overall_sentiment AS guest_overall_sentiment
-   FROM (public.agent_response_queue arq
-     LEFT JOIN public.guest_profiles gp ON (((arq.phone_number)::text = (gp.phone_number)::text)))
-  WHERE ((arq.status)::text = 'pending_review'::text)
-  ORDER BY arq.urgency_level DESC, arq.created_at;
+ALTER SEQUENCE public.owner_charges_id_seq OWNED BY public.owner_charges.id;
 
 
 --
--- Name: persona_scores; Type: TABLE; Schema: public; Owner: -
+-- Name: owner_magic_tokens; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.persona_scores (
-    persona_slug character varying(50) NOT NULL,
-    persona_name character varying(100) NOT NULL,
-    total_votes integer DEFAULT 0 NOT NULL,
-    correct_votes integer DEFAULT 0 NOT NULL,
-    brier_score double precision DEFAULT 0.0 NOT NULL,
-    streak integer DEFAULT 0 NOT NULL,
-    last_signal character varying(20),
-    last_conviction double precision,
-    last_voted_at timestamp with time zone,
-    last_updated timestamp with time zone DEFAULT now() NOT NULL
+CREATE TABLE public.owner_magic_tokens (
+    id bigint NOT NULL,
+    token_hash character varying(128) NOT NULL,
+    owner_email character varying(255) NOT NULL,
+    sl_owner_id character varying(50) NOT NULL,
+    expires_at timestamp with time zone NOT NULL,
+    used_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    commission_rate numeric(5,4),
+    mailing_address_line1 character varying(255),
+    mailing_address_line2 character varying(255),
+    mailing_address_city character varying(100),
+    mailing_address_state character varying(50),
+    mailing_address_postal_code character varying(20),
+    mailing_address_country character varying(50) DEFAULT 'USA'::character varying,
+    CONSTRAINT chk_omt_commission_rate CHECK (((commission_rate >= (0)::numeric) AND (commission_rate <= 0.5000)))
+);
+
+
+--
+-- Name: owner_magic_tokens_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.owner_magic_tokens_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: owner_magic_tokens_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.owner_magic_tokens_id_seq OWNED BY public.owner_magic_tokens.id;
+
+
+--
+-- Name: owner_marketing_preferences; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.owner_marketing_preferences (
+    id bigint NOT NULL,
+    property_id character varying(100) NOT NULL,
+    marketing_pct numeric(6,2) DEFAULT 0 NOT NULL,
+    enabled boolean DEFAULT false NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_by character varying(100)
+);
+
+
+--
+-- Name: owner_marketing_preferences_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.owner_marketing_preferences_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: owner_marketing_preferences_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.owner_marketing_preferences_id_seq OWNED BY public.owner_marketing_preferences.id;
+
+
+--
+-- Name: owner_markup_rules; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.owner_markup_rules (
+    id bigint NOT NULL,
+    property_id character varying(100) NOT NULL,
+    expense_category character varying(64) DEFAULT 'ALL'::character varying NOT NULL,
+    markup_percentage numeric(6,2) NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: owner_markup_rules_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.owner_markup_rules_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: owner_markup_rules_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.owner_markup_rules_id_seq OWNED BY public.owner_markup_rules.id;
+
+
+--
+-- Name: owner_payout_accounts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.owner_payout_accounts (
+    id bigint NOT NULL,
+    property_id character varying(100) NOT NULL,
+    owner_name character varying(255) NOT NULL,
+    owner_email character varying(255),
+    stripe_account_id character varying(255),
+    account_status character varying(64) DEFAULT 'onboarding'::character varying NOT NULL,
+    instant_payout boolean DEFAULT false NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    payout_schedule character varying(20) DEFAULT 'manual'::character varying NOT NULL,
+    payout_day_of_week integer,
+    payout_day_of_month integer,
+    last_payout_at timestamp with time zone,
+    next_scheduled_payout timestamp with time zone,
+    minimum_payout_threshold numeric(10,2) DEFAULT 100.00 NOT NULL,
+    commission_rate numeric(5,4) NOT NULL,
+    streamline_owner_id integer,
+    mailing_address_line1 character varying(255),
+    mailing_address_line2 character varying(255),
+    mailing_address_city character varying(100),
+    mailing_address_state character varying(50),
+    mailing_address_postal_code character varying(20),
+    mailing_address_country character varying(50) DEFAULT 'USA'::character varying,
+    owner_middle_name character varying(100),
+    CONSTRAINT chk_opa_commission_rate CHECK (((commission_rate >= (0)::numeric) AND (commission_rate <= 0.5000)))
+);
+
+
+--
+-- Name: owner_payout_accounts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.owner_payout_accounts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: owner_payout_accounts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.owner_payout_accounts_id_seq OWNED BY public.owner_payout_accounts.id;
+
+
+--
+-- Name: owner_property_map; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.owner_property_map (
+    id bigint NOT NULL,
+    sl_owner_id character varying(50) NOT NULL,
+    unit_id character varying(100) NOT NULL,
+    owner_name character varying(255) NOT NULL,
+    email character varying(255),
+    phone character varying(40),
+    property_name character varying(255),
+    live_balance numeric(12,2) DEFAULT 0 NOT NULL,
+    synced_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: owner_property_map_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.owner_property_map_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: owner_property_map_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.owner_property_map_id_seq OWNED BY public.owner_property_map.id;
+
+
+--
+-- Name: owner_statement_sends; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.owner_statement_sends (
+    id bigint NOT NULL,
+    owner_payout_account_id bigint NOT NULL,
+    property_id uuid NOT NULL,
+    statement_period_start date NOT NULL,
+    statement_period_end date NOT NULL,
+    sent_at timestamp with time zone,
+    sent_to_email character varying(255),
+    crog_total_amount numeric(12,2),
+    streamline_total_amount numeric(12,2),
+    source_used character varying(20),
+    comparison_status character varying(30),
+    comparison_diff_cents integer,
+    email_message_id character varying(255),
+    error_message text,
+    is_test boolean DEFAULT false NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT owner_statement_sends_comparison_status_check CHECK (((comparison_status)::text = ANY ((ARRAY['match'::character varying, 'mismatch'::character varying, 'streamline_unavailable'::character varying, 'not_compared'::character varying])::text[]))),
+    CONSTRAINT owner_statement_sends_source_used_check CHECK (((source_used)::text = ANY ((ARRAY['crog'::character varying, 'streamline'::character varying, 'failed'::character varying])::text[])))
+);
+
+
+--
+-- Name: owner_statement_sends_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.owner_statement_sends_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: owner_statement_sends_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.owner_statement_sends_id_seq OWNED BY public.owner_statement_sends.id;
+
+
+--
+-- Name: parity_audits; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.parity_audits (
+    id uuid NOT NULL,
+    reservation_id uuid NOT NULL,
+    confirmation_id character varying(100) NOT NULL,
+    local_total numeric(12,2) NOT NULL,
+    streamline_total numeric(12,2) NOT NULL,
+    delta numeric(12,2) NOT NULL,
+    local_breakdown jsonb DEFAULT '{}'::jsonb NOT NULL,
+    streamline_breakdown jsonb DEFAULT '{}'::jsonb NOT NULL,
+    status character varying(30) NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: payout_ledger; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.payout_ledger (
+    id bigint NOT NULL,
+    property_id character varying(100) NOT NULL,
+    confirmation_code character varying(100),
+    gross_amount numeric(12,2) DEFAULT 0 NOT NULL,
+    owner_amount numeric(12,2) DEFAULT 0 NOT NULL,
+    stripe_transfer_id character varying(255),
+    stripe_payout_id character varying(255),
+    status character varying(64) DEFAULT 'staged'::character varying NOT NULL,
+    initiated_at timestamp with time zone,
+    completed_at timestamp with time zone,
+    failure_reason text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: payout_ledger_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.payout_ledger_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: payout_ledger_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.payout_ledger_id_seq OWNED BY public.payout_ledger.id;
+
+
+--
+-- Name: pending_sync; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.pending_sync (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    reservation_id uuid NOT NULL,
+    property_id uuid NOT NULL,
+    sync_type character varying(50) DEFAULT 'create_reservation'::character varying NOT NULL,
+    status character varying(30) DEFAULT 'pending'::character varying NOT NULL,
+    attempt_count integer DEFAULT 0 NOT NULL,
+    last_error text,
+    payload jsonb DEFAULT '{}'::jsonb NOT NULL,
+    created_at timestamp with time zone DEFAULT now(),
+    updated_at timestamp with time zone DEFAULT now(),
+    resolved_at timestamp with time zone
+);
+
+
+--
+-- Name: pricing_overrides; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.pricing_overrides (
+    id uuid NOT NULL,
+    property_id uuid NOT NULL,
+    start_date date NOT NULL,
+    end_date date NOT NULL,
+    adjustment_percentage numeric(6,2) NOT NULL,
+    reason character varying(500) NOT NULL,
+    approved_by character varying(255) NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL,
+    CONSTRAINT ck_pricing_overrides_adjustment_range CHECK (((adjustment_percentage >= '-100.00'::numeric) AND (adjustment_percentage <= 100.00))),
+    CONSTRAINT ck_pricing_overrides_date_order CHECK ((end_date >= start_date))
 );
 
 
@@ -5336,903 +2825,704 @@ CREATE TABLE public.persona_scores (
 --
 
 CREATE TABLE public.properties (
-    id integer NOT NULL,
-    name character varying(100) NOT NULL,
-    address character varying(255),
-    parcel_id character varying(50),
-    county character varying(50) DEFAULT 'Fannin'::character varying,
-    acres numeric(5,2),
-    acquisition_date date,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    ownership_status character varying(20) DEFAULT 'UNKNOWN'::character varying NOT NULL,
-    cost_basis numeric(12,2),
-    current_value numeric(12,2),
-    depreciation_start date,
-    owner_contact_info jsonb,
-    streamline_id integer,
-    management_status character varying(20) DEFAULT 'active'::character varying,
-    launch_date date
-);
-
-
---
--- Name: properties_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.properties_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: properties_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.properties_id_seq OWNED BY public.properties.id;
-
-
---
--- Name: property_events; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.property_events (
-    id integer NOT NULL,
-    property_id integer,
-    event_type character varying(50),
-    event_date date,
-    status character varying(20) DEFAULT 'PENDING'::character varying,
-    notes text,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
-);
-
-
---
--- Name: property_events_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.property_events_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: property_events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.property_events_id_seq OWNED BY public.property_events.id;
-
-
---
--- Name: property_sms_config; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.property_sms_config (
-    id integer NOT NULL,
-    property_id integer NOT NULL,
-    property_name character varying(255) NOT NULL,
-    cabin_name character varying(100),
-    assigned_phone_number character varying(20) NOT NULL,
-    provider_id integer,
-    ai_enabled boolean DEFAULT true,
-    ai_model_preference character varying(100),
-    auto_reply_enabled boolean DEFAULT true,
-    require_human_approval boolean DEFAULT false,
-    business_hours_start time without time zone,
-    business_hours_end time without time zone,
-    timezone character varying(50) DEFAULT 'America/New_York'::character varying,
-    after_hours_behavior character varying(50),
-    welcome_message_template text,
-    checkin_info_template text,
-    checkout_reminder_template text,
-    wifi_info_template text,
-    wifi_ssid character varying(100),
-    wifi_password character varying(100),
-    door_code character varying(20),
+    id uuid NOT NULL,
+    name character varying(255) NOT NULL,
+    slug character varying(255) NOT NULL,
+    property_type character varying(50) NOT NULL,
+    bedrooms integer NOT NULL,
+    bathrooms numeric(3,1) NOT NULL,
+    max_guests integer NOT NULL,
     address text,
-    checkin_instructions text,
-    house_rules text,
-    emergency_contact character varying(20),
-    escalation_phone character varying(20),
-    escalation_email character varying(255),
-    escalation_keywords text[],
-    created_at timestamp without time zone DEFAULT now(),
-    updated_at timestamp without time zone DEFAULT now()
+    latitude numeric(10,8),
+    longitude numeric(11,8),
+    wifi_ssid character varying(255),
+    wifi_password character varying(255),
+    access_code_type character varying(50),
+    access_code_location text,
+    parking_instructions text,
+    rate_card jsonb,
+    availability jsonb,
+    default_housekeeper_id uuid,
+    default_clean_minutes integer,
+    streamline_checklist_id character varying(100),
+    amenities jsonb,
+    qdrant_point_id uuid,
+    streamline_property_id character varying(100),
+    ota_metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
+    owner_id character varying(100),
+    owner_name character varying(255),
+    owner_balance jsonb,
+    is_active boolean,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone,
+    rates_notes text,
+    video_urls jsonb,
+    county character varying(100),
+    city_limits boolean DEFAULT false NOT NULL,
+    cleaning_fee numeric(10,2),
+    renting_state public.property_renting_state DEFAULT 'active'::public.property_renting_state NOT NULL,
+    property_group character varying(100),
+    city character varying(100),
+    state character varying(50),
+    postal_code character varying(20)
 );
 
 
 --
--- Name: property_sms_config_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: property_fees; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.property_sms_config_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: property_sms_config_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.property_sms_config_id_seq OWNED BY public.property_sms_config.id;
-
-
---
--- Name: quarantine_inbox; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.quarantine_inbox (
-    id integer NOT NULL,
-    sender text NOT NULL,
-    subject text,
-    content text,
-    sent_at timestamp without time zone,
-    blocked_by text NOT NULL,
-    blocked_reason text,
-    file_path text,
-    category text,
-    quarantined_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+CREATE TABLE public.property_fees (
+    id uuid NOT NULL,
+    property_id uuid NOT NULL,
+    fee_id uuid NOT NULL,
+    is_active boolean DEFAULT true NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
 );
 
 
 --
--- Name: quarantine_inbox_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: property_images; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.quarantine_inbox_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: quarantine_inbox_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.quarantine_inbox_id_seq OWNED BY public.quarantine_inbox.id;
-
-
---
--- Name: rag_query_feedback; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.rag_query_feedback (
-    id integer NOT NULL,
-    query_text text NOT NULL,
-    brain text,
-    collection text,
-    top_k integer,
-    chunks_retrieved integer,
-    relevance_score numeric(5,4),
-    reranker_used boolean DEFAULT false,
-    response_quality integer,
-    latency_retrieval_ms integer,
-    latency_llm_ms integer,
-    created_at timestamp without time zone DEFAULT now()
+CREATE TABLE public.property_images (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    property_id uuid NOT NULL,
+    legacy_url character varying(2048) NOT NULL,
+    sovereign_url character varying(2048),
+    display_order integer DEFAULT 0 NOT NULL,
+    alt_text character varying(512) DEFAULT ''::character varying NOT NULL,
+    is_hero boolean DEFAULT false NOT NULL,
+    status character varying(20) DEFAULT 'pending'::character varying NOT NULL,
+    CONSTRAINT ck_property_images_status CHECK (((status)::text = ANY ((ARRAY['pending'::character varying, 'ingested'::character varying, 'failed'::character varying])::text[])))
 );
 
 
 --
--- Name: rag_query_feedback_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: property_knowledge; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.rag_query_feedback_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: rag_query_feedback_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.rag_query_feedback_id_seq OWNED BY public.rag_query_feedback.id;
+CREATE TABLE public.property_knowledge (
+    id uuid NOT NULL,
+    property_id uuid,
+    category character varying(80) NOT NULL,
+    content text NOT NULL,
+    source character varying(120) NOT NULL,
+    tags jsonb NOT NULL,
+    confidence character varying(20) NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
 
 
 --
--- Name: real_estate_intel; Type: TABLE; Schema: public; Owner: -
+-- Name: property_knowledge_chunks; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.real_estate_intel (
-    id integer NOT NULL,
-    property_name character varying(255),
-    property_value numeric(15,2),
-    property_address text,
-    zillow_estimate numeric(15,2),
-    date date,
-    source_email_id integer,
-    raw_content text,
+CREATE TABLE public.property_knowledge_chunks (
+    id uuid NOT NULL,
+    property_id uuid NOT NULL,
+    content text NOT NULL,
+    embedding text NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: property_stay_restrictions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.property_stay_restrictions (
+    id uuid NOT NULL,
+    property_id uuid NOT NULL,
+    start_date date NOT NULL,
+    end_date date NOT NULL,
+    is_blackout boolean NOT NULL,
+    must_check_in_on_day smallint,
+    must_check_out_on_day smallint,
+    source character varying(32) NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: property_taxes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.property_taxes (
+    id uuid NOT NULL,
+    property_id uuid NOT NULL,
+    tax_id uuid NOT NULL,
+    is_active boolean DEFAULT true NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: property_utilities; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.property_utilities (
+    id uuid NOT NULL,
+    property_id uuid NOT NULL,
+    service_type character varying(50) NOT NULL,
+    provider_name character varying(255) NOT NULL,
+    account_number character varying(255),
+    account_holder character varying(255),
+    portal_url text,
+    portal_username text,
+    portal_password_enc text,
+    contact_phone character varying(50),
+    contact_email character varying(255),
+    notes text,
+    monthly_budget numeric(10,2),
+    is_active boolean,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
+);
+
+
+--
+-- Name: quote_options; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.quote_options (
+    id uuid NOT NULL,
+    quote_id uuid NOT NULL,
+    property_id uuid NOT NULL,
+    check_in_date date NOT NULL,
+    check_out_date date NOT NULL,
+    base_rent numeric(12,2),
+    taxes numeric(12,2),
+    fees numeric(12,2),
+    total_price numeric(12,2),
+    booking_link character varying(500),
     created_at timestamp without time zone
 );
 
 
 --
--- Name: real_estate_intel_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: quotes; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.real_estate_intel_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: real_estate_intel_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.real_estate_intel_id_seq OWNED BY public.real_estate_intel.id;
-
-
---
--- Name: recent_conversations; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public.recent_conversations AS
- SELECT ct.id AS thread_id,
-    ct.phone_number,
-    gp.name AS guest_name,
-    ct.property_id,
-    psc.cabin_name,
-    ct.message_count,
-    ct.status,
-    ct.last_message_at,
-    ct.handled_by_ai,
-    gp.vip_guest,
-    ( SELECT message_archive.message_body
-           FROM public.message_archive
-          WHERE ((message_archive.phone_number)::text = (ct.phone_number)::text)
-          ORDER BY message_archive.sent_at DESC
-         LIMIT 1) AS last_message
-   FROM ((public.conversation_threads ct
-     LEFT JOIN public.guest_profiles gp ON (((ct.phone_number)::text = (gp.phone_number)::text)))
-     LEFT JOIN public.property_sms_config psc ON ((ct.property_id = psc.property_id)))
-  WHERE ((ct.status)::text = 'active'::text)
-  ORDER BY ct.last_message_at DESC;
-
-
---
--- Name: recursive_trace_log; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.recursive_trace_log (
-    id integer NOT NULL,
-    run_id text NOT NULL,
-    user_id text,
-    query text NOT NULL,
-    step_number integer NOT NULL,
-    stage text NOT NULL,
-    content text,
-    critic_score integer,
-    critic_tags text[],
-    model text,
-    latency_ms integer,
-    metadata jsonb DEFAULT '{}'::jsonb,
-    created_at timestamp without time zone DEFAULT now()
+CREATE TABLE public.quotes (
+    id uuid NOT NULL,
+    lead_id uuid NOT NULL,
+    status character varying(20) NOT NULL,
+    payment_method character varying(20),
+    expires_at timestamp without time zone,
+    ai_drafted_email_body text,
+    ai_draft_model character varying(100),
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
 );
 
 
 --
--- Name: recursive_trace_log_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: recovery_parity_comparisons; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.recursive_trace_log_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: recursive_trace_log_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.recursive_trace_log_id_seq OWNED BY public.recursive_trace_log.id;
-
-
---
--- Name: revenue_ledger; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.revenue_ledger (
-    id integer NOT NULL,
-    run_id text NOT NULL,
-    cabin_name text NOT NULL,
-    target_date date NOT NULL,
-    target_dow text,
-    base_rate numeric(10,2),
-    seasonal_baseline numeric(10,2),
-    adjusted_rate numeric(10,2) NOT NULL,
-    alpha numeric(10,2),
-    previous_rate numeric(10,2),
-    rate_change numeric(10,2),
-    rate_change_pct numeric(6,2),
-    sentiment_score numeric(6,4),
-    weather_factor numeric(6,4),
-    event_factor numeric(6,4),
-    competitor_factor numeric(6,4),
-    volatility_index numeric(6,4),
-    trading_signal text,
-    confidence numeric(6,4),
-    weather_condition text,
-    weather_temp_f real,
-    event_name text,
-    event_weight integer,
-    competitor_direction text,
-    competitor_rate_change numeric(10,2),
-    days_until_checkin integer,
-    engine_version text DEFAULT '1.0.0'::text,
-    tier text,
-    generated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
-);
-
-
---
--- Name: revenue_ledger_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.revenue_ledger_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: revenue_ledger_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.revenue_ledger_id_seq OWNED BY public.revenue_ledger.id;
-
-
---
--- Name: ruebarue_area_guide; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.ruebarue_area_guide (
-    id integer NOT NULL,
-    section character varying(100) NOT NULL,
-    entry_number integer,
-    place_name text,
-    address text,
-    distance text,
-    phone text,
-    rating text,
-    tip text,
-    raw_text text NOT NULL,
-    created_at timestamp without time zone DEFAULT now()
-);
-
-
---
--- Name: ruebarue_area_guide_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.ruebarue_area_guide_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: ruebarue_area_guide_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.ruebarue_area_guide_id_seq OWNED BY public.ruebarue_area_guide.id;
-
-
---
--- Name: ruebarue_contacts; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.ruebarue_contacts (
-    id integer NOT NULL,
-    name character varying(200) NOT NULL,
-    phone character varying(50),
-    email character varying(200),
-    role character varying(50),
-    properties text,
-    tags text,
-    created_at timestamp without time zone DEFAULT now()
-);
-
-
---
--- Name: ruebarue_contacts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.ruebarue_contacts_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: ruebarue_contacts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.ruebarue_contacts_id_seq OWNED BY public.ruebarue_contacts.id;
-
-
---
--- Name: ruebarue_guests; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.ruebarue_guests (
-    id integer NOT NULL,
-    guest_info text NOT NULL,
-    property_info text,
-    door_code text,
-    created_at timestamp without time zone DEFAULT now()
-);
-
-
---
--- Name: ruebarue_guests_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.ruebarue_guests_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: ruebarue_guests_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.ruebarue_guests_id_seq OWNED BY public.ruebarue_guests.id;
-
-
---
--- Name: ruebarue_knowledge_base; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.ruebarue_knowledge_base (
-    id integer NOT NULL,
-    category character varying(100) NOT NULL,
-    subcategory character varying(100),
-    title text NOT NULL,
-    content text NOT NULL,
-    source character varying(50) NOT NULL,
-    property_name character varying(200),
-    metadata jsonb,
-    created_at timestamp without time zone DEFAULT now(),
-    updated_at timestamp without time zone DEFAULT now()
-);
-
-
---
--- Name: ruebarue_knowledge_base_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.ruebarue_knowledge_base_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: ruebarue_knowledge_base_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.ruebarue_knowledge_base_id_seq OWNED BY public.ruebarue_knowledge_base.id;
-
-
---
--- Name: ruebarue_message_templates; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.ruebarue_message_templates (
-    id integer NOT NULL,
-    name character varying(200) NOT NULL,
-    type character varying(20) NOT NULL,
-    active boolean DEFAULT true,
-    schedule character varying(200),
-    tags text,
-    booking_source character varying(200),
-    flags text,
-    subject text,
-    message_text text,
-    full_modal_text text,
-    created_at timestamp without time zone DEFAULT now()
-);
-
-
---
--- Name: ruebarue_message_templates_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.ruebarue_message_templates_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: ruebarue_message_templates_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.ruebarue_message_templates_id_seq OWNED BY public.ruebarue_message_templates.id;
-
-
---
--- Name: sales_intel; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.sales_intel (
-    id integer NOT NULL,
-    signal_type text,
-    cabin_name text,
-    event_type text,
-    check_in date,
-    check_out date,
-    nights integer,
-    guest_count integer,
-    total_quoted numeric(12,2),
-    bedrooms integer,
-    selling_points text[],
-    guest_objections text,
-    conversion_outcome text,
-    competitive_mention text,
-    source_email_id integer,
-    extracted_at timestamp without time zone DEFAULT now()
-);
-
-
---
--- Name: sales_intel_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.sales_intel_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: sales_intel_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.sales_intel_id_seq OWNED BY public.sales_intel.id;
-
-
---
--- Name: schema_drift_log; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.schema_drift_log (
-    id integer NOT NULL,
-    endpoint text NOT NULL,
-    model_name text NOT NULL,
-    unknown_keys jsonb NOT NULL,
-    sample_values jsonb,
-    record_id text,
+CREATE TABLE public.recovery_parity_comparisons (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    dedupe_hash character varying(64) NOT NULL,
+    session_fp character varying(128) NOT NULL,
+    guest_id uuid,
+    property_slug character varying(255),
+    drop_off_point character varying(64) NOT NULL,
+    intent_score_estimate double precision NOT NULL,
+    legacy_template_key character varying(80) NOT NULL,
+    legacy_body text NOT NULL,
+    sovereign_body text NOT NULL,
+    parity_summary jsonb NOT NULL,
+    candidate_snapshot jsonb NOT NULL,
+    async_job_run_id uuid,
     created_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 
 --
--- Name: schema_drift_log_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: rental_agreements; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.schema_drift_log_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: schema_drift_log_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.schema_drift_log_id_seq OWNED BY public.schema_drift_log.id;
-
-
---
--- Name: sender_registry; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.sender_registry (
-    id integer NOT NULL,
-    sender_raw text NOT NULL,
-    email_address text,
-    display_name text,
-    domain text,
-    status character varying(20) DEFAULT 'REVIEW'::character varying,
-    division character varying(50),
-    total_volume integer DEFAULT 0,
-    mined_count integer DEFAULT 0,
-    empty_extraction_count integer DEFAULT 0,
-    last_seen timestamp without time zone,
-    signal_ratio double precision GENERATED ALWAYS AS (
-CASE
-    WHEN (total_volume = 0) THEN (0)::double precision
-    ELSE ((mined_count)::double precision / (total_volume)::double precision)
-END) STORED,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+CREATE TABLE public.rental_agreements (
+    id uuid NOT NULL,
+    guest_id uuid NOT NULL,
+    reservation_id uuid,
+    property_id uuid,
+    template_id uuid,
+    agreement_type character varying(50) NOT NULL,
+    rendered_content text NOT NULL,
+    status character varying(30) NOT NULL,
+    sent_at timestamp without time zone,
+    sent_via character varying(20),
+    agreement_url text,
+    expires_at timestamp without time zone,
+    first_viewed_at timestamp without time zone,
+    view_count integer,
+    signed_at timestamp without time zone,
+    signature_type character varying(30),
+    signature_data text,
+    signer_name character varying(200),
+    signer_email character varying(255),
+    initials_data text,
+    initials_pages jsonb,
+    signer_ip_address character varying(45),
+    signer_user_agent text,
+    signer_device_fingerprint character varying(255),
+    consent_recorded boolean,
+    pdf_url text,
+    pdf_generated_at timestamp without time zone,
+    reminder_count integer,
+    last_reminder_at timestamp without time zone,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
 );
 
 
 --
--- Name: sender_registry_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: reservation_holds; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.sender_registry_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: sender_registry_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.sender_registry_id_seq OWNED BY public.sender_registry.id;
-
-
---
--- Name: sentinel_alerts; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.sentinel_alerts (
-    id integer NOT NULL,
-    source text NOT NULL,
-    name text NOT NULL,
-    priority text NOT NULL,
-    message text NOT NULL,
-    arm64 boolean DEFAULT false,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
+CREATE TABLE public.reservation_holds (
+    id uuid NOT NULL,
+    property_id uuid NOT NULL,
+    guest_id uuid,
+    converted_reservation_id uuid,
+    session_id character varying(255) NOT NULL,
+    check_in_date date NOT NULL,
+    check_out_date date NOT NULL,
+    num_guests integer NOT NULL,
+    status character varying(50) NOT NULL,
+    amount_total numeric(12,2),
+    quote_snapshot jsonb,
+    payment_intent_id character varying(255),
+    special_requests text,
+    expires_at timestamp with time zone NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL,
+    CONSTRAINT ck_reservation_holds_date_order CHECK ((check_out_date > check_in_date)),
+    CONSTRAINT ck_reservation_holds_status CHECK (((status)::text = ANY ((ARRAY['active'::character varying, 'expired'::character varying, 'converted'::character varying])::text[])))
 );
 
 
 --
--- Name: sentinel_alerts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: reservations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.sentinel_alerts_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
+CREATE TABLE public.reservations (
+    id uuid NOT NULL,
+    confirmation_code character varying(50) NOT NULL,
+    guest_id uuid NOT NULL,
+    property_id uuid NOT NULL,
+    guest_email character varying(255) DEFAULT ''::character varying NOT NULL,
+    guest_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    guest_phone character varying(50),
+    check_in_date date NOT NULL,
+    check_out_date date NOT NULL,
+    num_guests integer NOT NULL,
+    num_adults integer,
+    num_children integer,
+    num_pets integer,
+    special_requests text,
+    status character varying(50) NOT NULL,
+    access_code character varying(20),
+    access_code_valid_from timestamp with time zone,
+    access_code_valid_until timestamp with time zone,
+    booking_source character varying(100),
+    total_amount numeric(10,2),
+    paid_amount numeric(10,2),
+    balance_due numeric(10,2),
+    nightly_rate numeric(10,2),
+    cleaning_fee numeric(10,2),
+    pet_fee numeric(10,2),
+    damage_waiver_fee numeric(10,2),
+    service_fee numeric(10,2),
+    tax_amount numeric(10,2),
+    nights_count integer,
+    price_breakdown jsonb,
+    currency character varying(3),
+    digital_guide_sent boolean,
+    pre_arrival_sent boolean,
+    access_info_sent boolean,
+    mid_stay_checkin_sent boolean,
+    checkout_reminder_sent boolean,
+    post_stay_followup_sent boolean,
+    guest_rating integer,
+    guest_feedback text,
+    internal_notes text,
+    streamline_notes jsonb,
+    streamline_financial_detail jsonb,
+    qdrant_point_id uuid,
+    security_deposit_required boolean DEFAULT false NOT NULL,
+    security_deposit_amount numeric(12,2) DEFAULT 500.00 NOT NULL,
+    security_deposit_status character varying(20) DEFAULT 'none'::character varying NOT NULL,
+    security_deposit_stripe_pi character varying(255),
+    security_deposit_updated_at timestamp with time zone,
+    streamline_reservation_id character varying(100),
+    created_at timestamp with time zone,
+    updated_at timestamp with time zone,
+    tax_breakdown jsonb,
+    security_deposit_payment_method_id character varying(255),
+    is_owner_booking boolean DEFAULT false NOT NULL
+);
 
 
 --
--- Name: sentinel_alerts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+-- Name: restricted_captures; Type: TABLE; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.sentinel_alerts_id_seq OWNED BY public.sentinel_alerts.id;
+CREATE TABLE public.restricted_captures (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    prompt text NOT NULL,
+    response text NOT NULL,
+    source_persona character varying(128),
+    source_module character varying(128),
+    restriction_reason character varying(256) NOT NULL,
+    matched_patterns character varying[] DEFAULT '{}'::character varying[] NOT NULL,
+    capture_metadata jsonb,
+    eval_holdout boolean DEFAULT false NOT NULL,
+    served_by_endpoint character varying(256),
+    served_vector_store character varying(64),
+    escalated_from character varying(256),
+    sovereign_attempt text,
+    teacher_endpoint character varying(256),
+    teacher_model character varying(128),
+    task_type character varying(64),
+    judge_decision character varying(16),
+    judge_reasoning text
+);
 
 
 --
--- Name: sentinel_state; Type: TABLE; Schema: public; Owner: -
+-- Name: rue_bar_rue_legacy_recovery_templates; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.sentinel_state (
-    key text NOT NULL,
-    value text NOT NULL,
-    source text DEFAULT 'unknown'::text NOT NULL,
-    priority text DEFAULT 'MEDIUM'::text NOT NULL,
-    note text DEFAULT ''::text,
+CREATE TABLE public.rue_bar_rue_legacy_recovery_templates (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    template_key character varying(80) NOT NULL,
+    channel character varying(16) NOT NULL,
+    audience_rule character varying(64) DEFAULT '*'::character varying NOT NULL,
+    body_template text NOT NULL,
+    is_active boolean DEFAULT true NOT NULL,
+    source_system character varying(64) DEFAULT 'rue_ba_rue'::character varying NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 
 --
--- Name: sms_providers; Type: TABLE; Schema: public; Owner: -
+-- Name: scheduled_messages; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.sms_providers (
-    id integer NOT NULL,
-    name character varying(50) NOT NULL,
-    account_sid character varying(255),
-    auth_token_encrypted text,
-    phone_numbers text[],
-    supports_mms boolean DEFAULT false,
-    supports_unicode boolean DEFAULT true,
-    max_message_length integer DEFAULT 160,
-    priority integer DEFAULT 100,
-    enabled boolean DEFAULT true,
-    cost_per_message numeric(6,4),
-    cost_per_segment numeric(6,4),
-    monthly_fee numeric(8,2),
-    total_messages_sent integer DEFAULT 0,
-    success_rate numeric(5,4),
-    avg_delivery_time_seconds integer,
-    last_failure_at timestamp without time zone,
-    consecutive_failures integer DEFAULT 0,
-    rate_limit_per_second integer,
-    rate_limit_per_minute integer,
-    rate_limit_per_hour integer,
-    created_at timestamp without time zone DEFAULT now(),
-    updated_at timestamp without time zone DEFAULT now()
+CREATE TABLE public.scheduled_messages (
+    id uuid NOT NULL,
+    guest_id uuid NOT NULL,
+    reservation_id uuid,
+    template_id uuid,
+    scheduled_for timestamp without time zone NOT NULL,
+    sent_at timestamp without time zone,
+    phone_to character varying(20) NOT NULL,
+    body text NOT NULL,
+    status character varying(50) NOT NULL,
+    message_id uuid,
+    error_message text,
+    created_at timestamp without time zone
 );
 
 
 --
--- Name: sms_providers_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: seo_patch_queue; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.sms_providers_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
+CREATE TABLE public.seo_patch_queue (
+    id uuid NOT NULL,
+    target_type character varying(32) NOT NULL,
+    target_slug character varying(255) NOT NULL,
+    property_id uuid,
+    status character varying(30) NOT NULL,
+    target_keyword character varying(255),
+    campaign character varying(100) NOT NULL,
+    rubric_version character varying(50),
+    source_hash character varying(128) NOT NULL,
+    proposed_title character varying(255) NOT NULL,
+    proposed_meta_description text NOT NULL,
+    proposed_h1 character varying(255) NOT NULL,
+    proposed_intro text NOT NULL,
+    proposed_faq jsonb NOT NULL,
+    proposed_json_ld jsonb NOT NULL,
+    fact_snapshot jsonb NOT NULL,
+    score_overall double precision,
+    score_breakdown jsonb NOT NULL,
+    proposed_by character varying(100) NOT NULL,
+    proposal_run_id character varying(100),
+    reviewed_by character varying(100),
+    review_note text,
+    approved_payload jsonb NOT NULL,
+    approved_at timestamp without time zone,
+    deployed_at timestamp without time zone,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    CONSTRAINT ck_seo_patch_queue_status CHECK (((status)::text = ANY ((ARRAY['proposed'::character varying, 'needs_revision'::character varying, 'approved'::character varying, 'rejected'::character varying, 'deployed'::character varying, 'superseded'::character varying])::text[]))),
+    CONSTRAINT ck_seo_patch_queue_target_type CHECK (((target_type)::text = ANY ((ARRAY['property'::character varying, 'archive_review'::character varying])::text[])))
+);
 
 
 --
--- Name: sms_providers_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+-- Name: seo_patches; Type: TABLE; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.sms_providers_id_seq OWNED BY public.sms_providers.id;
+CREATE TABLE public.seo_patches (
+    id uuid NOT NULL,
+    property_id uuid,
+    rubric_id uuid,
+    source_intelligence_id uuid,
+    source_agent character varying(120) NOT NULL,
+    page_path character varying NOT NULL,
+    patch_version integer NOT NULL,
+    title character varying(255),
+    meta_description text,
+    og_title character varying(255),
+    og_description text,
+    jsonld_payload jsonb,
+    canonical_url character varying(2048),
+    h1_suggestion character varying(255),
+    alt_tags jsonb,
+    godhead_score double precision,
+    godhead_model character varying(255),
+    godhead_feedback jsonb,
+    grade_attempts integer NOT NULL,
+    status character varying(50) NOT NULL,
+    reviewed_by character varying(255),
+    reviewed_at timestamp with time zone,
+    final_payload jsonb,
+    deployed_at timestamp with time zone,
+    deploy_task_id uuid,
+    deploy_status character varying(50),
+    deploy_queued_at timestamp with time zone,
+    deploy_acknowledged_at timestamp with time zone,
+    deploy_attempts integer DEFAULT 0 NOT NULL,
+    deploy_last_error text,
+    deploy_last_http_status integer,
+    swarm_model character varying(255),
+    swarm_node character varying(255),
+    generation_ms integer,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
 
 
 --
--- Name: sovereign_cycles; Type: TABLE; Schema: public; Owner: -
+-- Name: seo_rank_snapshots; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.sovereign_cycles (
-    id integer NOT NULL,
-    cycle_id integer NOT NULL,
-    "timestamp" timestamp with time zone DEFAULT now() NOT NULL,
-    health_status text NOT NULL,
-    health_score real,
-    directives jsonb DEFAULT '[]'::jsonb,
-    optimization_triggers jsonb DEFAULT '[]'::jsonb,
-    division_a_summary jsonb,
-    division_b_summary jsonb,
+CREATE TABLE public.seo_rank_snapshots (
+    id uuid NOT NULL,
+    property_id uuid,
+    keyword character varying(255) NOT NULL,
+    rank_position character varying(30) NOT NULL,
+    snapshot_date date NOT NULL,
+    source character varying(120) NOT NULL,
+    metadata_json jsonb NOT NULL
+);
+
+
+--
+-- Name: seo_redirect_remap_queue; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.seo_redirect_remap_queue (
+    id uuid NOT NULL,
+    source_path character varying(1024) NOT NULL,
+    current_destination_path character varying(1024),
+    proposed_destination_path character varying(1024) NOT NULL,
+    applied_destination_path character varying(1024),
+    grounding_mode character varying(100) NOT NULL,
+    status character varying(30) NOT NULL,
+    campaign character varying(100) NOT NULL,
+    rubric_version character varying(50) NOT NULL,
+    proposal_run_id character varying(100) NOT NULL,
+    proposed_by character varying(100) NOT NULL,
+    extracted_entities jsonb NOT NULL,
+    source_snapshot jsonb NOT NULL,
+    route_candidates jsonb NOT NULL,
+    rationale text NOT NULL,
+    grade_score double precision,
+    grade_payload jsonb NOT NULL,
+    reviewed_by character varying(255),
+    review_note text,
+    approved_at timestamp without time zone,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    CONSTRAINT ck_seo_redirect_remap_queue_status CHECK (((status)::text = ANY ((ARRAY['proposed'::character varying, 'promoted'::character varying, 'rejected'::character varying, 'applied'::character varying, 'superseded'::character varying])::text[])))
+);
+
+
+--
+-- Name: seo_redirects; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.seo_redirects (
+    id uuid NOT NULL,
+    source_path character varying(1024) NOT NULL,
+    destination_path character varying(1024) NOT NULL,
+    is_permanent boolean NOT NULL,
+    reason character varying(255),
+    created_by character varying(255),
+    updated_by character varying(255),
+    is_active boolean NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: seo_rubrics; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.seo_rubrics (
+    id uuid NOT NULL,
+    keyword_cluster text NOT NULL,
+    rubric_payload jsonb NOT NULL,
+    source_model character varying(255) NOT NULL,
+    min_pass_score double precision NOT NULL,
+    status character varying(50) NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: shadow_discrepancies; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.shadow_discrepancies (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    "timestamp" timestamp without time zone DEFAULT now() NOT NULL,
+    property_id uuid NOT NULL,
+    legacy_total_cents integer NOT NULL,
+    dgx_total_cents integer NOT NULL,
+    delta_cents integer NOT NULL,
+    legacy_payload jsonb,
+    dgx_payload jsonb,
+    hermes_diagnosis text,
+    status character varying(20) DEFAULT 'pending'::character varying NOT NULL
+);
+
+
+--
+-- Name: staff_invites; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.staff_invites (
+    id uuid NOT NULL,
+    email character varying(255) NOT NULL,
+    first_name character varying(100) NOT NULL,
+    last_name character varying(100) NOT NULL,
+    role character varying(50) NOT NULL,
+    token character varying(128) NOT NULL,
+    invited_by uuid NOT NULL,
+    status character varying(20) NOT NULL,
+    expires_at timestamp without time zone NOT NULL,
+    accepted_at timestamp without time zone,
+    created_at timestamp without time zone
+);
+
+
+--
+-- Name: staff_users; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.staff_users (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    email character varying(255) NOT NULL,
+    password_hash character varying(255) NOT NULL,
+    first_name character varying(100) NOT NULL,
+    last_name character varying(100) NOT NULL,
+    role character varying(11) DEFAULT 'super_admin'::character varying NOT NULL,
+    permissions jsonb,
+    is_active boolean DEFAULT true NOT NULL,
+    last_login_at timestamp without time zone,
+    notification_phone character varying(20),
+    notification_email character varying(255),
+    notify_urgent boolean DEFAULT true NOT NULL,
+    notify_workorders boolean DEFAULT true NOT NULL,
+    created_at timestamp without time zone DEFAULT now() NOT NULL,
+    updated_at timestamp without time zone DEFAULT now() NOT NULL,
+    CONSTRAINT staff_role CHECK (((role)::text = ANY ((ARRAY['super_admin'::character varying, 'admin'::character varying, 'manager'::character varying, 'reviewer'::character varying, 'operator'::character varying, 'staff'::character varying, 'maintenance'::character varying])::text[])))
+);
+
+
+--
+-- Name: storefront_intent_events; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.storefront_intent_events (
+    id uuid NOT NULL,
+    session_fp character varying(64) NOT NULL,
+    event_type character varying(64) NOT NULL,
+    consent_marketing boolean DEFAULT false NOT NULL,
+    property_slug character varying(255),
+    meta jsonb DEFAULT '{}'::jsonb NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 
 --
--- Name: sovereign_cycles_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: storefront_session_guest_links; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.sovereign_cycles_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: sovereign_cycles_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.sovereign_cycles_id_seq OWNED BY public.sovereign_cycles.id;
-
-
---
--- Name: starred_responses; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.starred_responses (
-    id integer NOT NULL,
-    message_body text NOT NULL,
-    embedding public.vector(768),
-    intent character varying(100),
-    cabin_name character varying(200),
-    guest_name character varying(200),
-    phone_number_hash character varying(64),
-    loyalty_tier character varying(50),
-    response_type character varying(20) DEFAULT 'approved'::character varying NOT NULL,
-    quality_grade integer,
-    queue_id bigint,
-    ai_model character varying(100),
-    original_draft text,
-    edit_distance_pct numeric(5,2),
-    created_at timestamp with time zone DEFAULT now()
+CREATE TABLE public.storefront_session_guest_links (
+    id uuid NOT NULL,
+    session_fp character varying(64) NOT NULL,
+    guest_id uuid NOT NULL,
+    reservation_hold_id uuid,
+    source character varying(32) DEFAULT 'checkout_hold'::character varying NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 
 --
--- Name: starred_responses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: streamline_payload_vault; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.starred_responses_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: starred_responses_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.starred_responses_id_seq OWNED BY public.starred_responses.id;
-
-
---
--- Name: sys_api_credentials; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.sys_api_credentials (
-    service_name character varying(255) NOT NULL,
-    token_key character varying(255) NOT NULL,
-    token_secret character varying(255) NOT NULL,
-    expiration_date timestamp with time zone,
-    last_updated timestamp with time zone DEFAULT now()
+CREATE TABLE public.streamline_payload_vault (
+    id uuid NOT NULL,
+    reservation_id character varying(100),
+    event_type character varying(100) NOT NULL,
+    raw_payload jsonb DEFAULT '{}'::jsonb NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 
 --
--- Name: system_directives; Type: TABLE; Schema: public; Owner: -
+-- Name: stripe_connect_events; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.system_directives (
+CREATE TABLE public.stripe_connect_events (
     id bigint NOT NULL,
-    directive_text text NOT NULL,
-    source_failure_cluster character varying(512),
-    embedding_metadata jsonb DEFAULT '{}'::jsonb,
-    active boolean DEFAULT true NOT NULL,
-    version smallint DEFAULT '1'::smallint NOT NULL,
+    stripe_event_id character varying(255) NOT NULL,
+    event_type character varying(100) NOT NULL,
+    account_id character varying(255),
+    transfer_id character varying(255),
+    payout_id character varying(255),
+    amount numeric(12,2),
+    status character varying(64),
+    failure_code character varying(100),
+    failure_message text,
+    raw_payload jsonb,
     created_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 
 --
--- Name: system_directives_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: stripe_connect_events_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.system_directives_id_seq
+CREATE SEQUENCE public.stripe_connect_events_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6241,120 +3531,108 @@ CREATE SEQUENCE public.system_directives_id_seq
 
 
 --
--- Name: system_directives_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+-- Name: stripe_connect_events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.system_directives_id_seq OWNED BY public.system_directives.id;
+ALTER SEQUENCE public.stripe_connect_events_id_seq OWNED BY public.stripe_connect_events.id;
 
 
 --
--- Name: system_drift_alerts; Type: TABLE; Schema: public; Owner: -
+-- Name: survey_templates; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.system_drift_alerts (
-    id integer NOT NULL,
-    run_id text NOT NULL,
-    intent text NOT NULL,
-    metric text NOT NULL,
-    current_value numeric NOT NULL,
-    threshold numeric NOT NULL,
-    sample_count integer NOT NULL,
-    detail text,
-    created_at timestamp with time zone DEFAULT now()
+CREATE TABLE public.survey_templates (
+    id uuid NOT NULL,
+    name character varying(255) NOT NULL,
+    description text,
+    survey_type character varying(50) NOT NULL,
+    questions jsonb NOT NULL,
+    trigger_type character varying(50),
+    trigger_offset_hours integer,
+    send_method character varying(20),
+    is_active boolean,
+    usage_count integer,
+    avg_completion_rate numeric(5,2),
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
 );
 
 
 --
--- Name: system_drift_alerts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: swarm_escalations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.system_drift_alerts_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: system_drift_alerts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.system_drift_alerts_id_seq OWNED BY public.system_drift_alerts.id;
-
-
---
--- Name: system_post_mortems; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.system_post_mortems (
-    id integer NOT NULL,
-    occurred_at timestamp with time zone DEFAULT now() NOT NULL,
-    sector character varying(10) NOT NULL,
-    severity character varying(10) NOT NULL,
-    component text NOT NULL,
-    error_summary text NOT NULL,
-    root_cause text,
-    remediation text,
-    status character varying(20) DEFAULT 'open'::character varying,
-    resolved_by character varying(50),
-    resolved_at timestamp with time zone
+CREATE TABLE public.swarm_escalations (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    decision_id uuid NOT NULL,
+    reason_code character varying(100) NOT NULL,
+    status character varying(8) DEFAULT 'pending'::character varying NOT NULL,
+    CONSTRAINT swarm_escalation_status CHECK (((status)::text = ANY ((ARRAY['pending'::character varying, 'resolved'::character varying])::text[])))
 );
 
 
 --
--- Name: system_post_mortems_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: taxes; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.system_post_mortems_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: system_post_mortems_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.system_post_mortems_id_seq OWNED BY public.system_post_mortems.id;
-
-
---
--- Name: system_telemetry; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.system_telemetry (
-    id integer NOT NULL,
-    hostname text,
-    cpu_usage real,
-    ram_usage real,
-    disk_usage real,
-    recorded_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+CREATE TABLE public.taxes (
+    id uuid NOT NULL,
+    name character varying(255) NOT NULL,
+    percentage_rate numeric(6,2) NOT NULL,
+    is_active boolean DEFAULT true NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
 );
 
 
 --
--- Name: system_telemetry_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: taxonomy_categories; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.system_telemetry_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
+CREATE TABLE public.taxonomy_categories (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    name character varying(255) NOT NULL,
+    slug character varying(255) NOT NULL,
+    description text,
+    meta_title character varying(255),
+    meta_description text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
 
 
 --
--- Name: system_telemetry_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+-- Name: taylor_quote_requests; Type: TABLE; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.system_telemetry_id_seq OWNED BY public.system_telemetry.id;
+CREATE TABLE public.taylor_quote_requests (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    guest_email character varying(320) NOT NULL,
+    check_in date NOT NULL,
+    check_out date NOT NULL,
+    nights integer NOT NULL,
+    adults integer DEFAULT 2 NOT NULL,
+    children integer DEFAULT 0 NOT NULL,
+    pets integer DEFAULT 0 NOT NULL,
+    status character varying(30) DEFAULT 'pending_approval'::character varying NOT NULL,
+    property_options jsonb DEFAULT '[]'::jsonb NOT NULL,
+    approved_by character varying(320),
+    sent_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: trust_accounts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.trust_accounts (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    name character varying(255) NOT NULL,
+    type character varying(9) NOT NULL,
+    CONSTRAINT trust_account_type CHECK (((type)::text = ANY ((ARRAY['asset'::character varying, 'liability'::character varying])::text[])))
+);
 
 
 --
@@ -6362,14 +3640,13 @@ ALTER SEQUENCE public.system_telemetry_id_seq OWNED BY public.system_telemetry.i
 --
 
 CREATE TABLE public.trust_balance (
-    id integer NOT NULL,
-    property_id text NOT NULL,
-    owner_funds numeric(15,2) DEFAULT 0 NOT NULL,
-    operating_funds numeric(15,2) DEFAULT 0 NOT NULL,
-    escrow_funds numeric(15,2) DEFAULT 0 NOT NULL,
-    security_deps numeric(15,2) DEFAULT 0 NOT NULL,
-    last_entry_id integer,
-    last_updated timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+    id bigint NOT NULL,
+    property_id character varying(100) NOT NULL,
+    owner_funds numeric(12,2) DEFAULT 0 NOT NULL,
+    operating_funds numeric(12,2) DEFAULT 0 NOT NULL,
+    escrow_funds numeric(12,2) DEFAULT 0 NOT NULL,
+    security_deps numeric(12,2) DEFAULT 0 NOT NULL,
+    last_updated timestamp with time zone DEFAULT now() NOT NULL
 );
 
 
@@ -6378,7 +3655,6 @@ CREATE TABLE public.trust_balance (
 --
 
 CREATE SEQUENCE public.trust_balance_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6394,722 +3670,304 @@ ALTER SEQUENCE public.trust_balance_id_seq OWNED BY public.trust_balance.id;
 
 
 --
--- Name: v_property_lifecycle; Type: VIEW; Schema: public; Owner: -
+-- Name: trust_decisions; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE VIEW public.v_property_lifecycle AS
- SELECT op.property_id,
-    op.name AS display_name,
-    op.bedrooms,
-    op.max_occupants,
-    op.city,
-    op.streamline_id,
-    op.status_name AS ops_status,
-    p.management_status,
-    p.launch_date,
-    p.cost_basis,
-    p.current_value,
-        CASE
-            WHEN ((p.management_status)::text = 'retired'::text) THEN 'RETIRED'::text
-            WHEN (op.status_name = 'Retired'::text) THEN 'ORPHAN'::text
-            WHEN ((p.launch_date IS NOT NULL) AND (p.launch_date > (CURRENT_DATE - '90 days'::interval))) THEN 'RAMP_UP'::text
-            ELSE 'MATURE'::text
-        END AS lifecycle_stage,
-    (COALESCE(r.forecast_revenue, (0)::numeric))::numeric(12,2) AS forecast_revenue,
-    (COALESCE(r.avg_nightly, (0)::numeric))::numeric(10,2) AS avg_nightly_rate,
-    COALESCE(r.entry_count, (0)::bigint) AS rate_entries,
-    COALESCE(t.open_tasks, (0)::bigint) AS open_tasks,
-    COALESCE(t.urgent_tasks, (0)::bigint) AS urgent_tasks,
-    COALESCE(t.overdue_tasks, (0)::bigint) AS overdue_tasks,
-    t.next_deadline
-   FROM (((public.ops_properties op
-     LEFT JOIN public.properties p ON ((p.streamline_id = op.streamline_id)))
-     LEFT JOIN ( SELECT revenue_ledger.cabin_name,
-            sum(revenue_ledger.adjusted_rate) AS forecast_revenue,
-            avg(revenue_ledger.adjusted_rate) AS avg_nightly,
-            count(*) AS entry_count
-           FROM public.revenue_ledger
-          GROUP BY revenue_ledger.cabin_name) r ON ((r.cabin_name = (op.property_id)::text)))
-     LEFT JOIN ( SELECT ops_tasks.property_id,
-            count(*) AS open_tasks,
-            count(*) FILTER (WHERE ((ops_tasks.priority)::text = 'URGENT'::text)) AS urgent_tasks,
-            count(*) FILTER (WHERE (ops_tasks.deadline < now())) AS overdue_tasks,
-            min(ops_tasks.deadline) AS next_deadline
-           FROM public.ops_tasks
-          WHERE ((ops_tasks.status)::text = 'OPEN'::text)
-          GROUP BY ops_tasks.property_id) t ON (((t.property_id)::text = (op.property_id)::text)));
-
-
---
--- Name: v_comp_dashboard; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public.v_comp_dashboard AS
- SELECT ( SELECT (COALESCE(sum(rl.adjusted_rate), (0)::numeric))::numeric(12,2) AS "coalesce"
-           FROM public.revenue_ledger rl
-          WHERE (EXISTS ( SELECT 1
-                   FROM public.ops_properties op
-                  WHERE (((op.property_id)::text = rl.cabin_name) AND (op.status_name = 'Active'::text))))) AS forecast_revenue,
-    ( SELECT (avg(rl.adjusted_rate))::numeric(10,2) AS avg
-           FROM public.revenue_ledger rl
-          WHERE (EXISTS ( SELECT 1
-                   FROM public.ops_properties op
-                  WHERE (((op.property_id)::text = rl.cabin_name) AND (op.status_name = 'Active'::text))))) AS avg_nightly_rate,
-    ( SELECT count(DISTINCT rl.cabin_name) AS count
-           FROM public.revenue_ledger rl
-          WHERE (EXISTS ( SELECT 1
-                   FROM public.ops_properties op
-                  WHERE (((op.property_id)::text = rl.cabin_name) AND (op.status_name = 'Active'::text))))) AS active_cabins,
-    ( SELECT count(*) AS count
-           FROM public.v_property_lifecycle
-          WHERE (v_property_lifecycle.lifecycle_stage = 'RAMP_UP'::text)) AS cabins_in_ramp_up,
-    ( SELECT (COALESCE(sum(fi.amount), (0)::numeric))::numeric(14,2) AS "coalesce"
-           FROM (public.finance_invoices fi
-             JOIN finance.vendor_classifications vc ON ((fi.vendor ~~ vc.vendor_pattern)))
-          WHERE (vc.classification = 'REAL_BUSINESS'::text)) AS real_business_expenses,
-    ( SELECT (COALESCE(sum(fi.amount), (0)::numeric))::numeric(14,2) AS "coalesce"
-           FROM (public.finance_invoices fi
-             JOIN finance.vendor_classifications vc ON ((fi.vendor ~~ vc.vendor_pattern)))
-          WHERE (vc.classification = ANY (ARRAY['NOISE'::text, 'FAMILY_INTERNAL'::text, 'CROG_INTERNAL'::text]))) AS excluded_noise_total,
-    ( SELECT (COALESCE(sum(fi.amount), (0)::numeric))::numeric(14,2) AS "coalesce"
-           FROM (public.finance_invoices fi
-             LEFT JOIN finance.vendor_classifications vc ON ((fi.vendor ~~ vc.vendor_pattern)))
-          WHERE (vc.classification IS NULL)) AS unclassified_total,
-    ( SELECT (COALESCE(sum(
-                CASE
-                    WHEN (transactions.amount > (0)::numeric) THEN transactions.amount
-                    ELSE (0)::numeric
-                END), (0)::numeric))::numeric(12,2) AS "coalesce"
-           FROM division_a.transactions) AS ledger_credits,
-    ( SELECT (COALESCE(sum(
-                CASE
-                    WHEN (transactions.amount < (0)::numeric) THEN abs(transactions.amount)
-                    ELSE (0)::numeric
-                END), (0)::numeric))::numeric(12,2) AS "coalesce"
-           FROM division_a.transactions) AS ledger_debits,
-    (( SELECT (COALESCE(sum(rl.adjusted_rate), (0)::numeric))::numeric(12,2) AS "coalesce"
-           FROM public.revenue_ledger rl
-          WHERE (EXISTS ( SELECT 1
-                   FROM public.ops_properties op
-                  WHERE (((op.property_id)::text = rl.cabin_name) AND (op.status_name = 'Active'::text))))) + ( SELECT (COALESCE(sum(transactions.amount), (0)::numeric))::numeric(12,2) AS "coalesce"
-           FROM division_a.transactions)) AS corrected_revenue,
-    ( SELECT (COALESCE(sum(rl.adjusted_rate), (0)::numeric))::numeric(12,2) AS "coalesce"
-           FROM public.revenue_ledger rl
-          WHERE (NOT (EXISTS ( SELECT 1
-                   FROM public.ops_properties op
-                  WHERE (((op.property_id)::text = rl.cabin_name) AND (op.status_name = 'Active'::text)))))) AS excluded_retired_revenue,
-    now() AS report_timestamp,
-    'TITAN-R1-671B v2 (2026-02-13)'::text AS classified_by;
-
-
---
--- Name: v_financial_summary; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public.v_financial_summary AS
- WITH forecast AS (
-         SELECT 'FORECAST'::text AS source,
-            revenue_ledger.cabin_name AS entity,
-            revenue_ledger.target_date AS entry_date,
-            revenue_ledger.adjusted_rate AS amount,
-            revenue_ledger.trading_signal AS category,
-            revenue_ledger.run_id AS reference,
-            'Pricing engine forecast rate'::text AS description
-           FROM public.revenue_ledger
-        ), invoices AS (
-         SELECT 'INVOICE'::text AS source,
-            fi.vendor AS entity,
-            fi.date AS entry_date,
-            fi.amount,
-            COALESCE(fi.category, 'Uncategorized'::text) AS category,
-            ('INV-'::text || (fi.id)::text) AS reference,
-                CASE
-                    WHEN (vc.classification IS NOT NULL) THEN (('['::text || vc.classification) || '] Email-extracted invoice'::text)
-                    ELSE 'Email-extracted invoice (UNCLASSIFIED)'::text
-                END AS description
-           FROM (public.finance_invoices fi
-             LEFT JOIN finance.vendor_classifications vc ON ((fi.vendor ~~ vc.vendor_pattern)))
-          WHERE ((vc.classification IS NULL) OR (vc.classification = 'REAL_BUSINESS'::text) OR (vc.classification = 'UNKNOWN'::text))
-        ), transactions AS (
-         SELECT 'LEDGER'::text AS source,
-            transactions.vendor AS entity,
-            transactions.date AS entry_date,
-            transactions.amount,
-            COALESCE(transactions.category, 'Uncategorized'::text) AS category,
-            ('TXN-'::text || (transactions.id)::text) AS reference,
-            COALESCE(transactions.reasoning, 'Double-entry transaction'::text) AS description
-           FROM division_a.transactions
-        )
- SELECT forecast.source,
-    forecast.entity,
-    forecast.entry_date,
-    forecast.amount,
-    forecast.category,
-    forecast.reference,
-    forecast.description
-   FROM forecast
-UNION ALL
- SELECT invoices.source,
-    invoices.entity,
-    invoices.entry_date,
-    invoices.amount,
-    invoices.category,
-    invoices.reference,
-    invoices.description
-   FROM invoices
-UNION ALL
- SELECT transactions.source,
-    transactions.entity,
-    transactions.entry_date,
-    transactions.amount,
-    transactions.category,
-    transactions.reference,
-    transactions.description
-   FROM transactions;
-
-
---
--- Name: v_journal_detail; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public.v_journal_detail AS
- SELECT je.id AS entry_id,
-    je.entry_date,
-    je.description,
-    je.reference_id,
-    je.reference_type,
-    je.property_id,
-    je.posted_by,
-    je.source_system,
-    je.is_void,
-    jli.id AS line_id,
-    a.code AS account_code,
-    a.name AS account_name,
-    a.account_type,
-    jli.debit,
-    jli.credit,
-    jli.memo,
-    je.created_at
-   FROM ((public.journal_entries je
-     JOIN public.journal_line_items jli ON ((jli.journal_entry_id = je.id)))
-     JOIN public.accounts a ON ((a.id = jli.account_id)))
-  ORDER BY je.entry_date DESC, je.id, jli.id;
-
-
---
--- Name: v_trial_balance; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public.v_trial_balance AS
- SELECT a.id AS account_id,
-    a.code,
-    a.name AS account_name,
-    a.account_type,
-    a.normal_balance,
-    COALESCE(sum(jli.debit), (0)::numeric) AS total_debits,
-    COALESCE(sum(jli.credit), (0)::numeric) AS total_credits,
-    (COALESCE(sum(jli.debit), (0)::numeric) - COALESCE(sum(jli.credit), (0)::numeric)) AS net_balance
-   FROM ((public.accounts a
-     LEFT JOIN public.journal_line_items jli ON ((jli.account_id = a.id)))
-     LEFT JOIN public.journal_entries je ON (((je.id = jli.journal_entry_id) AND (je.is_void = false))))
-  WHERE (a.is_active = true)
-  GROUP BY a.id, a.code, a.name, a.account_type, a.normal_balance
-  ORDER BY a.code;
-
-
---
--- Name: v_trust_summary; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public.v_trust_summary AS
- SELECT property_id,
-    owner_funds,
-    operating_funds,
-    escrow_funds,
-    security_deps,
-    (((owner_funds + operating_funds) + escrow_funds) + security_deps) AS total_funds,
-    last_updated
-   FROM public.trust_balance
-  ORDER BY property_id;
-
-
---
--- Name: vault_alpha_state_law; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.vault_alpha_state_law (
-    id integer NOT NULL,
-    code_section text NOT NULL,
-    statute_text text NOT NULL,
-    embedding public.vector(768),
-    text_search tsvector GENERATED ALWAYS AS (to_tsvector('english'::regconfig, statute_text)) STORED,
-    title text,
-    metadata jsonb DEFAULT '{}'::jsonb,
-    inserted_at timestamp with time zone DEFAULT now()
+CREATE TABLE public.trust_decisions (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    run_id uuid NOT NULL,
+    proposed_payload jsonb NOT NULL,
+    deterministic_score double precision NOT NULL,
+    policy_evaluation jsonb NOT NULL,
+    status character varying(13) NOT NULL,
+    CONSTRAINT ck_trust_decisions_deterministic_score_nonnegative CHECK ((deterministic_score >= (0)::double precision)),
+    CONSTRAINT trust_decision_status CHECK (((status)::text = ANY ((ARRAY['auto_approved'::character varying, 'escalated'::character varying, 'blocked'::character varying])::text[])))
 );
 
 
 --
--- Name: vault_alpha_state_law_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: trust_ledger_entries; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.vault_alpha_state_law_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: vault_alpha_state_law_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.vault_alpha_state_law_id_seq OWNED BY public.vault_alpha_state_law.id;
-
-
---
--- Name: vault_beta_federal_law; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.vault_beta_federal_law (
-    id integer NOT NULL,
-    title_chapter_section text NOT NULL,
-    statute_text text NOT NULL,
-    embedding public.vector(768),
-    text_search tsvector GENERATED ALWAYS AS (to_tsvector('english'::regconfig, statute_text)) STORED,
-    title text,
-    metadata jsonb DEFAULT '{}'::jsonb,
-    inserted_at timestamp with time zone DEFAULT now()
+CREATE TABLE public.trust_ledger_entries (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    transaction_id uuid NOT NULL,
+    account_id uuid NOT NULL,
+    amount_cents integer NOT NULL,
+    entry_type character varying(6) NOT NULL,
+    CONSTRAINT ck_trust_ledger_entries_amount_positive CHECK ((amount_cents > 0)),
+    CONSTRAINT trust_ledger_entry_type CHECK (((entry_type)::text = ANY ((ARRAY['debit'::character varying, 'credit'::character varying])::text[])))
 );
 
 
 --
--- Name: vault_beta_federal_law_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: trust_transactions; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.vault_beta_federal_law_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: vault_beta_federal_law_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.vault_beta_federal_law_id_seq OWNED BY public.vault_beta_federal_law.id;
-
-
---
--- Name: vault_delta; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.vault_delta (
-    id integer NOT NULL,
-    citation character varying(100) NOT NULL,
-    case_name text NOT NULL,
-    court character varying(150),
-    date_decided date,
-    docket_number character varying(100),
-    opinion_type character varying(30),
-    author character varying(150),
-    chunk_index integer NOT NULL,
-    chunk_text text NOT NULL,
-    embedding public.vector(768),
-    source_file character varying(255),
-    topics text[],
-    created_at timestamp without time zone DEFAULT now(),
-    text_search tsvector GENERATED ALWAYS AS (to_tsvector('english'::regconfig, ((((COALESCE(chunk_text, ''::text) || ' '::text) || COALESCE(case_name, ''::text)) || ' '::text) || (COALESCE(citation, ''::character varying))::text))) STORED
+CREATE TABLE public.trust_transactions (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    streamline_event_id character varying(255) NOT NULL,
+    decision_id uuid,
+    "timestamp" timestamp with time zone DEFAULT now() NOT NULL,
+    signature character varying(64),
+    previous_signature character varying(64)
 );
 
 
 --
--- Name: vault_delta_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: utility_readings; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.vault_delta_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: vault_delta_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.vault_delta_id_seq OWNED BY public.vault_delta.id;
-
-
---
--- Name: vault_gamma_evidence; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.vault_gamma_evidence (
-    id integer NOT NULL,
-    file_hash text NOT NULL,
-    file_path text NOT NULL,
-    metadata jsonb,
-    raw_text text NOT NULL,
-    embedding public.vector(768),
-    text_search tsvector GENERATED ALWAYS AS (to_tsvector('english'::regconfig, raw_text)) STORED,
-    doc_type text,
-    parties text[],
-    date_authored date,
-    inserted_at timestamp with time zone DEFAULT now()
+CREATE TABLE public.utility_readings (
+    id uuid NOT NULL,
+    utility_id uuid NOT NULL,
+    reading_date date NOT NULL,
+    cost numeric(10,2) NOT NULL,
+    usage_amount numeric(12,4),
+    usage_unit character varying(30),
+    notes text,
+    created_at timestamp without time zone
 );
 
 
 --
--- Name: vault_gamma_evidence_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: v_labeling_stats; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.vault_gamma_evidence_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
+CREATE VIEW public.v_labeling_stats AS
+ SELECT date((created_at AT TIME ZONE 'America/New_York'::text)) AS label_date,
+    task_type,
+    count(*) AS total_labeled,
+    count(*) FILTER (WHERE ((godhead_decision)::text = 'confident'::text)) AS confident_count,
+    count(*) FILTER (WHERE ((godhead_decision)::text = 'uncertain'::text)) AS uncertain_count,
+    count(*) FILTER (WHERE ((godhead_decision)::text = 'escalate'::text)) AS escalate_count,
+    count(*) FILTER (WHERE ((godhead_decision)::text = 'skip'::text)) AS skip_count,
+    COALESCE(sum(godhead_cost_usd), (0)::numeric) AS total_cost_usd,
+    count(*) FILTER (WHERE (qc_sampled = true)) AS qc_sampled_count,
+    count(*) FILTER (WHERE (qc_reviewed_at IS NOT NULL)) AS qc_reviewed_count
+   FROM public.capture_labels
+  GROUP BY (date((created_at AT TIME ZONE 'America/New_York'::text))), task_type;
 
 
 --
--- Name: vault_gamma_evidence_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+-- Name: v_qc_queue; Type: VIEW; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.vault_gamma_evidence_id_seq OWNED BY public.vault_gamma_evidence.id;
+CREATE VIEW public.v_qc_queue AS
+ SELECT id,
+    created_at,
+    task_type,
+    capture_table,
+    godhead_model,
+    godhead_decision,
+    godhead_reasoning,
+    godhead_cost_usd,
+    COALESCE(( SELECT tc.user_prompt
+           FROM public.llm_training_captures tc
+          WHERE (tc.id = cl.capture_id)), ( SELECT rc.prompt
+           FROM public.restricted_captures rc
+          WHERE (rc.id = cl.capture_id))) AS user_prompt,
+    COALESCE(( SELECT tc.assistant_resp
+           FROM public.llm_training_captures tc
+          WHERE (tc.id = cl.capture_id)), ( SELECT rc.response
+           FROM public.restricted_captures rc
+          WHERE (rc.id = cl.capture_id))) AS assistant_resp,
+    COALESCE(( SELECT tc.source_module
+           FROM public.llm_training_captures tc
+          WHERE (tc.id = cl.capture_id)), ( SELECT rc.source_module
+           FROM public.restricted_captures rc
+          WHERE (rc.id = cl.capture_id))) AS source_module
+   FROM public.capture_labels cl
+  WHERE ((qc_sampled = true) AND (qc_reviewed_at IS NULL))
+  ORDER BY created_at DESC;
 
 
 --
--- Name: vision_runs; Type: TABLE; Schema: public; Owner: -
+-- Name: vault_audit_logs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.vision_runs (
-    run_id integer NOT NULL,
-    scan_path text NOT NULL,
-    model_used character varying(100),
-    images_found integer DEFAULT 0,
-    images_processed integer DEFAULT 0,
-    images_failed integer DEFAULT 0,
-    images_skipped integer DEFAULT 0,
-    started_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    completed_at timestamp without time zone,
-    status character varying(20) DEFAULT 'RUNNING'::character varying
+CREATE TABLE public.vault_audit_logs (
+    id uuid NOT NULL,
+    user_id character varying(255) NOT NULL,
+    user_email character varying(255),
+    action character varying(50) NOT NULL,
+    query_text text NOT NULL,
+    filters_applied jsonb NOT NULL,
+    result_count integer NOT NULL,
+    top_score character varying(10),
+    ip_address character varying(45),
+    user_agent text,
+    created_at timestamp without time zone NOT NULL
 );
 
 
 --
--- Name: vision_runs_run_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.vision_runs_run_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: vision_runs_run_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.vision_runs_run_id_seq OWNED BY public.vision_runs.run_id;
-
-
---
--- Name: account_mappings id; Type: DEFAULT; Schema: division_a; Owner: -
---
-
-ALTER TABLE ONLY division_a.account_mappings ALTER COLUMN id SET DEFAULT nextval('division_a.account_mappings_id_seq'::regclass);
-
-
---
--- Name: audit_log id; Type: DEFAULT; Schema: division_a; Owner: -
---
-
-ALTER TABLE ONLY division_a.audit_log ALTER COLUMN id SET DEFAULT nextval('division_a.audit_log_id_seq'::regclass);
-
-
---
--- Name: chart_of_accounts id; Type: DEFAULT; Schema: division_a; Owner: -
---
-
-ALTER TABLE ONLY division_a.chart_of_accounts ALTER COLUMN id SET DEFAULT nextval('division_a.chart_of_accounts_id_seq'::regclass);
-
-
---
--- Name: general_ledger id; Type: DEFAULT; Schema: division_a; Owner: -
---
-
-ALTER TABLE ONLY division_a.general_ledger ALTER COLUMN id SET DEFAULT nextval('division_a.general_ledger_id_seq'::regclass);
-
-
---
--- Name: journal_entries id; Type: DEFAULT; Schema: division_a; Owner: -
---
-
-ALTER TABLE ONLY division_a.journal_entries ALTER COLUMN id SET DEFAULT nextval('division_a.journal_entries_id_seq'::regclass);
-
-
---
--- Name: predictions id; Type: DEFAULT; Schema: division_a; Owner: -
---
-
-ALTER TABLE ONLY division_a.predictions ALTER COLUMN id SET DEFAULT nextval('division_a.predictions_id_seq'::regclass);
-
-
---
--- Name: transactions id; Type: DEFAULT; Schema: division_a; Owner: -
---
-
-ALTER TABLE ONLY division_a.transactions ALTER COLUMN id SET DEFAULT nextval('division_a.transactions_id_seq'::regclass);
-
-
---
--- Name: account_mappings id; Type: DEFAULT; Schema: division_b; Owner: -
---
-
-ALTER TABLE ONLY division_b.account_mappings ALTER COLUMN id SET DEFAULT nextval('division_b.account_mappings_id_seq'::regclass);
-
-
---
--- Name: chart_of_accounts id; Type: DEFAULT; Schema: division_b; Owner: -
---
-
-ALTER TABLE ONLY division_b.chart_of_accounts ALTER COLUMN id SET DEFAULT nextval('division_b.chart_of_accounts_id_seq'::regclass);
-
-
---
--- Name: escrow id; Type: DEFAULT; Schema: division_b; Owner: -
---
-
-ALTER TABLE ONLY division_b.escrow ALTER COLUMN id SET DEFAULT nextval('division_b.escrow_id_seq'::regclass);
-
-
---
--- Name: general_ledger id; Type: DEFAULT; Schema: division_b; Owner: -
---
-
-ALTER TABLE ONLY division_b.general_ledger ALTER COLUMN id SET DEFAULT nextval('division_b.general_ledger_id_seq'::regclass);
-
-
---
--- Name: journal_entries id; Type: DEFAULT; Schema: division_b; Owner: -
---
-
-ALTER TABLE ONLY division_b.journal_entries ALTER COLUMN id SET DEFAULT nextval('division_b.journal_entries_id_seq'::regclass);
-
-
---
--- Name: predictions id; Type: DEFAULT; Schema: division_b; Owner: -
---
-
-ALTER TABLE ONLY division_b.predictions ALTER COLUMN id SET DEFAULT nextval('division_b.predictions_id_seq'::regclass);
-
-
---
--- Name: transactions id; Type: DEFAULT; Schema: division_b; Owner: -
---
-
-ALTER TABLE ONLY division_b.transactions ALTER COLUMN id SET DEFAULT nextval('division_b.transactions_id_seq'::regclass);
-
-
---
--- Name: trust_ledger id; Type: DEFAULT; Schema: division_b; Owner: -
---
-
-ALTER TABLE ONLY division_b.trust_ledger ALTER COLUMN id SET DEFAULT nextval('division_b.trust_ledger_id_seq'::regclass);
-
-
---
--- Name: vendor_payouts id; Type: DEFAULT; Schema: division_b; Owner: -
---
-
-ALTER TABLE ONLY division_b.vendor_payouts ALTER COLUMN id SET DEFAULT nextval('division_b.vendor_payouts_id_seq'::regclass);
-
-
---
--- Name: change_orders id; Type: DEFAULT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.change_orders ALTER COLUMN id SET DEFAULT nextval('engineering.change_orders_id_seq'::regclass);
-
-
---
--- Name: compliance_log id; Type: DEFAULT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.compliance_log ALTER COLUMN id SET DEFAULT nextval('engineering.compliance_log_id_seq'::regclass);
-
-
---
--- Name: cost_estimates id; Type: DEFAULT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.cost_estimates ALTER COLUMN id SET DEFAULT nextval('engineering.cost_estimates_id_seq'::regclass);
-
-
---
--- Name: drawings id; Type: DEFAULT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.drawings ALTER COLUMN id SET DEFAULT nextval('engineering.drawings_id_seq'::regclass);
-
-
---
--- Name: inspections id; Type: DEFAULT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.inspections ALTER COLUMN id SET DEFAULT nextval('engineering.inspections_id_seq'::regclass);
-
-
---
--- Name: mep_systems id; Type: DEFAULT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.mep_systems ALTER COLUMN id SET DEFAULT nextval('engineering.mep_systems_id_seq'::regclass);
-
-
---
--- Name: permits id; Type: DEFAULT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.permits ALTER COLUMN id SET DEFAULT nextval('engineering.permits_id_seq'::regclass);
-
-
---
--- Name: projects id; Type: DEFAULT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.projects ALTER COLUMN id SET DEFAULT nextval('engineering.projects_id_seq'::regclass);
-
-
---
--- Name: punch_items id; Type: DEFAULT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.punch_items ALTER COLUMN id SET DEFAULT nextval('engineering.punch_items_id_seq'::regclass);
-
-
---
--- Name: rfis id; Type: DEFAULT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.rfis ALTER COLUMN id SET DEFAULT nextval('engineering.rfis_id_seq'::regclass);
-
-
---
--- Name: submittals id; Type: DEFAULT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.submittals ALTER COLUMN id SET DEFAULT nextval('engineering.submittals_id_seq'::regclass);
-
-
---
--- Name: classification_rules id; Type: DEFAULT; Schema: finance; Owner: -
---
-
-ALTER TABLE ONLY finance.classification_rules ALTER COLUMN id SET DEFAULT nextval('finance.classification_rules_id_seq'::regclass);
-
-
---
--- Name: vendor_classifications id; Type: DEFAULT; Schema: finance; Owner: -
---
-
-ALTER TABLE ONLY finance.vendor_classifications ALTER COLUMN id SET DEFAULT nextval('finance.vendor_classifications_id_seq'::regclass);
-
-
---
--- Name: active_strategies id; Type: DEFAULT; Schema: hedge_fund; Owner: -
---
-
-ALTER TABLE ONLY hedge_fund.active_strategies ALTER COLUMN id SET DEFAULT nextval('hedge_fund.active_strategies_id_seq'::regclass);
-
-
---
--- Name: extraction_log id; Type: DEFAULT; Schema: hedge_fund; Owner: -
---
-
-ALTER TABLE ONLY hedge_fund.extraction_log ALTER COLUMN id SET DEFAULT nextval('hedge_fund.extraction_log_id_seq'::regclass);
-
-
---
--- Name: market_signals id; Type: DEFAULT; Schema: hedge_fund; Owner: -
---
-
-ALTER TABLE ONLY hedge_fund.market_signals ALTER COLUMN id SET DEFAULT nextval('hedge_fund.market_signals_id_seq'::regclass);
-
-
---
--- Name: watchlist id; Type: DEFAULT; Schema: hedge_fund; Owner: -
---
-
-ALTER TABLE ONLY hedge_fund.watchlist ALTER COLUMN id SET DEFAULT nextval('hedge_fund.watchlist_id_seq'::regclass);
+-- Name: vendors; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.vendors (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    name character varying(200) NOT NULL,
+    trade character varying(80),
+    phone character varying(40),
+    email character varying(255),
+    insurance_expiry date,
+    active boolean DEFAULT true NOT NULL,
+    hourly_rate numeric(8,2),
+    regions jsonb DEFAULT '[]'::jsonb NOT NULL,
+    notes text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: vrs_add_ons; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.vrs_add_ons (
+    id uuid NOT NULL,
+    name character varying(255) NOT NULL,
+    description text NOT NULL,
+    price numeric(12,2) NOT NULL,
+    pricing_model character varying(9) NOT NULL,
+    is_active boolean NOT NULL,
+    scope character varying(17) NOT NULL,
+    property_id uuid,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    CONSTRAINT ck_vrs_add_ons_price_nonnegative CHECK ((price >= (0)::numeric)),
+    CONSTRAINT ck_vrs_add_ons_scope_property_consistency CHECK (((((scope)::text = 'global'::text) AND (property_id IS NULL)) OR (((scope)::text = 'property_specific'::text) AND (property_id IS NOT NULL)))),
+    CONSTRAINT vrs_add_on_pricing_model CHECK (((pricing_model)::text = ANY ((ARRAY['flat_fee'::character varying, 'per_night'::character varying, 'per_guest'::character varying])::text[]))),
+    CONSTRAINT vrs_add_on_scope CHECK (((scope)::text = ANY ((ARRAY['global'::character varying, 'property_specific'::character varying])::text[])))
+);
 
 
 --
--- Name: entities id; Type: DEFAULT; Schema: intelligence; Owner: -
+-- Name: vrs_automation_events; Type: TABLE; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY intelligence.entities ALTER COLUMN id SET DEFAULT nextval('intelligence.entities_id_seq'::regclass);
+CREATE TABLE public.vrs_automation_events (
+    id uuid NOT NULL,
+    rule_id uuid,
+    entity_type character varying(50) NOT NULL,
+    entity_id character varying(100) NOT NULL,
+    event_type character varying(50) NOT NULL,
+    previous_state jsonb DEFAULT '{}'::jsonb NOT NULL,
+    current_state jsonb DEFAULT '{}'::jsonb NOT NULL,
+    action_result character varying(20),
+    error_detail text,
+    created_at timestamp without time zone
+);
 
 
 --
--- Name: golden_reasoning id; Type: DEFAULT; Schema: intelligence; Owner: -
+-- Name: vrs_automations; Type: TABLE; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY intelligence.golden_reasoning ALTER COLUMN id SET DEFAULT nextval('intelligence.golden_reasoning_id_seq'::regclass);
+CREATE TABLE public.vrs_automations (
+    id uuid NOT NULL,
+    name character varying(255) NOT NULL,
+    target_entity character varying(50) NOT NULL,
+    trigger_event character varying(50) NOT NULL,
+    conditions jsonb DEFAULT '{}'::jsonb NOT NULL,
+    action_type character varying(50) NOT NULL,
+    action_payload jsonb DEFAULT '{}'::jsonb NOT NULL,
+    is_active boolean DEFAULT true NOT NULL,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
+);
 
 
 --
--- Name: relationships id; Type: DEFAULT; Schema: intelligence; Owner: -
+-- Name: work_orders; Type: TABLE; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY intelligence.relationships ALTER COLUMN id SET DEFAULT nextval('intelligence.relationships_id_seq'::regclass);
+CREATE TABLE public.work_orders (
+    id uuid NOT NULL,
+    ticket_number character varying(50) NOT NULL,
+    property_id uuid NOT NULL,
+    reservation_id uuid,
+    guest_id uuid,
+    reported_via_message_id uuid,
+    title character varying(255) NOT NULL,
+    description text NOT NULL,
+    category character varying(50) NOT NULL,
+    priority character varying(20) NOT NULL,
+    status character varying(50) NOT NULL,
+    assigned_to character varying(255),
+    assigned_at timestamp without time zone,
+    resolved_at timestamp without time zone,
+    resolution_notes text,
+    cost_amount numeric(10,2),
+    photo_urls character varying[],
+    qdrant_point_id uuid,
+    created_by character varying(100),
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone,
+    legacy_assigned_to character varying(255),
+    assigned_vendor_id uuid
+);
 
 
 --
--- Name: titan_traces id; Type: DEFAULT; Schema: intelligence; Owner: -
+-- Name: yield_overrides; Type: TABLE; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY intelligence.titan_traces ALTER COLUMN id SET DEFAULT nextval('intelligence.titan_traces_id_seq'::regclass);
+CREATE TABLE public.yield_overrides (
+    id uuid NOT NULL,
+    property_id uuid NOT NULL,
+    reason character varying(255) NOT NULL,
+    override_payload jsonb NOT NULL,
+    created_by character varying(120) NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
 
 
 --
--- Name: case_actions id; Type: DEFAULT; Schema: legal; Owner: -
+-- Name: yield_simulations; Type: TABLE; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY legal.case_actions ALTER COLUMN id SET DEFAULT nextval('legal.case_actions_id_seq'::regclass);
+CREATE TABLE public.yield_simulations (
+    id uuid NOT NULL,
+    property_id uuid NOT NULL,
+    assumptions jsonb NOT NULL,
+    simulated_revenue numeric(12,2) NOT NULL,
+    simulated_margin numeric(12,2) NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
 
 
 --
--- Name: case_evidence id; Type: DEFAULT; Schema: legal; Owner: -
+-- Name: products; Type: TABLE; Schema: verses_schema; Owner: -
 --
 
-ALTER TABLE ONLY legal.case_evidence ALTER COLUMN id SET DEFAULT nextval('legal.case_evidence_id_seq'::regclass);
+CREATE TABLE verses_schema.products (
+    id uuid NOT NULL,
+    sku character varying(50) NOT NULL,
+    title character varying(255) NOT NULL,
+    seo_description text,
+    typography_metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
+    image_metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
+    stock_level integer,
+    status character varying(30),
+    created_at timestamp with time zone DEFAULT now(),
+    updated_at timestamp with time zone DEFAULT now()
+);
 
 
 --
--- Name: case_precedents id; Type: DEFAULT; Schema: legal; Owner: -
+-- Name: ai_audit_ledger id; Type: DEFAULT; Schema: legal; Owner: -
 --
 
-ALTER TABLE ONLY legal.case_precedents ALTER COLUMN id SET DEFAULT nextval('legal.case_precedents_id_seq'::regclass);
+ALTER TABLE ONLY legal.ai_audit_ledger ALTER COLUMN id SET DEFAULT nextval('legal.ai_audit_ledger_id_seq'::regclass);
 
 
 --
--- Name: case_watchdog id; Type: DEFAULT; Schema: legal; Owner: -
+-- Name: case_statements id; Type: DEFAULT; Schema: legal; Owner: -
 --
 
-ALTER TABLE ONLY legal.case_watchdog ALTER COLUMN id SET DEFAULT nextval('legal.case_watchdog_id_seq'::regclass);
+ALTER TABLE ONLY legal.case_statements ALTER COLUMN id SET DEFAULT nextval('legal.case_statements_id_seq'::regclass);
 
 
 --
@@ -7120,73 +3978,10 @@ ALTER TABLE ONLY legal.cases ALTER COLUMN id SET DEFAULT nextval('legal.cases_id
 
 
 --
--- Name: correspondence id; Type: DEFAULT; Schema: legal; Owner: -
+-- Name: vault_documents id; Type: DEFAULT; Schema: legal; Owner: -
 --
 
-ALTER TABLE ONLY legal.correspondence ALTER COLUMN id SET DEFAULT nextval('legal.correspondence_id_seq'::regclass);
-
-
---
--- Name: deadlines id; Type: DEFAULT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.deadlines ALTER COLUMN id SET DEFAULT nextval('legal.deadlines_id_seq'::regclass);
-
-
---
--- Name: email_intake_queue id; Type: DEFAULT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.email_intake_queue ALTER COLUMN id SET DEFAULT nextval('legal.email_intake_queue_id_seq'::regclass);
-
-
---
--- Name: expense_intake id; Type: DEFAULT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.expense_intake ALTER COLUMN id SET DEFAULT nextval('legal.expense_intake_id_seq'::regclass);
-
-
---
--- Name: filings id; Type: DEFAULT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.filings ALTER COLUMN id SET DEFAULT nextval('legal.filings_id_seq'::regclass);
-
-
---
--- Name: timeline_events id; Type: DEFAULT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.timeline_events ALTER COLUMN id SET DEFAULT nextval('legal.timeline_events_id_seq'::regclass);
-
-
---
--- Name: uploads id; Type: DEFAULT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.uploads ALTER COLUMN id SET DEFAULT nextval('legal.uploads_id_seq'::regclass);
-
-
---
--- Name: attorney_scoring id; Type: DEFAULT; Schema: legal_cmd; Owner: -
---
-
-ALTER TABLE ONLY legal_cmd.attorney_scoring ALTER COLUMN id SET DEFAULT nextval('legal_cmd.attorney_scoring_id_seq'::regclass);
-
-
---
--- Name: ab_test_observations id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ab_test_observations ALTER COLUMN id SET DEFAULT nextval('public.ab_test_observations_id_seq'::regclass);
-
-
---
--- Name: ab_tests id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ab_tests ALTER COLUMN id SET DEFAULT nextval('public.ab_tests_id_seq'::regclass);
+ALTER TABLE ONLY legal.vault_documents ALTER COLUMN id SET DEFAULT nextval('legal.vault_documents_id_seq'::regclass);
 
 
 --
@@ -7197,87 +3992,10 @@ ALTER TABLE ONLY public.accounts ALTER COLUMN id SET DEFAULT nextval('public.acc
 
 
 --
--- Name: active_learning_queue id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: capex_staging id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.active_learning_queue ALTER COLUMN id SET DEFAULT nextval('public.active_learning_queue_id_seq'::regclass);
-
-
---
--- Name: agent_learning_log id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.agent_learning_log ALTER COLUMN id SET DEFAULT nextval('public.agent_learning_log_id_seq'::regclass);
-
-
---
--- Name: agent_memory id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.agent_memory ALTER COLUMN id SET DEFAULT nextval('public.agent_memory_id_seq'::regclass);
-
-
---
--- Name: agent_performance_log id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.agent_performance_log ALTER COLUMN id SET DEFAULT nextval('public.agent_performance_log_id_seq'::regclass);
-
-
---
--- Name: agent_response_queue id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.agent_response_queue ALTER COLUMN id SET DEFAULT nextval('public.agent_response_queue_id_seq'::regclass);
-
-
---
--- Name: agent_telemetry id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.agent_telemetry ALTER COLUMN id SET DEFAULT nextval('public.agent_telemetry_id_seq'::regclass);
-
-
---
--- Name: ai_training_labels id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ai_training_labels ALTER COLUMN id SET DEFAULT nextval('public.ai_training_labels_id_seq'::regclass);
-
-
---
--- Name: anomaly_flags id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.anomaly_flags ALTER COLUMN id SET DEFAULT nextval('public.anomaly_flags_id_seq'::regclass);
-
-
---
--- Name: api_key_vault id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.api_key_vault ALTER COLUMN id SET DEFAULT nextval('public.api_key_vault_id_seq'::regclass);
-
-
---
--- Name: asset_docs id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.asset_docs ALTER COLUMN id SET DEFAULT nextval('public.asset_docs_id_seq'::regclass);
-
-
---
--- Name: conversation_threads id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.conversation_threads ALTER COLUMN id SET DEFAULT nextval('public.conversation_threads_id_seq'::regclass);
-
-
---
--- Name: data_sanitizer_log id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.data_sanitizer_log ALTER COLUMN id SET DEFAULT nextval('public.data_sanitizer_log_id_seq'::regclass);
+ALTER TABLE ONLY public.capex_staging ALTER COLUMN id SET DEFAULT nextval('public.capex_staging_id_seq'::regclass);
 
 
 --
@@ -7285,139 +4003,6 @@ ALTER TABLE ONLY public.data_sanitizer_log ALTER COLUMN id SET DEFAULT nextval('
 --
 
 ALTER TABLE ONLY public.deferred_api_writes ALTER COLUMN id SET DEFAULT nextval('public.deferred_api_writes_id_seq'::regclass);
-
-
---
--- Name: email_archive id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.email_archive ALTER COLUMN id SET DEFAULT nextval('public.email_archive_id_seq'::regclass);
-
-
---
--- Name: email_classification_rules id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.email_classification_rules ALTER COLUMN id SET DEFAULT nextval('public.email_classification_rules_id_seq'::regclass);
-
-
---
--- Name: email_dead_letter_queue id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.email_dead_letter_queue ALTER COLUMN id SET DEFAULT nextval('public.email_dead_letter_queue_id_seq'::regclass);
-
-
---
--- Name: email_escalation_queue id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.email_escalation_queue ALTER COLUMN id SET DEFAULT nextval('public.email_escalation_queue_id_seq'::regclass);
-
-
---
--- Name: email_escalation_rules id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.email_escalation_rules ALTER COLUMN id SET DEFAULT nextval('public.email_escalation_rules_id_seq'::regclass);
-
-
---
--- Name: email_intake_review_log id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.email_intake_review_log ALTER COLUMN id SET DEFAULT nextval('public.email_intake_review_log_id_seq'::regclass);
-
-
---
--- Name: email_quarantine id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.email_quarantine ALTER COLUMN id SET DEFAULT nextval('public.email_quarantine_id_seq'::regclass);
-
-
---
--- Name: email_routing_rules id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.email_routing_rules ALTER COLUMN id SET DEFAULT nextval('public.email_routing_rules_id_seq'::regclass);
-
-
---
--- Name: email_triage_precedents id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.email_triage_precedents ALTER COLUMN id SET DEFAULT nextval('public.email_triage_precedents_id_seq'::regclass);
-
-
---
--- Name: fin_revenue_snapshots snapshot_id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.fin_revenue_snapshots ALTER COLUMN snapshot_id SET DEFAULT nextval('public.fin_revenue_snapshots_snapshot_id_seq'::regclass);
-
-
---
--- Name: finance_invoices id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.finance_invoices ALTER COLUMN id SET DEFAULT nextval('public.finance_invoices_id_seq'::regclass);
-
-
---
--- Name: fortress_api_keys id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.fortress_api_keys ALTER COLUMN id SET DEFAULT nextval('public.fortress_api_keys_id_seq'::regclass);
-
-
---
--- Name: fortress_users id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.fortress_users ALTER COLUMN id SET DEFAULT nextval('public.fortress_users_id_seq'::regclass);
-
-
---
--- Name: general_ledger id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.general_ledger ALTER COLUMN id SET DEFAULT nextval('public.general_ledger_id_seq'::regclass);
-
-
---
--- Name: godhead_query_log id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.godhead_query_log ALTER COLUMN id SET DEFAULT nextval('public.godhead_query_log_id_seq'::regclass);
-
-
---
--- Name: guest_leads id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.guest_leads ALTER COLUMN id SET DEFAULT nextval('public.guest_leads_id_seq'::regclass);
-
-
---
--- Name: guest_profiles id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.guest_profiles ALTER COLUMN id SET DEFAULT nextval('public.guest_profiles_id_seq'::regclass);
-
-
---
--- Name: images id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.images ALTER COLUMN id SET DEFAULT nextval('public.images_id_seq'::regclass);
-
-
---
--- Name: ingestion_dlq id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ingestion_dlq ALTER COLUMN id SET DEFAULT nextval('public.ingestion_dlq_id_seq'::regclass);
 
 
 --
@@ -7435,325 +4020,87 @@ ALTER TABLE ONLY public.journal_line_items ALTER COLUMN id SET DEFAULT nextval('
 
 
 --
--- Name: learning_judgments id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: management_splits id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.learning_judgments ALTER COLUMN id SET DEFAULT nextval('public.learning_judgments_id_seq'::regclass);
+ALTER TABLE ONLY public.management_splits ALTER COLUMN id SET DEFAULT nextval('public.management_splits_id_seq'::regclass);
 
 
 --
--- Name: learning_optimizations id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: marketing_attribution id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.learning_optimizations ALTER COLUMN id SET DEFAULT nextval('public.learning_optimizations_id_seq'::regclass);
+ALTER TABLE ONLY public.marketing_attribution ALTER COLUMN id SET DEFAULT nextval('public.marketing_attribution_id_seq'::regclass);
 
 
 --
--- Name: legacy_cdc_event_queue id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: owner_balance_periods id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.legacy_cdc_event_queue ALTER COLUMN id SET DEFAULT nextval('public.legacy_cdc_event_queue_id_seq'::regclass);
+ALTER TABLE ONLY public.owner_balance_periods ALTER COLUMN id SET DEFAULT nextval('public.owner_balance_periods_id_seq'::regclass);
 
 
 --
--- Name: legal_clients client_id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: owner_charges id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.legal_clients ALTER COLUMN client_id SET DEFAULT nextval('public.legal_clients_client_id_seq'::regclass);
+ALTER TABLE ONLY public.owner_charges ALTER COLUMN id SET DEFAULT nextval('public.owner_charges_id_seq'::regclass);
 
 
 --
--- Name: legal_docket doc_id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: owner_magic_tokens id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.legal_docket ALTER COLUMN doc_id SET DEFAULT nextval('public.legal_docket_doc_id_seq'::regclass);
+ALTER TABLE ONLY public.owner_magic_tokens ALTER COLUMN id SET DEFAULT nextval('public.owner_magic_tokens_id_seq'::regclass);
 
 
 --
--- Name: legal_intel id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: owner_marketing_preferences id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.legal_intel ALTER COLUMN id SET DEFAULT nextval('public.legal_intel_id_seq'::regclass);
+ALTER TABLE ONLY public.owner_marketing_preferences ALTER COLUMN id SET DEFAULT nextval('public.owner_marketing_preferences_id_seq'::regclass);
 
 
 --
--- Name: legal_matter_notes note_id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: owner_markup_rules id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.legal_matter_notes ALTER COLUMN note_id SET DEFAULT nextval('public.legal_matter_notes_note_id_seq'::regclass);
+ALTER TABLE ONLY public.owner_markup_rules ALTER COLUMN id SET DEFAULT nextval('public.owner_markup_rules_id_seq'::regclass);
 
 
 --
--- Name: maintenance_log id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: owner_payout_accounts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.maintenance_log ALTER COLUMN id SET DEFAULT nextval('public.maintenance_log_id_seq'::regclass);
+ALTER TABLE ONLY public.owner_payout_accounts ALTER COLUMN id SET DEFAULT nextval('public.owner_payout_accounts_id_seq'::regclass);
 
 
 --
--- Name: market_intel id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: owner_property_map id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.market_intel ALTER COLUMN id SET DEFAULT nextval('public.market_intel_id_seq'::regclass);
+ALTER TABLE ONLY public.owner_property_map ALTER COLUMN id SET DEFAULT nextval('public.owner_property_map_id_seq'::regclass);
 
 
 --
--- Name: market_signals id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: owner_statement_sends id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.market_signals ALTER COLUMN id SET DEFAULT nextval('public.market_signals_id_seq'::regclass);
+ALTER TABLE ONLY public.owner_statement_sends ALTER COLUMN id SET DEFAULT nextval('public.owner_statement_sends_id_seq'::regclass);
 
 
 --
--- Name: message_analytics id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: payout_ledger id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.message_analytics ALTER COLUMN id SET DEFAULT nextval('public.message_analytics_id_seq'::regclass);
+ALTER TABLE ONLY public.payout_ledger ALTER COLUMN id SET DEFAULT nextval('public.payout_ledger_id_seq'::regclass);
 
 
 --
--- Name: message_archive id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: stripe_connect_events id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.message_archive ALTER COLUMN id SET DEFAULT nextval('public.message_archive_id_seq'::regclass);
-
-
---
--- Name: model_telemetry id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.model_telemetry ALTER COLUMN id SET DEFAULT nextval('public.model_telemetry_id_seq'::regclass);
-
-
---
--- Name: nim_arm64_probe_results id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.nim_arm64_probe_results ALTER COLUMN id SET DEFAULT nextval('public.nim_arm64_probe_results_id_seq'::regclass);
-
-
---
--- Name: ops_crew id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ops_crew ALTER COLUMN id SET DEFAULT nextval('public.ops_crew_id_seq'::regclass);
-
-
---
--- Name: ops_historical_guests id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ops_historical_guests ALTER COLUMN id SET DEFAULT nextval('public.ops_historical_guests_id_seq'::regclass);
-
-
---
--- Name: ops_log id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ops_log ALTER COLUMN id SET DEFAULT nextval('public.ops_log_id_seq'::regclass);
-
-
---
--- Name: ops_overrides id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ops_overrides ALTER COLUMN id SET DEFAULT nextval('public.ops_overrides_id_seq'::regclass);
-
-
---
--- Name: ops_tasks id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ops_tasks ALTER COLUMN id SET DEFAULT nextval('public.ops_tasks_id_seq'::regclass);
-
-
---
--- Name: ops_turnovers id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ops_turnovers ALTER COLUMN id SET DEFAULT nextval('public.ops_turnovers_id_seq'::regclass);
-
-
---
--- Name: ops_visuals image_id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ops_visuals ALTER COLUMN image_id SET DEFAULT nextval('public.ops_visuals_image_id_seq'::regclass);
-
-
---
--- Name: pages id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.pages ALTER COLUMN id SET DEFAULT nextval('public.pages_id_seq'::regclass);
-
-
---
--- Name: properties id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.properties ALTER COLUMN id SET DEFAULT nextval('public.properties_id_seq'::regclass);
-
-
---
--- Name: property_events id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.property_events ALTER COLUMN id SET DEFAULT nextval('public.property_events_id_seq'::regclass);
-
-
---
--- Name: property_sms_config id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.property_sms_config ALTER COLUMN id SET DEFAULT nextval('public.property_sms_config_id_seq'::regclass);
-
-
---
--- Name: quarantine_inbox id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.quarantine_inbox ALTER COLUMN id SET DEFAULT nextval('public.quarantine_inbox_id_seq'::regclass);
-
-
---
--- Name: rag_query_feedback id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.rag_query_feedback ALTER COLUMN id SET DEFAULT nextval('public.rag_query_feedback_id_seq'::regclass);
-
-
---
--- Name: real_estate_intel id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.real_estate_intel ALTER COLUMN id SET DEFAULT nextval('public.real_estate_intel_id_seq'::regclass);
-
-
---
--- Name: recursive_trace_log id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.recursive_trace_log ALTER COLUMN id SET DEFAULT nextval('public.recursive_trace_log_id_seq'::regclass);
-
-
---
--- Name: revenue_ledger id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.revenue_ledger ALTER COLUMN id SET DEFAULT nextval('public.revenue_ledger_id_seq'::regclass);
-
-
---
--- Name: ruebarue_area_guide id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ruebarue_area_guide ALTER COLUMN id SET DEFAULT nextval('public.ruebarue_area_guide_id_seq'::regclass);
-
-
---
--- Name: ruebarue_contacts id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ruebarue_contacts ALTER COLUMN id SET DEFAULT nextval('public.ruebarue_contacts_id_seq'::regclass);
-
-
---
--- Name: ruebarue_guests id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ruebarue_guests ALTER COLUMN id SET DEFAULT nextval('public.ruebarue_guests_id_seq'::regclass);
-
-
---
--- Name: ruebarue_knowledge_base id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ruebarue_knowledge_base ALTER COLUMN id SET DEFAULT nextval('public.ruebarue_knowledge_base_id_seq'::regclass);
-
-
---
--- Name: ruebarue_message_templates id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ruebarue_message_templates ALTER COLUMN id SET DEFAULT nextval('public.ruebarue_message_templates_id_seq'::regclass);
-
-
---
--- Name: sales_intel id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.sales_intel ALTER COLUMN id SET DEFAULT nextval('public.sales_intel_id_seq'::regclass);
-
-
---
--- Name: schema_drift_log id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.schema_drift_log ALTER COLUMN id SET DEFAULT nextval('public.schema_drift_log_id_seq'::regclass);
-
-
---
--- Name: sender_registry id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.sender_registry ALTER COLUMN id SET DEFAULT nextval('public.sender_registry_id_seq'::regclass);
-
-
---
--- Name: sentinel_alerts id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.sentinel_alerts ALTER COLUMN id SET DEFAULT nextval('public.sentinel_alerts_id_seq'::regclass);
-
-
---
--- Name: sms_providers id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.sms_providers ALTER COLUMN id SET DEFAULT nextval('public.sms_providers_id_seq'::regclass);
-
-
---
--- Name: sovereign_cycles id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.sovereign_cycles ALTER COLUMN id SET DEFAULT nextval('public.sovereign_cycles_id_seq'::regclass);
-
-
---
--- Name: starred_responses id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.starred_responses ALTER COLUMN id SET DEFAULT nextval('public.starred_responses_id_seq'::regclass);
-
-
---
--- Name: system_directives id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.system_directives ALTER COLUMN id SET DEFAULT nextval('public.system_directives_id_seq'::regclass);
-
-
---
--- Name: system_drift_alerts id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.system_drift_alerts ALTER COLUMN id SET DEFAULT nextval('public.system_drift_alerts_id_seq'::regclass);
-
-
---
--- Name: system_post_mortems id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.system_post_mortems ALTER COLUMN id SET DEFAULT nextval('public.system_post_mortems_id_seq'::regclass);
-
-
---
--- Name: system_telemetry id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.system_telemetry ALTER COLUMN id SET DEFAULT nextval('public.system_telemetry_id_seq'::regclass);
+ALTER TABLE ONLY public.stripe_connect_events ALTER COLUMN id SET DEFAULT nextval('public.stripe_connect_events_id_seq'::regclass);
 
 
 --
@@ -7764,470 +4111,187 @@ ALTER TABLE ONLY public.trust_balance ALTER COLUMN id SET DEFAULT nextval('publi
 
 
 --
--- Name: vault_alpha_state_law id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: deliberation_logs deliberation_logs_pkey; Type: CONSTRAINT; Schema: core; Owner: -
 --
 
-ALTER TABLE ONLY public.vault_alpha_state_law ALTER COLUMN id SET DEFAULT nextval('public.vault_alpha_state_law_id_seq'::regclass);
+ALTER TABLE ONLY core.deliberation_logs
+    ADD CONSTRAINT deliberation_logs_pkey PRIMARY KEY (id);
 
 
 --
--- Name: vault_beta_federal_law id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: acquisition_documents acquisition_documents_pkey; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
 --
 
-ALTER TABLE ONLY public.vault_beta_federal_law ALTER COLUMN id SET DEFAULT nextval('public.vault_beta_federal_law_id_seq'::regclass);
+ALTER TABLE ONLY crog_acquisition.acquisition_documents
+    ADD CONSTRAINT acquisition_documents_pkey PRIMARY KEY (id);
 
 
 --
--- Name: vault_delta id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: acquisition_pipeline acquisition_pipeline_pkey; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
 --
 
-ALTER TABLE ONLY public.vault_delta ALTER COLUMN id SET DEFAULT nextval('public.vault_delta_id_seq'::regclass);
+ALTER TABLE ONLY crog_acquisition.acquisition_pipeline
+    ADD CONSTRAINT acquisition_pipeline_pkey PRIMARY KEY (id);
 
 
 --
--- Name: vault_gamma_evidence id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: due_diligence due_diligence_pkey; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
 --
 
-ALTER TABLE ONLY public.vault_gamma_evidence ALTER COLUMN id SET DEFAULT nextval('public.vault_gamma_evidence_id_seq'::regclass);
+ALTER TABLE ONLY crog_acquisition.due_diligence
+    ADD CONSTRAINT due_diligence_pkey PRIMARY KEY (id);
 
 
 --
--- Name: vision_runs run_id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: intel_events intel_events_pkey; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
 --
 
-ALTER TABLE ONLY public.vision_runs ALTER COLUMN run_id SET DEFAULT nextval('public.vision_runs_run_id_seq'::regclass);
+ALTER TABLE ONLY crog_acquisition.intel_events
+    ADD CONSTRAINT intel_events_pkey PRIMARY KEY (id);
 
 
 --
--- Name: account_mappings account_mappings_pkey; Type: CONSTRAINT; Schema: division_a; Owner: -
+-- Name: owner_contacts owner_contacts_pkey; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
 --
 
-ALTER TABLE ONLY division_a.account_mappings
-    ADD CONSTRAINT account_mappings_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY crog_acquisition.owner_contacts
+    ADD CONSTRAINT owner_contacts_pkey PRIMARY KEY (id);
 
 
 --
--- Name: audit_log audit_log_pkey; Type: CONSTRAINT; Schema: division_a; Owner: -
+-- Name: owners owners_pkey; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
 --
 
-ALTER TABLE ONLY division_a.audit_log
-    ADD CONSTRAINT audit_log_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY crog_acquisition.owners
+    ADD CONSTRAINT owners_pkey PRIMARY KEY (id);
 
 
 --
--- Name: chart_of_accounts chart_of_accounts_code_key; Type: CONSTRAINT; Schema: division_a; Owner: -
+-- Name: parcels parcels_pkey; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
 --
 
-ALTER TABLE ONLY division_a.chart_of_accounts
-    ADD CONSTRAINT chart_of_accounts_code_key UNIQUE (code);
+ALTER TABLE ONLY crog_acquisition.parcels
+    ADD CONSTRAINT parcels_pkey PRIMARY KEY (id);
 
 
 --
--- Name: chart_of_accounts chart_of_accounts_pkey; Type: CONSTRAINT; Schema: division_a; Owner: -
+-- Name: properties properties_airbnb_listing_id_key; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
 --
 
-ALTER TABLE ONLY division_a.chart_of_accounts
-    ADD CONSTRAINT chart_of_accounts_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY crog_acquisition.properties
+    ADD CONSTRAINT properties_airbnb_listing_id_key UNIQUE (airbnb_listing_id);
 
 
 --
--- Name: general_ledger general_ledger_pkey; Type: CONSTRAINT; Schema: division_a; Owner: -
+-- Name: properties properties_blue_ridge_str_permit_key; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
 --
 
-ALTER TABLE ONLY division_a.general_ledger
-    ADD CONSTRAINT general_ledger_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY crog_acquisition.properties
+    ADD CONSTRAINT properties_blue_ridge_str_permit_key UNIQUE (blue_ridge_str_permit);
 
 
 --
--- Name: journal_entries journal_entries_entry_id_key; Type: CONSTRAINT; Schema: division_a; Owner: -
+-- Name: properties properties_fannin_str_cert_id_key; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
 --
 
-ALTER TABLE ONLY division_a.journal_entries
-    ADD CONSTRAINT journal_entries_entry_id_key UNIQUE (entry_id);
+ALTER TABLE ONLY crog_acquisition.properties
+    ADD CONSTRAINT properties_fannin_str_cert_id_key UNIQUE (fannin_str_cert_id);
 
 
 --
--- Name: journal_entries journal_entries_pkey; Type: CONSTRAINT; Schema: division_a; Owner: -
+-- Name: properties properties_google_place_id_key; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
 --
 
-ALTER TABLE ONLY division_a.journal_entries
-    ADD CONSTRAINT journal_entries_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY crog_acquisition.properties
+    ADD CONSTRAINT properties_google_place_id_key UNIQUE (google_place_id);
 
 
 --
--- Name: predictions predictions_pkey; Type: CONSTRAINT; Schema: division_a; Owner: -
+-- Name: properties properties_pkey; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
 --
 
-ALTER TABLE ONLY division_a.predictions
-    ADD CONSTRAINT predictions_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY crog_acquisition.properties
+    ADD CONSTRAINT properties_pkey PRIMARY KEY (id);
 
 
 --
--- Name: transactions transactions_pkey; Type: CONSTRAINT; Schema: division_a; Owner: -
+-- Name: properties properties_vrbo_listing_id_key; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
 --
 
-ALTER TABLE ONLY division_a.transactions
-    ADD CONSTRAINT transactions_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY crog_acquisition.properties
+    ADD CONSTRAINT properties_vrbo_listing_id_key UNIQUE (vrbo_listing_id);
 
 
 --
--- Name: transactions transactions_plaid_txn_id_key; Type: CONSTRAINT; Schema: division_a; Owner: -
+-- Name: properties properties_zillow_zpid_key; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
 --
 
-ALTER TABLE ONLY division_a.transactions
-    ADD CONSTRAINT transactions_plaid_txn_id_key UNIQUE (plaid_txn_id);
+ALTER TABLE ONLY crog_acquisition.properties
+    ADD CONSTRAINT properties_zillow_zpid_key UNIQUE (zillow_zpid);
 
 
 --
--- Name: account_mappings unique_vendor_mapping; Type: CONSTRAINT; Schema: division_a; Owner: -
+-- Name: str_signals str_signals_pkey; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
 --
 
-ALTER TABLE ONLY division_a.account_mappings
-    ADD CONSTRAINT unique_vendor_mapping UNIQUE (vendor_name);
+ALTER TABLE ONLY crog_acquisition.str_signals
+    ADD CONSTRAINT str_signals_pkey PRIMARY KEY (id);
 
 
 --
--- Name: account_mappings account_mappings_pkey; Type: CONSTRAINT; Schema: division_b; Owner: -
+-- Name: owner_contacts uq_acquisition_owner_contacts_owner_value; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
 --
 
-ALTER TABLE ONLY division_b.account_mappings
-    ADD CONSTRAINT account_mappings_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY crog_acquisition.owner_contacts
+    ADD CONSTRAINT uq_acquisition_owner_contacts_owner_value UNIQUE (owner_id, contact_value);
 
 
 --
--- Name: chart_of_accounts chart_of_accounts_code_key; Type: CONSTRAINT; Schema: division_b; Owner: -
+-- Name: parcels uq_acquisition_parcels_parcel_id; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
 --
 
-ALTER TABLE ONLY division_b.chart_of_accounts
-    ADD CONSTRAINT chart_of_accounts_code_key UNIQUE (code);
+ALTER TABLE ONLY crog_acquisition.parcels
+    ADD CONSTRAINT uq_acquisition_parcels_parcel_id UNIQUE (parcel_id);
 
 
 --
--- Name: chart_of_accounts chart_of_accounts_pkey; Type: CONSTRAINT; Schema: division_b; Owner: -
+-- Name: acquisition_pipeline uq_acquisition_pipeline_property_id; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
 --
 
-ALTER TABLE ONLY division_b.chart_of_accounts
-    ADD CONSTRAINT chart_of_accounts_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY crog_acquisition.acquisition_pipeline
+    ADD CONSTRAINT uq_acquisition_pipeline_property_id UNIQUE (property_id);
 
 
 --
--- Name: escrow escrow_pkey; Type: CONSTRAINT; Schema: division_b; Owner: -
+-- Name: due_diligence uq_dd_pipeline_item; Type: CONSTRAINT; Schema: crog_acquisition; Owner: -
 --
 
-ALTER TABLE ONLY division_b.escrow
-    ADD CONSTRAINT escrow_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY crog_acquisition.due_diligence
+    ADD CONSTRAINT uq_dd_pipeline_item UNIQUE (pipeline_id, item_key);
 
 
 --
--- Name: escrow escrow_reservation_id_key; Type: CONSTRAINT; Schema: division_b; Owner: -
+-- Name: device_events device_events_pkey; Type: CONSTRAINT; Schema: iot_schema; Owner: -
 --
 
-ALTER TABLE ONLY division_b.escrow
-    ADD CONSTRAINT escrow_reservation_id_key UNIQUE (reservation_id);
+ALTER TABLE ONLY iot_schema.device_events
+    ADD CONSTRAINT device_events_pkey PRIMARY KEY (id);
 
 
 --
--- Name: general_ledger general_ledger_pkey; Type: CONSTRAINT; Schema: division_b; Owner: -
+-- Name: digital_twins digital_twins_pkey; Type: CONSTRAINT; Schema: iot_schema; Owner: -
 --
 
-ALTER TABLE ONLY division_b.general_ledger
-    ADD CONSTRAINT general_ledger_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY iot_schema.digital_twins
+    ADD CONSTRAINT digital_twins_pkey PRIMARY KEY (id);
 
 
 --
--- Name: journal_entries journal_entries_entry_id_key; Type: CONSTRAINT; Schema: division_b; Owner: -
+-- Name: ai_audit_ledger ai_audit_ledger_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
 --
 
-ALTER TABLE ONLY division_b.journal_entries
-    ADD CONSTRAINT journal_entries_entry_id_key UNIQUE (entry_id);
-
-
---
--- Name: journal_entries journal_entries_pkey; Type: CONSTRAINT; Schema: division_b; Owner: -
---
-
-ALTER TABLE ONLY division_b.journal_entries
-    ADD CONSTRAINT journal_entries_pkey PRIMARY KEY (id);
-
-
---
--- Name: predictions predictions_pkey; Type: CONSTRAINT; Schema: division_b; Owner: -
---
-
-ALTER TABLE ONLY division_b.predictions
-    ADD CONSTRAINT predictions_pkey PRIMARY KEY (id);
-
-
---
--- Name: transactions transactions_pkey; Type: CONSTRAINT; Schema: division_b; Owner: -
---
-
-ALTER TABLE ONLY division_b.transactions
-    ADD CONSTRAINT transactions_pkey PRIMARY KEY (id);
-
-
---
--- Name: transactions transactions_plaid_txn_id_key; Type: CONSTRAINT; Schema: division_b; Owner: -
---
-
-ALTER TABLE ONLY division_b.transactions
-    ADD CONSTRAINT transactions_plaid_txn_id_key UNIQUE (plaid_txn_id);
-
-
---
--- Name: trust_ledger trust_ledger_pkey; Type: CONSTRAINT; Schema: division_b; Owner: -
---
-
-ALTER TABLE ONLY division_b.trust_ledger
-    ADD CONSTRAINT trust_ledger_pkey PRIMARY KEY (id);
-
-
---
--- Name: account_mappings unique_vendor_mapping; Type: CONSTRAINT; Schema: division_b; Owner: -
---
-
-ALTER TABLE ONLY division_b.account_mappings
-    ADD CONSTRAINT unique_vendor_mapping UNIQUE (vendor_name);
-
-
---
--- Name: vendor_payouts vendor_payouts_pkey; Type: CONSTRAINT; Schema: division_b; Owner: -
---
-
-ALTER TABLE ONLY division_b.vendor_payouts
-    ADD CONSTRAINT vendor_payouts_pkey PRIMARY KEY (id);
-
-
---
--- Name: change_orders change_orders_pkey; Type: CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.change_orders
-    ADD CONSTRAINT change_orders_pkey PRIMARY KEY (id);
-
-
---
--- Name: compliance_log compliance_log_pkey; Type: CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.compliance_log
-    ADD CONSTRAINT compliance_log_pkey PRIMARY KEY (id);
-
-
---
--- Name: cost_estimates cost_estimates_pkey; Type: CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.cost_estimates
-    ADD CONSTRAINT cost_estimates_pkey PRIMARY KEY (id);
-
-
---
--- Name: drawings drawings_file_path_key; Type: CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.drawings
-    ADD CONSTRAINT drawings_file_path_key UNIQUE (file_path);
-
-
---
--- Name: drawings drawings_pkey; Type: CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.drawings
-    ADD CONSTRAINT drawings_pkey PRIMARY KEY (id);
-
-
---
--- Name: inspections inspections_pkey; Type: CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.inspections
-    ADD CONSTRAINT inspections_pkey PRIMARY KEY (id);
-
-
---
--- Name: mep_systems mep_systems_pkey; Type: CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.mep_systems
-    ADD CONSTRAINT mep_systems_pkey PRIMARY KEY (id);
-
-
---
--- Name: permits permits_permit_number_key; Type: CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.permits
-    ADD CONSTRAINT permits_permit_number_key UNIQUE (permit_number);
-
-
---
--- Name: permits permits_pkey; Type: CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.permits
-    ADD CONSTRAINT permits_pkey PRIMARY KEY (id);
-
-
---
--- Name: projects projects_pkey; Type: CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.projects
-    ADD CONSTRAINT projects_pkey PRIMARY KEY (id);
-
-
---
--- Name: projects projects_project_code_key; Type: CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.projects
-    ADD CONSTRAINT projects_project_code_key UNIQUE (project_code);
-
-
---
--- Name: punch_items punch_items_pkey; Type: CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.punch_items
-    ADD CONSTRAINT punch_items_pkey PRIMARY KEY (id);
-
-
---
--- Name: rfis rfis_pkey; Type: CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.rfis
-    ADD CONSTRAINT rfis_pkey PRIMARY KEY (id);
-
-
---
--- Name: submittals submittals_pkey; Type: CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.submittals
-    ADD CONSTRAINT submittals_pkey PRIMARY KEY (id);
-
-
---
--- Name: classification_rules classification_rules_pkey; Type: CONSTRAINT; Schema: finance; Owner: -
---
-
-ALTER TABLE ONLY finance.classification_rules
-    ADD CONSTRAINT classification_rules_pkey PRIMARY KEY (id);
-
-
---
--- Name: vendor_classifications vendor_classifications_pkey; Type: CONSTRAINT; Schema: finance; Owner: -
---
-
-ALTER TABLE ONLY finance.vendor_classifications
-    ADD CONSTRAINT vendor_classifications_pkey PRIMARY KEY (id);
-
-
---
--- Name: vendor_classifications vendor_classifications_vendor_pattern_key; Type: CONSTRAINT; Schema: finance; Owner: -
---
-
-ALTER TABLE ONLY finance.vendor_classifications
-    ADD CONSTRAINT vendor_classifications_vendor_pattern_key UNIQUE (vendor_pattern);
-
-
---
--- Name: active_strategies active_strategies_pkey; Type: CONSTRAINT; Schema: hedge_fund; Owner: -
---
-
-ALTER TABLE ONLY hedge_fund.active_strategies
-    ADD CONSTRAINT active_strategies_pkey PRIMARY KEY (id);
-
-
---
--- Name: extraction_log extraction_log_pkey; Type: CONSTRAINT; Schema: hedge_fund; Owner: -
---
-
-ALTER TABLE ONLY hedge_fund.extraction_log
-    ADD CONSTRAINT extraction_log_pkey PRIMARY KEY (id);
-
-
---
--- Name: market_signals market_signals_pkey; Type: CONSTRAINT; Schema: hedge_fund; Owner: -
---
-
-ALTER TABLE ONLY hedge_fund.market_signals
-    ADD CONSTRAINT market_signals_pkey PRIMARY KEY (id);
-
-
---
--- Name: watchlist watchlist_pkey; Type: CONSTRAINT; Schema: hedge_fund; Owner: -
---
-
-ALTER TABLE ONLY hedge_fund.watchlist
-    ADD CONSTRAINT watchlist_pkey PRIMARY KEY (id);
-
-
---
--- Name: watchlist watchlist_ticker_key; Type: CONSTRAINT; Schema: hedge_fund; Owner: -
---
-
-ALTER TABLE ONLY hedge_fund.watchlist
-    ADD CONSTRAINT watchlist_ticker_key UNIQUE (ticker);
-
-
---
--- Name: entities entities_entity_key_key; Type: CONSTRAINT; Schema: intelligence; Owner: -
---
-
-ALTER TABLE ONLY intelligence.entities
-    ADD CONSTRAINT entities_entity_key_key UNIQUE (entity_key);
-
-
---
--- Name: entities entities_pkey; Type: CONSTRAINT; Schema: intelligence; Owner: -
---
-
-ALTER TABLE ONLY intelligence.entities
-    ADD CONSTRAINT entities_pkey PRIMARY KEY (id);
-
-
---
--- Name: golden_reasoning golden_reasoning_pkey; Type: CONSTRAINT; Schema: intelligence; Owner: -
---
-
-ALTER TABLE ONLY intelligence.golden_reasoning
-    ADD CONSTRAINT golden_reasoning_pkey PRIMARY KEY (id);
-
-
---
--- Name: relationships relationships_from_entity_id_to_entity_id_relationship_type_key; Type: CONSTRAINT; Schema: intelligence; Owner: -
---
-
-ALTER TABLE ONLY intelligence.relationships
-    ADD CONSTRAINT relationships_from_entity_id_to_entity_id_relationship_type_key UNIQUE (from_entity_id, to_entity_id, relationship_type);
-
-
---
--- Name: relationships relationships_pkey; Type: CONSTRAINT; Schema: intelligence; Owner: -
---
-
-ALTER TABLE ONLY intelligence.relationships
-    ADD CONSTRAINT relationships_pkey PRIMARY KEY (id);
-
-
---
--- Name: titan_traces titan_traces_pkey; Type: CONSTRAINT; Schema: intelligence; Owner: -
---
-
-ALTER TABLE ONLY intelligence.titan_traces
-    ADD CONSTRAINT titan_traces_pkey PRIMARY KEY (id);
-
-
---
--- Name: case_actions case_actions_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.case_actions
-    ADD CONSTRAINT case_actions_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY legal.ai_audit_ledger
+    ADD CONSTRAINT ai_audit_ledger_pkey PRIMARY KEY (id);
 
 
 --
@@ -8239,19 +4303,51 @@ ALTER TABLE ONLY legal.case_evidence
 
 
 --
--- Name: case_precedents case_precedents_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
+-- Name: case_graph_edges case_graph_edges_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
 --
 
-ALTER TABLE ONLY legal.case_precedents
-    ADD CONSTRAINT case_precedents_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY legal.case_graph_edges
+    ADD CONSTRAINT case_graph_edges_pkey PRIMARY KEY (id);
 
 
 --
--- Name: case_watchdog case_watchdog_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
+-- Name: case_graph_edges_v2 case_graph_edges_v2_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
 --
 
-ALTER TABLE ONLY legal.case_watchdog
-    ADD CONSTRAINT case_watchdog_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY legal.case_graph_edges_v2
+    ADD CONSTRAINT case_graph_edges_v2_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: case_graph_nodes case_graph_nodes_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.case_graph_nodes
+    ADD CONSTRAINT case_graph_nodes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: case_graph_nodes_v2 case_graph_nodes_v2_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.case_graph_nodes_v2
+    ADD CONSTRAINT case_graph_nodes_v2_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: case_statements case_statements_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.case_statements
+    ADD CONSTRAINT case_statements_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: case_statements_v2 case_statements_v2_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.case_statements_v2
+    ADD CONSTRAINT case_statements_v2_pkey PRIMARY KEY (id);
 
 
 --
@@ -8271,59 +4367,83 @@ ALTER TABLE ONLY legal.cases
 
 
 --
--- Name: correspondence correspondence_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
+-- Name: deposition_kill_sheets_v2 deposition_kill_sheets_v2_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
 --
 
-ALTER TABLE ONLY legal.correspondence
-    ADD CONSTRAINT correspondence_pkey PRIMARY KEY (id);
-
-
---
--- Name: deadlines deadlines_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.deadlines
-    ADD CONSTRAINT deadlines_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY legal.deposition_kill_sheets_v2
+    ADD CONSTRAINT deposition_kill_sheets_v2_pkey PRIMARY KEY (id);
 
 
 --
--- Name: email_intake_queue email_intake_queue_message_uid_key; Type: CONSTRAINT; Schema: legal; Owner: -
+-- Name: discovery_draft_items_v2 discovery_draft_items_v2_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
 --
 
-ALTER TABLE ONLY legal.email_intake_queue
-    ADD CONSTRAINT email_intake_queue_message_uid_key UNIQUE (message_uid);
-
-
---
--- Name: email_intake_queue email_intake_queue_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.email_intake_queue
-    ADD CONSTRAINT email_intake_queue_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY legal.discovery_draft_items_v2
+    ADD CONSTRAINT discovery_draft_items_v2_pkey PRIMARY KEY (id);
 
 
 --
--- Name: expense_intake expense_intake_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
+-- Name: discovery_draft_packs_v2 discovery_draft_packs_v2_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
 --
 
-ALTER TABLE ONLY legal.expense_intake
-    ADD CONSTRAINT expense_intake_pkey PRIMARY KEY (id);
-
-
---
--- Name: filings filings_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.filings
-    ADD CONSTRAINT filings_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY legal.discovery_draft_packs_v2
+    ADD CONSTRAINT discovery_draft_packs_v2_pkey PRIMARY KEY (id);
 
 
 --
--- Name: ingest_runs ingest_runs_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
+-- Name: distillation_memory distillation_memory_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
 --
 
-ALTER TABLE ONLY legal.ingest_runs
-    ADD CONSTRAINT ingest_runs_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY legal.distillation_memory
+    ADD CONSTRAINT distillation_memory_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: entities entities_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.entities
+    ADD CONSTRAINT entities_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: legal_cases legal_cases_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.legal_cases
+    ADD CONSTRAINT legal_cases_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: legal_cases legal_cases_slug_key; Type: CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.legal_cases
+    ADD CONSTRAINT legal_cases_slug_key UNIQUE (slug);
+
+
+--
+-- Name: legal_exemplars legal_exemplars_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.legal_exemplars
+    ADD CONSTRAINT legal_exemplars_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: sanctions_alerts_v2 sanctions_alerts_v2_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.sanctions_alerts_v2
+    ADD CONSTRAINT sanctions_alerts_v2_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: sanctions_tripwire_runs_v2 sanctions_tripwire_runs_v2_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.sanctions_tripwire_runs_v2
+    ADD CONSTRAINT sanctions_tripwire_runs_v2_pkey PRIMARY KEY (id);
 
 
 --
@@ -8335,123 +4455,11 @@ ALTER TABLE ONLY legal.timeline_events
 
 
 --
--- Name: uploads uploads_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.uploads
-    ADD CONSTRAINT uploads_pkey PRIMARY KEY (id);
-
-
---
--- Name: vault_documents uq_vault_documents_case_hash; Type: CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.vault_documents
-    ADD CONSTRAINT uq_vault_documents_case_hash UNIQUE (case_slug, file_hash);
-
-
---
 -- Name: vault_documents vault_documents_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
 --
 
 ALTER TABLE ONLY legal.vault_documents
     ADD CONSTRAINT vault_documents_pkey PRIMARY KEY (id);
-
-
---
--- Name: attorney_scoring attorney_scoring_pkey; Type: CONSTRAINT; Schema: legal_cmd; Owner: -
---
-
-ALTER TABLE ONLY legal_cmd.attorney_scoring
-    ADD CONSTRAINT attorney_scoring_pkey PRIMARY KEY (id);
-
-
---
--- Name: attorneys attorneys_pkey; Type: CONSTRAINT; Schema: legal_cmd; Owner: -
---
-
-ALTER TABLE ONLY legal_cmd.attorneys
-    ADD CONSTRAINT attorneys_pkey PRIMARY KEY (id);
-
-
---
--- Name: deliberation_events deliberation_events_pkey; Type: CONSTRAINT; Schema: legal_cmd; Owner: -
---
-
-ALTER TABLE ONLY legal_cmd.deliberation_events
-    ADD CONSTRAINT deliberation_events_pkey PRIMARY KEY (event_id);
-
-
---
--- Name: deliberation_events deliberation_events_sha256_signature_key; Type: CONSTRAINT; Schema: legal_cmd; Owner: -
---
-
-ALTER TABLE ONLY legal_cmd.deliberation_events
-    ADD CONSTRAINT deliberation_events_sha256_signature_key UNIQUE (sha256_signature);
-
-
---
--- Name: documents documents_pkey; Type: CONSTRAINT; Schema: legal_cmd; Owner: -
---
-
-ALTER TABLE ONLY legal_cmd.documents
-    ADD CONSTRAINT documents_pkey PRIMARY KEY (id);
-
-
---
--- Name: matters matters_pkey; Type: CONSTRAINT; Schema: legal_cmd; Owner: -
---
-
-ALTER TABLE ONLY legal_cmd.matters
-    ADD CONSTRAINT matters_pkey PRIMARY KEY (id);
-
-
---
--- Name: matters matters_reference_code_key; Type: CONSTRAINT; Schema: legal_cmd; Owner: -
---
-
-ALTER TABLE ONLY legal_cmd.matters
-    ADD CONSTRAINT matters_reference_code_key UNIQUE (reference_code);
-
-
---
--- Name: meetings meetings_pkey; Type: CONSTRAINT; Schema: legal_cmd; Owner: -
---
-
-ALTER TABLE ONLY legal_cmd.meetings
-    ADD CONSTRAINT meetings_pkey PRIMARY KEY (id);
-
-
---
--- Name: timeline timeline_pkey; Type: CONSTRAINT; Schema: legal_cmd; Owner: -
---
-
-ALTER TABLE ONLY legal_cmd.timeline
-    ADD CONSTRAINT timeline_pkey PRIMARY KEY (id);
-
-
---
--- Name: ab_test_observations ab_test_observations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ab_test_observations
-    ADD CONSTRAINT ab_test_observations_pkey PRIMARY KEY (id);
-
-
---
--- Name: ab_tests ab_tests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ab_tests
-    ADD CONSTRAINT ab_tests_pkey PRIMARY KEY (id);
-
-
---
--- Name: accounts accounts_code_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.accounts
-    ADD CONSTRAINT accounts_code_key UNIQUE (code);
 
 
 --
@@ -8463,35 +4471,27 @@ ALTER TABLE ONLY public.accounts
 
 
 --
--- Name: active_learning_queue active_learning_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: activities activities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.active_learning_queue
-    ADD CONSTRAINT active_learning_queue_pkey PRIMARY KEY (id);
-
-
---
--- Name: agent_learning_log agent_learning_log_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.agent_learning_log
-    ADD CONSTRAINT agent_learning_log_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.activities
+    ADD CONSTRAINT activities_pkey PRIMARY KEY (id);
 
 
 --
--- Name: agent_memory agent_memory_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: agent_queue agent_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.agent_memory
-    ADD CONSTRAINT agent_memory_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.agent_queue
+    ADD CONSTRAINT agent_queue_pkey PRIMARY KEY (id);
 
 
 --
--- Name: agent_performance_log agent_performance_log_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: agent_registry agent_registry_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.agent_performance_log
-    ADD CONSTRAINT agent_performance_log_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.agent_registry
+    ADD CONSTRAINT agent_registry_pkey PRIMARY KEY (id);
 
 
 --
@@ -8503,19 +4503,27 @@ ALTER TABLE ONLY public.agent_response_queue
 
 
 --
--- Name: agent_telemetry agent_telemetry_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: agent_runs agent_runs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.agent_telemetry
-    ADD CONSTRAINT agent_telemetry_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.agent_runs
+    ADD CONSTRAINT agent_runs_pkey PRIMARY KEY (id);
 
 
 --
--- Name: ai_training_labels ai_training_labels_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: agreement_templates agreement_templates_name_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ai_training_labels
-    ADD CONSTRAINT ai_training_labels_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.agreement_templates
+    ADD CONSTRAINT agreement_templates_name_key UNIQUE (name);
+
+
+--
+-- Name: agreement_templates agreement_templates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agreement_templates
+    ADD CONSTRAINT agreement_templates_pkey PRIMARY KEY (id);
 
 
 --
@@ -8527,75 +4535,115 @@ ALTER TABLE ONLY public.alembic_version
 
 
 --
--- Name: anomaly_flags anomaly_flags_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: analytics_events analytics_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.anomaly_flags
-    ADD CONSTRAINT anomaly_flags_pkey PRIMARY KEY (id);
-
-
---
--- Name: api_key_vault api_key_vault_key_name_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.api_key_vault
-    ADD CONSTRAINT api_key_vault_key_name_key UNIQUE (key_name);
+ALTER TABLE ONLY public.analytics_events
+    ADD CONSTRAINT analytics_events_pkey PRIMARY KEY (id);
 
 
 --
--- Name: api_key_vault api_key_vault_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: async_job_runs async_job_runs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.api_key_vault
-    ADD CONSTRAINT api_key_vault_pkey PRIMARY KEY (id);
-
-
---
--- Name: asset_docs asset_docs_file_path_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.asset_docs
-    ADD CONSTRAINT asset_docs_file_path_key UNIQUE (file_path);
+ALTER TABLE ONLY public.async_job_runs
+    ADD CONSTRAINT async_job_runs_pkey PRIMARY KEY (id);
 
 
 --
--- Name: asset_docs asset_docs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: blocked_days blocked_days_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.asset_docs
-    ADD CONSTRAINT asset_docs_pkey PRIMARY KEY (id);
-
-
---
--- Name: conversation_threads conversation_threads_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.conversation_threads
-    ADD CONSTRAINT conversation_threads_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.blocked_days
+    ADD CONSTRAINT blocked_days_pkey PRIMARY KEY (id);
 
 
 --
--- Name: conversation_threads conversation_threads_thread_hash_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: blogs blogs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.conversation_threads
-    ADD CONSTRAINT conversation_threads_thread_hash_key UNIQUE (thread_hash);
-
-
---
--- Name: council_votes council_votes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.council_votes
-    ADD CONSTRAINT council_votes_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.blogs
+    ADD CONSTRAINT blogs_pkey PRIMARY KEY (id);
 
 
 --
--- Name: data_sanitizer_log data_sanitizer_log_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: capex_staging capex_staging_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.data_sanitizer_log
-    ADD CONSTRAINT data_sanitizer_log_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.capex_staging
+    ADD CONSTRAINT capex_staging_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: capture_labels capture_labels_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.capture_labels
+    ADD CONSTRAINT capture_labels_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: channel_mappings channel_mappings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.channel_mappings
+    ADD CONSTRAINT channel_mappings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: citation_records citation_records_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.citation_records
+    ADD CONSTRAINT citation_records_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: cleaners cleaners_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.cleaners
+    ADD CONSTRAINT cleaners_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: competitor_listings competitor_listings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.competitor_listings
+    ADD CONSTRAINT competitor_listings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: concierge_queue concierge_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.concierge_queue
+    ADD CONSTRAINT concierge_queue_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: concierge_recovery_dispatches concierge_recovery_dispatches_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.concierge_recovery_dispatches
+    ADD CONSTRAINT concierge_recovery_dispatches_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: damage_claims damage_claims_claim_number_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.damage_claims
+    ADD CONSTRAINT damage_claims_claim_number_key UNIQUE (claim_number);
+
+
+--
+-- Name: damage_claims damage_claims_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.damage_claims
+    ADD CONSTRAINT damage_claims_pkey PRIMARY KEY (id);
 
 
 --
@@ -8607,243 +4655,171 @@ ALTER TABLE ONLY public.deferred_api_writes
 
 
 --
--- Name: document_oracle_manifest document_oracle_manifest_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: distillation_queue distillation_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.document_oracle_manifest
-    ADD CONSTRAINT document_oracle_manifest_pkey PRIMARY KEY (file_path);
-
-
---
--- Name: email_archive email_archive_file_path_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.email_archive
-    ADD CONSTRAINT email_archive_file_path_key UNIQUE (file_path);
+ALTER TABLE ONLY public.distillation_queue
+    ADD CONSTRAINT distillation_queue_pkey PRIMARY KEY (id);
 
 
 --
--- Name: email_archive email_archive_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: email_inquirers email_inquirers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.email_archive
-    ADD CONSTRAINT email_archive_pkey PRIMARY KEY (id);
-
-
---
--- Name: email_classification_rules email_classification_rules_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.email_classification_rules
-    ADD CONSTRAINT email_classification_rules_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.email_inquirers
+    ADD CONSTRAINT email_inquirers_pkey PRIMARY KEY (id);
 
 
 --
--- Name: email_dead_letter_queue email_dead_letter_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: email_messages email_messages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.email_dead_letter_queue
-    ADD CONSTRAINT email_dead_letter_queue_pkey PRIMARY KEY (id);
-
-
---
--- Name: email_escalation_queue email_escalation_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.email_escalation_queue
-    ADD CONSTRAINT email_escalation_queue_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.email_messages
+    ADD CONSTRAINT email_messages_pkey PRIMARY KEY (id);
 
 
 --
--- Name: email_escalation_rules email_escalation_rules_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: email_templates email_templates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.email_escalation_rules
-    ADD CONSTRAINT email_escalation_rules_pkey PRIMARY KEY (id);
-
-
---
--- Name: email_intake_review_log email_intake_review_log_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.email_intake_review_log
-    ADD CONSTRAINT email_intake_review_log_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.email_templates
+    ADD CONSTRAINT email_templates_pkey PRIMARY KEY (id);
 
 
 --
--- Name: email_quarantine email_quarantine_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: extra_orders extra_orders_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.email_quarantine
-    ADD CONSTRAINT email_quarantine_pkey PRIMARY KEY (id);
-
-
---
--- Name: email_routing_rules email_routing_rules_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.email_routing_rules
-    ADD CONSTRAINT email_routing_rules_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.extra_orders
+    ADD CONSTRAINT extra_orders_pkey PRIMARY KEY (id);
 
 
 --
--- Name: email_sensors email_sensors_email_address_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: extras extras_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.email_sensors
-    ADD CONSTRAINT email_sensors_email_address_key UNIQUE (email_address);
-
-
---
--- Name: email_sensors email_sensors_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.email_sensors
-    ADD CONSTRAINT email_sensors_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.extras
+    ADD CONSTRAINT extras_pkey PRIMARY KEY (id);
 
 
 --
--- Name: email_triage_precedents email_triage_precedents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: fees fees_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.email_triage_precedents
-    ADD CONSTRAINT email_triage_precedents_pkey PRIMARY KEY (id);
-
-
---
--- Name: fin_owner_balances fin_owner_balances_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.fin_owner_balances
-    ADD CONSTRAINT fin_owner_balances_pkey PRIMARY KEY (property_id);
+ALTER TABLE ONLY public.fees
+    ADD CONSTRAINT fees_pkey PRIMARY KEY (id);
 
 
 --
--- Name: fin_reservations fin_reservations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: financial_approvals financial_approvals_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.fin_reservations
-    ADD CONSTRAINT fin_reservations_pkey PRIMARY KEY (res_id);
-
-
---
--- Name: fin_revenue_snapshots fin_revenue_snapshots_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.fin_revenue_snapshots
-    ADD CONSTRAINT fin_revenue_snapshots_pkey PRIMARY KEY (snapshot_id);
+ALTER TABLE ONLY public.financial_approvals
+    ADD CONSTRAINT financial_approvals_pkey PRIMARY KEY (id);
 
 
 --
--- Name: finance_invoices finance_invoices_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: functional_nodes functional_nodes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.finance_invoices
-    ADD CONSTRAINT finance_invoices_pkey PRIMARY KEY (id);
-
-
---
--- Name: fortress_api_keys fortress_api_keys_key_hash_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.fortress_api_keys
-    ADD CONSTRAINT fortress_api_keys_key_hash_key UNIQUE (key_hash);
+ALTER TABLE ONLY public.functional_nodes
+    ADD CONSTRAINT functional_nodes_pkey PRIMARY KEY (id);
 
 
 --
--- Name: fortress_api_keys fortress_api_keys_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: guest_activities guest_activities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.fortress_api_keys
-    ADD CONSTRAINT fortress_api_keys_pkey PRIMARY KEY (id);
-
-
---
--- Name: fortress_users fortress_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.fortress_users
-    ADD CONSTRAINT fortress_users_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.guest_activities
+    ADD CONSTRAINT guest_activities_pkey PRIMARY KEY (id);
 
 
 --
--- Name: fortress_users fortress_users_username_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: guest_quotes guest_quotes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.fortress_users
-    ADD CONSTRAINT fortress_users_username_key UNIQUE (username);
-
-
---
--- Name: general_ledger general_ledger_filepath_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.general_ledger
-    ADD CONSTRAINT general_ledger_filepath_key UNIQUE (filepath);
+ALTER TABLE ONLY public.guest_quotes
+    ADD CONSTRAINT guest_quotes_pkey PRIMARY KEY (id);
 
 
 --
--- Name: general_ledger general_ledger_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: guest_reviews guest_reviews_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.general_ledger
-    ADD CONSTRAINT general_ledger_pkey PRIMARY KEY (id);
-
-
---
--- Name: godhead_query_log godhead_query_log_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.godhead_query_log
-    ADD CONSTRAINT godhead_query_log_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.guest_reviews
+    ADD CONSTRAINT guest_reviews_pkey PRIMARY KEY (id);
 
 
 --
--- Name: guest_leads guest_leads_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: guest_surveys guest_surveys_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.guest_leads
-    ADD CONSTRAINT guest_leads_pkey PRIMARY KEY (id);
-
-
---
--- Name: guest_profiles guest_profiles_phone_number_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.guest_profiles
-    ADD CONSTRAINT guest_profiles_phone_number_key UNIQUE (phone_number);
+ALTER TABLE ONLY public.guest_surveys
+    ADD CONSTRAINT guest_surveys_pkey PRIMARY KEY (id);
 
 
 --
--- Name: guest_profiles guest_profiles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: guest_verifications guest_verifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.guest_profiles
-    ADD CONSTRAINT guest_profiles_pkey PRIMARY KEY (id);
-
-
---
--- Name: images images_filename_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.images
-    ADD CONSTRAINT images_filename_key UNIQUE (filename);
+ALTER TABLE ONLY public.guest_verifications
+    ADD CONSTRAINT guest_verifications_pkey PRIMARY KEY (id);
 
 
 --
--- Name: images images_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: guestbook_guides guestbook_guides_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.images
-    ADD CONSTRAINT images_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.guestbook_guides
+    ADD CONSTRAINT guestbook_guides_pkey PRIMARY KEY (id);
 
 
 --
--- Name: ingestion_dlq ingestion_dlq_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: guests guests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ingestion_dlq
-    ADD CONSTRAINT ingestion_dlq_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.guests
+    ADD CONSTRAINT guests_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: housekeeping_tasks housekeeping_tasks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.housekeeping_tasks
+    ADD CONSTRAINT housekeeping_tasks_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: hunter_queue hunter_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.hunter_queue
+    ADD CONSTRAINT hunter_queue_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: hunter_recovery_ops hunter_recovery_ops_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.hunter_recovery_ops
+    ADD CONSTRAINT hunter_recovery_ops_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: hunter_runs hunter_runs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.hunter_runs
+    ADD CONSTRAINT hunter_runs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: intelligence_ledger intelligence_ledger_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.intelligence_ledger
+    ADD CONSTRAINT intelligence_ledger_pkey PRIMARY KEY (id);
 
 
 --
@@ -8863,283 +4839,235 @@ ALTER TABLE ONLY public.journal_line_items
 
 
 --
--- Name: learning_judgments learning_judgments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: knowledge_base_entries knowledge_base_entries_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.learning_judgments
-    ADD CONSTRAINT learning_judgments_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.knowledge_base_entries
+    ADD CONSTRAINT knowledge_base_entries_pkey PRIMARY KEY (id);
 
 
 --
--- Name: learning_optimizations learning_optimizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: leads leads_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.learning_optimizations
-    ADD CONSTRAINT learning_optimizations_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.leads
+    ADD CONSTRAINT leads_pkey PRIMARY KEY (id);
 
 
 --
--- Name: legacy_cdc_checkpoints legacy_cdc_checkpoints_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: learned_rules learned_rules_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.legacy_cdc_checkpoints
-    ADD CONSTRAINT legacy_cdc_checkpoints_pkey PRIMARY KEY (stream_name);
+ALTER TABLE ONLY public.learned_rules
+    ADD CONSTRAINT learned_rules_pkey PRIMARY KEY (id);
 
 
 --
--- Name: legacy_cdc_event_queue legacy_cdc_event_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: legacy_pages legacy_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.legacy_cdc_event_queue
-    ADD CONSTRAINT legacy_cdc_event_queue_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.legacy_pages
+    ADD CONSTRAINT legacy_pages_pkey PRIMARY KEY (id);
 
 
 --
--- Name: legacy_cdc_row_state legacy_cdc_row_state_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: legal_case_statements legal_case_statements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.legacy_cdc_row_state
-    ADD CONSTRAINT legacy_cdc_row_state_pkey PRIMARY KEY (source_table, primary_key_hash);
+ALTER TABLE ONLY public.legal_case_statements
+    ADD CONSTRAINT legal_case_statements_pkey PRIMARY KEY (id);
 
 
 --
--- Name: legal_clients legal_clients_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: legal_hive_mind_feedback_events legal_hive_mind_feedback_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.legal_clients
-    ADD CONSTRAINT legal_clients_pkey PRIMARY KEY (client_id);
+ALTER TABLE ONLY public.legal_hive_mind_feedback_events
+    ADD CONSTRAINT legal_hive_mind_feedback_events_pkey PRIMARY KEY (id);
 
 
 --
--- Name: legal_docket legal_docket_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: llm_training_captures llm_training_captures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.legal_docket
-    ADD CONSTRAINT legal_docket_pkey PRIMARY KEY (doc_id);
+ALTER TABLE ONLY public.llm_training_captures
+    ADD CONSTRAINT llm_training_captures_pkey PRIMARY KEY (id);
 
 
 --
--- Name: legal_intel legal_intel_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: management_splits management_splits_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.legal_intel
-    ADD CONSTRAINT legal_intel_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.management_splits
+    ADD CONSTRAINT management_splits_pkey PRIMARY KEY (id);
 
 
 --
--- Name: legal_matter_notes legal_matter_notes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: marketing_articles marketing_articles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.legal_matter_notes
-    ADD CONSTRAINT legal_matter_notes_pkey PRIMARY KEY (note_id);
+ALTER TABLE ONLY public.marketing_articles
+    ADD CONSTRAINT marketing_articles_pkey PRIMARY KEY (id);
 
 
 --
--- Name: legal_matters legal_matters_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: marketing_attribution marketing_attribution_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.legal_matters
-    ADD CONSTRAINT legal_matters_pkey PRIMARY KEY (matter_id);
+ALTER TABLE ONLY public.marketing_attribution
+    ADD CONSTRAINT marketing_attribution_pkey PRIMARY KEY (id);
 
 
 --
--- Name: maintenance_log maintenance_log_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: message_queue message_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.maintenance_log
-    ADD CONSTRAINT maintenance_log_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.message_queue
+    ADD CONSTRAINT message_queue_pkey PRIMARY KEY (id);
 
 
 --
--- Name: market_intel market_intel_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: message_templates message_templates_name_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.market_intel
-    ADD CONSTRAINT market_intel_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.message_templates
+    ADD CONSTRAINT message_templates_name_key UNIQUE (name);
 
 
 --
--- Name: market_signals market_signals_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: message_templates message_templates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.market_signals
-    ADD CONSTRAINT market_signals_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.message_templates
+    ADD CONSTRAINT message_templates_pkey PRIMARY KEY (id);
 
 
 --
--- Name: message_analytics message_analytics_date_hour_property_id_source_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: messages messages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.message_analytics
-    ADD CONSTRAINT message_analytics_date_hour_property_id_source_key UNIQUE (date, hour, property_id, source);
+ALTER TABLE ONLY public.messages
+    ADD CONSTRAINT messages_pkey PRIMARY KEY (id);
 
 
 --
--- Name: message_analytics message_analytics_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: openshell_audit_logs openshell_audit_logs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.message_analytics
-    ADD CONSTRAINT message_analytics_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.openshell_audit_logs
+    ADD CONSTRAINT openshell_audit_logs_pkey PRIMARY KEY (id);
 
 
 --
--- Name: message_archive message_archive_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: operator_overrides operator_overrides_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.message_archive
-    ADD CONSTRAINT message_archive_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.operator_overrides
+    ADD CONSTRAINT operator_overrides_pkey PRIMARY KEY (id);
 
 
 --
--- Name: model_telemetry model_telemetry_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: ota_micro_updates ota_micro_updates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.model_telemetry
-    ADD CONSTRAINT model_telemetry_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.ota_micro_updates
+    ADD CONSTRAINT ota_micro_updates_pkey PRIMARY KEY (id);
 
 
 --
--- Name: nas_legal_vault nas_legal_vault_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: owner_balance_periods owner_balance_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.nas_legal_vault
-    ADD CONSTRAINT nas_legal_vault_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.owner_balance_periods
+    ADD CONSTRAINT owner_balance_periods_pkey PRIMARY KEY (id);
 
 
 --
--- Name: nas_legal_vault nas_legal_vault_source_file_chunk_index_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: owner_charges owner_charges_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.nas_legal_vault
-    ADD CONSTRAINT nas_legal_vault_source_file_chunk_index_key UNIQUE (source_file, chunk_index);
+ALTER TABLE ONLY public.owner_charges
+    ADD CONSTRAINT owner_charges_pkey PRIMARY KEY (id);
 
 
 --
--- Name: nim_arm64_probe_results nim_arm64_probe_results_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: owner_magic_tokens owner_magic_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.nim_arm64_probe_results
-    ADD CONSTRAINT nim_arm64_probe_results_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.owner_magic_tokens
+    ADD CONSTRAINT owner_magic_tokens_pkey PRIMARY KEY (id);
 
 
 --
--- Name: nim_arm64_probe_results nim_arm64_probe_results_probe_date_image_path_tag_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: owner_marketing_preferences owner_marketing_preferences_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.nim_arm64_probe_results
-    ADD CONSTRAINT nim_arm64_probe_results_probe_date_image_path_tag_key UNIQUE (probe_date, image_path, tag);
+ALTER TABLE ONLY public.owner_marketing_preferences
+    ADD CONSTRAINT owner_marketing_preferences_pkey PRIMARY KEY (id);
 
 
 --
--- Name: ops_crew ops_crew_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: owner_markup_rules owner_markup_rules_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ops_crew
-    ADD CONSTRAINT ops_crew_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.owner_markup_rules
+    ADD CONSTRAINT owner_markup_rules_pkey PRIMARY KEY (id);
 
 
 --
--- Name: ops_historical_guests ops_historical_guests_guest_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: owner_payout_accounts owner_payout_accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ops_historical_guests
-    ADD CONSTRAINT ops_historical_guests_guest_id_key UNIQUE (guest_id);
+ALTER TABLE ONLY public.owner_payout_accounts
+    ADD CONSTRAINT owner_payout_accounts_pkey PRIMARY KEY (id);
 
 
 --
--- Name: ops_historical_guests ops_historical_guests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: owner_property_map owner_property_map_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ops_historical_guests
-    ADD CONSTRAINT ops_historical_guests_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.owner_property_map
+    ADD CONSTRAINT owner_property_map_pkey PRIMARY KEY (id);
 
 
 --
--- Name: ops_log ops_log_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: owner_statement_sends owner_statement_sends_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ops_log
-    ADD CONSTRAINT ops_log_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.owner_statement_sends
+    ADD CONSTRAINT owner_statement_sends_pkey PRIMARY KEY (id);
 
 
 --
--- Name: ops_overrides ops_overrides_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: parity_audits parity_audits_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ops_overrides
-    ADD CONSTRAINT ops_overrides_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.parity_audits
+    ADD CONSTRAINT parity_audits_pkey PRIMARY KEY (id);
 
 
 --
--- Name: ops_properties ops_properties_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: payout_ledger payout_ledger_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ops_properties
-    ADD CONSTRAINT ops_properties_pkey PRIMARY KEY (property_id);
+ALTER TABLE ONLY public.payout_ledger
+    ADD CONSTRAINT payout_ledger_pkey PRIMARY KEY (id);
 
 
 --
--- Name: ops_properties ops_properties_streamline_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: pending_sync pending_sync_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ops_properties
-    ADD CONSTRAINT ops_properties_streamline_id_key UNIQUE (streamline_id);
+ALTER TABLE ONLY public.pending_sync
+    ADD CONSTRAINT pending_sync_pkey PRIMARY KEY (id);
 
 
 --
--- Name: ops_tasks ops_tasks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: pricing_overrides pricing_overrides_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ops_tasks
-    ADD CONSTRAINT ops_tasks_pkey PRIMARY KEY (id);
-
-
---
--- Name: ops_turnovers ops_turnovers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ops_turnovers
-    ADD CONSTRAINT ops_turnovers_pkey PRIMARY KEY (id);
-
-
---
--- Name: ops_visuals ops_visuals_file_path_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ops_visuals
-    ADD CONSTRAINT ops_visuals_file_path_key UNIQUE (file_path);
-
-
---
--- Name: ops_visuals ops_visuals_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ops_visuals
-    ADD CONSTRAINT ops_visuals_pkey PRIMARY KEY (image_id);
-
-
---
--- Name: pages pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.pages
-    ADD CONSTRAINT pages_pkey PRIMARY KEY (id);
-
-
---
--- Name: pages pages_url_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.pages
-    ADD CONSTRAINT pages_url_key UNIQUE (url);
-
-
---
--- Name: persona_scores persona_scores_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.persona_scores
-    ADD CONSTRAINT persona_scores_pkey PRIMARY KEY (persona_slug);
+ALTER TABLE ONLY public.pricing_overrides
+    ADD CONSTRAINT pricing_overrides_pkey PRIMARY KEY (id);
 
 
 --
@@ -9159,227 +5087,299 @@ ALTER TABLE ONLY public.properties
 
 
 --
--- Name: properties properties_streamline_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: property_fees property_fees_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.properties
-    ADD CONSTRAINT properties_streamline_id_key UNIQUE (streamline_id);
-
-
---
--- Name: property_events property_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.property_events
-    ADD CONSTRAINT property_events_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.property_fees
+    ADD CONSTRAINT property_fees_pkey PRIMARY KEY (id);
 
 
 --
--- Name: property_sms_config property_sms_config_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: property_images property_images_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.property_sms_config
-    ADD CONSTRAINT property_sms_config_pkey PRIMARY KEY (id);
-
-
---
--- Name: property_sms_config property_sms_config_property_id_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.property_sms_config
-    ADD CONSTRAINT property_sms_config_property_id_key UNIQUE (property_id);
+ALTER TABLE ONLY public.property_images
+    ADD CONSTRAINT property_images_pkey PRIMARY KEY (id);
 
 
 --
--- Name: quarantine_inbox quarantine_inbox_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: property_knowledge_chunks property_knowledge_chunks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quarantine_inbox
-    ADD CONSTRAINT quarantine_inbox_pkey PRIMARY KEY (id);
-
-
---
--- Name: rag_query_feedback rag_query_feedback_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.rag_query_feedback
-    ADD CONSTRAINT rag_query_feedback_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.property_knowledge_chunks
+    ADD CONSTRAINT property_knowledge_chunks_pkey PRIMARY KEY (id);
 
 
 --
--- Name: real_estate_intel real_estate_intel_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: property_knowledge property_knowledge_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.real_estate_intel
-    ADD CONSTRAINT real_estate_intel_pkey PRIMARY KEY (id);
-
-
---
--- Name: recursive_trace_log recursive_trace_log_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.recursive_trace_log
-    ADD CONSTRAINT recursive_trace_log_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.property_knowledge
+    ADD CONSTRAINT property_knowledge_pkey PRIMARY KEY (id);
 
 
 --
--- Name: revenue_ledger revenue_ledger_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: property_stay_restrictions property_stay_restrictions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.revenue_ledger
-    ADD CONSTRAINT revenue_ledger_pkey PRIMARY KEY (id);
-
-
---
--- Name: ruebarue_area_guide ruebarue_area_guide_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ruebarue_area_guide
-    ADD CONSTRAINT ruebarue_area_guide_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.property_stay_restrictions
+    ADD CONSTRAINT property_stay_restrictions_pkey PRIMARY KEY (id);
 
 
 --
--- Name: ruebarue_contacts ruebarue_contacts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: property_taxes property_taxes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ruebarue_contacts
-    ADD CONSTRAINT ruebarue_contacts_pkey PRIMARY KEY (id);
-
-
---
--- Name: ruebarue_guests ruebarue_guests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ruebarue_guests
-    ADD CONSTRAINT ruebarue_guests_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.property_taxes
+    ADD CONSTRAINT property_taxes_pkey PRIMARY KEY (id);
 
 
 --
--- Name: ruebarue_knowledge_base ruebarue_knowledge_base_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: property_utilities property_utilities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ruebarue_knowledge_base
-    ADD CONSTRAINT ruebarue_knowledge_base_pkey PRIMARY KEY (id);
-
-
---
--- Name: ruebarue_message_templates ruebarue_message_templates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ruebarue_message_templates
-    ADD CONSTRAINT ruebarue_message_templates_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.property_utilities
+    ADD CONSTRAINT property_utilities_pkey PRIMARY KEY (id);
 
 
 --
--- Name: sales_intel sales_intel_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: quote_options quote_options_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.sales_intel
-    ADD CONSTRAINT sales_intel_pkey PRIMARY KEY (id);
-
-
---
--- Name: schema_drift_log schema_drift_log_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.schema_drift_log
-    ADD CONSTRAINT schema_drift_log_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.quote_options
+    ADD CONSTRAINT quote_options_pkey PRIMARY KEY (id);
 
 
 --
--- Name: sender_registry sender_registry_raw_unique; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: quotes quotes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.sender_registry
-    ADD CONSTRAINT sender_registry_raw_unique UNIQUE (sender_raw);
-
-
---
--- Name: sentinel_alerts sentinel_alerts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.sentinel_alerts
-    ADD CONSTRAINT sentinel_alerts_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.quotes
+    ADD CONSTRAINT quotes_pkey PRIMARY KEY (id);
 
 
 --
--- Name: sentinel_state sentinel_state_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: recovery_parity_comparisons recovery_parity_comparisons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.sentinel_state
-    ADD CONSTRAINT sentinel_state_pkey PRIMARY KEY (key);
-
-
---
--- Name: sms_providers sms_providers_name_account_sid_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.sms_providers
-    ADD CONSTRAINT sms_providers_name_account_sid_key UNIQUE (name, account_sid);
+ALTER TABLE ONLY public.recovery_parity_comparisons
+    ADD CONSTRAINT recovery_parity_comparisons_pkey PRIMARY KEY (id);
 
 
 --
--- Name: sms_providers sms_providers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: rental_agreements rental_agreements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.sms_providers
-    ADD CONSTRAINT sms_providers_pkey PRIMARY KEY (id);
-
-
---
--- Name: sovereign_cycles sovereign_cycles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.sovereign_cycles
-    ADD CONSTRAINT sovereign_cycles_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.rental_agreements
+    ADD CONSTRAINT rental_agreements_pkey PRIMARY KEY (id);
 
 
 --
--- Name: starred_responses starred_responses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: reservation_holds reservation_holds_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.starred_responses
-    ADD CONSTRAINT starred_responses_pkey PRIMARY KEY (id);
-
-
---
--- Name: sys_api_credentials sys_api_credentials_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.sys_api_credentials
-    ADD CONSTRAINT sys_api_credentials_pkey PRIMARY KEY (service_name);
+ALTER TABLE ONLY public.reservation_holds
+    ADD CONSTRAINT reservation_holds_pkey PRIMARY KEY (id);
 
 
 --
--- Name: system_directives system_directives_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: reservations reservations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.system_directives
-    ADD CONSTRAINT system_directives_pkey PRIMARY KEY (id);
-
-
---
--- Name: system_drift_alerts system_drift_alerts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.system_drift_alerts
-    ADD CONSTRAINT system_drift_alerts_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.reservations
+    ADD CONSTRAINT reservations_pkey PRIMARY KEY (id);
 
 
 --
--- Name: system_post_mortems system_post_mortems_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: restricted_captures restricted_captures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.system_post_mortems
-    ADD CONSTRAINT system_post_mortems_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.restricted_captures
+    ADD CONSTRAINT restricted_captures_pkey PRIMARY KEY (id);
 
 
 --
--- Name: system_telemetry system_telemetry_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: rue_bar_rue_legacy_recovery_templates rue_bar_rue_legacy_recovery_templates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.system_telemetry
-    ADD CONSTRAINT system_telemetry_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.rue_bar_rue_legacy_recovery_templates
+    ADD CONSTRAINT rue_bar_rue_legacy_recovery_templates_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: scheduled_messages scheduled_messages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.scheduled_messages
+    ADD CONSTRAINT scheduled_messages_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: seo_patch_queue seo_patch_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.seo_patch_queue
+    ADD CONSTRAINT seo_patch_queue_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: seo_patches seo_patches_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.seo_patches
+    ADD CONSTRAINT seo_patches_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: seo_rank_snapshots seo_rank_snapshots_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.seo_rank_snapshots
+    ADD CONSTRAINT seo_rank_snapshots_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: seo_redirect_remap_queue seo_redirect_remap_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.seo_redirect_remap_queue
+    ADD CONSTRAINT seo_redirect_remap_queue_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: seo_redirects seo_redirects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.seo_redirects
+    ADD CONSTRAINT seo_redirects_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: seo_rubrics seo_rubrics_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.seo_rubrics
+    ADD CONSTRAINT seo_rubrics_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: shadow_discrepancies shadow_discrepancies_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.shadow_discrepancies
+    ADD CONSTRAINT shadow_discrepancies_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: staff_invites staff_invites_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.staff_invites
+    ADD CONSTRAINT staff_invites_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: staff_users staff_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.staff_users
+    ADD CONSTRAINT staff_users_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: storefront_intent_events storefront_intent_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.storefront_intent_events
+    ADD CONSTRAINT storefront_intent_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: storefront_session_guest_links storefront_session_guest_links_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.storefront_session_guest_links
+    ADD CONSTRAINT storefront_session_guest_links_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: streamline_payload_vault streamline_payload_vault_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.streamline_payload_vault
+    ADD CONSTRAINT streamline_payload_vault_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: stripe_connect_events stripe_connect_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.stripe_connect_events
+    ADD CONSTRAINT stripe_connect_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: survey_templates survey_templates_name_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.survey_templates
+    ADD CONSTRAINT survey_templates_name_key UNIQUE (name);
+
+
+--
+-- Name: survey_templates survey_templates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.survey_templates
+    ADD CONSTRAINT survey_templates_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: swarm_escalations swarm_escalations_decision_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.swarm_escalations
+    ADD CONSTRAINT swarm_escalations_decision_id_key UNIQUE (decision_id);
+
+
+--
+-- Name: swarm_escalations swarm_escalations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.swarm_escalations
+    ADD CONSTRAINT swarm_escalations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: taxes taxes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.taxes
+    ADD CONSTRAINT taxes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: taxonomy_categories taxonomy_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.taxonomy_categories
+    ADD CONSTRAINT taxonomy_categories_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: taylor_quote_requests taylor_quote_requests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.taylor_quote_requests
+    ADD CONSTRAINT taylor_quote_requests_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: trust_accounts trust_accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.trust_accounts
+    ADD CONSTRAINT trust_accounts_pkey PRIMARY KEY (id);
 
 
 --
@@ -9391,3023 +5391,4200 @@ ALTER TABLE ONLY public.trust_balance
 
 
 --
--- Name: trust_balance uq_trust_property; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: trust_decisions trust_decisions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.trust_balance
-    ADD CONSTRAINT uq_trust_property UNIQUE (property_id);
+ALTER TABLE ONLY public.trust_decisions
+    ADD CONSTRAINT trust_decisions_pkey PRIMARY KEY (id);
 
 
 --
--- Name: vault_alpha_state_law vault_alpha_state_law_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: trust_ledger_entries trust_ledger_entries_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.vault_alpha_state_law
-    ADD CONSTRAINT vault_alpha_state_law_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.trust_ledger_entries
+    ADD CONSTRAINT trust_ledger_entries_pkey PRIMARY KEY (id);
 
 
 --
--- Name: vault_beta_federal_law vault_beta_federal_law_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: trust_transactions trust_transactions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.vault_beta_federal_law
-    ADD CONSTRAINT vault_beta_federal_law_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.trust_transactions
+    ADD CONSTRAINT trust_transactions_pkey PRIMARY KEY (id);
 
 
 --
--- Name: vault_delta vault_delta_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.vault_delta
-    ADD CONSTRAINT vault_delta_pkey PRIMARY KEY (id);
-
-
---
--- Name: vault_gamma_evidence vault_gamma_evidence_file_hash_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.vault_gamma_evidence
-    ADD CONSTRAINT vault_gamma_evidence_file_hash_key UNIQUE (file_hash);
-
-
---
--- Name: vault_gamma_evidence vault_gamma_evidence_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.vault_gamma_evidence
-    ADD CONSTRAINT vault_gamma_evidence_pkey PRIMARY KEY (id);
-
-
---
--- Name: vision_runs vision_runs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.vision_runs
-    ADD CONSTRAINT vision_runs_pkey PRIMARY KEY (run_id);
-
-
---
--- Name: idx_div_a_pred_metric; Type: INDEX; Schema: division_a; Owner: -
---
-
-CREATE INDEX idx_div_a_pred_metric ON division_a.predictions USING btree (metric_name);
-
-
---
--- Name: idx_div_a_txn_category; Type: INDEX; Schema: division_a; Owner: -
---
-
-CREATE INDEX idx_div_a_txn_category ON division_a.transactions USING btree (category);
-
-
---
--- Name: idx_div_a_txn_date; Type: INDEX; Schema: division_a; Owner: -
---
-
-CREATE INDEX idx_div_a_txn_date ON division_a.transactions USING btree (date);
-
-
---
--- Name: idx_div_a_txn_vendor; Type: INDEX; Schema: division_a; Owner: -
---
-
-CREATE INDEX idx_div_a_txn_vendor ON division_a.transactions USING btree (vendor);
-
-
---
--- Name: idx_division_a_am_vendor; Type: INDEX; Schema: division_a; Owner: -
---
-
-CREATE INDEX idx_division_a_am_vendor ON division_a.account_mappings USING btree (vendor_name);
-
-
---
--- Name: idx_division_a_coa_type; Type: INDEX; Schema: division_a; Owner: -
---
-
-CREATE INDEX idx_division_a_coa_type ON division_a.chart_of_accounts USING btree (account_type);
-
-
---
--- Name: idx_division_a_gl_account; Type: INDEX; Schema: division_a; Owner: -
---
-
-CREATE INDEX idx_division_a_gl_account ON division_a.general_ledger USING btree (account_code);
-
-
---
--- Name: idx_division_a_gl_date; Type: INDEX; Schema: division_a; Owner: -
---
-
-CREATE INDEX idx_division_a_gl_date ON division_a.general_ledger USING btree (created_at);
-
-
---
--- Name: idx_division_a_gl_entry; Type: INDEX; Schema: division_a; Owner: -
---
-
-CREATE INDEX idx_division_a_gl_entry ON division_a.general_ledger USING btree (journal_entry_id);
-
-
---
--- Name: idx_division_a_je_date; Type: INDEX; Schema: division_a; Owner: -
---
-
-CREATE INDEX idx_division_a_je_date ON division_a.journal_entries USING btree (entry_date);
-
-
---
--- Name: idx_division_a_je_source; Type: INDEX; Schema: division_a; Owner: -
---
-
-CREATE INDEX idx_division_a_je_source ON division_a.journal_entries USING btree (source_ref);
-
-
---
--- Name: idx_div_b_escrow_cabin; Type: INDEX; Schema: division_b; Owner: -
---
-
-CREATE INDEX idx_div_b_escrow_cabin ON division_b.escrow USING btree (cabin_id);
-
-
---
--- Name: idx_div_b_escrow_status; Type: INDEX; Schema: division_b; Owner: -
---
-
-CREATE INDEX idx_div_b_escrow_status ON division_b.escrow USING btree (status);
-
-
---
--- Name: idx_div_b_txn_date; Type: INDEX; Schema: division_b; Owner: -
---
-
-CREATE INDEX idx_div_b_txn_date ON division_b.transactions USING btree (date);
-
-
---
--- Name: idx_div_b_txn_trust; Type: INDEX; Schema: division_b; Owner: -
---
-
-CREATE INDEX idx_div_b_txn_trust ON division_b.transactions USING btree (trust_related);
-
-
---
--- Name: idx_division_b_am_vendor; Type: INDEX; Schema: division_b; Owner: -
---
-
-CREATE INDEX idx_division_b_am_vendor ON division_b.account_mappings USING btree (vendor_name);
-
-
---
--- Name: idx_division_b_coa_type; Type: INDEX; Schema: division_b; Owner: -
---
-
-CREATE INDEX idx_division_b_coa_type ON division_b.chart_of_accounts USING btree (account_type);
-
-
---
--- Name: idx_division_b_gl_account; Type: INDEX; Schema: division_b; Owner: -
---
-
-CREATE INDEX idx_division_b_gl_account ON division_b.general_ledger USING btree (account_code);
-
-
---
--- Name: idx_division_b_gl_date; Type: INDEX; Schema: division_b; Owner: -
---
-
-CREATE INDEX idx_division_b_gl_date ON division_b.general_ledger USING btree (created_at);
-
-
---
--- Name: idx_division_b_gl_entry; Type: INDEX; Schema: division_b; Owner: -
---
-
-CREATE INDEX idx_division_b_gl_entry ON division_b.general_ledger USING btree (journal_entry_id);
-
-
---
--- Name: idx_division_b_je_date; Type: INDEX; Schema: division_b; Owner: -
---
-
-CREATE INDEX idx_division_b_je_date ON division_b.journal_entries USING btree (entry_date);
-
-
---
--- Name: idx_division_b_je_source; Type: INDEX; Schema: division_b; Owner: -
---
-
-CREATE INDEX idx_division_b_je_source ON division_b.journal_entries USING btree (source_ref);
-
-
---
--- Name: idx_eng_co_project; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_co_project ON engineering.change_orders USING btree (project_id);
-
-
---
--- Name: idx_eng_co_status; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_co_status ON engineering.change_orders USING btree (status);
-
-
---
--- Name: idx_eng_comp_project; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_comp_project ON engineering.compliance_log USING btree (project_id);
-
-
---
--- Name: idx_eng_comp_severity; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_comp_severity ON engineering.compliance_log USING btree (severity);
-
-
---
--- Name: idx_eng_comp_status; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_comp_status ON engineering.compliance_log USING btree (status);
-
-
---
--- Name: idx_eng_cost_project; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_cost_project ON engineering.cost_estimates USING btree (project_id);
-
-
---
--- Name: idx_eng_cost_type; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_cost_type ON engineering.cost_estimates USING btree (estimate_type);
-
-
---
--- Name: idx_eng_draw_discipline; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_draw_discipline ON engineering.drawings USING btree (discipline);
-
-
---
--- Name: idx_eng_draw_doc_type; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_draw_doc_type ON engineering.drawings USING btree (doc_type);
-
-
---
--- Name: idx_eng_draw_project; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_draw_project ON engineering.drawings USING btree (project_id);
-
-
---
--- Name: idx_eng_draw_property; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_draw_property ON engineering.drawings USING btree (property_id);
-
-
---
--- Name: idx_eng_insp_project; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_insp_project ON engineering.inspections USING btree (project_id);
-
-
---
--- Name: idx_eng_insp_result; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_insp_result ON engineering.inspections USING btree (result);
-
-
---
--- Name: idx_eng_insp_scheduled; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_insp_scheduled ON engineering.inspections USING btree (scheduled_date);
-
-
---
--- Name: idx_eng_mep_condition; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_mep_condition ON engineering.mep_systems USING btree (condition);
-
-
---
--- Name: idx_eng_mep_property; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_mep_property ON engineering.mep_systems USING btree (property_id);
-
-
---
--- Name: idx_eng_mep_type; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_mep_type ON engineering.mep_systems USING btree (system_type);
-
-
---
--- Name: idx_eng_perm_expiration; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_perm_expiration ON engineering.permits USING btree (expiration_date);
-
-
---
--- Name: idx_eng_perm_project; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_perm_project ON engineering.permits USING btree (project_id);
-
-
---
--- Name: idx_eng_perm_status; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_perm_status ON engineering.permits USING btree (status);
-
-
---
--- Name: idx_eng_proj_phase; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_proj_phase ON engineering.projects USING btree (phase);
-
-
---
--- Name: idx_eng_proj_property; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_proj_property ON engineering.projects USING btree (property_id);
-
-
---
--- Name: idx_eng_proj_status; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_proj_status ON engineering.projects USING btree (status);
-
-
---
--- Name: idx_eng_punch_project; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_punch_project ON engineering.punch_items USING btree (project_id);
-
-
---
--- Name: idx_eng_punch_status; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_punch_status ON engineering.punch_items USING btree (status);
-
-
---
--- Name: idx_eng_rfi_project; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_rfi_project ON engineering.rfis USING btree (project_id);
-
-
---
--- Name: idx_eng_rfi_status; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_rfi_status ON engineering.rfis USING btree (status);
-
-
---
--- Name: idx_eng_sub_project; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_sub_project ON engineering.submittals USING btree (project_id);
-
-
---
--- Name: idx_eng_sub_status; Type: INDEX; Schema: engineering; Owner: -
---
-
-CREATE INDEX idx_eng_sub_status ON engineering.submittals USING btree (status);
-
-
---
--- Name: idx_classification_rules_embedding_hnsw; Type: INDEX; Schema: finance; Owner: -
---
-
-CREATE INDEX idx_classification_rules_embedding_hnsw ON finance.classification_rules USING hnsw (embedding public.vector_cosine_ops) WITH (m='16', ef_construction='64');
-
-
---
--- Name: idx_rules_category; Type: INDEX; Schema: finance; Owner: -
---
-
-CREATE INDEX idx_rules_category ON finance.classification_rules USING btree (assigned_category);
-
-
---
--- Name: idx_rules_embedding_hnsw; Type: INDEX; Schema: finance; Owner: -
---
-
-CREATE INDEX idx_rules_embedding_hnsw ON finance.classification_rules USING hnsw (embedding public.vector_cosine_ops) WITH (m='16', ef_construction='64');
-
-
---
--- Name: idx_vendor_class_pattern; Type: INDEX; Schema: finance; Owner: -
---
-
-CREATE INDEX idx_vendor_class_pattern ON finance.vendor_classifications USING btree (vendor_pattern);
-
-
---
--- Name: idx_hf_extraction_email_unique; Type: INDEX; Schema: hedge_fund; Owner: -
---
-
-CREATE UNIQUE INDEX idx_hf_extraction_email_unique ON hedge_fund.extraction_log USING btree (email_id);
-
-
---
--- Name: idx_hf_signals_action; Type: INDEX; Schema: hedge_fund; Owner: -
---
-
-CREATE INDEX idx_hf_signals_action ON hedge_fund.market_signals USING btree (action);
-
-
---
--- Name: idx_hf_signals_confidence; Type: INDEX; Schema: hedge_fund; Owner: -
---
-
-CREATE INDEX idx_hf_signals_confidence ON hedge_fund.market_signals USING btree (confidence_score);
-
-
---
--- Name: idx_hf_signals_extracted; Type: INDEX; Schema: hedge_fund; Owner: -
---
-
-CREATE INDEX idx_hf_signals_extracted ON hedge_fund.market_signals USING btree (extracted_at);
-
-
---
--- Name: idx_hf_signals_ticker; Type: INDEX; Schema: hedge_fund; Owner: -
---
-
-CREATE INDEX idx_hf_signals_ticker ON hedge_fund.market_signals USING btree (ticker);
-
-
---
--- Name: idx_hf_watchlist_ticker; Type: INDEX; Schema: hedge_fund; Owner: -
---
-
-CREATE INDEX idx_hf_watchlist_ticker ON hedge_fund.watchlist USING btree (ticker);
-
-
---
--- Name: idx_entities_key; Type: INDEX; Schema: intelligence; Owner: -
---
-
-CREATE INDEX idx_entities_key ON intelligence.entities USING btree (entity_key);
-
-
---
--- Name: idx_entities_type; Type: INDEX; Schema: intelligence; Owner: -
---
-
-CREATE INDEX idx_entities_type ON intelligence.entities USING btree (entity_type);
-
-
---
--- Name: idx_golden_entity; Type: INDEX; Schema: intelligence; Owner: -
---
-
-CREATE INDEX idx_golden_entity ON intelligence.golden_reasoning USING btree (entity_key);
-
-
---
--- Name: idx_golden_topic; Type: INDEX; Schema: intelligence; Owner: -
---
-
-CREATE INDEX idx_golden_topic ON intelligence.golden_reasoning USING btree (topic);
-
-
---
--- Name: idx_rel_from; Type: INDEX; Schema: intelligence; Owner: -
---
-
-CREATE INDEX idx_rel_from ON intelligence.relationships USING btree (from_entity_id);
-
-
---
--- Name: idx_rel_to; Type: INDEX; Schema: intelligence; Owner: -
---
-
-CREATE INDEX idx_rel_to ON intelligence.relationships USING btree (to_entity_id);
-
-
---
--- Name: idx_rel_type; Type: INDEX; Schema: intelligence; Owner: -
---
-
-CREATE INDEX idx_rel_type ON intelligence.relationships USING btree (relationship_type);
-
-
---
--- Name: idx_traces_created; Type: INDEX; Schema: intelligence; Owner: -
---
-
-CREATE INDEX idx_traces_created ON intelligence.titan_traces USING btree (created_at DESC);
-
-
---
--- Name: idx_traces_session; Type: INDEX; Schema: intelligence; Owner: -
---
-
-CREATE INDEX idx_traces_session ON intelligence.titan_traces USING btree (session_type);
-
-
---
--- Name: idx_case_actions_case; Type: INDEX; Schema: legal; Owner: -
---
-
-CREATE INDEX idx_case_actions_case ON legal.case_actions USING btree (case_id);
-
-
---
--- Name: idx_case_evidence_case; Type: INDEX; Schema: legal; Owner: -
---
-
-CREATE INDEX idx_case_evidence_case ON legal.case_evidence USING btree (case_id);
-
-
---
--- Name: idx_case_precedents_score; Type: INDEX; Schema: legal; Owner: -
---
-
-CREATE INDEX idx_case_precedents_score ON legal.case_precedents USING btree (relevance_score DESC);
-
-
---
--- Name: idx_case_precedents_slug; Type: INDEX; Schema: legal; Owner: -
---
-
-CREATE INDEX idx_case_precedents_slug ON legal.case_precedents USING btree (case_slug);
-
-
---
--- Name: idx_case_slug; Type: INDEX; Schema: legal; Owner: -
---
-
-CREATE INDEX idx_case_slug ON legal.cases USING btree (case_slug);
-
-
---
--- Name: idx_case_watchdog_case; Type: INDEX; Schema: legal; Owner: -
---
-
-CREATE INDEX idx_case_watchdog_case ON legal.case_watchdog USING btree (case_id);
-
-
---
--- Name: idx_correspondence_case; Type: INDEX; Schema: legal; Owner: -
---
-
-CREATE INDEX idx_correspondence_case ON legal.correspondence USING btree (case_id);
-
-
---
--- Name: idx_correspondence_status; Type: INDEX; Schema: legal; Owner: -
---
-
-CREATE INDEX idx_correspondence_status ON legal.correspondence USING btree (status);
-
-
---
--- Name: idx_deadlines_case; Type: INDEX; Schema: legal; Owner: -
---
-
-CREATE INDEX idx_deadlines_case ON legal.deadlines USING btree (case_id);
-
-
---
--- Name: idx_deadlines_due; Type: INDEX; Schema: legal; Owner: -
---
-
-CREATE INDEX idx_deadlines_due ON legal.deadlines USING btree (due_date);
-
-
---
--- Name: idx_deadlines_status; Type: INDEX; Schema: legal; Owner: -
---
-
-CREATE INDEX idx_deadlines_status ON legal.deadlines USING btree (status);
-
-
---
--- Name: idx_filings_case; Type: INDEX; Schema: legal; Owner: -
---
-
-CREATE INDEX idx_filings_case ON legal.filings USING btree (case_id);
-
-
---
--- Name: idx_ingest_runs_case_slug; Type: INDEX; Schema: legal; Owner: -
---
-
-CREATE INDEX idx_ingest_runs_case_slug ON legal.ingest_runs USING btree (case_slug);
-
-
---
--- Name: idx_ingest_runs_started_at; Type: INDEX; Schema: legal; Owner: -
---
-
-CREATE INDEX idx_ingest_runs_started_at ON legal.ingest_runs USING btree (started_at DESC);
-
-
---
--- Name: idx_ingest_runs_status; Type: INDEX; Schema: legal; Owner: -
---
-
-CREATE INDEX idx_ingest_runs_status ON legal.ingest_runs USING btree (status) WHERE (status = ANY (ARRAY['running'::text, 'error'::text]));
-
-
---
--- Name: idx_legalexp_case; Type: INDEX; Schema: legal; Owner: -
---
-
-CREATE INDEX idx_legalexp_case ON legal.expense_intake USING btree (case_slug);
-
-
---
--- Name: idx_uploads_case; Type: INDEX; Schema: legal; Owner: -
---
-
-CREATE INDEX idx_uploads_case ON legal.uploads USING btree (case_id);
-
-
---
--- Name: idx_uploads_filing; Type: INDEX; Schema: legal; Owner: -
---
-
-CREATE INDEX idx_uploads_filing ON legal.uploads USING btree (filing_id);
-
-
---
--- Name: idx_vault_documents_case_slug; Type: INDEX; Schema: legal; Owner: -
---
-
-CREATE INDEX idx_vault_documents_case_slug ON legal.vault_documents USING btree (case_slug);
-
-
---
--- Name: idx_vault_documents_created_at; Type: INDEX; Schema: legal; Owner: -
---
-
-CREATE INDEX idx_vault_documents_created_at ON legal.vault_documents USING btree (created_at DESC);
-
-
---
--- Name: idx_vault_documents_file_hash; Type: INDEX; Schema: legal; Owner: -
---
-
-CREATE INDEX idx_vault_documents_file_hash ON legal.vault_documents USING btree (file_hash);
-
-
---
--- Name: idx_vault_documents_status; Type: INDEX; Schema: legal; Owner: -
---
-
-CREATE INDEX idx_vault_documents_status ON legal.vault_documents USING btree (processing_status) WHERE (processing_status = ANY (ARRAY['pending'::text, 'processing'::text, 'vectorizing'::text, 'error'::text, 'failed'::text, 'ocr_failed'::text]));
-
-
---
--- Name: ix_legal_email_intake_case; Type: INDEX; Schema: legal; Owner: -
---
-
-CREATE INDEX ix_legal_email_intake_case ON legal.email_intake_queue USING btree (case_slug);
-
-
---
--- Name: ix_legal_email_intake_rcvd; Type: INDEX; Schema: legal; Owner: -
---
-
-CREATE INDEX ix_legal_email_intake_rcvd ON legal.email_intake_queue USING btree (received_at DESC);
-
-
---
--- Name: ix_legal_email_intake_status; Type: INDEX; Schema: legal; Owner: -
---
-
-CREATE INDEX ix_legal_email_intake_status ON legal.email_intake_queue USING btree (intake_status);
-
-
---
--- Name: uq_deadlines_content_hash; Type: INDEX; Schema: legal; Owner: -
---
-
-CREATE UNIQUE INDEX uq_deadlines_content_hash ON legal.deadlines USING btree (content_hash) WHERE (content_hash IS NOT NULL);
-
-
---
--- Name: idx_attorney_score; Type: INDEX; Schema: legal_cmd; Owner: -
---
-
-CREATE INDEX idx_attorney_score ON legal_cmd.attorney_scoring USING btree (sota_match_score DESC);
-
-
---
--- Name: idx_attorneys_ai_score; Type: INDEX; Schema: legal_cmd; Owner: -
---
-
-CREATE INDEX idx_attorneys_ai_score ON legal_cmd.attorneys USING btree (ai_score DESC);
-
-
---
--- Name: idx_attorneys_outreach; Type: INDEX; Schema: legal_cmd; Owner: -
---
-
-CREATE INDEX idx_attorneys_outreach ON legal_cmd.attorneys USING btree (outreach_status);
-
-
---
--- Name: idx_attorneys_practice; Type: INDEX; Schema: legal_cmd; Owner: -
---
-
-CREATE INDEX idx_attorneys_practice ON legal_cmd.attorneys USING gin (practice_areas);
-
-
---
--- Name: idx_attorneys_specialty; Type: INDEX; Schema: legal_cmd; Owner: -
---
-
-CREATE INDEX idx_attorneys_specialty ON legal_cmd.attorneys USING btree (specialty);
-
-
---
--- Name: idx_attorneys_status; Type: INDEX; Schema: legal_cmd; Owner: -
---
-
-CREATE INDEX idx_attorneys_status ON legal_cmd.attorneys USING btree (status);
-
-
---
--- Name: idx_delib_case; Type: INDEX; Schema: legal_cmd; Owner: -
---
-
-CREATE INDEX idx_delib_case ON legal_cmd.deliberation_events USING btree (case_slug, "timestamp" DESC);
-
-
---
--- Name: idx_delib_sig; Type: INDEX; Schema: legal_cmd; Owner: -
---
-
-CREATE INDEX idx_delib_sig ON legal_cmd.deliberation_events USING btree (sha256_signature);
-
-
---
--- Name: idx_documents_matter; Type: INDEX; Schema: legal_cmd; Owner: -
---
-
-CREATE INDEX idx_documents_matter ON legal_cmd.documents USING btree (matter_id);
-
-
---
--- Name: idx_documents_type; Type: INDEX; Schema: legal_cmd; Owner: -
---
-
-CREATE INDEX idx_documents_type ON legal_cmd.documents USING btree (doc_type);
-
-
---
--- Name: idx_matters_attorney; Type: INDEX; Schema: legal_cmd; Owner: -
---
-
-CREATE INDEX idx_matters_attorney ON legal_cmd.matters USING btree (attorney_id);
-
-
---
--- Name: idx_matters_category; Type: INDEX; Schema: legal_cmd; Owner: -
---
-
-CREATE INDEX idx_matters_category ON legal_cmd.matters USING btree (category);
-
-
---
--- Name: idx_matters_priority; Type: INDEX; Schema: legal_cmd; Owner: -
---
-
-CREATE INDEX idx_matters_priority ON legal_cmd.matters USING btree (priority);
-
-
---
--- Name: idx_matters_status; Type: INDEX; Schema: legal_cmd; Owner: -
---
-
-CREATE INDEX idx_matters_status ON legal_cmd.matters USING btree (status);
-
-
---
--- Name: idx_meetings_attorney; Type: INDEX; Schema: legal_cmd; Owner: -
---
-
-CREATE INDEX idx_meetings_attorney ON legal_cmd.meetings USING btree (attorney_id);
-
-
---
--- Name: idx_meetings_date; Type: INDEX; Schema: legal_cmd; Owner: -
---
-
-CREATE INDEX idx_meetings_date ON legal_cmd.meetings USING btree (meeting_date);
-
-
---
--- Name: idx_meetings_matter; Type: INDEX; Schema: legal_cmd; Owner: -
---
-
-CREATE INDEX idx_meetings_matter ON legal_cmd.meetings USING btree (matter_id);
-
-
---
--- Name: idx_timeline_created; Type: INDEX; Schema: legal_cmd; Owner: -
---
-
-CREATE INDEX idx_timeline_created ON legal_cmd.timeline USING btree (created_at);
-
-
---
--- Name: idx_timeline_matter; Type: INDEX; Schema: legal_cmd; Owner: -
---
-
-CREATE INDEX idx_timeline_matter ON legal_cmd.timeline USING btree (matter_id);
-
-
---
--- Name: idx_timeline_type; Type: INDEX; Schema: legal_cmd; Owner: -
---
-
-CREATE INDEX idx_timeline_type ON legal_cmd.timeline USING btree (entry_type);
-
-
---
--- Name: alpha_gin_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX alpha_gin_idx ON public.vault_alpha_state_law USING gin (text_search);
-
-
---
--- Name: alpha_meta_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX alpha_meta_idx ON public.vault_alpha_state_law USING gin (metadata);
-
-
---
--- Name: alpha_state_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX alpha_state_idx ON public.vault_alpha_state_law USING gin (text_search);
-
-
---
--- Name: beta_federal_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX beta_federal_idx ON public.vault_beta_federal_law USING gin (text_search);
-
-
---
--- Name: beta_gin_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX beta_gin_idx ON public.vault_beta_federal_law USING gin (text_search);
-
-
---
--- Name: beta_meta_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX beta_meta_idx ON public.vault_beta_federal_law USING gin (metadata);
-
-
---
--- Name: council_log_session_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX council_log_session_idx ON public.godhead_query_log USING btree (session_id);
-
-
---
--- Name: council_log_time_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX council_log_time_idx ON public.godhead_query_log USING btree (queried_at DESC);
-
-
---
--- Name: gamma_date_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX gamma_date_idx ON public.vault_gamma_evidence USING btree (date_authored);
-
-
---
--- Name: gamma_hash_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX gamma_hash_idx ON public.vault_gamma_evidence USING btree (file_hash);
-
-
---
--- Name: gamma_metadata_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX gamma_metadata_idx ON public.vault_gamma_evidence USING gin (metadata);
-
-
---
--- Name: gamma_text_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX gamma_text_idx ON public.vault_gamma_evidence USING gin (text_search);
-
-
---
--- Name: gamma_type_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX gamma_type_idx ON public.vault_gamma_evidence USING btree (doc_type);
-
-
---
--- Name: idx_ab_agent; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ab_agent ON public.ab_tests USING btree (agent_id);
-
-
---
--- Name: idx_ab_status; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ab_status ON public.ab_tests USING btree (status);
-
-
---
--- Name: idx_abo_created; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_abo_created ON public.ab_test_observations USING btree (created_at);
-
-
---
--- Name: idx_abo_test; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_abo_test ON public.ab_test_observations USING btree (test_id);
-
-
---
--- Name: idx_abo_variant; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_abo_variant ON public.ab_test_observations USING btree (variant);
-
-
---
--- Name: idx_acct_code; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_acct_code ON public.accounts USING btree (code);
-
-
---
--- Name: idx_acct_property; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_acct_property ON public.accounts USING btree (property_id);
-
-
---
--- Name: idx_acct_type; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_acct_type ON public.accounts USING btree (account_type);
-
-
---
--- Name: idx_ad_doc_type; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ad_doc_type ON public.asset_docs USING btree (doc_type);
-
-
---
--- Name: idx_ad_property_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ad_property_id ON public.asset_docs USING btree (property_id);
-
-
---
--- Name: idx_ad_property_name; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ad_property_name ON public.asset_docs USING btree (property_name);
-
-
---
--- Name: idx_af_entry; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_af_entry ON public.anomaly_flags USING btree (journal_entry_id);
-
-
---
--- Name: idx_af_reviewed; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_af_reviewed ON public.anomaly_flags USING btree (reviewed);
-
-
---
--- Name: idx_af_severity; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_af_severity ON public.anomaly_flags USING btree (severity);
-
-
---
--- Name: idx_af_type; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_af_type ON public.anomaly_flags USING btree (flag_type);
-
-
---
--- Name: idx_agent_memory_created_at; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_agent_memory_created_at ON public.agent_memory USING btree (created_at);
-
-
---
--- Name: idx_agent_telemetry_created_at; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_agent_telemetry_created_at ON public.agent_telemetry USING btree (created_at);
-
-
---
--- Name: idx_agent_telemetry_success; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_agent_telemetry_success ON public.agent_telemetry USING btree (error_class) WHERE (error_class IS NULL);
-
-
---
--- Name: idx_alq_agent; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_alq_agent ON public.active_learning_queue USING btree (agent_id);
-
-
---
--- Name: idx_alq_status; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_alq_status ON public.active_learning_queue USING btree (status);
-
-
---
--- Name: idx_analytics_date; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_analytics_date ON public.message_analytics USING btree (date DESC);
-
-
---
--- Name: idx_analytics_property; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_analytics_property ON public.message_analytics USING btree (property_id);
-
-
---
--- Name: idx_apl_date; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX idx_apl_date ON public.agent_performance_log USING btree (date);
-
-
---
--- Name: idx_arq_cabin; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_arq_cabin ON public.agent_response_queue USING btree (cabin_name);
-
-
---
--- Name: idx_arq_created; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_arq_created ON public.agent_response_queue USING btree (created_at DESC);
-
-
---
--- Name: idx_arq_status; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_arq_status ON public.agent_response_queue USING btree (status);
-
-
---
--- Name: idx_arq_urgency; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_arq_urgency ON public.agent_response_queue USING btree (urgency_level DESC);
-
-
---
--- Name: idx_class_rules_active; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_class_rules_active ON public.email_classification_rules USING btree (division, is_active) WHERE (is_active = true);
-
-
---
--- Name: idx_council_votes_created; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_council_votes_created ON public.council_votes USING btree (created_at DESC);
-
-
---
--- Name: idx_council_votes_resolved; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_council_votes_resolved ON public.council_votes USING btree (resolved_at) WHERE (resolved_at IS NOT NULL);
-
-
---
--- Name: idx_deferred_writes_service; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_deferred_writes_service ON public.deferred_api_writes USING btree (service, method);
-
-
---
--- Name: idx_deferred_writes_status; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_deferred_writes_status ON public.deferred_api_writes USING btree (status, next_retry_at);
-
-
---
--- Name: idx_dlq_created; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_dlq_created ON public.ingestion_dlq USING btree (created_at DESC);
-
-
---
--- Name: idx_dlq_source; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_dlq_source ON public.ingestion_dlq USING btree (source, resolved);
-
-
---
--- Name: idx_dlq_status_retry; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_dlq_status_retry ON public.email_dead_letter_queue USING btree (status, next_retry_at);
-
-
---
--- Name: idx_docket_matter; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_docket_matter ON public.legal_docket USING btree (matter_id);
-
-
---
--- Name: idx_drift_endpoint; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_drift_endpoint ON public.schema_drift_log USING btree (endpoint, created_at DESC);
-
-
---
--- Name: idx_email_category; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_email_category ON public.email_archive USING btree (category);
-
-
---
--- Name: idx_email_division; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_email_division ON public.email_archive USING btree (division);
-
-
---
--- Name: idx_email_division_null; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_email_division_null ON public.email_archive USING btree (id) WHERE (division IS NULL);
-
-
---
--- Name: idx_email_ingested_from; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_email_ingested_from ON public.email_archive USING btree (ingested_from);
-
-
---
--- Name: idx_email_message_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_email_message_id ON public.email_archive USING btree (message_id);
-
-
---
--- Name: idx_email_mined; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_email_mined ON public.email_archive USING btree (is_mined);
-
-
---
--- Name: idx_email_to_addr; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_email_to_addr ON public.email_archive USING btree (to_addresses);
-
-
---
--- Name: idx_email_triage_precedents_embedding_hnsw; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_email_triage_precedents_embedding_hnsw ON public.email_triage_precedents USING hnsw (embedding public.vector_cosine_ops) WITH (m='16', ef_construction='64');
-
-
---
--- Name: idx_email_ts; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_email_ts ON public.email_archive USING gin (ts);
-
-
---
--- Name: idx_escalation_pending; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_escalation_pending ON public.email_escalation_queue USING btree (status, priority) WHERE ((status)::text = 'pending'::text);
-
-
---
--- Name: idx_etp_division; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_etp_division ON public.email_triage_precedents USING btree (division);
-
-
---
--- Name: idx_etp_embedding; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_etp_embedding ON public.email_triage_precedents USING hnsw (embedding public.vector_cosine_ops);
-
-
---
--- Name: idx_fin_res_dates; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_fin_res_dates ON public.fin_reservations USING btree (check_in, check_out);
-
-
---
--- Name: idx_fin_res_property; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_fin_res_property ON public.fin_reservations USING btree (property_id);
-
-
---
--- Name: idx_fin_res_status; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_fin_res_status ON public.fin_reservations USING btree (status);
-
-
---
--- Name: idx_fin_snap_period; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_fin_snap_period ON public.fin_revenue_snapshots USING btree (period_start, period_end);
-
-
---
--- Name: idx_finance_date; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_finance_date ON public.finance_invoices USING btree (date);
-
-
---
--- Name: idx_finance_source_email; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_finance_source_email ON public.finance_invoices USING btree (source_email_id);
-
-
---
--- Name: idx_finance_vendor; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_finance_vendor ON public.finance_invoices USING btree (vendor);
-
-
---
--- Name: idx_gl_business; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_gl_business ON public.general_ledger USING btree (business);
-
-
---
--- Name: idx_gl_cabin; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_gl_cabin ON public.general_ledger USING btree (cabin);
-
-
---
--- Name: idx_gl_category; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_gl_category ON public.general_ledger USING btree (category);
-
-
---
--- Name: idx_gl_checkin; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_gl_checkin ON public.guest_leads USING btree (check_in);
-
-
---
--- Name: idx_gl_doc_type; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_gl_doc_type ON public.general_ledger USING btree (doc_type);
-
-
---
--- Name: idx_gl_email; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_gl_email ON public.guest_leads USING btree (source_email_id);
-
-
---
--- Name: idx_gl_event; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_gl_event ON public.guest_leads USING btree (event_type);
-
-
---
--- Name: idx_gl_status; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_gl_status ON public.guest_leads USING btree (status);
-
-
---
--- Name: idx_gl_tax_year; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_gl_tax_year ON public.general_ledger USING btree (tax_year);
-
-
---
--- Name: idx_guest_email; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_guest_email ON public.guest_profiles USING btree (email);
-
-
---
--- Name: idx_guest_last_contact; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_guest_last_contact ON public.guest_profiles USING btree (last_contact DESC);
-
-
---
--- Name: idx_guest_phone; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_guest_phone ON public.guest_profiles USING btree (phone_number);
-
-
---
--- Name: idx_guest_vip; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_guest_vip ON public.guest_profiles USING btree (vip_guest) WHERE (vip_guest = true);
-
-
---
--- Name: idx_je_date; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_je_date ON public.journal_entries USING btree (entry_date);
-
-
---
--- Name: idx_je_property; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_je_property ON public.journal_entries USING btree (property_id);
-
-
---
--- Name: idx_je_ref; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_je_ref ON public.journal_entries USING btree (reference_id);
-
-
---
--- Name: idx_je_ref_type; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_je_ref_type ON public.journal_entries USING btree (reference_type);
-
-
---
--- Name: idx_je_source; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_je_source ON public.journal_entries USING btree (source_system);
-
-
---
--- Name: idx_je_void; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_je_void ON public.journal_entries USING btree (is_void);
-
-
---
--- Name: idx_jli_account; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_jli_account ON public.journal_line_items USING btree (account_id);
-
-
---
--- Name: idx_jli_entry; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_jli_entry ON public.journal_line_items USING btree (journal_entry_id);
-
-
---
--- Name: idx_lj_agent; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_lj_agent ON public.learning_judgments USING btree (agent_id);
-
-
---
--- Name: idx_lj_created; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_lj_created ON public.learning_judgments USING btree (created_at);
-
-
---
--- Name: idx_lj_metric; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_lj_metric ON public.learning_judgments USING btree (metric_name);
-
-
---
--- Name: idx_lj_passed; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_lj_passed ON public.learning_judgments USING btree (passed);
-
-
---
--- Name: idx_lo_agent; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_lo_agent ON public.learning_optimizations USING btree (agent_id);
-
-
---
--- Name: idx_lo_created; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_lo_created ON public.learning_optimizations USING btree (created_at);
-
-
---
--- Name: idx_lo_method; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_lo_method ON public.learning_optimizations USING btree (method);
-
-
---
--- Name: idx_market_action; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_market_action ON public.market_signals USING btree (action);
-
-
---
--- Name: idx_market_source_email; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_market_source_email ON public.market_signals USING btree (source_email_id);
-
-
---
--- Name: idx_market_ticker; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_market_ticker ON public.market_signals USING btree (ticker);
-
-
---
--- Name: idx_matters_client; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_matters_client ON public.legal_matters USING btree (client_id);
-
-
---
--- Name: idx_matters_status; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_matters_status ON public.legal_matters USING btree (status);
-
-
---
--- Name: idx_message_body_fts; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_message_body_fts ON public.message_archive USING gin (to_tsvector('english'::regconfig, message_body));
-
-
---
--- Name: idx_message_direction; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_message_direction ON public.message_archive USING btree (direction);
-
-
---
--- Name: idx_message_external_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_message_external_id ON public.message_archive USING btree (external_id);
-
-
---
--- Name: idx_message_intent; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_message_intent ON public.message_archive USING btree (intent);
-
-
---
--- Name: idx_message_phone; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_message_phone ON public.message_archive USING btree (phone_number);
-
-
---
--- Name: idx_message_property; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_message_property ON public.message_archive USING btree (property_id);
-
-
---
--- Name: idx_message_sent_at; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_message_sent_at ON public.message_archive USING btree (sent_at DESC);
-
-
---
--- Name: idx_message_source; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_message_source ON public.message_archive USING btree (source);
-
-
---
--- Name: idx_message_status; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_message_status ON public.message_archive USING btree (status);
-
-
---
--- Name: idx_message_training; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_message_training ON public.message_archive USING btree (used_for_training) WHERE (used_for_training = true);
-
-
---
--- Name: idx_ml_cabin; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ml_cabin ON public.maintenance_log USING btree (cabin_name);
-
-
---
--- Name: idx_ml_date; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ml_date ON public.maintenance_log USING btree (generated_at);
-
-
---
--- Name: idx_ml_room; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ml_room ON public.maintenance_log USING btree (room_type);
-
-
---
--- Name: idx_ml_run; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ml_run ON public.maintenance_log USING btree (run_id);
-
-
---
--- Name: idx_ml_verdict; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ml_verdict ON public.maintenance_log USING btree (verdict);
-
-
---
--- Name: idx_mt_created; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_mt_created ON public.model_telemetry USING btree (created_at);
-
-
---
--- Name: idx_mt_model; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_mt_model ON public.model_telemetry USING btree (model_name);
-
-
---
--- Name: idx_mt_node; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_mt_node ON public.model_telemetry USING btree (node);
-
-
---
--- Name: idx_mt_op; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_mt_op ON public.model_telemetry USING btree (operation);
-
-
---
--- Name: idx_mt_success; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_mt_success ON public.model_telemetry USING btree (success);
-
-
---
--- Name: idx_nas_vault_case_number; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_nas_vault_case_number ON public.nas_legal_vault USING btree (((metadata ->> 'case_number'::text)));
-
-
---
--- Name: idx_nas_vault_deadline; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_nas_vault_deadline ON public.nas_legal_vault USING btree (((metadata ->> 'next_deadline'::text)));
-
-
---
--- Name: idx_nas_vault_doc_type; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_nas_vault_doc_type ON public.nas_legal_vault USING btree (((metadata ->> 'doc_type'::text)));
-
-
---
--- Name: idx_nas_vault_embedding; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_nas_vault_embedding ON public.nas_legal_vault USING hnsw (embedding public.vector_cosine_ops);
-
-
---
--- Name: idx_nas_vault_priority; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_nas_vault_priority ON public.nas_legal_vault USING btree (((metadata ->> 'priority'::text)));
-
-
---
--- Name: idx_nas_vault_source_file; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_nas_vault_source_file ON public.nas_legal_vault USING btree (source_file);
-
-
---
--- Name: idx_nim_arm64_probe_date; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_nim_arm64_probe_date ON public.nim_arm64_probe_results USING btree (probe_date);
-
-
---
--- Name: idx_nim_arm64_probe_image; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_nim_arm64_probe_image ON public.nim_arm64_probe_results USING btree (image_path);
-
-
---
--- Name: idx_notes_matter; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_notes_matter ON public.legal_matter_notes USING btree (matter_id);
-
-
---
--- Name: idx_ops_crew_role; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ops_crew_role ON public.ops_crew USING btree (role);
-
-
---
--- Name: idx_ops_crew_status; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ops_crew_status ON public.ops_crew USING btree (status);
-
-
---
--- Name: idx_ops_hist_guests_email; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ops_hist_guests_email ON public.ops_historical_guests USING btree (email);
-
-
---
--- Name: idx_ops_hist_guests_last_seen; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ops_hist_guests_last_seen ON public.ops_historical_guests USING btree (last_seen);
-
-
---
--- Name: idx_ops_hist_guests_phone; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ops_hist_guests_phone ON public.ops_historical_guests USING btree (phone);
-
-
---
--- Name: idx_ops_log_actor; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ops_log_actor ON public.ops_log USING btree (actor);
-
-
---
--- Name: idx_ops_log_entity; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ops_log_entity ON public.ops_log USING btree (entity_type, entity_id);
-
-
---
--- Name: idx_ops_log_time; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ops_log_time ON public.ops_log USING btree ("timestamp");
-
-
---
--- Name: idx_ops_prop_streamline; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ops_prop_streamline ON public.ops_properties USING btree (streamline_id);
-
-
---
--- Name: idx_ops_props_name; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ops_props_name ON public.ops_properties USING btree (internal_name);
-
-
---
--- Name: idx_ops_tasks_assignee; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ops_tasks_assignee ON public.ops_tasks USING btree (assigned_to);
-
-
---
--- Name: idx_ops_tasks_deadline; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ops_tasks_deadline ON public.ops_tasks USING btree (deadline);
-
-
---
--- Name: idx_ops_tasks_priority; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ops_tasks_priority ON public.ops_tasks USING btree (priority);
-
-
---
--- Name: idx_ops_tasks_property; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ops_tasks_property ON public.ops_tasks USING btree (property_id);
-
-
---
--- Name: idx_ops_tasks_status; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ops_tasks_status ON public.ops_tasks USING btree (status);
-
-
---
--- Name: idx_ops_tasks_turnover; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ops_tasks_turnover ON public.ops_tasks USING btree (turnover_id);
-
-
---
--- Name: idx_ops_tasks_type; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ops_tasks_type ON public.ops_tasks USING btree (type);
-
-
---
--- Name: idx_ops_turn_checkout; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ops_turn_checkout ON public.ops_turnovers USING btree (checkout_time);
-
-
---
--- Name: idx_ops_turn_property; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ops_turn_property ON public.ops_turnovers USING btree (property_id);
-
-
---
--- Name: idx_ops_turn_status; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_ops_turn_status ON public.ops_turnovers USING btree (status);
-
-
---
--- Name: idx_overrides_active; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_overrides_active ON public.ops_overrides USING btree (active, entity_type);
-
-
---
--- Name: idx_overrides_entity; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_overrides_entity ON public.ops_overrides USING btree (entity_type, entity_id);
-
-
---
--- Name: idx_pe_event_type; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_pe_event_type ON public.property_events USING btree (event_type);
-
-
---
--- Name: idx_pe_property_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_pe_property_id ON public.property_events USING btree (property_id);
-
-
---
--- Name: idx_property_ai_enabled; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_property_ai_enabled ON public.property_sms_config USING btree (ai_enabled);
-
-
---
--- Name: idx_property_phone; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_property_phone ON public.property_sms_config USING btree (assigned_phone_number);
-
-
---
--- Name: idx_provider_enabled; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_provider_enabled ON public.sms_providers USING btree (enabled, priority) WHERE (enabled = true);
-
-
---
--- Name: idx_quarantine_at; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_quarantine_at ON public.quarantine_inbox USING btree (quarantined_at);
-
-
---
--- Name: idx_quarantine_sender; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_quarantine_sender ON public.quarantine_inbox USING btree (sender);
-
-
---
--- Name: idx_quarantine_status; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_quarantine_status ON public.email_quarantine USING btree (status) WHERE ((status)::text = 'quarantined'::text);
-
-
---
--- Name: idx_queue_attribution; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_queue_attribution ON public.agent_response_queue USING btree (phone_number, intent) WHERE ((intent)::text = 'proactive_sales'::text);
-
-
---
--- Name: idx_rag_section; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_rag_section ON public.ruebarue_area_guide USING btree (section);
-
-
---
--- Name: idx_review_log_actor; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_review_log_actor ON public.email_intake_review_log USING btree (actor, created_at DESC);
-
-
---
--- Name: idx_review_log_email; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_review_log_email ON public.email_intake_review_log USING btree (email_id);
-
-
---
--- Name: idx_review_log_esc; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_review_log_esc ON public.email_intake_review_log USING btree (escalation_id);
-
-
---
--- Name: idx_rkb_category; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_rkb_category ON public.ruebarue_knowledge_base USING btree (category);
-
-
---
--- Name: idx_rkb_source; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_rkb_source ON public.ruebarue_knowledge_base USING btree (source);
-
-
---
--- Name: idx_rl_cabin; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_rl_cabin ON public.revenue_ledger USING btree (cabin_name);
-
-
---
--- Name: idx_rl_cabin_date_run; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX idx_rl_cabin_date_run ON public.revenue_ledger USING btree (cabin_name, target_date, run_id);
-
-
---
--- Name: idx_rl_date; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_rl_date ON public.revenue_ledger USING btree (target_date);
-
-
---
--- Name: idx_rl_run; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_rl_run ON public.revenue_ledger USING btree (run_id);
-
-
---
--- Name: idx_rl_signal; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_rl_signal ON public.revenue_ledger USING btree (trading_signal);
-
-
---
--- Name: idx_routing_rules_active; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_routing_rules_active ON public.email_routing_rules USING btree (rule_type, is_active) WHERE (is_active = true);
-
-
---
--- Name: idx_rqf_brain; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_rqf_brain ON public.rag_query_feedback USING btree (brain);
-
-
---
--- Name: idx_rqf_created; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_rqf_created ON public.rag_query_feedback USING btree (created_at);
-
-
---
--- Name: idx_rqf_quality; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_rqf_quality ON public.rag_query_feedback USING btree (response_quality);
-
-
---
--- Name: idx_sanitizer_log_run; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_sanitizer_log_run ON public.data_sanitizer_log USING btree (run_id);
-
-
---
--- Name: idx_sanitizer_log_table; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_sanitizer_log_table ON public.data_sanitizer_log USING btree (table_name, column_name);
-
-
---
--- Name: idx_sensors_active; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_sensors_active ON public.email_sensors USING btree (is_active) WHERE (is_active = true);
-
-
---
--- Name: idx_sentinel_source; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_sentinel_source ON public.sentinel_state USING btree (source);
-
-
---
--- Name: idx_si_cabin; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_si_cabin ON public.sales_intel USING btree (cabin_name);
-
-
---
--- Name: idx_si_email; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_si_email ON public.sales_intel USING btree (source_email_id);
-
-
---
--- Name: idx_si_type; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_si_type ON public.sales_intel USING btree (signal_type);
-
-
---
--- Name: idx_sr_domain; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_sr_domain ON public.sender_registry USING btree (domain);
-
-
---
--- Name: idx_sr_email; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_sr_email ON public.sender_registry USING btree (email_address);
-
-
---
--- Name: idx_sr_signal; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_sr_signal ON public.sender_registry USING btree (signal_ratio);
-
-
---
--- Name: idx_sr_status; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_sr_status ON public.sender_registry USING btree (status);
-
-
---
--- Name: idx_starred_embedding; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_starred_embedding ON public.starred_responses USING ivfflat (embedding public.vector_cosine_ops) WITH (lists='10');
-
-
---
--- Name: idx_starred_intent; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_starred_intent ON public.starred_responses USING btree (intent);
-
-
---
--- Name: idx_system_directives_active_created; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_system_directives_active_created ON public.system_directives USING btree (active, created_at);
-
-
---
--- Name: idx_tb_property; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_tb_property ON public.trust_balance USING btree (property_id);
-
-
---
--- Name: idx_thread_last_message; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_thread_last_message ON public.conversation_threads USING btree (last_message_at DESC);
-
-
---
--- Name: idx_thread_phone; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_thread_phone ON public.conversation_threads USING btree (phone_number);
-
-
---
--- Name: idx_thread_property; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_thread_property ON public.conversation_threads USING btree (property_id);
-
-
---
--- Name: idx_thread_status; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_thread_status ON public.conversation_threads USING btree (status);
-
-
---
--- Name: idx_trace_created; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_trace_created ON public.recursive_trace_log USING btree (created_at);
-
-
---
--- Name: idx_trace_run_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_trace_run_id ON public.recursive_trace_log USING btree (run_id);
-
-
---
--- Name: idx_trace_stage; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_trace_stage ON public.recursive_trace_log USING btree (stage);
-
-
---
--- Name: idx_trace_user; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_trace_user ON public.recursive_trace_log USING btree (user_id);
-
-
---
--- Name: idx_training_intent; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_training_intent ON public.ai_training_labels USING btree (labeled_intent);
-
-
---
--- Name: idx_training_labeled_at; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_training_labeled_at ON public.ai_training_labels USING btree (labeled_at DESC);
-
-
---
--- Name: idx_training_message; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_training_message ON public.ai_training_labels USING btree (message_id);
-
-
---
--- Name: idx_vault_delta_citation; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_vault_delta_citation ON public.vault_delta USING btree (citation);
-
-
---
--- Name: idx_vault_delta_court; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_vault_delta_court ON public.vault_delta USING btree (court);
-
-
---
--- Name: idx_vault_delta_embedding; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_vault_delta_embedding ON public.vault_delta USING ivfflat (embedding public.vector_cosine_ops) WITH (lists='100');
-
-
---
--- Name: idx_vault_delta_text_search; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_vault_delta_text_search ON public.vault_delta USING gin (text_search);
-
-
---
--- Name: idx_vis_ext; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_vis_ext ON public.ops_visuals USING btree (file_ext);
-
-
---
--- Name: idx_vis_path; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_vis_path ON public.ops_visuals USING btree (file_path);
-
-
---
--- Name: idx_vis_prop; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_vis_prop ON public.ops_visuals USING btree (property_id);
-
-
---
--- Name: idx_vis_propname; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_vis_propname ON public.ops_visuals USING btree (property_name);
-
-
---
--- Name: idx_vis_room; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_vis_room ON public.ops_visuals USING btree (room_type);
-
-
---
--- Name: idx_vis_scanned; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_vis_scanned ON public.ops_visuals USING btree (scanned_at);
-
-
---
--- Name: idx_vis_status; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_vis_status ON public.ops_visuals USING btree (status);
-
-
---
--- Name: idx_visual_hash; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_visual_hash ON public.ops_visuals USING btree (visual_hash);
-
-
---
--- Name: ix_agent_memory_model; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_agent_memory_model ON public.agent_memory USING btree (model);
-
-
---
--- Name: ix_agent_memory_request_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_agent_memory_request_id ON public.agent_memory USING btree (request_id);
-
-
---
--- Name: ix_agent_telemetry_error_class; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_agent_telemetry_error_class ON public.agent_telemetry USING btree (error_class);
-
-
---
--- Name: ix_agent_telemetry_model; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_agent_telemetry_model ON public.agent_telemetry USING btree (model);
-
-
---
--- Name: ix_agent_telemetry_prompt_hash; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_agent_telemetry_prompt_hash ON public.agent_telemetry USING btree (prompt_hash);
-
-
---
--- Name: ix_agent_telemetry_request_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_agent_telemetry_request_id ON public.agent_telemetry USING btree (request_id);
-
-
---
--- Name: ix_agent_telemetry_user_feedback_signal; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_agent_telemetry_user_feedback_signal ON public.agent_telemetry USING btree (user_feedback_signal);
-
-
---
--- Name: ix_system_directives_active; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_system_directives_active ON public.system_directives USING btree (active);
-
-
---
--- Name: attorneys trg_attorneys_updated; Type: TRIGGER; Schema: legal_cmd; Owner: -
---
-
-CREATE TRIGGER trg_attorneys_updated BEFORE UPDATE ON legal_cmd.attorneys FOR EACH ROW EXECUTE FUNCTION legal_cmd.update_timestamp();
-
-
---
--- Name: matters trg_matters_updated; Type: TRIGGER; Schema: legal_cmd; Owner: -
---
-
-CREATE TRIGGER trg_matters_updated BEFORE UPDATE ON legal_cmd.matters FOR EACH ROW EXECUTE FUNCTION legal_cmd.update_timestamp();
-
-
---
--- Name: meetings trg_meetings_updated; Type: TRIGGER; Schema: legal_cmd; Owner: -
---
-
-CREATE TRIGGER trg_meetings_updated BEFORE UPDATE ON legal_cmd.meetings FOR EACH ROW EXECUTE FUNCTION legal_cmd.update_timestamp();
-
-
---
--- Name: journal_line_items trg_immutable_line_items; Type: TRIGGER; Schema: public; Owner: -
---
-
-CREATE TRIGGER trg_immutable_line_items BEFORE DELETE OR UPDATE ON public.journal_line_items FOR EACH ROW EXECUTE FUNCTION public.enforce_immutable_line_items();
-
-
---
--- Name: journal_entries trg_journal_entry_integrity; Type: TRIGGER; Schema: public; Owner: -
---
-
-CREATE TRIGGER trg_journal_entry_integrity BEFORE DELETE OR UPDATE ON public.journal_entries FOR EACH ROW EXECUTE FUNCTION public.enforce_journal_entry_integrity();
-
-
---
--- Name: journal_line_items trg_verify_balance; Type: TRIGGER; Schema: public; Owner: -
---
-
-CREATE CONSTRAINT TRIGGER trg_verify_balance AFTER INSERT OR UPDATE ON public.journal_line_items DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION public.verify_journal_balance();
-
-
---
--- Name: conversation_threads update_conversation_threads_updated_at; Type: TRIGGER; Schema: public; Owner: -
---
-
-CREATE TRIGGER update_conversation_threads_updated_at BEFORE UPDATE ON public.conversation_threads FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
-
-
---
--- Name: guest_profiles update_guest_profiles_updated_at; Type: TRIGGER; Schema: public; Owner: -
---
-
-CREATE TRIGGER update_guest_profiles_updated_at BEFORE UPDATE ON public.guest_profiles FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
-
-
---
--- Name: message_archive update_message_archive_updated_at; Type: TRIGGER; Schema: public; Owner: -
---
-
-CREATE TRIGGER update_message_archive_updated_at BEFORE UPDATE ON public.message_archive FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
-
-
---
--- Name: account_mappings account_mappings_credit_account_fkey; Type: FK CONSTRAINT; Schema: division_a; Owner: -
---
-
-ALTER TABLE ONLY division_a.account_mappings
-    ADD CONSTRAINT account_mappings_credit_account_fkey FOREIGN KEY (credit_account) REFERENCES division_a.chart_of_accounts(code);
-
-
---
--- Name: account_mappings account_mappings_debit_account_fkey; Type: FK CONSTRAINT; Schema: division_a; Owner: -
---
-
-ALTER TABLE ONLY division_a.account_mappings
-    ADD CONSTRAINT account_mappings_debit_account_fkey FOREIGN KEY (debit_account) REFERENCES division_a.chart_of_accounts(code);
-
-
---
--- Name: general_ledger general_ledger_account_code_fkey; Type: FK CONSTRAINT; Schema: division_a; Owner: -
---
-
-ALTER TABLE ONLY division_a.general_ledger
-    ADD CONSTRAINT general_ledger_account_code_fkey FOREIGN KEY (account_code) REFERENCES division_a.chart_of_accounts(code);
-
-
---
--- Name: general_ledger general_ledger_journal_entry_id_fkey; Type: FK CONSTRAINT; Schema: division_a; Owner: -
---
-
-ALTER TABLE ONLY division_a.general_ledger
-    ADD CONSTRAINT general_ledger_journal_entry_id_fkey FOREIGN KEY (journal_entry_id) REFERENCES division_a.journal_entries(entry_id);
-
-
---
--- Name: account_mappings account_mappings_credit_account_fkey; Type: FK CONSTRAINT; Schema: division_b; Owner: -
---
-
-ALTER TABLE ONLY division_b.account_mappings
-    ADD CONSTRAINT account_mappings_credit_account_fkey FOREIGN KEY (credit_account) REFERENCES division_b.chart_of_accounts(code);
-
-
---
--- Name: account_mappings account_mappings_debit_account_fkey; Type: FK CONSTRAINT; Schema: division_b; Owner: -
---
-
-ALTER TABLE ONLY division_b.account_mappings
-    ADD CONSTRAINT account_mappings_debit_account_fkey FOREIGN KEY (debit_account) REFERENCES division_b.chart_of_accounts(code);
-
-
---
--- Name: general_ledger general_ledger_account_code_fkey; Type: FK CONSTRAINT; Schema: division_b; Owner: -
---
-
-ALTER TABLE ONLY division_b.general_ledger
-    ADD CONSTRAINT general_ledger_account_code_fkey FOREIGN KEY (account_code) REFERENCES division_b.chart_of_accounts(code);
-
-
---
--- Name: general_ledger general_ledger_journal_entry_id_fkey; Type: FK CONSTRAINT; Schema: division_b; Owner: -
---
-
-ALTER TABLE ONLY division_b.general_ledger
-    ADD CONSTRAINT general_ledger_journal_entry_id_fkey FOREIGN KEY (journal_entry_id) REFERENCES division_b.journal_entries(entry_id);
-
-
---
--- Name: change_orders change_orders_project_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.change_orders
-    ADD CONSTRAINT change_orders_project_id_fkey FOREIGN KEY (project_id) REFERENCES engineering.projects(id);
-
-
---
--- Name: compliance_log compliance_log_drawing_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.compliance_log
-    ADD CONSTRAINT compliance_log_drawing_id_fkey FOREIGN KEY (drawing_id) REFERENCES engineering.drawings(id);
-
-
---
--- Name: compliance_log compliance_log_project_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.compliance_log
-    ADD CONSTRAINT compliance_log_project_id_fkey FOREIGN KEY (project_id) REFERENCES engineering.projects(id);
-
-
---
--- Name: compliance_log compliance_log_property_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.compliance_log
-    ADD CONSTRAINT compliance_log_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id);
-
-
---
--- Name: cost_estimates cost_estimates_project_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.cost_estimates
-    ADD CONSTRAINT cost_estimates_project_id_fkey FOREIGN KEY (project_id) REFERENCES engineering.projects(id);
-
-
---
--- Name: drawings drawings_project_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.drawings
-    ADD CONSTRAINT drawings_project_id_fkey FOREIGN KEY (project_id) REFERENCES engineering.projects(id);
-
-
---
--- Name: drawings drawings_property_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.drawings
-    ADD CONSTRAINT drawings_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id);
-
-
---
--- Name: inspections inspections_permit_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.inspections
-    ADD CONSTRAINT inspections_permit_id_fkey FOREIGN KEY (permit_id) REFERENCES engineering.permits(id);
-
-
---
--- Name: inspections inspections_project_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.inspections
-    ADD CONSTRAINT inspections_project_id_fkey FOREIGN KEY (project_id) REFERENCES engineering.projects(id);
-
-
---
--- Name: inspections inspections_property_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.inspections
-    ADD CONSTRAINT inspections_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id);
-
-
---
--- Name: mep_systems mep_systems_property_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.mep_systems
-    ADD CONSTRAINT mep_systems_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id);
-
-
---
--- Name: permits permits_project_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.permits
-    ADD CONSTRAINT permits_project_id_fkey FOREIGN KEY (project_id) REFERENCES engineering.projects(id);
-
-
---
--- Name: permits permits_property_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.permits
-    ADD CONSTRAINT permits_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id);
-
-
---
--- Name: projects projects_property_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.projects
-    ADD CONSTRAINT projects_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id);
-
-
---
--- Name: punch_items punch_items_inspection_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.punch_items
-    ADD CONSTRAINT punch_items_inspection_id_fkey FOREIGN KEY (inspection_id) REFERENCES engineering.inspections(id);
-
-
---
--- Name: punch_items punch_items_project_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.punch_items
-    ADD CONSTRAINT punch_items_project_id_fkey FOREIGN KEY (project_id) REFERENCES engineering.projects(id);
-
-
---
--- Name: rfis rfis_project_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.rfis
-    ADD CONSTRAINT rfis_project_id_fkey FOREIGN KEY (project_id) REFERENCES engineering.projects(id);
-
-
---
--- Name: submittals submittals_project_id_fkey; Type: FK CONSTRAINT; Schema: engineering; Owner: -
---
-
-ALTER TABLE ONLY engineering.submittals
-    ADD CONSTRAINT submittals_project_id_fkey FOREIGN KEY (project_id) REFERENCES engineering.projects(id);
-
-
---
--- Name: classification_rules classification_rules_source_vendor_id_fkey; Type: FK CONSTRAINT; Schema: finance; Owner: -
---
-
-ALTER TABLE ONLY finance.classification_rules
-    ADD CONSTRAINT classification_rules_source_vendor_id_fkey FOREIGN KEY (source_vendor_id) REFERENCES finance.vendor_classifications(id);
-
-
---
--- Name: extraction_log extraction_log_email_id_fkey; Type: FK CONSTRAINT; Schema: hedge_fund; Owner: -
---
-
-ALTER TABLE ONLY hedge_fund.extraction_log
-    ADD CONSTRAINT extraction_log_email_id_fkey FOREIGN KEY (email_id) REFERENCES public.email_archive(id) ON DELETE SET NULL;
-
-
---
--- Name: market_signals market_signals_source_email_id_fkey; Type: FK CONSTRAINT; Schema: hedge_fund; Owner: -
---
-
-ALTER TABLE ONLY hedge_fund.market_signals
-    ADD CONSTRAINT market_signals_source_email_id_fkey FOREIGN KEY (source_email_id) REFERENCES public.email_archive(id) ON DELETE SET NULL;
-
-
---
--- Name: relationships relationships_from_entity_id_fkey; Type: FK CONSTRAINT; Schema: intelligence; Owner: -
---
-
-ALTER TABLE ONLY intelligence.relationships
-    ADD CONSTRAINT relationships_from_entity_id_fkey FOREIGN KEY (from_entity_id) REFERENCES intelligence.entities(id) ON DELETE CASCADE;
-
-
---
--- Name: relationships relationships_to_entity_id_fkey; Type: FK CONSTRAINT; Schema: intelligence; Owner: -
---
-
-ALTER TABLE ONLY intelligence.relationships
-    ADD CONSTRAINT relationships_to_entity_id_fkey FOREIGN KEY (to_entity_id) REFERENCES intelligence.entities(id) ON DELETE CASCADE;
-
-
---
--- Name: case_actions case_actions_case_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.case_actions
-    ADD CONSTRAINT case_actions_case_id_fkey FOREIGN KEY (case_id) REFERENCES legal.cases(id);
-
-
---
--- Name: case_evidence case_evidence_case_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.case_evidence
-    ADD CONSTRAINT case_evidence_case_id_fkey FOREIGN KEY (case_id) REFERENCES legal.cases(id);
-
-
---
--- Name: case_watchdog case_watchdog_case_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.case_watchdog
-    ADD CONSTRAINT case_watchdog_case_id_fkey FOREIGN KEY (case_id) REFERENCES legal.cases(id);
-
-
---
--- Name: correspondence correspondence_case_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.correspondence
-    ADD CONSTRAINT correspondence_case_id_fkey FOREIGN KEY (case_id) REFERENCES legal.cases(id);
-
-
---
--- Name: deadlines deadlines_case_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.deadlines
-    ADD CONSTRAINT deadlines_case_id_fkey FOREIGN KEY (case_id) REFERENCES legal.cases(id);
-
-
---
--- Name: filings filings_case_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.filings
-    ADD CONSTRAINT filings_case_id_fkey FOREIGN KEY (case_id) REFERENCES legal.cases(id);
-
-
---
--- Name: ingest_runs fk_ingest_runs_case_slug; Type: FK CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.ingest_runs
-    ADD CONSTRAINT fk_ingest_runs_case_slug FOREIGN KEY (case_slug) REFERENCES legal.cases(case_slug) ON DELETE CASCADE;
-
-
---
--- Name: case_precedents fk_precedent_case_slug; Type: FK CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.case_precedents
-    ADD CONSTRAINT fk_precedent_case_slug FOREIGN KEY (case_slug) REFERENCES legal.cases(case_slug);
-
-
---
--- Name: vault_documents fk_vault_documents_case_slug; Type: FK CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.vault_documents
-    ADD CONSTRAINT fk_vault_documents_case_slug FOREIGN KEY (case_slug) REFERENCES legal.cases(case_slug) ON DELETE CASCADE;
-
-
---
--- Name: uploads uploads_case_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.uploads
-    ADD CONSTRAINT uploads_case_id_fkey FOREIGN KEY (case_id) REFERENCES legal.cases(id);
-
-
---
--- Name: uploads uploads_filing_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
---
-
-ALTER TABLE ONLY legal.uploads
-    ADD CONSTRAINT uploads_filing_id_fkey FOREIGN KEY (filing_id) REFERENCES legal.filings(id);
-
-
---
--- Name: attorney_scoring attorney_scoring_attorney_id_fkey; Type: FK CONSTRAINT; Schema: legal_cmd; Owner: -
---
-
-ALTER TABLE ONLY legal_cmd.attorney_scoring
-    ADD CONSTRAINT attorney_scoring_attorney_id_fkey FOREIGN KEY (attorney_id) REFERENCES legal_cmd.attorneys(id) ON DELETE CASCADE;
-
-
---
--- Name: documents documents_matter_id_fkey; Type: FK CONSTRAINT; Schema: legal_cmd; Owner: -
---
-
-ALTER TABLE ONLY legal_cmd.documents
-    ADD CONSTRAINT documents_matter_id_fkey FOREIGN KEY (matter_id) REFERENCES legal_cmd.matters(id);
-
-
---
--- Name: matters matters_attorney_id_fkey; Type: FK CONSTRAINT; Schema: legal_cmd; Owner: -
---
-
-ALTER TABLE ONLY legal_cmd.matters
-    ADD CONSTRAINT matters_attorney_id_fkey FOREIGN KEY (attorney_id) REFERENCES legal_cmd.attorneys(id);
-
-
---
--- Name: meetings meetings_attorney_id_fkey; Type: FK CONSTRAINT; Schema: legal_cmd; Owner: -
---
-
-ALTER TABLE ONLY legal_cmd.meetings
-    ADD CONSTRAINT meetings_attorney_id_fkey FOREIGN KEY (attorney_id) REFERENCES legal_cmd.attorneys(id);
-
-
---
--- Name: meetings meetings_matter_id_fkey; Type: FK CONSTRAINT; Schema: legal_cmd; Owner: -
---
-
-ALTER TABLE ONLY legal_cmd.meetings
-    ADD CONSTRAINT meetings_matter_id_fkey FOREIGN KEY (matter_id) REFERENCES legal_cmd.matters(id);
-
-
---
--- Name: timeline timeline_matter_id_fkey; Type: FK CONSTRAINT; Schema: legal_cmd; Owner: -
---
-
-ALTER TABLE ONLY legal_cmd.timeline
-    ADD CONSTRAINT timeline_matter_id_fkey FOREIGN KEY (matter_id) REFERENCES legal_cmd.matters(id);
-
-
---
--- Name: timeline timeline_related_attorney_id_fkey; Type: FK CONSTRAINT; Schema: legal_cmd; Owner: -
---
-
-ALTER TABLE ONLY legal_cmd.timeline
-    ADD CONSTRAINT timeline_related_attorney_id_fkey FOREIGN KEY (related_attorney_id) REFERENCES legal_cmd.attorneys(id);
-
-
---
--- Name: timeline timeline_related_meeting_id_fkey; Type: FK CONSTRAINT; Schema: legal_cmd; Owner: -
---
-
-ALTER TABLE ONLY legal_cmd.timeline
-    ADD CONSTRAINT timeline_related_meeting_id_fkey FOREIGN KEY (related_meeting_id) REFERENCES legal_cmd.meetings(id);
-
-
---
--- Name: ab_test_observations ab_test_observations_test_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ab_test_observations
-    ADD CONSTRAINT ab_test_observations_test_id_fkey FOREIGN KEY (test_id) REFERENCES public.ab_tests(id);
-
-
---
--- Name: accounts accounts_parent_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: accounts uq_accounts_code; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.accounts
-    ADD CONSTRAINT accounts_parent_id_fkey FOREIGN KEY (parent_id) REFERENCES public.accounts(id);
+    ADD CONSTRAINT uq_accounts_code UNIQUE (code);
 
 
 --
--- Name: active_learning_queue active_learning_queue_judgment_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: agent_registry uq_agent_registry_name; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.active_learning_queue
-    ADD CONSTRAINT active_learning_queue_judgment_id_fkey FOREIGN KEY (judgment_id) REFERENCES public.learning_judgments(id);
-
-
---
--- Name: agent_learning_log agent_learning_log_queue_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.agent_learning_log
-    ADD CONSTRAINT agent_learning_log_queue_id_fkey FOREIGN KEY (queue_id) REFERENCES public.agent_response_queue(id);
+ALTER TABLE ONLY public.agent_registry
+    ADD CONSTRAINT uq_agent_registry_name UNIQUE (name);
 
 
 --
--- Name: agent_response_queue agent_response_queue_inbound_message_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: blocked_days uq_blocked_days_prop_dates_type; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.blocked_days
+    ADD CONSTRAINT uq_blocked_days_prop_dates_type UNIQUE (property_id, start_date, end_date, block_type);
+
+
+--
+-- Name: capture_labels uq_capture_labels_capture; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.capture_labels
+    ADD CONSTRAINT uq_capture_labels_capture UNIQUE (capture_id, capture_table);
+
+
+--
+-- Name: channel_mappings uq_channel_mappings_property_channel; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.channel_mappings
+    ADD CONSTRAINT uq_channel_mappings_property_channel UNIQUE (property_id, channel);
+
+
+--
+-- Name: competitor_listings uq_competitor_listings_dedupe_hash; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.competitor_listings
+    ADD CONSTRAINT uq_competitor_listings_dedupe_hash UNIQUE (dedupe_hash);
+
+
+--
+-- Name: email_inquirers uq_email_inquirers_email; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_inquirers
+    ADD CONSTRAINT uq_email_inquirers_email UNIQUE (email);
+
+
+--
+-- Name: hunter_queue uq_hunter_queue_session_fp; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.hunter_queue
+    ADD CONSTRAINT uq_hunter_queue_session_fp UNIQUE (session_fp);
+
+
+--
+-- Name: intelligence_ledger uq_intelligence_ledger_dedupe_hash; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.intelligence_ledger
+    ADD CONSTRAINT uq_intelligence_ledger_dedupe_hash UNIQUE (dedupe_hash);
+
+
+--
+-- Name: management_splits uq_management_splits_property_id; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.management_splits
+    ADD CONSTRAINT uq_management_splits_property_id UNIQUE (property_id);
+
+
+--
+-- Name: marketing_attribution uq_marketing_attribution_property_period; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.marketing_attribution
+    ADD CONSTRAINT uq_marketing_attribution_property_period UNIQUE (property_id, period_start, period_end);
+
+
+--
+-- Name: message_queue uq_message_queue_quote_template; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.message_queue
+    ADD CONSTRAINT uq_message_queue_quote_template UNIQUE (quote_id, template_id);
+
+
+--
+-- Name: owner_balance_periods uq_obp_owner_period; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.owner_balance_periods
+    ADD CONSTRAINT uq_obp_owner_period UNIQUE (owner_payout_account_id, period_start, period_end);
+
+
+--
+-- Name: owner_magic_tokens uq_owner_magic_tokens_token_hash; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.owner_magic_tokens
+    ADD CONSTRAINT uq_owner_magic_tokens_token_hash UNIQUE (token_hash);
+
+
+--
+-- Name: owner_marketing_preferences uq_owner_marketing_preferences_property_id; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.owner_marketing_preferences
+    ADD CONSTRAINT uq_owner_marketing_preferences_property_id UNIQUE (property_id);
+
+
+--
+-- Name: owner_markup_rules uq_owner_markup_rules_property_category; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.owner_markup_rules
+    ADD CONSTRAINT uq_owner_markup_rules_property_category UNIQUE (property_id, expense_category);
+
+
+--
+-- Name: owner_payout_accounts uq_owner_payout_accounts_property_id; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.owner_payout_accounts
+    ADD CONSTRAINT uq_owner_payout_accounts_property_id UNIQUE (property_id);
+
+
+--
+-- Name: owner_payout_accounts uq_owner_payout_accounts_stripe_account_id; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.owner_payout_accounts
+    ADD CONSTRAINT uq_owner_payout_accounts_stripe_account_id UNIQUE (stripe_account_id);
+
+
+--
+-- Name: owner_property_map uq_owner_property_map_owner_unit; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.owner_property_map
+    ADD CONSTRAINT uq_owner_property_map_owner_unit UNIQUE (sl_owner_id, unit_id);
+
+
+--
+-- Name: property_fees uq_property_fees_property_fee; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.property_fees
+    ADD CONSTRAINT uq_property_fees_property_fee UNIQUE (property_id, fee_id);
+
+
+--
+-- Name: property_images uq_property_images_property_legacy_url; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.property_images
+    ADD CONSTRAINT uq_property_images_property_legacy_url UNIQUE (property_id, legacy_url);
+
+
+--
+-- Name: property_taxes uq_property_taxes_property_tax; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.property_taxes
+    ADD CONSTRAINT uq_property_taxes_property_tax UNIQUE (property_id, tax_id);
+
+
+--
+-- Name: rue_bar_rue_legacy_recovery_templates uq_rbr_legacy_recovery_template_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rue_bar_rue_legacy_recovery_templates
+    ADD CONSTRAINT uq_rbr_legacy_recovery_template_key UNIQUE (template_key);
+
+
+--
+-- Name: utility_readings uq_reading_per_day; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.utility_readings
+    ADD CONSTRAINT uq_reading_per_day UNIQUE (utility_id, reading_date);
+
+
+--
+-- Name: recovery_parity_comparisons uq_recovery_parity_comparisons_dedupe_hash; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.recovery_parity_comparisons
+    ADD CONSTRAINT uq_recovery_parity_comparisons_dedupe_hash UNIQUE (dedupe_hash);
+
+
+--
+-- Name: seo_patch_queue uq_seo_patch_queue_target_campaign_source; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.seo_patch_queue
+    ADD CONSTRAINT uq_seo_patch_queue_target_campaign_source UNIQUE (target_type, target_slug, campaign, source_hash);
+
+
+--
+-- Name: seo_redirect_remap_queue uq_seo_redirect_remap_queue_source_campaign_run; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.seo_redirect_remap_queue
+    ADD CONSTRAINT uq_seo_redirect_remap_queue_source_campaign_run UNIQUE (source_path, campaign, proposal_run_id);
+
+
+--
+-- Name: stripe_connect_events uq_stripe_connect_events_event_id; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.stripe_connect_events
+    ADD CONSTRAINT uq_stripe_connect_events_event_id UNIQUE (stripe_event_id);
+
+
+--
+-- Name: trust_accounts uq_trust_accounts_name; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.trust_accounts
+    ADD CONSTRAINT uq_trust_accounts_name UNIQUE (name);
+
+
+--
+-- Name: trust_balance uq_trust_balance_property_id; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.trust_balance
+    ADD CONSTRAINT uq_trust_balance_property_id UNIQUE (property_id);
+
+
+--
+-- Name: trust_transactions uq_trust_transactions_signature; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.trust_transactions
+    ADD CONSTRAINT uq_trust_transactions_signature UNIQUE (signature);
+
+
+--
+-- Name: trust_transactions uq_trust_transactions_streamline_event_id; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.trust_transactions
+    ADD CONSTRAINT uq_trust_transactions_streamline_event_id UNIQUE (streamline_event_id);
+
+
+--
+-- Name: utility_readings utility_readings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.utility_readings
+    ADD CONSTRAINT utility_readings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: vault_audit_logs vault_audit_logs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vault_audit_logs
+    ADD CONSTRAINT vault_audit_logs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: vendors vendors_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vendors
+    ADD CONSTRAINT vendors_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: vrs_add_ons vrs_add_ons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vrs_add_ons
+    ADD CONSTRAINT vrs_add_ons_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: vrs_automation_events vrs_automation_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vrs_automation_events
+    ADD CONSTRAINT vrs_automation_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: vrs_automations vrs_automations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vrs_automations
+    ADD CONSTRAINT vrs_automations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: work_orders work_orders_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.work_orders
+    ADD CONSTRAINT work_orders_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: work_orders work_orders_ticket_number_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.work_orders
+    ADD CONSTRAINT work_orders_ticket_number_key UNIQUE (ticket_number);
+
+
+--
+-- Name: yield_overrides yield_overrides_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.yield_overrides
+    ADD CONSTRAINT yield_overrides_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: yield_simulations yield_simulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.yield_simulations
+    ADD CONSTRAINT yield_simulations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: products products_pkey; Type: CONSTRAINT; Schema: verses_schema; Owner: -
+--
+
+ALTER TABLE ONLY verses_schema.products
+    ADD CONSTRAINT products_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ix_core_deliberation_logs_created_at; Type: INDEX; Schema: core; Owner: -
+--
+
+CREATE INDEX ix_core_deliberation_logs_created_at ON core.deliberation_logs USING btree (created_at);
+
+
+--
+-- Name: ix_core_deliberation_logs_guest_id; Type: INDEX; Schema: core; Owner: -
+--
+
+CREATE INDEX ix_core_deliberation_logs_guest_id ON core.deliberation_logs USING btree (guest_id);
+
+
+--
+-- Name: ix_core_deliberation_logs_message_id; Type: INDEX; Schema: core; Owner: -
+--
+
+CREATE INDEX ix_core_deliberation_logs_message_id ON core.deliberation_logs USING btree (message_id);
+
+
+--
+-- Name: ix_core_deliberation_logs_property_id; Type: INDEX; Schema: core; Owner: -
+--
+
+CREATE INDEX ix_core_deliberation_logs_property_id ON core.deliberation_logs USING btree (property_id);
+
+
+--
+-- Name: ix_core_deliberation_logs_reservation_id; Type: INDEX; Schema: core; Owner: -
+--
+
+CREATE INDEX ix_core_deliberation_logs_reservation_id ON core.deliberation_logs USING btree (reservation_id);
+
+
+--
+-- Name: ix_core_deliberation_logs_session_id; Type: INDEX; Schema: core; Owner: -
+--
+
+CREATE INDEX ix_core_deliberation_logs_session_id ON core.deliberation_logs USING btree (session_id);
+
+
+--
+-- Name: ix_core_deliberation_logs_verdict_type; Type: INDEX; Schema: core; Owner: -
+--
+
+CREATE INDEX ix_core_deliberation_logs_verdict_type ON core.deliberation_logs USING btree (verdict_type);
+
+
+--
+-- Name: idx_acquisition_intel_event_type; Type: INDEX; Schema: crog_acquisition; Owner: -
+--
+
+CREATE INDEX idx_acquisition_intel_event_type ON crog_acquisition.intel_events USING btree (event_type);
+
+
+--
+-- Name: idx_acquisition_intel_property_time; Type: INDEX; Schema: crog_acquisition; Owner: -
+--
+
+CREATE INDEX idx_acquisition_intel_property_time ON crog_acquisition.intel_events USING btree (property_id, detected_at);
+
+
+--
+-- Name: idx_acquisition_owner_contacts_owner; Type: INDEX; Schema: crog_acquisition; Owner: -
+--
+
+CREATE INDEX idx_acquisition_owner_contacts_owner ON crog_acquisition.owner_contacts USING btree (owner_id);
+
+
+--
+-- Name: idx_acquisition_owners_legal_name; Type: INDEX; Schema: crog_acquisition; Owner: -
+--
+
+CREATE INDEX idx_acquisition_owners_legal_name ON crog_acquisition.owners USING btree (legal_name);
+
+
+--
+-- Name: idx_acquisition_parcels_assessed; Type: INDEX; Schema: crog_acquisition; Owner: -
+--
+
+CREATE INDEX idx_acquisition_parcels_assessed ON crog_acquisition.parcels USING btree (assessed_value);
+
+
+--
+-- Name: idx_acquisition_parcels_geom; Type: INDEX; Schema: crog_acquisition; Owner: -
+--
+
+
+
+--
+-- Name: idx_acquisition_pipeline_next_action_date; Type: INDEX; Schema: crog_acquisition; Owner: -
+--
+
+CREATE INDEX idx_acquisition_pipeline_next_action_date ON crog_acquisition.acquisition_pipeline USING btree (next_action_date);
+
+
+--
+-- Name: idx_acquisition_pipeline_stage; Type: INDEX; Schema: crog_acquisition; Owner: -
+--
+
+CREATE INDEX idx_acquisition_pipeline_stage ON crog_acquisition.acquisition_pipeline USING btree (stage);
+
+
+--
+-- Name: idx_acquisition_properties_mgmt; Type: INDEX; Schema: crog_acquisition; Owner: -
+--
+
+CREATE INDEX idx_acquisition_properties_mgmt ON crog_acquisition.properties USING btree (management_company);
+
+
+--
+-- Name: idx_acquisition_properties_status; Type: INDEX; Schema: crog_acquisition; Owner: -
+--
+
+CREATE INDEX idx_acquisition_properties_status ON crog_acquisition.properties USING btree (status);
+
+
+--
+-- Name: idx_acquisition_str_signals_detected_at; Type: INDEX; Schema: crog_acquisition; Owner: -
+--
+
+CREATE INDEX idx_acquisition_str_signals_detected_at ON crog_acquisition.str_signals USING btree (detected_at);
+
+
+--
+-- Name: idx_acquisition_str_signals_property; Type: INDEX; Schema: crog_acquisition; Owner: -
+--
+
+CREATE INDEX idx_acquisition_str_signals_property ON crog_acquisition.str_signals USING btree (property_id);
+
+
+--
+-- Name: idx_acquisition_str_signals_source; Type: INDEX; Schema: crog_acquisition; Owner: -
+--
+
+CREATE INDEX idx_acquisition_str_signals_source ON crog_acquisition.str_signals USING btree (signal_source);
+
+
+--
+-- Name: ix_acq_docs_pipeline_id; Type: INDEX; Schema: crog_acquisition; Owner: -
+--
+
+CREATE INDEX ix_acq_docs_pipeline_id ON crog_acquisition.acquisition_documents USING btree (pipeline_id);
+
+
+--
+-- Name: ix_crog_acquisition_properties_owner_id; Type: INDEX; Schema: crog_acquisition; Owner: -
+--
+
+CREATE INDEX ix_crog_acquisition_properties_owner_id ON crog_acquisition.properties USING btree (owner_id);
+
+
+--
+-- Name: ix_crog_acquisition_properties_parcel_id; Type: INDEX; Schema: crog_acquisition; Owner: -
+--
+
+CREATE INDEX ix_crog_acquisition_properties_parcel_id ON crog_acquisition.properties USING btree (parcel_id);
+
+
+--
+-- Name: ix_dd_pipeline_id; Type: INDEX; Schema: crog_acquisition; Owner: -
+--
+
+CREATE INDEX ix_dd_pipeline_id ON crog_acquisition.due_diligence USING btree (pipeline_id);
+
+
+--
+-- Name: ix_dd_status; Type: INDEX; Schema: crog_acquisition; Owner: -
+--
+
+CREATE INDEX ix_dd_status ON crog_acquisition.due_diligence USING btree (status);
+
+
+--
+-- Name: ix_iot_schema_device_events_created_at; Type: INDEX; Schema: iot_schema; Owner: -
+--
+
+CREATE INDEX ix_iot_schema_device_events_created_at ON iot_schema.device_events USING btree (created_at);
+
+
+--
+-- Name: ix_iot_schema_device_events_device_id; Type: INDEX; Schema: iot_schema; Owner: -
+--
+
+CREATE INDEX ix_iot_schema_device_events_device_id ON iot_schema.device_events USING btree (device_id);
+
+
+--
+-- Name: ix_iot_schema_digital_twins_device_id; Type: INDEX; Schema: iot_schema; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_iot_schema_digital_twins_device_id ON iot_schema.digital_twins USING btree (device_id);
+
+
+--
+-- Name: ix_iot_schema_digital_twins_property_id; Type: INDEX; Schema: iot_schema; Owner: -
+--
+
+CREATE INDEX ix_iot_schema_digital_twins_property_id ON iot_schema.digital_twins USING btree (property_id);
+
+
+--
+-- Name: ix_ai_audit_ledger_prompt_hash; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_ai_audit_ledger_prompt_hash ON legal.ai_audit_ledger USING btree (prompt_hash);
+
+
+--
+-- Name: ix_case_graph_nodes_case_id; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_case_graph_nodes_case_id ON legal.case_graph_nodes USING btree (case_id);
+
+
+--
+-- Name: ix_case_statements_slug; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_case_statements_slug ON legal.case_statements USING btree (case_slug);
+
+
+--
+-- Name: ix_legal_case_evidence_case_slug; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_case_evidence_case_slug ON legal.case_evidence USING btree (case_slug);
+
+
+--
+-- Name: ix_legal_case_evidence_entity_id; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_case_evidence_entity_id ON legal.case_evidence USING btree (entity_id);
+
+
+--
+-- Name: ix_legal_case_evidence_qdrant_point_id; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_case_evidence_qdrant_point_id ON legal.case_evidence USING btree (qdrant_point_id);
+
+
+--
+-- Name: ix_legal_case_evidence_sha256_hash; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_case_evidence_sha256_hash ON legal.case_evidence USING btree (sha256_hash);
+
+
+--
+-- Name: ix_legal_case_graph_edges_v2_case_slug; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_case_graph_edges_v2_case_slug ON legal.case_graph_edges_v2 USING btree (case_slug);
+
+
+--
+-- Name: ix_legal_case_graph_edges_v2_source_evidence_id; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_case_graph_edges_v2_source_evidence_id ON legal.case_graph_edges_v2 USING btree (source_evidence_id);
+
+
+--
+-- Name: ix_legal_case_graph_edges_v2_source_node_id; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_case_graph_edges_v2_source_node_id ON legal.case_graph_edges_v2 USING btree (source_node_id);
+
+
+--
+-- Name: ix_legal_case_graph_edges_v2_target_node_id; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_case_graph_edges_v2_target_node_id ON legal.case_graph_edges_v2 USING btree (target_node_id);
+
+
+--
+-- Name: ix_legal_case_graph_nodes_v2_case_slug; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_case_graph_nodes_v2_case_slug ON legal.case_graph_nodes_v2 USING btree (case_slug);
+
+
+--
+-- Name: ix_legal_case_graph_nodes_v2_entity_reference_id; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_case_graph_nodes_v2_entity_reference_id ON legal.case_graph_nodes_v2 USING btree (entity_reference_id);
+
+
+--
+-- Name: ix_legal_case_graph_nodes_v2_entity_type; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_case_graph_nodes_v2_entity_type ON legal.case_graph_nodes_v2 USING btree (entity_type);
+
+
+--
+-- Name: ix_legal_case_statements_v2_case_slug; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_case_statements_v2_case_slug ON legal.case_statements_v2 USING btree (case_slug);
+
+
+--
+-- Name: ix_legal_case_statements_v2_doc_id; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_case_statements_v2_doc_id ON legal.case_statements_v2 USING btree (doc_id);
+
+
+--
+-- Name: ix_legal_case_statements_v2_entity_id; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_case_statements_v2_entity_id ON legal.case_statements_v2 USING btree (entity_id);
+
+
+--
+-- Name: ix_legal_case_statements_v2_stated_at; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_case_statements_v2_stated_at ON legal.case_statements_v2 USING btree (stated_at);
+
+
+--
+-- Name: ix_legal_cases_slug; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_cases_slug ON legal.legal_cases USING btree (slug);
+
+
+--
+-- Name: ix_legal_deposition_kill_sheets_v2_case_slug; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_deposition_kill_sheets_v2_case_slug ON legal.deposition_kill_sheets_v2 USING btree (case_slug);
+
+
+--
+-- Name: ix_legal_deposition_kill_sheets_v2_deponent_entity; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_deposition_kill_sheets_v2_deponent_entity ON legal.deposition_kill_sheets_v2 USING btree (deponent_entity);
+
+
+--
+-- Name: ix_legal_deposition_kill_sheets_v2_status; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_deposition_kill_sheets_v2_status ON legal.deposition_kill_sheets_v2 USING btree (status);
+
+
+--
+-- Name: ix_legal_discovery_draft_items_v2_category; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_discovery_draft_items_v2_category ON legal.discovery_draft_items_v2 USING btree (category);
+
+
+--
+-- Name: ix_legal_discovery_draft_items_v2_pack_id; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_discovery_draft_items_v2_pack_id ON legal.discovery_draft_items_v2 USING btree (pack_id);
+
+
+--
+-- Name: ix_legal_discovery_draft_packs_v2_case_slug; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_discovery_draft_packs_v2_case_slug ON legal.discovery_draft_packs_v2 USING btree (case_slug);
+
+
+--
+-- Name: ix_legal_discovery_draft_packs_v2_status; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_discovery_draft_packs_v2_status ON legal.discovery_draft_packs_v2 USING btree (status);
+
+
+--
+-- Name: ix_legal_discovery_draft_packs_v2_target_entity; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_discovery_draft_packs_v2_target_entity ON legal.discovery_draft_packs_v2 USING btree (target_entity);
+
+
+--
+-- Name: ix_legal_distillation_memory_context_hash; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_legal_distillation_memory_context_hash ON legal.distillation_memory USING btree (context_hash);
+
+
+--
+-- Name: ix_legal_entities_name; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_entities_name ON legal.entities USING btree (name);
+
+
+--
+-- Name: ix_legal_entities_type; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_entities_type ON legal.entities USING btree (type);
+
+
+--
+-- Name: ix_legal_legal_exemplars_category; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_legal_exemplars_category ON legal.legal_exemplars USING btree (category);
+
+
+--
+-- Name: ix_legal_sanctions_alerts_v2_alert_type; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_sanctions_alerts_v2_alert_type ON legal.sanctions_alerts_v2 USING btree (alert_type);
+
+
+--
+-- Name: ix_legal_sanctions_alerts_v2_case_slug; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_sanctions_alerts_v2_case_slug ON legal.sanctions_alerts_v2 USING btree (case_slug);
+
+
+--
+-- Name: ix_legal_sanctions_alerts_v2_confidence_score; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_sanctions_alerts_v2_confidence_score ON legal.sanctions_alerts_v2 USING btree (confidence_score);
+
+
+--
+-- Name: ix_legal_sanctions_alerts_v2_status; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_sanctions_alerts_v2_status ON legal.sanctions_alerts_v2 USING btree (status);
+
+
+--
+-- Name: ix_legal_sanctions_tripwire_runs_v2_case_slug; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_sanctions_tripwire_runs_v2_case_slug ON legal.sanctions_tripwire_runs_v2 USING btree (case_slug);
+
+
+--
+-- Name: ix_legal_sanctions_tripwire_runs_v2_status; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_sanctions_tripwire_runs_v2_status ON legal.sanctions_tripwire_runs_v2 USING btree (status);
+
+
+--
+-- Name: ix_legal_sanctions_tripwire_runs_v2_trigger_source; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_sanctions_tripwire_runs_v2_trigger_source ON legal.sanctions_tripwire_runs_v2 USING btree (trigger_source);
+
+
+--
+-- Name: ix_legal_timeline_events_case_slug; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_timeline_events_case_slug ON legal.timeline_events USING btree (case_slug);
+
+
+--
+-- Name: ix_legal_timeline_events_event_date; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_timeline_events_event_date ON legal.timeline_events USING btree (event_date);
+
+
+--
+-- Name: ix_legal_timeline_events_source_evidence_id; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_legal_timeline_events_source_evidence_id ON legal.timeline_events USING btree (source_evidence_id);
+
+
+--
+-- Name: ix_shadow_legal_cases_slug; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_shadow_legal_cases_slug ON legal.cases USING btree (case_slug);
+
+
+--
+-- Name: ix_vault_documents_slug; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX ix_vault_documents_slug ON legal.vault_documents USING btree (case_slug);
+
+
+--
+-- Name: idx_cl_capture_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_cl_capture_id ON public.capture_labels USING btree (capture_id);
+
+
+--
+-- Name: idx_cl_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_cl_created_at ON public.capture_labels USING btree (created_at);
+
+
+--
+-- Name: idx_cl_godhead_decision; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_cl_godhead_decision ON public.capture_labels USING btree (godhead_decision);
+
+
+--
+-- Name: idx_cl_qc_queue; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_cl_qc_queue ON public.capture_labels USING btree (created_at DESC) WHERE ((qc_sampled = true) AND (qc_reviewed_at IS NULL));
+
+
+--
+-- Name: idx_cl_task_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_cl_task_type ON public.capture_labels USING btree (task_type);
+
+
+--
+-- Name: idx_email_inquirers_guest_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_email_inquirers_guest_id ON public.email_inquirers USING btree (guest_id);
+
+
+--
+-- Name: idx_email_messages_imap_uid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_email_messages_imap_uid ON public.email_messages USING btree (imap_uid) WHERE (imap_uid IS NOT NULL);
+
+
+--
+-- Name: idx_email_messages_inquirer; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_email_messages_inquirer ON public.email_messages USING btree (inquirer_id, received_at DESC);
+
+
+--
+-- Name: idx_email_messages_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_email_messages_status ON public.email_messages USING btree (approval_status, received_at DESC);
+
+
+--
+-- Name: idx_email_messages_thread; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_email_messages_thread ON public.email_messages USING btree (in_reply_to_message_id);
+
+
+--
+-- Name: idx_llm_tc_judge_decision; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_llm_tc_judge_decision ON public.llm_training_captures USING btree (judge_decision);
+
+
+--
+-- Name: idx_llm_tc_served_by_endpoint; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_llm_tc_served_by_endpoint ON public.llm_training_captures USING btree (served_by_endpoint);
+
+
+--
+-- Name: idx_llm_tc_task_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_llm_tc_task_type ON public.llm_training_captures USING btree (task_type);
+
+
+--
+-- Name: idx_llm_tc_teacher_model; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_llm_tc_teacher_model ON public.llm_training_captures USING btree (teacher_model);
+
+
+--
+-- Name: idx_llm_training_captures_eval_holdout; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_llm_training_captures_eval_holdout ON public.llm_training_captures USING btree (eval_holdout);
+
+
+--
+-- Name: idx_rc_judge_decision; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_rc_judge_decision ON public.restricted_captures USING btree (judge_decision);
+
+
+--
+-- Name: idx_rc_served_by_endpoint; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_rc_served_by_endpoint ON public.restricted_captures USING btree (served_by_endpoint);
+
+
+--
+-- Name: idx_rc_task_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_rc_task_type ON public.restricted_captures USING btree (task_type);
+
+
+--
+-- Name: idx_rc_teacher_model; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_rc_teacher_model ON public.restricted_captures USING btree (teacher_model);
+
+
+--
+-- Name: idx_restricted_captures_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_restricted_captures_created_at ON public.restricted_captures USING btree (created_at);
+
+
+--
+-- Name: idx_restricted_captures_eval_holdout; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_restricted_captures_eval_holdout ON public.restricted_captures USING btree (eval_holdout);
+
+
+--
+-- Name: idx_restricted_captures_source_persona; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_restricted_captures_source_persona ON public.restricted_captures USING btree (source_persona);
+
+
+--
+-- Name: ix_accounts_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_accounts_code ON public.accounts USING btree (code);
+
+
+--
+-- Name: ix_activities_activity_slug; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_activities_activity_slug ON public.activities USING btree (activity_slug);
+
+
+--
+-- Name: ix_activities_slug; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_activities_slug ON public.activities USING btree (slug);
+
+
+--
+-- Name: ix_agent_queue_guest_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_agent_queue_guest_id ON public.agent_queue USING btree (guest_id);
+
+
+--
+-- Name: ix_agent_queue_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_agent_queue_property_id ON public.agent_queue USING btree (property_id);
+
+
+--
+-- Name: ix_agent_queue_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_agent_queue_status ON public.agent_queue USING btree (status);
+
+
+--
+-- Name: ix_agent_queue_twilio_sid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_agent_queue_twilio_sid ON public.agent_queue USING btree (twilio_sid);
+
+
+--
+-- Name: ix_agent_registry_is_active; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_agent_registry_is_active ON public.agent_registry USING btree (is_active);
+
+
+--
+-- Name: ix_agent_registry_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_agent_registry_name ON public.agent_registry USING btree (name);
+
+
+--
+-- Name: ix_agent_registry_role; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_agent_registry_role ON public.agent_registry USING btree (role);
+
+
+--
+-- Name: ix_agent_response_queue_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_agent_response_queue_created_at ON public.agent_response_queue USING btree (created_at);
+
+
+--
+-- Name: ix_agent_response_queue_guest_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_agent_response_queue_guest_id ON public.agent_response_queue USING btree (guest_id);
+
+
+--
+-- Name: ix_agent_response_queue_intent; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_agent_response_queue_intent ON public.agent_response_queue USING btree (intent);
+
+
+--
+-- Name: ix_agent_response_queue_message_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_agent_response_queue_message_id ON public.agent_response_queue USING btree (message_id);
+
+
+--
+-- Name: ix_agent_response_queue_reservation_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_agent_response_queue_reservation_id ON public.agent_response_queue USING btree (reservation_id);
+
+
+--
+-- Name: ix_agent_response_queue_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_agent_response_queue_status ON public.agent_response_queue USING btree (status);
+
+
+--
+-- Name: ix_agent_runs_agent_status_started; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_agent_runs_agent_status_started ON public.agent_runs USING btree (agent_id, status, started_at);
+
+
+--
+-- Name: ix_agent_runs_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_agent_runs_status ON public.agent_runs USING btree (status);
+
+
+--
+-- Name: ix_agent_runs_trigger_source; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_agent_runs_trigger_source ON public.agent_runs USING btree (trigger_source);
+
+
+--
+-- Name: ix_agent_runs_trigger_status_started; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_agent_runs_trigger_status_started ON public.agent_runs USING btree (trigger_source, status, started_at);
+
+
+--
+-- Name: ix_agreement_templates_agreement_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_agreement_templates_agreement_type ON public.agreement_templates USING btree (agreement_type);
+
+
+--
+-- Name: ix_agreement_templates_is_active; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_agreement_templates_is_active ON public.agreement_templates USING btree (is_active);
+
+
+--
+-- Name: ix_analytics_events_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_analytics_events_created_at ON public.analytics_events USING btree (created_at);
+
+
+--
+-- Name: ix_analytics_events_event_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_analytics_events_event_type ON public.analytics_events USING btree (event_type);
+
+
+--
+-- Name: ix_analytics_events_guest_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_analytics_events_guest_id ON public.analytics_events USING btree (guest_id);
+
+
+--
+-- Name: ix_analytics_events_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_analytics_events_property_id ON public.analytics_events USING btree (property_id);
+
+
+--
+-- Name: ix_analytics_events_reservation_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_analytics_events_reservation_id ON public.analytics_events USING btree (reservation_id);
+
+
+--
+-- Name: ix_async_job_runs_arq_job_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_async_job_runs_arq_job_id ON public.async_job_runs USING btree (arq_job_id);
+
+
+--
+-- Name: ix_async_job_runs_job_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_async_job_runs_job_name ON public.async_job_runs USING btree (job_name);
+
+
+--
+-- Name: ix_async_job_runs_job_status_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_async_job_runs_job_status_created ON public.async_job_runs USING btree (job_name, status, created_at);
+
+
+--
+-- Name: ix_async_job_runs_queue_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_async_job_runs_queue_name ON public.async_job_runs USING btree (queue_name);
+
+
+--
+-- Name: ix_async_job_runs_request_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_async_job_runs_request_id ON public.async_job_runs USING btree (request_id);
+
+
+--
+-- Name: ix_async_job_runs_requested_by; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_async_job_runs_requested_by ON public.async_job_runs USING btree (requested_by);
+
+
+--
+-- Name: ix_async_job_runs_requested_by_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_async_job_runs_requested_by_created ON public.async_job_runs USING btree (requested_by, created_at);
+
+
+--
+-- Name: ix_async_job_runs_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_async_job_runs_status ON public.async_job_runs USING btree (status);
+
+
+--
+-- Name: ix_async_job_runs_status_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_async_job_runs_status_created ON public.async_job_runs USING btree (status, created_at);
+
+
+--
+-- Name: ix_async_job_runs_tenant_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_async_job_runs_tenant_id ON public.async_job_runs USING btree (tenant_id);
+
+
+--
+-- Name: ix_blocked_days_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_blocked_days_property_id ON public.blocked_days USING btree (property_id);
+
+
+--
+-- Name: ix_blogs_slug; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_blogs_slug ON public.blogs USING btree (slug);
+
+
+--
+-- Name: ix_channel_mappings_channel; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_channel_mappings_channel ON public.channel_mappings USING btree (channel);
+
+
+--
+-- Name: ix_channel_mappings_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_channel_mappings_property_id ON public.channel_mappings USING btree (property_id);
+
+
+--
+-- Name: ix_citation_records_directory_domain; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_citation_records_directory_domain ON public.citation_records USING btree (directory_domain);
+
+
+--
+-- Name: ix_citation_records_last_audited_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_citation_records_last_audited_at ON public.citation_records USING btree (last_audited_at);
+
+
+--
+-- Name: ix_citation_records_match_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_citation_records_match_status ON public.citation_records USING btree (match_status);
+
+
+--
+-- Name: ix_cleaners_active; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_cleaners_active ON public.cleaners USING btree (active);
+
+
+--
+-- Name: ix_competitor_listings_dedupe_hash; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_competitor_listings_dedupe_hash ON public.competitor_listings USING btree (dedupe_hash);
+
+
+--
+-- Name: ix_competitor_listings_last_observed; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_competitor_listings_last_observed ON public.competitor_listings USING btree (last_observed);
+
+
+--
+-- Name: ix_competitor_listings_platform; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_competitor_listings_platform ON public.competitor_listings USING btree (platform);
+
+
+--
+-- Name: ix_competitor_listings_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_competitor_listings_property_id ON public.competitor_listings USING btree (property_id);
+
+
+--
+-- Name: ix_competitor_listings_property_platform_observed; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_competitor_listings_property_platform_observed ON public.competitor_listings USING btree (property_id, platform, last_observed);
+
+
+--
+-- Name: ix_concierge_queue_guest_phone; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_concierge_queue_guest_phone ON public.concierge_queue USING btree (guest_phone);
+
+
+--
+-- Name: ix_concierge_queue_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_concierge_queue_property_id ON public.concierge_queue USING btree (property_id);
+
+
+--
+-- Name: ix_concierge_queue_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_concierge_queue_status ON public.concierge_queue USING btree (status);
+
+
+--
+-- Name: ix_concierge_queue_status_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_concierge_queue_status_created ON public.concierge_queue USING btree (status, created_at);
+
+
+--
+-- Name: ix_crd_guest_channel_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_crd_guest_channel_created ON public.concierge_recovery_dispatches USING btree (guest_id, channel, created_at);
+
+
+--
+-- Name: ix_crd_session_fp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_crd_session_fp ON public.concierge_recovery_dispatches USING btree (session_fp);
+
+
+--
+-- Name: ix_damage_claims_guest_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_damage_claims_guest_id ON public.damage_claims USING btree (guest_id);
+
+
+--
+-- Name: ix_damage_claims_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_damage_claims_property_id ON public.damage_claims USING btree (property_id);
+
+
+--
+-- Name: ix_damage_claims_reservation_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_damage_claims_reservation_id ON public.damage_claims USING btree (reservation_id);
+
+
+--
+-- Name: ix_deferred_api_writes_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_deferred_api_writes_created_at ON public.deferred_api_writes USING btree (created_at);
+
+
+--
+-- Name: ix_deferred_api_writes_service; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_deferred_api_writes_service ON public.deferred_api_writes USING btree (service);
+
+
+--
+-- Name: ix_deferred_api_writes_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_deferred_api_writes_status ON public.deferred_api_writes USING btree (status);
+
+
+--
+-- Name: ix_distillation_queue_source_intelligence_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_distillation_queue_source_intelligence_id ON public.distillation_queue USING btree (source_intelligence_id);
+
+
+--
+-- Name: ix_distillation_queue_source_module; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_distillation_queue_source_module ON public.distillation_queue USING btree (source_module);
+
+
+--
+-- Name: ix_distillation_queue_source_ref; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_distillation_queue_source_ref ON public.distillation_queue USING btree (source_ref);
+
+
+--
+-- Name: ix_distillation_queue_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_distillation_queue_status ON public.distillation_queue USING btree (status);
+
+
+--
+-- Name: ix_email_templates_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_email_templates_name ON public.email_templates USING btree (name);
+
+
+--
+-- Name: ix_email_templates_trigger_event; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_email_templates_trigger_event ON public.email_templates USING btree (trigger_event);
+
+
+--
+-- Name: ix_extra_orders_extra_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_extra_orders_extra_id ON public.extra_orders USING btree (extra_id);
+
+
+--
+-- Name: ix_extra_orders_reservation_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_extra_orders_reservation_id ON public.extra_orders USING btree (reservation_id);
+
+
+--
+-- Name: ix_extra_orders_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_extra_orders_status ON public.extra_orders USING btree (status);
+
+
+--
+-- Name: ix_extras_is_available; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_extras_is_available ON public.extras USING btree (is_available);
+
+
+--
+-- Name: ix_fees_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_fees_name ON public.fees USING btree (name);
+
+
+--
+-- Name: ix_financial_approvals_reservation_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_financial_approvals_reservation_id ON public.financial_approvals USING btree (reservation_id);
+
+
+--
+-- Name: ix_financial_approvals_resolution_strategy; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_financial_approvals_resolution_strategy ON public.financial_approvals USING btree (resolution_strategy);
+
+
+--
+-- Name: ix_financial_approvals_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_financial_approvals_status ON public.financial_approvals USING btree (status);
+
+
+--
+-- Name: ix_functional_nodes_canonical_path; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_functional_nodes_canonical_path ON public.functional_nodes USING btree (canonical_path);
+
+
+--
+-- Name: ix_functional_nodes_content_category; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_functional_nodes_content_category ON public.functional_nodes USING btree (content_category);
+
+
+--
+-- Name: ix_functional_nodes_crawl_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_functional_nodes_crawl_status ON public.functional_nodes USING btree (crawl_status);
+
+
+--
+-- Name: ix_functional_nodes_cutover_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_functional_nodes_cutover_status ON public.functional_nodes USING btree (cutover_status);
+
+
+--
+-- Name: ix_functional_nodes_functional_complexity; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_functional_nodes_functional_complexity ON public.functional_nodes USING btree (functional_complexity);
+
+
+--
+-- Name: ix_functional_nodes_is_published; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_functional_nodes_is_published ON public.functional_nodes USING btree (is_published);
+
+
+--
+-- Name: ix_functional_nodes_legacy_node_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_functional_nodes_legacy_node_id ON public.functional_nodes USING btree (legacy_node_id);
+
+
+--
+-- Name: ix_functional_nodes_mirror_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_functional_nodes_mirror_status ON public.functional_nodes USING btree (mirror_status);
+
+
+--
+-- Name: ix_functional_nodes_node_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_functional_nodes_node_type ON public.functional_nodes USING btree (node_type);
+
+
+--
+-- Name: ix_functional_nodes_priority_tier; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_functional_nodes_priority_tier ON public.functional_nodes USING btree (priority_tier);
+
+
+--
+-- Name: ix_functional_nodes_source_path; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_functional_nodes_source_path ON public.functional_nodes USING btree (source_path);
+
+
+--
+-- Name: ix_guest_activities_activity_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guest_activities_activity_type ON public.guest_activities USING btree (activity_type);
+
+
+--
+-- Name: ix_guest_activities_category; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guest_activities_category ON public.guest_activities USING btree (category);
+
+
+--
+-- Name: ix_guest_activities_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guest_activities_created_at ON public.guest_activities USING btree (created_at);
+
+
+--
+-- Name: ix_guest_activities_guest_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guest_activities_guest_id ON public.guest_activities USING btree (guest_id);
+
+
+--
+-- Name: ix_guest_quotes_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guest_quotes_property_id ON public.guest_quotes USING btree (property_id);
+
+
+--
+-- Name: ix_guest_quotes_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guest_quotes_status ON public.guest_quotes USING btree (status);
+
+
+--
+-- Name: ix_guest_quotes_status_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guest_quotes_status_created ON public.guest_quotes USING btree (status, created_at);
+
+
+--
+-- Name: ix_guest_quotes_target_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guest_quotes_target_property_id ON public.guest_quotes USING btree (target_property_id);
+
+
+--
+-- Name: ix_guest_reviews_direction; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guest_reviews_direction ON public.guest_reviews USING btree (direction);
+
+
+--
+-- Name: ix_guest_reviews_guest_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guest_reviews_guest_id ON public.guest_reviews USING btree (guest_id);
+
+
+--
+-- Name: ix_guest_reviews_is_published; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guest_reviews_is_published ON public.guest_reviews USING btree (is_published);
+
+
+--
+-- Name: ix_guest_reviews_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guest_reviews_property_id ON public.guest_reviews USING btree (property_id);
+
+
+--
+-- Name: ix_guest_reviews_reservation_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guest_reviews_reservation_id ON public.guest_reviews USING btree (reservation_id);
+
+
+--
+-- Name: ix_guest_surveys_guest_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guest_surveys_guest_id ON public.guest_surveys USING btree (guest_id);
+
+
+--
+-- Name: ix_guest_surveys_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guest_surveys_property_id ON public.guest_surveys USING btree (property_id);
+
+
+--
+-- Name: ix_guest_surveys_reservation_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guest_surveys_reservation_id ON public.guest_surveys USING btree (reservation_id);
+
+
+--
+-- Name: ix_guest_surveys_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guest_surveys_status ON public.guest_surveys USING btree (status);
+
+
+--
+-- Name: ix_guest_surveys_survey_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guest_surveys_survey_type ON public.guest_surveys USING btree (survey_type);
+
+
+--
+-- Name: ix_guest_surveys_template_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guest_surveys_template_id ON public.guest_surveys USING btree (template_id);
+
+
+--
+-- Name: ix_guest_verifications_guest_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guest_verifications_guest_id ON public.guest_verifications USING btree (guest_id);
+
+
+--
+-- Name: ix_guest_verifications_reservation_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guest_verifications_reservation_id ON public.guest_verifications USING btree (reservation_id);
+
+
+--
+-- Name: ix_guest_verifications_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guest_verifications_status ON public.guest_verifications USING btree (status);
+
+
+--
+-- Name: ix_guestbook_guides_guide_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guestbook_guides_guide_type ON public.guestbook_guides USING btree (guide_type);
+
+
+--
+-- Name: ix_guestbook_guides_is_visible; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guestbook_guides_is_visible ON public.guestbook_guides USING btree (is_visible);
+
+
+--
+-- Name: ix_guestbook_guides_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guestbook_guides_property_id ON public.guestbook_guides USING btree (property_id);
+
+
+--
+-- Name: ix_guests_email; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guests_email ON public.guests USING btree (email);
+
+
+--
+-- Name: ix_guests_guest_source; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guests_guest_source ON public.guests USING btree (guest_source);
+
+
+--
+-- Name: ix_guests_is_blacklisted; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guests_is_blacklisted ON public.guests USING btree (is_blacklisted);
+
+
+--
+-- Name: ix_guests_is_vip; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guests_is_vip ON public.guests USING btree (is_vip);
+
+
+--
+-- Name: ix_guests_loyalty_tier; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guests_loyalty_tier ON public.guests USING btree (loyalty_tier);
+
+
+--
+-- Name: ix_guests_phone; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_guests_phone ON public.guests USING btree (phone);
+
+
+--
+-- Name: ix_guests_verification_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_guests_verification_status ON public.guests USING btree (verification_status);
+
+
+--
+-- Name: ix_housekeeping_tasks_cleaner; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_housekeeping_tasks_cleaner ON public.housekeeping_tasks USING btree (assigned_cleaner_id);
+
+
+--
+-- Name: ix_housekeeping_tasks_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_housekeeping_tasks_property_id ON public.housekeeping_tasks USING btree (property_id);
+
+
+--
+-- Name: ix_housekeeping_tasks_reservation_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_housekeeping_tasks_reservation_id ON public.housekeeping_tasks USING btree (reservation_id);
+
+
+--
+-- Name: ix_housekeeping_tasks_scheduled_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_housekeeping_tasks_scheduled_date ON public.housekeeping_tasks USING btree (scheduled_date);
+
+
+--
+-- Name: ix_housekeeping_tasks_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_housekeeping_tasks_status ON public.housekeeping_tasks USING btree (status);
+
+
+--
+-- Name: ix_hunter_queue_guest_email; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_hunter_queue_guest_email ON public.hunter_queue USING btree (guest_email);
+
+
+--
+-- Name: ix_hunter_queue_guest_phone; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_hunter_queue_guest_phone ON public.hunter_queue USING btree (guest_phone);
+
+
+--
+-- Name: ix_hunter_queue_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_hunter_queue_property_id ON public.hunter_queue USING btree (property_id);
+
+
+--
+-- Name: ix_hunter_queue_reservation_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_hunter_queue_reservation_id ON public.hunter_queue USING btree (reservation_id);
+
+
+--
+-- Name: ix_hunter_queue_session_fp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_hunter_queue_session_fp ON public.hunter_queue USING btree (session_fp);
+
+
+--
+-- Name: ix_hunter_queue_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_hunter_queue_status ON public.hunter_queue USING btree (status);
+
+
+--
+-- Name: ix_hunter_queue_status_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_hunter_queue_status_created ON public.hunter_queue USING btree (status, created_at);
+
+
+--
+-- Name: ix_hunter_recovery_ops_cart_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_hunter_recovery_ops_cart_id ON public.hunter_recovery_ops USING btree (cart_id);
+
+
+--
+-- Name: ix_hunter_recovery_ops_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_hunter_recovery_ops_status ON public.hunter_recovery_ops USING btree (status);
+
+
+--
+-- Name: ix_hunter_recovery_ops_status_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_hunter_recovery_ops_status_created ON public.hunter_recovery_ops USING btree (status, created_at);
+
+
+--
+-- Name: ix_intelligence_ledger_category; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_intelligence_ledger_category ON public.intelligence_ledger USING btree (category);
+
+
+--
+-- Name: ix_intelligence_ledger_category_discovered; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_intelligence_ledger_category_discovered ON public.intelligence_ledger USING btree (category, discovered_at);
+
+
+--
+-- Name: ix_intelligence_ledger_dedupe_hash; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_intelligence_ledger_dedupe_hash ON public.intelligence_ledger USING btree (dedupe_hash);
+
+
+--
+-- Name: ix_intelligence_ledger_discovered_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_intelligence_ledger_discovered_at ON public.intelligence_ledger USING btree (discovered_at);
+
+
+--
+-- Name: ix_intelligence_ledger_locality; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_intelligence_ledger_locality ON public.intelligence_ledger USING btree (locality);
+
+
+--
+-- Name: ix_intelligence_ledger_market; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_intelligence_ledger_market ON public.intelligence_ledger USING btree (market);
+
+
+--
+-- Name: ix_intelligence_ledger_market_discovered; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_intelligence_ledger_market_discovered ON public.intelligence_ledger USING btree (market, discovered_at);
+
+
+--
+-- Name: ix_intelligence_ledger_query_topic; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_intelligence_ledger_query_topic ON public.intelligence_ledger USING btree (query_topic);
+
+
+--
+-- Name: ix_intelligence_ledger_scout_run_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_intelligence_ledger_scout_run_key ON public.intelligence_ledger USING btree (scout_run_key);
+
+
+--
+-- Name: ix_journal_entries_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_journal_entries_property_id ON public.journal_entries USING btree (property_id);
+
+
+--
+-- Name: ix_journal_entries_reference; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_journal_entries_reference ON public.journal_entries USING btree (reference_type, reference_id);
+
+
+--
+-- Name: ix_journal_line_items_journal_entry_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_journal_line_items_journal_entry_id ON public.journal_line_items USING btree (journal_entry_id);
+
+
+--
+-- Name: ix_knowledge_base_entries_category; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_knowledge_base_entries_category ON public.knowledge_base_entries USING btree (category);
+
+
+--
+-- Name: ix_knowledge_base_entries_is_active; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_knowledge_base_entries_is_active ON public.knowledge_base_entries USING btree (is_active);
+
+
+--
+-- Name: ix_knowledge_base_entries_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_knowledge_base_entries_property_id ON public.knowledge_base_entries USING btree (property_id);
+
+
+--
+-- Name: ix_leads_email; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_leads_email ON public.leads USING btree (email);
+
+
+--
+-- Name: ix_leads_source; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_leads_source ON public.leads USING btree (source);
+
+
+--
+-- Name: ix_leads_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_leads_status ON public.leads USING btree (status);
+
+
+--
+-- Name: ix_leads_streamline_lead_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_leads_streamline_lead_id ON public.leads USING btree (streamline_lead_id);
+
+
+--
+-- Name: ix_learned_rules_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_learned_rules_property_id ON public.learned_rules USING btree (property_id);
+
+
+--
+-- Name: ix_learned_rules_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_learned_rules_status ON public.learned_rules USING btree (status);
+
+
+--
+-- Name: ix_legacy_pages_slug; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_legacy_pages_slug ON public.legacy_pages USING btree (slug);
+
+
+--
+-- Name: ix_legal_case_statements_case_slug; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_legal_case_statements_case_slug ON public.legal_case_statements USING btree (case_slug);
+
+
+--
+-- Name: ix_legal_case_statements_entity_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_legal_case_statements_entity_name ON public.legal_case_statements USING btree (entity_name);
+
+
+--
+-- Name: ix_legal_case_statements_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_legal_case_statements_id ON public.legal_case_statements USING btree (id);
+
+
+--
+-- Name: ix_legal_hive_mind_feedback_events_case_slug; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_legal_hive_mind_feedback_events_case_slug ON public.legal_hive_mind_feedback_events USING btree (case_slug);
+
+
+--
+-- Name: ix_legal_hive_mind_feedback_events_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_legal_hive_mind_feedback_events_id ON public.legal_hive_mind_feedback_events USING btree (id);
+
+
+--
+-- Name: ix_legal_hive_mind_feedback_events_module_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_legal_hive_mind_feedback_events_module_type ON public.legal_hive_mind_feedback_events USING btree (module_type);
+
+
+--
+-- Name: ix_llm_training_captures_module; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_llm_training_captures_module ON public.llm_training_captures USING btree (source_module);
+
+
+--
+-- Name: ix_llm_training_captures_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_llm_training_captures_status ON public.llm_training_captures USING btree (status);
+
+
+--
+-- Name: ix_management_splits_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_management_splits_property_id ON public.management_splits USING btree (property_id);
+
+
+--
+-- Name: ix_marketing_articles_category_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_marketing_articles_category_id ON public.marketing_articles USING btree (category_id);
+
+
+--
+-- Name: ix_marketing_articles_published_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_marketing_articles_published_date ON public.marketing_articles USING btree (published_date);
+
+
+--
+-- Name: ix_marketing_articles_slug; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_marketing_articles_slug ON public.marketing_articles USING btree (slug);
+
+
+--
+-- Name: ix_message_queue_quote_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_message_queue_quote_id ON public.message_queue USING btree (quote_id);
+
+
+--
+-- Name: ix_message_queue_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_message_queue_status ON public.message_queue USING btree (status);
+
+
+--
+-- Name: ix_message_queue_template_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_message_queue_template_id ON public.message_queue USING btree (template_id);
+
+
+--
+-- Name: ix_message_templates_category; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_message_templates_category ON public.message_templates USING btree (category);
+
+
+--
+-- Name: ix_message_templates_is_active; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_message_templates_is_active ON public.message_templates USING btree (is_active);
+
+
+--
+-- Name: ix_messages_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_messages_created_at ON public.messages USING btree (created_at);
+
+
+--
+-- Name: ix_messages_direction; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_messages_direction ON public.messages USING btree (direction);
+
+
+--
+-- Name: ix_messages_external_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_messages_external_id ON public.messages USING btree (external_id);
+
+
+--
+-- Name: ix_messages_guest_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_messages_guest_id ON public.messages USING btree (guest_id);
+
+
+--
+-- Name: ix_messages_intent; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_messages_intent ON public.messages USING btree (intent);
+
+
+--
+-- Name: ix_messages_phone_from; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_messages_phone_from ON public.messages USING btree (phone_from);
+
+
+--
+-- Name: ix_messages_reservation_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_messages_reservation_id ON public.messages USING btree (reservation_id);
+
+
+--
+-- Name: ix_messages_sentiment; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_messages_sentiment ON public.messages USING btree (sentiment);
+
+
+--
+-- Name: ix_obp_owner_period; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_obp_owner_period ON public.owner_balance_periods USING btree (owner_payout_account_id, period_start);
+
+
+--
+-- Name: ix_obp_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_obp_status ON public.owner_balance_periods USING btree (status);
+
+
+--
+-- Name: ix_obp_stripe_transfer_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_obp_stripe_transfer_id ON public.owner_balance_periods USING btree (stripe_transfer_id) WHERE (stripe_transfer_id IS NOT NULL);
+
+
+--
+-- Name: ix_oc_active; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_oc_active ON public.owner_charges USING btree (owner_payout_account_id, posting_date) WHERE (voided_at IS NULL);
+
+
+--
+-- Name: ix_oc_owner_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_oc_owner_date ON public.owner_charges USING btree (owner_payout_account_id, posting_date);
+
+
+--
+-- Name: ix_oc_transaction_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_oc_transaction_type ON public.owner_charges USING btree (transaction_type);
+
+
+--
+-- Name: ix_opa_streamline_owner_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_opa_streamline_owner_id ON public.owner_payout_accounts USING btree (streamline_owner_id);
+
+
+--
+-- Name: ix_openshell_audit_logs_action; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_openshell_audit_logs_action ON public.openshell_audit_logs USING btree (action);
+
+
+--
+-- Name: ix_openshell_audit_logs_actor_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_openshell_audit_logs_actor_id ON public.openshell_audit_logs USING btree (actor_id);
+
+
+--
+-- Name: ix_openshell_audit_logs_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_openshell_audit_logs_created_at ON public.openshell_audit_logs USING btree (created_at);
+
+
+--
+-- Name: ix_openshell_audit_logs_entry_hash; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_openshell_audit_logs_entry_hash ON public.openshell_audit_logs USING btree (entry_hash);
+
+
+--
+-- Name: ix_openshell_audit_logs_model_route; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_openshell_audit_logs_model_route ON public.openshell_audit_logs USING btree (model_route);
+
+
+--
+-- Name: ix_openshell_audit_logs_outcome; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_openshell_audit_logs_outcome ON public.openshell_audit_logs USING btree (outcome);
+
+
+--
+-- Name: ix_openshell_audit_logs_payload_hash; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_openshell_audit_logs_payload_hash ON public.openshell_audit_logs USING btree (payload_hash);
+
+
+--
+-- Name: ix_openshell_audit_logs_prev_hash; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_openshell_audit_logs_prev_hash ON public.openshell_audit_logs USING btree (prev_hash);
+
+
+--
+-- Name: ix_openshell_audit_logs_redaction_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_openshell_audit_logs_redaction_status ON public.openshell_audit_logs USING btree (redaction_status);
+
+
+--
+-- Name: ix_openshell_audit_logs_request_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_openshell_audit_logs_request_id ON public.openshell_audit_logs USING btree (request_id);
+
+
+--
+-- Name: ix_openshell_audit_logs_resource_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_openshell_audit_logs_resource_type ON public.openshell_audit_logs USING btree (resource_type);
+
+
+--
+-- Name: ix_openshell_audit_logs_tool_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_openshell_audit_logs_tool_name ON public.openshell_audit_logs USING btree (tool_name);
+
+
+--
+-- Name: ix_operator_overrides_escalation_timestamp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_operator_overrides_escalation_timestamp ON public.operator_overrides USING btree (escalation_id, "timestamp");
+
+
+--
+-- Name: ix_operator_overrides_operator_email; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_operator_overrides_operator_email ON public.operator_overrides USING btree (operator_email);
+
+
+--
+-- Name: ix_operator_overrides_operator_timestamp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_operator_overrides_operator_timestamp ON public.operator_overrides USING btree (operator_email, "timestamp");
+
+
+--
+-- Name: ix_operator_overrides_timestamp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_operator_overrides_timestamp ON public.operator_overrides USING btree ("timestamp");
+
+
+--
+-- Name: ix_oss_owner_payout_account_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_oss_owner_payout_account_id ON public.owner_statement_sends USING btree (owner_payout_account_id);
+
+
+--
+-- Name: ix_oss_period; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_oss_period ON public.owner_statement_sends USING btree (statement_period_start, statement_period_end);
+
+
+--
+-- Name: ix_oss_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_oss_property_id ON public.owner_statement_sends USING btree (property_id);
+
+
+--
+-- Name: ix_oss_sent_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_oss_sent_at ON public.owner_statement_sends USING btree (sent_at);
+
+
+--
+-- Name: ix_ota_micro_updates_channel; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_ota_micro_updates_channel ON public.ota_micro_updates USING btree (channel);
+
+
+--
+-- Name: ix_ota_micro_updates_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_ota_micro_updates_property_id ON public.ota_micro_updates USING btree (property_id);
+
+
+--
+-- Name: ix_ota_micro_updates_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_ota_micro_updates_status ON public.ota_micro_updates USING btree (status);
+
+
+--
+-- Name: ix_owner_charges_vendor_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_owner_charges_vendor_id ON public.owner_charges USING btree (vendor_id);
+
+
+--
+-- Name: ix_owner_payout_accounts_owner_email; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_owner_payout_accounts_owner_email ON public.owner_payout_accounts USING btree (owner_email);
+
+
+--
+-- Name: ix_owner_payout_accounts_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_owner_payout_accounts_status ON public.owner_payout_accounts USING btree (account_status);
+
+
+--
+-- Name: ix_parity_audits_confirmation_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_parity_audits_confirmation_id ON public.parity_audits USING btree (confirmation_id);
+
+
+--
+-- Name: ix_parity_audits_reservation_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_parity_audits_reservation_id ON public.parity_audits USING btree (reservation_id);
+
+
+--
+-- Name: ix_parity_audits_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_parity_audits_status ON public.parity_audits USING btree (status);
+
+
+--
+-- Name: ix_payout_ledger_confirmation_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_payout_ledger_confirmation_code ON public.payout_ledger USING btree (confirmation_code);
+
+
+--
+-- Name: ix_payout_ledger_property_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_payout_ledger_property_created ON public.payout_ledger USING btree (property_id, created_at DESC);
+
+
+--
+-- Name: ix_payout_ledger_status_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_payout_ledger_status_created ON public.payout_ledger USING btree (status, created_at DESC);
+
+
+--
+-- Name: ix_pending_sync_reservation_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_pending_sync_reservation_id ON public.pending_sync USING btree (reservation_id);
+
+
+--
+-- Name: ix_pending_sync_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_pending_sync_status ON public.pending_sync USING btree (status);
+
+
+--
+-- Name: ix_pricing_overrides_property_dates; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_pricing_overrides_property_dates ON public.pricing_overrides USING btree (property_id, start_date, end_date);
+
+
+--
+-- Name: ix_pricing_overrides_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_pricing_overrides_property_id ON public.pricing_overrides USING btree (property_id);
+
+
+--
+-- Name: ix_properties_renting_state; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_properties_renting_state ON public.properties USING btree (renting_state);
+
+
+--
+-- Name: ix_properties_slug; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_properties_slug ON public.properties USING btree (slug);
+
+
+--
+-- Name: ix_properties_streamline_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_properties_streamline_property_id ON public.properties USING btree (streamline_property_id);
+
+
+--
+-- Name: ix_property_fees_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_property_fees_property_id ON public.property_fees USING btree (property_id);
+
+
+--
+-- Name: ix_property_images_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_property_images_property_id ON public.property_images USING btree (property_id);
+
+
+--
+-- Name: ix_property_images_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_property_images_status ON public.property_images USING btree (status);
+
+
+--
+-- Name: ix_property_knowledge_category; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_property_knowledge_category ON public.property_knowledge USING btree (category);
+
+
+--
+-- Name: ix_property_knowledge_chunks_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_property_knowledge_chunks_property_id ON public.property_knowledge_chunks USING btree (property_id);
+
+
+--
+-- Name: ix_property_knowledge_prop_cat_updated; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_property_knowledge_prop_cat_updated ON public.property_knowledge USING btree (property_id, category, updated_at);
+
+
+--
+-- Name: ix_property_knowledge_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_property_knowledge_property_id ON public.property_knowledge USING btree (property_id);
+
+
+--
+-- Name: ix_property_knowledge_updated_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_property_knowledge_updated_at ON public.property_knowledge USING btree (updated_at);
+
+
+--
+-- Name: ix_property_stay_restrictions_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_property_stay_restrictions_property_id ON public.property_stay_restrictions USING btree (property_id);
+
+
+--
+-- Name: ix_property_taxes_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_property_taxes_property_id ON public.property_taxes USING btree (property_id);
+
+
+--
+-- Name: ix_property_utilities_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_property_utilities_property_id ON public.property_utilities USING btree (property_id);
+
+
+--
+-- Name: ix_quote_options_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_quote_options_property_id ON public.quote_options USING btree (property_id);
+
+
+--
+-- Name: ix_quote_options_quote_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_quote_options_quote_id ON public.quote_options USING btree (quote_id);
+
+
+--
+-- Name: ix_quotes_lead_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_quotes_lead_id ON public.quotes USING btree (lead_id);
+
+
+--
+-- Name: ix_quotes_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_quotes_status ON public.quotes USING btree (status);
+
+
+--
+-- Name: ix_recovery_parity_comparisons_async_job_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_recovery_parity_comparisons_async_job_run_id ON public.recovery_parity_comparisons USING btree (async_job_run_id);
+
+
+--
+-- Name: ix_recovery_parity_comparisons_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_recovery_parity_comparisons_created_at ON public.recovery_parity_comparisons USING btree (created_at);
+
+
+--
+-- Name: ix_recovery_parity_comparisons_dedupe_hash; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_recovery_parity_comparisons_dedupe_hash ON public.recovery_parity_comparisons USING btree (dedupe_hash);
+
+
+--
+-- Name: ix_recovery_parity_comparisons_guest_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_recovery_parity_comparisons_guest_id ON public.recovery_parity_comparisons USING btree (guest_id);
+
+
+--
+-- Name: ix_recovery_parity_comparisons_session_fp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_recovery_parity_comparisons_session_fp ON public.recovery_parity_comparisons USING btree (session_fp);
+
+
+--
+-- Name: ix_recovery_parity_guest_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_recovery_parity_guest_created ON public.recovery_parity_comparisons USING btree (guest_id, created_at);
+
+
+--
+-- Name: ix_recovery_parity_session_fp_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_recovery_parity_session_fp_created ON public.recovery_parity_comparisons USING btree (session_fp, created_at);
+
+
+--
+-- Name: ix_rental_agreements_guest_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_rental_agreements_guest_id ON public.rental_agreements USING btree (guest_id);
+
+
+--
+-- Name: ix_rental_agreements_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_rental_agreements_property_id ON public.rental_agreements USING btree (property_id);
+
+
+--
+-- Name: ix_rental_agreements_reservation_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_rental_agreements_reservation_id ON public.rental_agreements USING btree (reservation_id);
+
+
+--
+-- Name: ix_rental_agreements_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_rental_agreements_status ON public.rental_agreements USING btree (status);
+
+
+--
+-- Name: ix_rental_agreements_template_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_rental_agreements_template_id ON public.rental_agreements USING btree (template_id);
+
+
+--
+-- Name: ix_reservation_holds_converted_reservation_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_reservation_holds_converted_reservation_id ON public.reservation_holds USING btree (converted_reservation_id);
+
+
+--
+-- Name: ix_reservation_holds_guest_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_reservation_holds_guest_id ON public.reservation_holds USING btree (guest_id);
+
+
+--
+-- Name: ix_reservation_holds_payment_intent_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_reservation_holds_payment_intent_id ON public.reservation_holds USING btree (payment_intent_id);
+
+
+--
+-- Name: ix_reservation_holds_property_dates; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_reservation_holds_property_dates ON public.reservation_holds USING btree (property_id, check_in_date, check_out_date);
+
+
+--
+-- Name: ix_reservation_holds_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_reservation_holds_property_id ON public.reservation_holds USING btree (property_id);
+
+
+--
+-- Name: ix_reservation_holds_session_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_reservation_holds_session_id ON public.reservation_holds USING btree (session_id);
+
+
+--
+-- Name: ix_reservation_holds_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_reservation_holds_status ON public.reservation_holds USING btree (status);
+
+
+--
+-- Name: ix_reservation_holds_status_expires; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_reservation_holds_status_expires ON public.reservation_holds USING btree (status, expires_at);
+
+
+--
+-- Name: ix_reservations_check_in_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_reservations_check_in_date ON public.reservations USING btree (check_in_date);
+
+
+--
+-- Name: ix_reservations_check_out_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_reservations_check_out_date ON public.reservations USING btree (check_out_date);
+
+
+--
+-- Name: ix_reservations_confirmation_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_reservations_confirmation_code ON public.reservations USING btree (confirmation_code);
+
+
+--
+-- Name: ix_reservations_guest_email; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_reservations_guest_email ON public.reservations USING btree (guest_email);
+
+
+--
+-- Name: ix_reservations_guest_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_reservations_guest_id ON public.reservations USING btree (guest_id);
+
+
+--
+-- Name: ix_reservations_is_owner_booking; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_reservations_is_owner_booking ON public.reservations USING btree (is_owner_booking);
+
+
+--
+-- Name: ix_reservations_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_reservations_property_id ON public.reservations USING btree (property_id);
+
+
+--
+-- Name: ix_reservations_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_reservations_status ON public.reservations USING btree (status);
+
+
+--
+-- Name: ix_rue_bar_rue_legacy_recovery_templates_audience_rule; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_rue_bar_rue_legacy_recovery_templates_audience_rule ON public.rue_bar_rue_legacy_recovery_templates USING btree (audience_rule);
+
+
+--
+-- Name: ix_rue_bar_rue_legacy_recovery_templates_channel; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_rue_bar_rue_legacy_recovery_templates_channel ON public.rue_bar_rue_legacy_recovery_templates USING btree (channel);
+
+
+--
+-- Name: ix_rue_bar_rue_legacy_recovery_templates_template_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_rue_bar_rue_legacy_recovery_templates_template_key ON public.rue_bar_rue_legacy_recovery_templates USING btree (template_key);
+
+
+--
+-- Name: ix_scheduled_messages_guest_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_scheduled_messages_guest_id ON public.scheduled_messages USING btree (guest_id);
+
+
+--
+-- Name: ix_scheduled_messages_reservation_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_scheduled_messages_reservation_id ON public.scheduled_messages USING btree (reservation_id);
+
+
+--
+-- Name: ix_scheduled_messages_scheduled_for; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_scheduled_messages_scheduled_for ON public.scheduled_messages USING btree (scheduled_for);
+
+
+--
+-- Name: ix_scheduled_messages_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_scheduled_messages_status ON public.scheduled_messages USING btree (status);
+
+
+--
+-- Name: ix_scheduled_messages_template_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_scheduled_messages_template_id ON public.scheduled_messages USING btree (template_id);
+
+
+--
+-- Name: ix_seo_patch_queue_campaign; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_patch_queue_campaign ON public.seo_patch_queue USING btree (campaign);
+
+
+--
+-- Name: ix_seo_patch_queue_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_patch_queue_created_at ON public.seo_patch_queue USING btree (created_at);
+
+
+--
+-- Name: ix_seo_patch_queue_property_approved; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_patch_queue_property_approved ON public.seo_patch_queue USING btree (property_id, approved_at);
+
+
+--
+-- Name: ix_seo_patch_queue_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_patch_queue_property_id ON public.seo_patch_queue USING btree (property_id);
+
+
+--
+-- Name: ix_seo_patch_queue_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_patch_queue_status ON public.seo_patch_queue USING btree (status);
+
+
+--
+-- Name: ix_seo_patch_queue_status_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_patch_queue_status_created ON public.seo_patch_queue USING btree (status, created_at);
+
+
+--
+-- Name: ix_seo_patch_queue_target_approved; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_patch_queue_target_approved ON public.seo_patch_queue USING btree (target_type, target_slug, approved_at);
+
+
+--
+-- Name: ix_seo_patch_queue_target_slug; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_patch_queue_target_slug ON public.seo_patch_queue USING btree (target_slug);
+
+
+--
+-- Name: ix_seo_patch_queue_target_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_patch_queue_target_type ON public.seo_patch_queue USING btree (target_type);
+
+
+--
+-- Name: ix_seo_patches_deploy_acknowledged_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_patches_deploy_acknowledged_at ON public.seo_patches USING btree (deploy_acknowledged_at);
+
+
+--
+-- Name: ix_seo_patches_deploy_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_patches_deploy_status ON public.seo_patches USING btree (deploy_status);
+
+
+--
+-- Name: ix_seo_patches_deployed_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_patches_deployed_at ON public.seo_patches USING btree (deployed_at);
+
+
+--
+-- Name: ix_seo_patches_page_path; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_patches_page_path ON public.seo_patches USING btree (page_path);
+
+
+--
+-- Name: ix_seo_patches_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_patches_property_id ON public.seo_patches USING btree (property_id);
+
+
+--
+-- Name: ix_seo_patches_rubric_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_patches_rubric_id ON public.seo_patches USING btree (rubric_id);
+
+
+--
+-- Name: ix_seo_patches_source_agent; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_patches_source_agent ON public.seo_patches USING btree (source_agent);
+
+
+--
+-- Name: ix_seo_patches_source_intelligence_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_patches_source_intelligence_id ON public.seo_patches USING btree (source_intelligence_id);
+
+
+--
+-- Name: ix_seo_patches_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_patches_status ON public.seo_patches USING btree (status);
+
+
+--
+-- Name: ix_seo_rank_snapshots_keyword; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_rank_snapshots_keyword ON public.seo_rank_snapshots USING btree (keyword);
+
+
+--
+-- Name: ix_seo_rank_snapshots_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_rank_snapshots_property_id ON public.seo_rank_snapshots USING btree (property_id);
+
+
+--
+-- Name: ix_seo_rank_snapshots_snapshot_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_rank_snapshots_snapshot_date ON public.seo_rank_snapshots USING btree (snapshot_date);
+
+
+--
+-- Name: ix_seo_redirect_remap_queue_campaign; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_redirect_remap_queue_campaign ON public.seo_redirect_remap_queue USING btree (campaign);
+
+
+--
+-- Name: ix_seo_redirect_remap_queue_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_redirect_remap_queue_created_at ON public.seo_redirect_remap_queue USING btree (created_at);
+
+
+--
+-- Name: ix_seo_redirect_remap_queue_proposal_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_redirect_remap_queue_proposal_run_id ON public.seo_redirect_remap_queue USING btree (proposal_run_id);
+
+
+--
+-- Name: ix_seo_redirect_remap_queue_source_path; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_redirect_remap_queue_source_path ON public.seo_redirect_remap_queue USING btree (source_path);
+
+
+--
+-- Name: ix_seo_redirect_remap_queue_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_redirect_remap_queue_status ON public.seo_redirect_remap_queue USING btree (status);
+
+
+--
+-- Name: ix_seo_redirect_remap_queue_status_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_redirect_remap_queue_status_created ON public.seo_redirect_remap_queue USING btree (status, created_at);
+
+
+--
+-- Name: ix_seo_redirects_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_redirects_created_at ON public.seo_redirects USING btree (created_at);
+
+
+--
+-- Name: ix_seo_redirects_is_active; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_redirects_is_active ON public.seo_redirects USING btree (is_active);
+
+
+--
+-- Name: ix_seo_redirects_source_path; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_seo_redirects_source_path ON public.seo_redirects USING btree (source_path);
+
+
+--
+-- Name: ix_seo_rubrics_keyword_cluster; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_rubrics_keyword_cluster ON public.seo_rubrics USING btree (keyword_cluster);
+
+
+--
+-- Name: ix_seo_rubrics_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_seo_rubrics_status ON public.seo_rubrics USING btree (status);
+
+
+--
+-- Name: ix_shadow_discrepancies_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_shadow_discrepancies_property_id ON public.shadow_discrepancies USING btree (property_id);
+
+
+--
+-- Name: ix_shadow_discrepancies_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_shadow_discrepancies_status ON public.shadow_discrepancies USING btree (status);
+
+
+--
+-- Name: ix_ssgl_guest_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_ssgl_guest_id ON public.storefront_session_guest_links USING btree (guest_id);
+
+
+--
+-- Name: ix_ssgl_session_fp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_ssgl_session_fp ON public.storefront_session_guest_links USING btree (session_fp);
+
+
+--
+-- Name: ix_ssgl_session_fp_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_ssgl_session_fp_created ON public.storefront_session_guest_links USING btree (session_fp, created_at);
+
+
+--
+-- Name: ix_staff_invites_email; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_staff_invites_email ON public.staff_invites USING btree (email);
+
+
+--
+-- Name: ix_staff_invites_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_staff_invites_token ON public.staff_invites USING btree (token);
+
+
+--
+-- Name: ix_staff_users_email; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_staff_users_email ON public.staff_users USING btree (email);
+
+
+--
+-- Name: ix_staff_users_role; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_staff_users_role ON public.staff_users USING btree (role);
+
+
+--
+-- Name: ix_storefront_intent_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_storefront_intent_created ON public.storefront_intent_events USING btree (created_at);
+
+
+--
+-- Name: ix_storefront_intent_events_session_fp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_storefront_intent_events_session_fp ON public.storefront_intent_events USING btree (session_fp);
+
+
+--
+-- Name: ix_storefront_intent_session_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_storefront_intent_session_created ON public.storefront_intent_events USING btree (session_fp, created_at);
+
+
+--
+-- Name: ix_streamline_payload_vault_event_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_streamline_payload_vault_event_type ON public.streamline_payload_vault USING btree (event_type);
+
+
+--
+-- Name: ix_streamline_payload_vault_reservation_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_streamline_payload_vault_reservation_id ON public.streamline_payload_vault USING btree (reservation_id);
+
+
+--
+-- Name: ix_stripe_connect_events_account_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_stripe_connect_events_account_id ON public.stripe_connect_events USING btree (account_id);
+
+
+--
+-- Name: ix_stripe_connect_events_event_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_stripe_connect_events_event_type ON public.stripe_connect_events USING btree (event_type);
+
+
+--
+-- Name: ix_stripe_connect_events_payout_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_stripe_connect_events_payout_id ON public.stripe_connect_events USING btree (payout_id);
+
+
+--
+-- Name: ix_stripe_connect_events_transfer_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_stripe_connect_events_transfer_id ON public.stripe_connect_events USING btree (transfer_id);
+
+
+--
+-- Name: ix_survey_templates_is_active; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_survey_templates_is_active ON public.survey_templates USING btree (is_active);
+
+
+--
+-- Name: ix_survey_templates_survey_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_survey_templates_survey_type ON public.survey_templates USING btree (survey_type);
+
+
+--
+-- Name: ix_swarm_escalations_reason_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_swarm_escalations_reason_code ON public.swarm_escalations USING btree (reason_code);
+
+
+--
+-- Name: ix_swarm_escalations_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_swarm_escalations_status ON public.swarm_escalations USING btree (status);
+
+
+--
+-- Name: ix_swarm_escalations_status_reason; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_swarm_escalations_status_reason ON public.swarm_escalations USING btree (status, reason_code);
+
+
+--
+-- Name: ix_taxes_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_taxes_name ON public.taxes USING btree (name);
+
+
+--
+-- Name: ix_taxonomy_categories_slug; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_taxonomy_categories_slug ON public.taxonomy_categories USING btree (slug);
+
+
+--
+-- Name: ix_taylor_quote_requests_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_taylor_quote_requests_created_at ON public.taylor_quote_requests USING btree (created_at DESC);
+
+
+--
+-- Name: ix_taylor_quote_requests_guest_email; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_taylor_quote_requests_guest_email ON public.taylor_quote_requests USING btree (guest_email);
+
+
+--
+-- Name: ix_taylor_quote_requests_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_taylor_quote_requests_status ON public.taylor_quote_requests USING btree (status);
+
+
+--
+-- Name: ix_trust_accounts_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_trust_accounts_name ON public.trust_accounts USING btree (name);
+
+
+--
+-- Name: ix_trust_accounts_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_trust_accounts_type ON public.trust_accounts USING btree (type);
+
+
+--
+-- Name: ix_trust_accounts_type_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_trust_accounts_type_name ON public.trust_accounts USING btree (type, name);
+
+
+--
+-- Name: ix_trust_decisions_run_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_trust_decisions_run_status ON public.trust_decisions USING btree (run_id, status);
+
+
+--
+-- Name: ix_trust_decisions_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_trust_decisions_status ON public.trust_decisions USING btree (status);
+
+
+--
+-- Name: ix_trust_ledger_entries_account_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_trust_ledger_entries_account_id ON public.trust_ledger_entries USING btree (account_id);
+
+
+--
+-- Name: ix_trust_ledger_entries_entry_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_trust_ledger_entries_entry_type ON public.trust_ledger_entries USING btree (entry_type);
+
+
+--
+-- Name: ix_trust_ledger_entries_transaction_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_trust_ledger_entries_transaction_id ON public.trust_ledger_entries USING btree (transaction_id);
+
+
+--
+-- Name: ix_trust_transactions_decision_timestamp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_trust_transactions_decision_timestamp ON public.trust_transactions USING btree (decision_id, "timestamp");
+
+
+--
+-- Name: ix_trust_transactions_previous_signature; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_trust_transactions_previous_signature ON public.trust_transactions USING btree (previous_signature);
+
+
+--
+-- Name: ix_trust_transactions_timestamp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_trust_transactions_timestamp ON public.trust_transactions USING btree ("timestamp");
+
+
+--
+-- Name: ix_utility_readings_utility_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_utility_readings_utility_id ON public.utility_readings USING btree (utility_id);
+
+
+--
+-- Name: ix_vault_audit_logs_action; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_vault_audit_logs_action ON public.vault_audit_logs USING btree (action);
+
+
+--
+-- Name: ix_vault_audit_logs_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_vault_audit_logs_created_at ON public.vault_audit_logs USING btree (created_at);
+
+
+--
+-- Name: ix_vault_audit_logs_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_vault_audit_logs_user_id ON public.vault_audit_logs USING btree (user_id);
+
+
+--
+-- Name: ix_vendors_active; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_vendors_active ON public.vendors USING btree (active);
+
+
+--
+-- Name: ix_vendors_trade; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_vendors_trade ON public.vendors USING btree (trade);
+
+
+--
+-- Name: ix_vrs_add_ons_active_scope_property; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_vrs_add_ons_active_scope_property ON public.vrs_add_ons USING btree (is_active, scope, property_id);
+
+
+--
+-- Name: ix_vrs_add_ons_is_active; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_vrs_add_ons_is_active ON public.vrs_add_ons USING btree (is_active);
+
+
+--
+-- Name: ix_vrs_add_ons_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_vrs_add_ons_property_id ON public.vrs_add_ons USING btree (property_id);
+
+
+--
+-- Name: ix_vrs_add_ons_scope; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_vrs_add_ons_scope ON public.vrs_add_ons USING btree (scope);
+
+
+--
+-- Name: ix_vrs_automation_events_entity_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_vrs_automation_events_entity_id ON public.vrs_automation_events USING btree (entity_id);
+
+
+--
+-- Name: ix_vrs_automation_events_entity_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_vrs_automation_events_entity_type ON public.vrs_automation_events USING btree (entity_type);
+
+
+--
+-- Name: ix_vrs_automation_events_event_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_vrs_automation_events_event_type ON public.vrs_automation_events USING btree (event_type);
+
+
+--
+-- Name: ix_vrs_automation_events_rule_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_vrs_automation_events_rule_id ON public.vrs_automation_events USING btree (rule_id);
+
+
+--
+-- Name: ix_vrs_automations_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_vrs_automations_name ON public.vrs_automations USING btree (name);
+
+
+--
+-- Name: ix_vrs_automations_target_entity; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_vrs_automations_target_entity ON public.vrs_automations USING btree (target_entity);
+
+
+--
+-- Name: ix_vrs_automations_trigger_event; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_vrs_automations_trigger_event ON public.vrs_automations USING btree (trigger_event);
+
+
+--
+-- Name: ix_work_orders_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_work_orders_created_at ON public.work_orders USING btree (created_at);
+
+
+--
+-- Name: ix_work_orders_guest_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_work_orders_guest_id ON public.work_orders USING btree (guest_id);
+
+
+--
+-- Name: ix_work_orders_priority; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_work_orders_priority ON public.work_orders USING btree (priority);
+
+
+--
+-- Name: ix_work_orders_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_work_orders_property_id ON public.work_orders USING btree (property_id);
+
+
+--
+-- Name: ix_work_orders_reservation_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_work_orders_reservation_id ON public.work_orders USING btree (reservation_id);
+
+
+--
+-- Name: ix_work_orders_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_work_orders_status ON public.work_orders USING btree (status);
+
+
+--
+-- Name: ix_work_orders_vendor; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_work_orders_vendor ON public.work_orders USING btree (assigned_vendor_id);
+
+
+--
+-- Name: ix_yield_overrides_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_yield_overrides_property_id ON public.yield_overrides USING btree (property_id);
+
+
+--
+-- Name: ix_yield_simulations_property_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_yield_simulations_property_id ON public.yield_simulations USING btree (property_id);
+
+
+--
+-- Name: uq_payout_ledger_stripe_transfer_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX uq_payout_ledger_stripe_transfer_id ON public.payout_ledger USING btree (stripe_transfer_id) WHERE (stripe_transfer_id IS NOT NULL);
+
+
+--
+-- Name: ix_verses_schema_products_sku; Type: INDEX; Schema: verses_schema; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_verses_schema_products_sku ON verses_schema.products USING btree (sku);
+
+
+--
+-- Name: streamline_payload_vault trg_immutable_streamline_payload_vault; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trg_immutable_streamline_payload_vault BEFORE DELETE OR UPDATE ON public.streamline_payload_vault FOR EACH ROW EXECUTE FUNCTION public.prevent_mutation();
+
+
+--
+-- Name: trust_ledger_entries trg_immutable_trust_ledger_entries; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trg_immutable_trust_ledger_entries BEFORE DELETE OR UPDATE ON public.trust_ledger_entries FOR EACH ROW EXECUTE FUNCTION public.prevent_mutation();
+
+
+--
+-- Name: trust_transactions trg_immutable_trust_transactions; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trg_immutable_trust_transactions BEFORE DELETE OR UPDATE ON public.trust_transactions FOR EACH ROW EXECUTE FUNCTION public.prevent_mutation();
+
+
+--
+-- Name: acquisition_documents acquisition_documents_pipeline_id_fkey; Type: FK CONSTRAINT; Schema: crog_acquisition; Owner: -
+--
+
+ALTER TABLE ONLY crog_acquisition.acquisition_documents
+    ADD CONSTRAINT acquisition_documents_pipeline_id_fkey FOREIGN KEY (pipeline_id) REFERENCES crog_acquisition.acquisition_pipeline(id) ON DELETE CASCADE;
+
+
+--
+-- Name: acquisition_pipeline acquisition_pipeline_property_id_fkey; Type: FK CONSTRAINT; Schema: crog_acquisition; Owner: -
+--
+
+ALTER TABLE ONLY crog_acquisition.acquisition_pipeline
+    ADD CONSTRAINT acquisition_pipeline_property_id_fkey FOREIGN KEY (property_id) REFERENCES crog_acquisition.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: due_diligence due_diligence_pipeline_id_fkey; Type: FK CONSTRAINT; Schema: crog_acquisition; Owner: -
+--
+
+ALTER TABLE ONLY crog_acquisition.due_diligence
+    ADD CONSTRAINT due_diligence_pipeline_id_fkey FOREIGN KEY (pipeline_id) REFERENCES crog_acquisition.acquisition_pipeline(id) ON DELETE CASCADE;
+
+
+--
+-- Name: intel_events intel_events_property_id_fkey; Type: FK CONSTRAINT; Schema: crog_acquisition; Owner: -
+--
+
+ALTER TABLE ONLY crog_acquisition.intel_events
+    ADD CONSTRAINT intel_events_property_id_fkey FOREIGN KEY (property_id) REFERENCES crog_acquisition.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: owner_contacts owner_contacts_owner_id_fkey; Type: FK CONSTRAINT; Schema: crog_acquisition; Owner: -
+--
+
+ALTER TABLE ONLY crog_acquisition.owner_contacts
+    ADD CONSTRAINT owner_contacts_owner_id_fkey FOREIGN KEY (owner_id) REFERENCES crog_acquisition.owners(id) ON DELETE CASCADE;
+
+
+--
+-- Name: properties properties_owner_id_fkey; Type: FK CONSTRAINT; Schema: crog_acquisition; Owner: -
+--
+
+ALTER TABLE ONLY crog_acquisition.properties
+    ADD CONSTRAINT properties_owner_id_fkey FOREIGN KEY (owner_id) REFERENCES crog_acquisition.owners(id) ON DELETE SET NULL;
+
+
+--
+-- Name: properties properties_parcel_id_fkey; Type: FK CONSTRAINT; Schema: crog_acquisition; Owner: -
+--
+
+ALTER TABLE ONLY crog_acquisition.properties
+    ADD CONSTRAINT properties_parcel_id_fkey FOREIGN KEY (parcel_id) REFERENCES crog_acquisition.parcels(id) ON DELETE CASCADE;
+
+
+--
+-- Name: str_signals str_signals_property_id_fkey; Type: FK CONSTRAINT; Schema: crog_acquisition; Owner: -
+--
+
+ALTER TABLE ONLY crog_acquisition.str_signals
+    ADD CONSTRAINT str_signals_property_id_fkey FOREIGN KEY (property_id) REFERENCES crog_acquisition.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: case_evidence case_evidence_entity_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.case_evidence
+    ADD CONSTRAINT case_evidence_entity_id_fkey FOREIGN KEY (entity_id) REFERENCES legal.entities(id) ON DELETE SET NULL;
+
+
+--
+-- Name: case_graph_edges case_graph_edges_case_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.case_graph_edges
+    ADD CONSTRAINT case_graph_edges_case_id_fkey FOREIGN KEY (case_id) REFERENCES legal.legal_cases(id) ON DELETE CASCADE;
+
+
+--
+-- Name: case_graph_edges case_graph_edges_source_node_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.case_graph_edges
+    ADD CONSTRAINT case_graph_edges_source_node_id_fkey FOREIGN KEY (source_node_id) REFERENCES legal.case_graph_nodes(id) ON DELETE CASCADE;
+
+
+--
+-- Name: case_graph_edges case_graph_edges_target_node_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.case_graph_edges
+    ADD CONSTRAINT case_graph_edges_target_node_id_fkey FOREIGN KEY (target_node_id) REFERENCES legal.case_graph_nodes(id) ON DELETE CASCADE;
+
+
+--
+-- Name: case_graph_edges_v2 case_graph_edges_v2_source_node_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.case_graph_edges_v2
+    ADD CONSTRAINT case_graph_edges_v2_source_node_id_fkey FOREIGN KEY (source_node_id) REFERENCES legal.case_graph_nodes_v2(id) ON DELETE CASCADE;
+
+
+--
+-- Name: case_graph_edges_v2 case_graph_edges_v2_target_node_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.case_graph_edges_v2
+    ADD CONSTRAINT case_graph_edges_v2_target_node_id_fkey FOREIGN KEY (target_node_id) REFERENCES legal.case_graph_nodes_v2(id) ON DELETE CASCADE;
+
+
+--
+-- Name: case_graph_nodes case_graph_nodes_case_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.case_graph_nodes
+    ADD CONSTRAINT case_graph_nodes_case_id_fkey FOREIGN KEY (case_id) REFERENCES legal.legal_cases(id) ON DELETE CASCADE;
+
+
+--
+-- Name: discovery_draft_items_v2 discovery_draft_items_v2_pack_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.discovery_draft_items_v2
+    ADD CONSTRAINT discovery_draft_items_v2_pack_id_fkey FOREIGN KEY (pack_id) REFERENCES legal.discovery_draft_packs_v2(id) ON DELETE CASCADE;
+
+
+--
+-- Name: timeline_events timeline_events_source_evidence_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.timeline_events
+    ADD CONSTRAINT timeline_events_source_evidence_id_fkey FOREIGN KEY (source_evidence_id) REFERENCES legal.case_evidence(id) ON DELETE SET NULL;
+
+
+--
+-- Name: agent_queue agent_queue_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agent_queue
+    ADD CONSTRAINT agent_queue_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE SET NULL;
+
+
+--
+-- Name: agent_queue agent_queue_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agent_queue
+    ADD CONSTRAINT agent_queue_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE SET NULL;
+
+
+--
+-- Name: agent_response_queue agent_response_queue_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.agent_response_queue
-    ADD CONSTRAINT agent_response_queue_inbound_message_id_fkey FOREIGN KEY (inbound_message_id) REFERENCES public.message_archive(id);
+    ADD CONSTRAINT agent_response_queue_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE SET NULL;
 
 
 --
--- Name: ai_training_labels ai_training_labels_message_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: agent_response_queue agent_response_queue_message_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ai_training_labels
-    ADD CONSTRAINT ai_training_labels_message_id_fkey FOREIGN KEY (message_id) REFERENCES public.message_archive(id);
-
-
---
--- Name: anomaly_flags anomaly_flags_account_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.anomaly_flags
-    ADD CONSTRAINT anomaly_flags_account_id_fkey FOREIGN KEY (account_id) REFERENCES public.accounts(id);
+ALTER TABLE ONLY public.agent_response_queue
+    ADD CONSTRAINT agent_response_queue_message_id_fkey FOREIGN KEY (message_id) REFERENCES public.messages(id) ON DELETE CASCADE;
 
 
 --
--- Name: anomaly_flags anomaly_flags_journal_entry_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: agent_response_queue agent_response_queue_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.anomaly_flags
-    ADD CONSTRAINT anomaly_flags_journal_entry_id_fkey FOREIGN KEY (journal_entry_id) REFERENCES public.journal_entries(id);
-
-
---
--- Name: asset_docs asset_docs_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.asset_docs
-    ADD CONSTRAINT asset_docs_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id);
+ALTER TABLE ONLY public.agent_response_queue
+    ADD CONSTRAINT agent_response_queue_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE SET NULL;
 
 
 --
--- Name: email_escalation_queue email_escalation_queue_email_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: agent_response_queue agent_response_queue_sent_message_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.email_escalation_queue
-    ADD CONSTRAINT email_escalation_queue_email_id_fkey FOREIGN KEY (email_id) REFERENCES public.email_archive(id);
-
-
---
--- Name: email_intake_review_log email_intake_review_log_email_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.email_intake_review_log
-    ADD CONSTRAINT email_intake_review_log_email_id_fkey FOREIGN KEY (email_id) REFERENCES public.email_archive(id);
+ALTER TABLE ONLY public.agent_response_queue
+    ADD CONSTRAINT agent_response_queue_sent_message_id_fkey FOREIGN KEY (sent_message_id) REFERENCES public.messages(id) ON DELETE SET NULL;
 
 
 --
--- Name: email_intake_review_log email_intake_review_log_escalation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: agent_runs agent_runs_agent_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.email_intake_review_log
-    ADD CONSTRAINT email_intake_review_log_escalation_id_fkey FOREIGN KEY (escalation_id) REFERENCES public.email_escalation_queue(id);
-
-
---
--- Name: email_quarantine email_quarantine_rule_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.email_quarantine
-    ADD CONSTRAINT email_quarantine_rule_id_fkey FOREIGN KEY (rule_id) REFERENCES public.email_routing_rules(id);
+ALTER TABLE ONLY public.agent_runs
+    ADD CONSTRAINT agent_runs_agent_id_fkey FOREIGN KEY (agent_id) REFERENCES public.agent_registry(id) ON DELETE RESTRICT;
 
 
 --
--- Name: finance_invoices finance_invoices_source_email_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: analytics_events analytics_events_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.finance_invoices
-    ADD CONSTRAINT finance_invoices_source_email_id_fkey FOREIGN KEY (source_email_id) REFERENCES public.email_archive(id) ON DELETE CASCADE;
-
-
---
--- Name: fortress_api_keys fortress_api_keys_owner_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.fortress_api_keys
-    ADD CONSTRAINT fortress_api_keys_owner_id_fkey FOREIGN KEY (owner_id) REFERENCES public.fortress_users(id);
+ALTER TABLE ONLY public.analytics_events
+    ADD CONSTRAINT analytics_events_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE SET NULL;
 
 
 --
--- Name: guest_leads guest_leads_source_email_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: analytics_events analytics_events_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.guest_leads
-    ADD CONSTRAINT guest_leads_source_email_id_fkey FOREIGN KEY (source_email_id) REFERENCES public.email_archive(id);
+ALTER TABLE ONLY public.analytics_events
+    ADD CONSTRAINT analytics_events_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE SET NULL;
+
+
+--
+-- Name: analytics_events analytics_events_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.analytics_events
+    ADD CONSTRAINT analytics_events_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE SET NULL;
+
+
+--
+-- Name: blocked_days blocked_days_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.blocked_days
+    ADD CONSTRAINT blocked_days_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: channel_mappings channel_mappings_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.channel_mappings
+    ADD CONSTRAINT channel_mappings_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: competitor_listings competitor_listings_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.competitor_listings
+    ADD CONSTRAINT competitor_listings_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: concierge_queue concierge_queue_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.concierge_queue
+    ADD CONSTRAINT concierge_queue_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE SET NULL;
+
+
+--
+-- Name: concierge_recovery_dispatches concierge_recovery_dispatches_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.concierge_recovery_dispatches
+    ADD CONSTRAINT concierge_recovery_dispatches_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE CASCADE;
+
+
+--
+-- Name: damage_claims damage_claims_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.damage_claims
+    ADD CONSTRAINT damage_claims_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE CASCADE;
+
+
+--
+-- Name: damage_claims damage_claims_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.damage_claims
+    ADD CONSTRAINT damage_claims_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: damage_claims damage_claims_rental_agreement_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.damage_claims
+    ADD CONSTRAINT damage_claims_rental_agreement_id_fkey FOREIGN KEY (rental_agreement_id) REFERENCES public.rental_agreements(id) ON DELETE SET NULL;
+
+
+--
+-- Name: damage_claims damage_claims_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.damage_claims
+    ADD CONSTRAINT damage_claims_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE CASCADE;
+
+
+--
+-- Name: distillation_queue distillation_queue_source_intelligence_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.distillation_queue
+    ADD CONSTRAINT distillation_queue_source_intelligence_id_fkey FOREIGN KEY (source_intelligence_id) REFERENCES public.intelligence_ledger(id) ON DELETE SET NULL;
+
+
+--
+-- Name: email_inquirers email_inquirers_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_inquirers
+    ADD CONSTRAINT email_inquirers_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE SET NULL;
+
+
+--
+-- Name: email_messages email_messages_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_messages
+    ADD CONSTRAINT email_messages_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE SET NULL;
+
+
+--
+-- Name: email_messages email_messages_human_reviewed_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_messages
+    ADD CONSTRAINT email_messages_human_reviewed_by_fkey FOREIGN KEY (human_reviewed_by) REFERENCES public.staff_users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: email_messages email_messages_inquirer_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_messages
+    ADD CONSTRAINT email_messages_inquirer_id_fkey FOREIGN KEY (inquirer_id) REFERENCES public.email_inquirers(id) ON DELETE CASCADE;
+
+
+--
+-- Name: email_messages email_messages_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_messages
+    ADD CONSTRAINT email_messages_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE SET NULL;
+
+
+--
+-- Name: extra_orders extra_orders_extra_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.extra_orders
+    ADD CONSTRAINT extra_orders_extra_id_fkey FOREIGN KEY (extra_id) REFERENCES public.extras(id) ON DELETE CASCADE;
+
+
+--
+-- Name: extra_orders extra_orders_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.extra_orders
+    ADD CONSTRAINT extra_orders_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE CASCADE;
+
+
+--
+-- Name: email_messages fk_email_messages_reply_to; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_messages
+    ADD CONSTRAINT fk_email_messages_reply_to FOREIGN KEY (in_reply_to_message_id) REFERENCES public.email_messages(id) ON DELETE SET NULL;
+
+
+--
+-- Name: guest_activities guest_activities_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.guest_activities
+    ADD CONSTRAINT guest_activities_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE CASCADE;
+
+
+--
+-- Name: guest_activities guest_activities_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.guest_activities
+    ADD CONSTRAINT guest_activities_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE SET NULL;
+
+
+--
+-- Name: guest_activities guest_activities_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.guest_activities
+    ADD CONSTRAINT guest_activities_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE SET NULL;
+
+
+--
+-- Name: guest_quotes guest_quotes_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.guest_quotes
+    ADD CONSTRAINT guest_quotes_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE SET NULL;
+
+
+--
+-- Name: guest_reviews guest_reviews_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.guest_reviews
+    ADD CONSTRAINT guest_reviews_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE CASCADE;
+
+
+--
+-- Name: guest_reviews guest_reviews_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.guest_reviews
+    ADD CONSTRAINT guest_reviews_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: guest_reviews guest_reviews_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.guest_reviews
+    ADD CONSTRAINT guest_reviews_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE SET NULL;
+
+
+--
+-- Name: guest_surveys guest_surveys_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.guest_surveys
+    ADD CONSTRAINT guest_surveys_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE CASCADE;
+
+
+--
+-- Name: guest_surveys guest_surveys_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.guest_surveys
+    ADD CONSTRAINT guest_surveys_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE SET NULL;
+
+
+--
+-- Name: guest_surveys guest_surveys_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.guest_surveys
+    ADD CONSTRAINT guest_surveys_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE SET NULL;
+
+
+--
+-- Name: guest_surveys guest_surveys_template_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.guest_surveys
+    ADD CONSTRAINT guest_surveys_template_id_fkey FOREIGN KEY (template_id) REFERENCES public.survey_templates(id) ON DELETE SET NULL;
+
+
+--
+-- Name: guest_verifications guest_verifications_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.guest_verifications
+    ADD CONSTRAINT guest_verifications_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE CASCADE;
+
+
+--
+-- Name: guest_verifications guest_verifications_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.guest_verifications
+    ADD CONSTRAINT guest_verifications_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE SET NULL;
+
+
+--
+-- Name: guestbook_guides guestbook_guides_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.guestbook_guides
+    ADD CONSTRAINT guestbook_guides_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: housekeeping_tasks housekeeping_tasks_assigned_cleaner_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.housekeeping_tasks
+    ADD CONSTRAINT housekeeping_tasks_assigned_cleaner_id_fkey FOREIGN KEY (assigned_cleaner_id) REFERENCES public.cleaners(id) ON DELETE SET NULL;
+
+
+--
+-- Name: housekeeping_tasks housekeeping_tasks_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.housekeeping_tasks
+    ADD CONSTRAINT housekeeping_tasks_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: housekeeping_tasks housekeeping_tasks_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.housekeeping_tasks
+    ADD CONSTRAINT housekeeping_tasks_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE SET NULL;
+
+
+--
+-- Name: hunter_queue hunter_queue_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.hunter_queue
+    ADD CONSTRAINT hunter_queue_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE SET NULL;
+
+
+--
+-- Name: hunter_queue hunter_queue_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.hunter_queue
+    ADD CONSTRAINT hunter_queue_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE SET NULL;
 
 
 --
@@ -12415,7 +9592,7 @@ ALTER TABLE ONLY public.guest_leads
 --
 
 ALTER TABLE ONLY public.journal_line_items
-    ADD CONSTRAINT journal_line_items_account_id_fkey FOREIGN KEY (account_id) REFERENCES public.accounts(id);
+    ADD CONSTRAINT journal_line_items_account_id_fkey FOREIGN KEY (account_id) REFERENCES public.accounts(id) ON DELETE RESTRICT;
 
 
 --
@@ -12427,103 +9604,519 @@ ALTER TABLE ONLY public.journal_line_items
 
 
 --
--- Name: legal_docket legal_docket_matter_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: knowledge_base_entries knowledge_base_entries_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.legal_docket
-    ADD CONSTRAINT legal_docket_matter_id_fkey FOREIGN KEY (matter_id) REFERENCES public.legal_matters(matter_id);
-
-
---
--- Name: legal_matter_notes legal_matter_notes_matter_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.legal_matter_notes
-    ADD CONSTRAINT legal_matter_notes_matter_id_fkey FOREIGN KEY (matter_id) REFERENCES public.legal_matters(matter_id);
+ALTER TABLE ONLY public.knowledge_base_entries
+    ADD CONSTRAINT knowledge_base_entries_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
 
 
 --
--- Name: legal_matters legal_matters_client_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: marketing_articles marketing_articles_category_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.legal_matters
-    ADD CONSTRAINT legal_matters_client_id_fkey FOREIGN KEY (client_id) REFERENCES public.legal_clients(client_id);
-
-
---
--- Name: ops_tasks ops_tasks_assigned_to_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ops_tasks
-    ADD CONSTRAINT ops_tasks_assigned_to_fkey FOREIGN KEY (assigned_to) REFERENCES public.ops_crew(id);
+ALTER TABLE ONLY public.marketing_articles
+    ADD CONSTRAINT marketing_articles_category_id_fkey FOREIGN KEY (category_id) REFERENCES public.taxonomy_categories(id) ON DELETE CASCADE;
 
 
 --
--- Name: ops_tasks ops_tasks_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: message_queue message_queue_quote_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ops_tasks
-    ADD CONSTRAINT ops_tasks_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.ops_properties(property_id);
-
-
---
--- Name: ops_tasks ops_tasks_turnover_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ops_tasks
-    ADD CONSTRAINT ops_tasks_turnover_id_fkey FOREIGN KEY (turnover_id) REFERENCES public.ops_turnovers(id);
+ALTER TABLE ONLY public.message_queue
+    ADD CONSTRAINT message_queue_quote_id_fkey FOREIGN KEY (quote_id) REFERENCES public.quotes(id) ON DELETE CASCADE;
 
 
 --
--- Name: ops_turnovers ops_turnovers_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: message_queue message_queue_template_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ops_turnovers
-    ADD CONSTRAINT ops_turnovers_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.ops_properties(property_id);
-
-
---
--- Name: ops_visuals ops_visuals_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ops_visuals
-    ADD CONSTRAINT ops_visuals_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.ops_properties(property_id) ON DELETE SET NULL;
+ALTER TABLE ONLY public.message_queue
+    ADD CONSTRAINT message_queue_template_id_fkey FOREIGN KEY (template_id) REFERENCES public.email_templates(id) ON DELETE CASCADE;
 
 
 --
--- Name: property_events property_events_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: messages messages_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.property_events
-    ADD CONSTRAINT property_events_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id);
-
-
---
--- Name: property_sms_config property_sms_config_provider_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.property_sms_config
-    ADD CONSTRAINT property_sms_config_provider_id_fkey FOREIGN KEY (provider_id) REFERENCES public.sms_providers(id);
+ALTER TABLE ONLY public.messages
+    ADD CONSTRAINT messages_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE SET NULL;
 
 
 --
--- Name: sales_intel sales_intel_source_email_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: messages messages_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.sales_intel
-    ADD CONSTRAINT sales_intel_source_email_id_fkey FOREIGN KEY (source_email_id) REFERENCES public.email_archive(id);
+ALTER TABLE ONLY public.messages
+    ADD CONSTRAINT messages_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE SET NULL;
 
 
 --
--- Name: trust_balance trust_balance_last_entry_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: operator_overrides operator_overrides_escalation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.trust_balance
-    ADD CONSTRAINT trust_balance_last_entry_id_fkey FOREIGN KEY (last_entry_id) REFERENCES public.journal_entries(id);
+ALTER TABLE ONLY public.operator_overrides
+    ADD CONSTRAINT operator_overrides_escalation_id_fkey FOREIGN KEY (escalation_id) REFERENCES public.swarm_escalations(id) ON DELETE CASCADE;
+
+
+--
+-- Name: ota_micro_updates ota_micro_updates_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ota_micro_updates
+    ADD CONSTRAINT ota_micro_updates_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: owner_balance_periods owner_balance_periods_owner_payout_account_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.owner_balance_periods
+    ADD CONSTRAINT owner_balance_periods_owner_payout_account_id_fkey FOREIGN KEY (owner_payout_account_id) REFERENCES public.owner_payout_accounts(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: owner_charges owner_charges_owner_payout_account_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.owner_charges
+    ADD CONSTRAINT owner_charges_owner_payout_account_id_fkey FOREIGN KEY (owner_payout_account_id) REFERENCES public.owner_payout_accounts(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: owner_charges owner_charges_vendor_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.owner_charges
+    ADD CONSTRAINT owner_charges_vendor_id_fkey FOREIGN KEY (vendor_id) REFERENCES public.vendors(id) ON DELETE SET NULL;
+
+
+--
+-- Name: owner_statement_sends owner_statement_sends_owner_payout_account_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.owner_statement_sends
+    ADD CONSTRAINT owner_statement_sends_owner_payout_account_id_fkey FOREIGN KEY (owner_payout_account_id) REFERENCES public.owner_payout_accounts(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: owner_statement_sends owner_statement_sends_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.owner_statement_sends
+    ADD CONSTRAINT owner_statement_sends_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: pricing_overrides pricing_overrides_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pricing_overrides
+    ADD CONSTRAINT pricing_overrides_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: properties properties_default_housekeeper_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.properties
+    ADD CONSTRAINT properties_default_housekeeper_id_fkey FOREIGN KEY (default_housekeeper_id) REFERENCES public.staff_users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: property_fees property_fees_fee_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.property_fees
+    ADD CONSTRAINT property_fees_fee_id_fkey FOREIGN KEY (fee_id) REFERENCES public.fees(id) ON DELETE CASCADE;
+
+
+--
+-- Name: property_fees property_fees_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.property_fees
+    ADD CONSTRAINT property_fees_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: property_images property_images_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.property_images
+    ADD CONSTRAINT property_images_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: property_knowledge_chunks property_knowledge_chunks_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.property_knowledge_chunks
+    ADD CONSTRAINT property_knowledge_chunks_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: property_knowledge property_knowledge_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.property_knowledge
+    ADD CONSTRAINT property_knowledge_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: property_stay_restrictions property_stay_restrictions_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.property_stay_restrictions
+    ADD CONSTRAINT property_stay_restrictions_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: property_taxes property_taxes_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.property_taxes
+    ADD CONSTRAINT property_taxes_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: property_taxes property_taxes_tax_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.property_taxes
+    ADD CONSTRAINT property_taxes_tax_id_fkey FOREIGN KEY (tax_id) REFERENCES public.taxes(id) ON DELETE CASCADE;
+
+
+--
+-- Name: property_utilities property_utilities_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.property_utilities
+    ADD CONSTRAINT property_utilities_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: quote_options quote_options_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quote_options
+    ADD CONSTRAINT quote_options_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: quote_options quote_options_quote_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quote_options
+    ADD CONSTRAINT quote_options_quote_id_fkey FOREIGN KEY (quote_id) REFERENCES public.quotes(id) ON DELETE CASCADE;
+
+
+--
+-- Name: quotes quotes_lead_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quotes
+    ADD CONSTRAINT quotes_lead_id_fkey FOREIGN KEY (lead_id) REFERENCES public.leads(id) ON DELETE CASCADE;
+
+
+--
+-- Name: recovery_parity_comparisons recovery_parity_comparisons_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.recovery_parity_comparisons
+    ADD CONSTRAINT recovery_parity_comparisons_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE SET NULL;
+
+
+--
+-- Name: rental_agreements rental_agreements_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rental_agreements
+    ADD CONSTRAINT rental_agreements_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE CASCADE;
+
+
+--
+-- Name: rental_agreements rental_agreements_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rental_agreements
+    ADD CONSTRAINT rental_agreements_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE SET NULL;
+
+
+--
+-- Name: rental_agreements rental_agreements_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rental_agreements
+    ADD CONSTRAINT rental_agreements_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE SET NULL;
+
+
+--
+-- Name: rental_agreements rental_agreements_template_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rental_agreements
+    ADD CONSTRAINT rental_agreements_template_id_fkey FOREIGN KEY (template_id) REFERENCES public.agreement_templates(id) ON DELETE SET NULL;
+
+
+--
+-- Name: reservation_holds reservation_holds_converted_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reservation_holds
+    ADD CONSTRAINT reservation_holds_converted_reservation_id_fkey FOREIGN KEY (converted_reservation_id) REFERENCES public.reservations(id) ON DELETE SET NULL;
+
+
+--
+-- Name: reservation_holds reservation_holds_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reservation_holds
+    ADD CONSTRAINT reservation_holds_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE CASCADE;
+
+
+--
+-- Name: reservation_holds reservation_holds_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reservation_holds
+    ADD CONSTRAINT reservation_holds_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: reservations reservations_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reservations
+    ADD CONSTRAINT reservations_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE CASCADE;
+
+
+--
+-- Name: reservations reservations_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reservations
+    ADD CONSTRAINT reservations_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: scheduled_messages scheduled_messages_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.scheduled_messages
+    ADD CONSTRAINT scheduled_messages_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE CASCADE;
+
+
+--
+-- Name: scheduled_messages scheduled_messages_message_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.scheduled_messages
+    ADD CONSTRAINT scheduled_messages_message_id_fkey FOREIGN KEY (message_id) REFERENCES public.messages(id) ON DELETE SET NULL;
+
+
+--
+-- Name: scheduled_messages scheduled_messages_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.scheduled_messages
+    ADD CONSTRAINT scheduled_messages_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE CASCADE;
+
+
+--
+-- Name: scheduled_messages scheduled_messages_template_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.scheduled_messages
+    ADD CONSTRAINT scheduled_messages_template_id_fkey FOREIGN KEY (template_id) REFERENCES public.message_templates(id) ON DELETE CASCADE;
+
+
+--
+-- Name: seo_patch_queue seo_patch_queue_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.seo_patch_queue
+    ADD CONSTRAINT seo_patch_queue_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: seo_patches seo_patches_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.seo_patches
+    ADD CONSTRAINT seo_patches_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: seo_patches seo_patches_rubric_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.seo_patches
+    ADD CONSTRAINT seo_patches_rubric_id_fkey FOREIGN KEY (rubric_id) REFERENCES public.seo_rubrics(id) ON DELETE SET NULL;
+
+
+--
+-- Name: seo_patches seo_patches_source_intelligence_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.seo_patches
+    ADD CONSTRAINT seo_patches_source_intelligence_id_fkey FOREIGN KEY (source_intelligence_id) REFERENCES public.intelligence_ledger(id) ON DELETE SET NULL;
+
+
+--
+-- Name: seo_rank_snapshots seo_rank_snapshots_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.seo_rank_snapshots
+    ADD CONSTRAINT seo_rank_snapshots_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: staff_invites staff_invites_invited_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.staff_invites
+    ADD CONSTRAINT staff_invites_invited_by_fkey FOREIGN KEY (invited_by) REFERENCES public.staff_users(id);
+
+
+--
+-- Name: storefront_session_guest_links storefront_session_guest_links_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.storefront_session_guest_links
+    ADD CONSTRAINT storefront_session_guest_links_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE CASCADE;
+
+
+--
+-- Name: storefront_session_guest_links storefront_session_guest_links_reservation_hold_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.storefront_session_guest_links
+    ADD CONSTRAINT storefront_session_guest_links_reservation_hold_id_fkey FOREIGN KEY (reservation_hold_id) REFERENCES public.reservation_holds(id) ON DELETE SET NULL;
+
+
+--
+-- Name: swarm_escalations swarm_escalations_decision_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.swarm_escalations
+    ADD CONSTRAINT swarm_escalations_decision_id_fkey FOREIGN KEY (decision_id) REFERENCES public.trust_decisions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: trust_decisions trust_decisions_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.trust_decisions
+    ADD CONSTRAINT trust_decisions_run_id_fkey FOREIGN KEY (run_id) REFERENCES public.agent_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: trust_ledger_entries trust_ledger_entries_account_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.trust_ledger_entries
+    ADD CONSTRAINT trust_ledger_entries_account_id_fkey FOREIGN KEY (account_id) REFERENCES public.trust_accounts(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: trust_ledger_entries trust_ledger_entries_transaction_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.trust_ledger_entries
+    ADD CONSTRAINT trust_ledger_entries_transaction_id_fkey FOREIGN KEY (transaction_id) REFERENCES public.trust_transactions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: trust_transactions trust_transactions_decision_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.trust_transactions
+    ADD CONSTRAINT trust_transactions_decision_id_fkey FOREIGN KEY (decision_id) REFERENCES public.trust_decisions(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: utility_readings utility_readings_utility_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.utility_readings
+    ADD CONSTRAINT utility_readings_utility_id_fkey FOREIGN KEY (utility_id) REFERENCES public.property_utilities(id) ON DELETE CASCADE;
+
+
+--
+-- Name: vrs_add_ons vrs_add_ons_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vrs_add_ons
+    ADD CONSTRAINT vrs_add_ons_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: vrs_automation_events vrs_automation_events_rule_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vrs_automation_events
+    ADD CONSTRAINT vrs_automation_events_rule_id_fkey FOREIGN KEY (rule_id) REFERENCES public.vrs_automations(id) ON DELETE SET NULL;
+
+
+--
+-- Name: work_orders work_orders_assigned_vendor_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.work_orders
+    ADD CONSTRAINT work_orders_assigned_vendor_id_fkey FOREIGN KEY (assigned_vendor_id) REFERENCES public.vendors(id) ON DELETE SET NULL;
+
+
+--
+-- Name: work_orders work_orders_guest_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.work_orders
+    ADD CONSTRAINT work_orders_guest_id_fkey FOREIGN KEY (guest_id) REFERENCES public.guests(id) ON DELETE SET NULL;
+
+
+--
+-- Name: work_orders work_orders_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.work_orders
+    ADD CONSTRAINT work_orders_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: work_orders work_orders_reported_via_message_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.work_orders
+    ADD CONSTRAINT work_orders_reported_via_message_id_fkey FOREIGN KEY (reported_via_message_id) REFERENCES public.messages(id) ON DELETE SET NULL;
+
+
+--
+-- Name: work_orders work_orders_reservation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.work_orders
+    ADD CONSTRAINT work_orders_reservation_id_fkey FOREIGN KEY (reservation_id) REFERENCES public.reservations(id) ON DELETE SET NULL;
+
+
+--
+-- Name: yield_overrides yield_overrides_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.yield_overrides
+    ADD CONSTRAINT yield_overrides_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
+
+
+--
+-- Name: yield_simulations yield_simulations_property_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.yield_simulations
+    ADD CONSTRAINT yield_simulations_property_id_fkey FOREIGN KEY (property_id) REFERENCES public.properties(id) ON DELETE CASCADE;
 
 
 --
 -- PostgreSQL database dump complete
 --
 
-\unrestrict VUrcdL6h86Va4b8PalMVliVEj9OibDpqKcdRaRctoyg85SNJEnJ3GJKYJj1pYCh
+\unrestrict FdO3Ro8PL5WgXQeaZzwcBMCxYm7tASohFPK6iWWOA4tAqKqVEW35qN3uEPfbMbp

--- a/fortress-guest-platform/docs/runbooks/legal-vault-ingest.md
+++ b/fortress-guest-platform/docs/runbooks/legal-vault-ingest.md
@@ -1,0 +1,315 @@
+# Runbook: `vault_ingest_legal_case`
+
+Operator playbook for the case-scoped vault ingestion script
+(`backend/scripts/vault_ingest_legal_case.py`). Read this before running
+against a new case, before triaging an interrupted run, and before
+attempting a rollback.
+
+Last updated: PR D (2026-04-25). Owner: Legal Platform.
+
+---
+
+## 1. What it is
+
+A single command that ingests every file referenced by
+`legal.cases.nas_layout` for a given case into the canonical legal
+pipeline, populating both PostgreSQL state (`legal.vault_documents` in
+`fortress_prod` and `fortress_db`) and the Qdrant `legal_ediscovery`
+collection so Council can retrieve case-tagged chunks.
+
+The script is the operational front-end for `process_vault_upload()`
+(in `backend/services/legal_ediscovery.py`). It wraps that function
+with:
+
+- physical-path dedup (the same file referenced by two logical subdirs
+  is processed once, not twice),
+- bounded concurrency (`--jobs N`),
+- a JSON manifest at `/mnt/fortress_nas/audits/`,
+- a `legal.ingest_runs` audit row (PR D-pre1 IngestRunTracker),
+- a lock file at `/tmp/vault-ingest-{slug}.lock`,
+- a fully-formed `--rollback` path that nukes all of a case's
+  vault_documents rows and Qdrant points with explicit confirmation.
+
+It does **not** OCR. Run `ocr_legal_case.py` (PR C) first if any PDFs
+in the case are image-only.
+
+---
+
+## 2. When to run
+
+- **Onboarding a new case** — after PR A inserts the row into
+  `legal.cases` (with `nas_layout` populated) and PR C has OCR'd any
+  image-only PDFs, run this script to populate the Vault panel.
+- **Adding new evidence to an existing case** — drop files into the
+  configured subdirs and re-run. Resume mode (default on) skips files
+  that already have a terminal `processing_status`, so the cost is
+  bounded by the *new* file count.
+- **Recovering a partial run** — if a previous run was killed, simply
+  re-run. Files in `pending` / `vectorizing` / `processing` are
+  re-processed; files in `complete`/`completed`/`ocr_failed`/
+  `locked_privileged` are skipped.
+
+Do not run this against a case whose nas_layout subdirs are not yet
+mounted (NAS down) — the pre-flight gate will reject it.
+
+---
+
+## 3. Pre-flight gates (all must pass before any work)
+
+The script refuses to open an `ingest_runs` audit row until every
+gate passes — failed pre-flights do not pollute the audit table.
+
+| # | Gate | Failure mode |
+| --- | --- | --- |
+| 1 | `legal.cases` row exists in **both** `fortress_prod` and `fortress_db` | run PR B first |
+| 2 | `nas_layout` is populated (non-NULL) for non-canonical cases | populate `legal.cases.nas_layout` JSONB |
+| 3 | `nas_layout.root` and every configured `subdirs.*` path exists on disk | mount the NAS / fix the layout JSON |
+| 4 | PostgreSQL is writable in both DBs (SELECT 1 + scratch INSERT into `legal.ingest_runs`) | check `POSTGRES_ADMIN_URI` and DB up |
+| 5 | PR D-pre2 constraints present in both DBs (`fk_*`, `uq_*`, `chk_*`) | apply alembic `d8e3c1f5b9a6` |
+| 6 | Qdrant `legal_ediscovery` collection reachable, vector size 768 | spin up Qdrant or fix `QDRANT_URL` |
+| 7 | `process_vault_upload` importable | resolve the import error before retry |
+| 8 | Lock file at `/tmp/vault-ingest-{slug}.lock` not held by another live run | wait for the other run, or `--force` after confirming staleness |
+
+Pre-flight exit code is **3**. Look for `PREFLIGHT FAILED:` on stderr.
+
+---
+
+## 4. How dedup works
+
+Three layers, in order:
+
+1. **Physical-path dedup (script-level).** `walk_unique_physical_files`
+   tracks `Path.resolve()` results in a set; a file referenced by two
+   logical subdirs (e.g. 7IL's `correspondence` and `certified_mail`
+   both pointing at "Correspondence") is yielded exactly once.
+
+2. **Hash dedup with terminal-status skip (resume mode).** Before
+   reading the file bytes, the script computes SHA-256 and checks
+   `legal.vault_documents` for an existing row matching `(case_slug,
+   file_hash)`. If the row's `processing_status` is in the resume
+   skip-set (default: `complete,completed,ocr_failed,
+   locked_privileged`), the file is logged and skipped.
+
+3. **Constraint dedup (race-safe, DB-level).** Inside
+   `process_vault_upload()`, the INSERT uses `ON CONFLICT ON CONSTRAINT
+   uq_vault_documents_case_hash DO NOTHING RETURNING id`. If two
+   workers race to ingest the same file, exactly one row lands; the
+   loser deletes the file it just wrote to NFS and returns
+   `{status: "duplicate"}`.
+
+Same hash across **different cases** is allowed by design — each case
+gets its own row, its own NFS copy, its own privilege classification.
+Discovery in case A does not leak into case B's audit trail.
+
+---
+
+## 5. Status state machine (link)
+
+See `docs/runbooks/legal-vault-documents.md` §2 for the full state
+machine and the bilingual vocabulary explanation. The script emits
+the following statuses to the manifest's `by_status` map:
+
+- `completed` — happy path, vectors live in Qdrant
+- `ocr_failed` — text extraction returned empty bytes on a PDF;
+  re-run `ocr_legal_case.py` to fix
+- `locked_privileged` — privilege shield triggered; legal review
+  before any further action
+- `failed` — pipeline blew up; check `manifest.errors` for
+  diagnosis
+- `skipped` — already done (resume), or above max-file-size, or
+  dry-run
+
+`vault_documents_inserted` counts only the first three terminal states
+(rows that the UI will actually render).
+
+---
+
+## 6. Reading the manifest
+
+Every successful run writes
+`/mnt/fortress_nas/audits/vault-ingest-{case_slug}-{ts}.json`:
+
+```json
+{
+  "case_slug":            "...",
+  "started_at":           "...",
+  "finished_at":          "...",
+  "runtime_seconds":      ...,
+  "args":                 {...},
+  "host":                 "...",
+  "pid":                  ...,
+  "ingest_run_id":        "uuid",
+  "layout_root":          "...",
+  "layout_recursive":     true,
+  "layout_subdirs":       {...},
+  "total_unique_files":   N,
+  "processed":            N,
+  "skipped":              N,
+  "errored":              N,
+  "by_status":            {"completed": N, "ocr_failed": N, ...},
+  "by_logical_subdir":    {"evidence": N, ...},
+  "by_mime_type":         {"application/pdf": N, ...},
+  "errors":               [{...}],
+  "qdrant_points_estimate": N,
+  "vault_documents_inserted": N
+}
+```
+
+Quick triage by manifest:
+
+- **`errored == 0` and `vault_documents_inserted == total_unique_files
+  - skipped`** → clean run.
+- **`by_status.ocr_failed > 0`** → run `ocr_legal_case.py` for the
+  case, then re-run vault ingest.
+- **`qdrant_points_estimate == 0` despite `completed > 0`** → Qdrant
+  was unreachable or returned 0 indexed; check Qdrant health and
+  re-run for rows with `vectors_indexed=0`.
+- **`errored > 0`** → see `manifest.errors[]` — each entry has the
+  exact path, logical subdir, and error string.
+
+The `ingest_run_id` cross-references `legal.ingest_runs` for
+durable audit.
+
+---
+
+## 7. Recovery
+
+### 7.1  Ctrl-C / SIGTERM during a run
+
+The IngestRunTracker exits with `status='interrupted'`. Files that
+were in flight may have left rows in `pending` / `vectorizing` /
+`processing` — these are the resume targets. Just re-run the same
+command; resume mode picks up where it left off.
+
+### 7.2  OOM / network blip
+
+Same path. Re-run; resume skips terminal rows.
+
+### 7.3  Lock file left behind by a crashed run
+
+The lock contains the PID and an ISO timestamp. After confirming via
+`ps` that the PID is no longer alive, either:
+
+- delete the lock file manually and re-run, or
+- pass `--force` if the lock is older than 6 h.
+
+The script refuses `--force` on a fresh lock as a safety net.
+
+### 7.4  A subset of files keep erroring
+
+Inspect `manifest.errors` for the path and error class. The most
+common patterns:
+
+- **`mirror_failed:psycopg2.*`** — fortress_db unreachable when
+  mirroring after fortress_prod write succeeded; the row is in
+  fortress_prod but not yet in fortress_db. Re-run; the mirror is
+  idempotent (`ON CONFLICT DO UPDATE`).
+- **`stat_failed:` / `read_failed:`** — NAS hiccup on that specific
+  file. Re-run.
+- **PDF parser stack traces from `process_vault_upload`** — the file
+  is malformed. Move it out of the case tree, file an issue, and
+  re-run.
+
+---
+
+## 8. Rollback
+
+`--rollback` deletes:
+
+- every `legal.vault_documents` row for the case in **both**
+  fortress_prod and fortress_db,
+- every Qdrant point in `legal_ediscovery` whose payload `case_slug`
+  matches.
+
+It does **not** touch:
+
+- NAS files,
+- `legal.cases` row,
+- `legal.privilege_log` entries (audit trail must outlive the data),
+- `fortress_knowledge` collection (Sentinel-owned).
+
+```
+python -m backend.scripts.vault_ingest_legal_case \
+    --case-slug 7il-v-knight-ndga --rollback
+```
+
+You will be prompted to type the case_slug back as confirmation.
+Pass `--force` to skip the prompt — only do this from automation
+where the case_slug is already strongly bound. Rollback writes a
+separate manifest at `/mnt/fortress_nas/audits/vault-rollback-
+{case_slug}-{ts}.json` and emits its own `legal.ingest_runs` row
+with `args.rollback=true` for audit.
+
+If post-rollback counts are non-zero (concurrent writer beat us),
+the script exits 1 with a `WARNING:` log line — investigate before
+retrying.
+
+---
+
+## 9. Common errors and fixes
+
+| Error | Fix |
+| --- | --- |
+| `case_slug 'X' not found in fortress_prod.legal.cases` | run PR B's case-insertion path for X |
+| `nas_layout is NULL for X in fortress_prod` | populate the JSONB `nas_layout` column for the case |
+| `nas_layout subdirs missing from disk` | mount the NAS or fix the relative paths in the layout |
+| `qdrant collection 'legal_ediscovery' not found` | create with `vector_size=768 distance=Cosine` |
+| `missing PR D-pre2 constraints` | apply alembic `d8e3c1f5b9a6` against that DB |
+| `another vault ingest run appears active` | locate the live run via the PID in the lock file; wait for it or pass `--force` after confirming staleness |
+| Long tail of `mirror_failed:` errors | fortress_db is down or migrating — run when it stabilizes |
+
+---
+
+## 10. Adding a new case to ingestion
+
+1. Insert the row into `legal.cases` (PR B-style migration). Populate
+   `nas_layout` JSONB matching the on-disk layout, e.g.:
+   ```json
+   {
+     "root": "/mnt/fortress_nas/path/to/case",
+     "subdirs": {
+       "filings_incoming": "Pleadings",
+       "evidence":         "Discovery",
+       "correspondence":   "Mail"
+     },
+     "recursive": true
+   }
+   ```
+2. Run `ocr_legal_case.py --case-slug <slug>` to add text layers to
+   any image-only PDFs.
+3. Run `vault_ingest_legal_case.py --case-slug <slug>` to populate
+   `legal.vault_documents` and Qdrant.
+4. Verify in the UI's Vault panel that the case renders.
+
+---
+
+## 11. Performance tuning
+
+- `--jobs N` — bounded concurrency for per-file processing. Default
+  4. Bottleneck is usually the embedding endpoint (nomic via
+  Ollama); push to 6–8 only when the embed service is on a
+  dedicated host. Past ~8, expect Qdrant upsert contention.
+- `--max-file-size-mb N` — skip files above this cap. Default 500.
+  Large PDFs (1 GB+ deposition transcripts) blow up text extraction
+  and chunking; process them out-of-band with a tighter pipeline.
+- `--limit N` — cap on unique physical files. Useful for smoke tests
+  and incremental rollouts.
+- File hashing streams above 100 MB; below that it loads into memory
+  for speed.
+
+For the 7IL corpus (~552 PDFs after dedup), expect 30–60 minutes wall
+time at `--jobs 6` on a typical embed host.
+
+---
+
+## 12. Cross-references
+
+- **PR A** — `legal.cases.nas_layout` JSONB column (`backend/api/legal_cases.py`)
+- **PR B** — case-row insertion pattern (see PR #186 history)
+- **PR C** — OCR sweep (`backend/scripts/ocr_legal_case.py`)
+- **PR D-pre1** — `legal.ingest_runs` + `IngestRunTracker`
+  (`backend/services/ingest_run_tracker.py`)
+- **PR D-pre2** — `legal.vault_documents` schema integrity
+  (`docs/runbooks/legal-vault-documents.md`)
+- **Issue #189** — Whisper ASR for video evidence (out of scope here)
+- **Issue #194** — vocabulary cleanup followup


### PR DESCRIPTION
## Summary
- Production-grade case-scoped vault ingestion script (`backend/scripts/vault_ingest_legal_case.py`) walks `legal.cases.nas_layout` with physical-path dedup, processes each file via `process_vault_upload()` (privilege filter → text extraction → chunking → nomic embed → Qdrant upsert), and populates `legal.vault_documents` in BOTH `fortress_prod` and `fortress_db` so the UI's LegacySession reads consistent state.
- 8-gate pre-flight refuses to open a `legal.ingest_runs` audit row until every check passes (case existence in both DBs, `nas_layout` populated, paths on disk, Postgres writable + ingest_runs INSERT probe, PR D-pre2 schema constraints present, Qdrant reachable with vector_size=768, pipeline importable, lock not held). Failed pre-flight does not pollute the audit table.
- `--rollback` flag deletes `vault_documents` rows in both DBs + Qdrant points filtered by `payload.case_slug`, with explicit "type the slug back" confirmation (unless `--force`). Writes a separate `vault-rollback-{slug}-{ts}.json` manifest. Does NOT touch NAS files, `legal.cases`, `legal.privilege_log`, or `fortress_knowledge`.

## Architecture (Gary-confirmed)
- One canonical `vault_documents` row per physical file (race-safe via `ON CONFLICT ON CONSTRAINT uq_vault_documents_case_hash DO NOTHING`).
- Dual-listed subdirs (e.g. 7IL's `correspondence` and `certified_mail` both pointing at "Correspondence") are handled by `Path.resolve()` set-dedup before any hashing — same physical file is processed exactly once.
- OCR-failed files (image-only PDFs with empty text extract, plus 3 PR C errors): `processing_status='ocr_failed'`, `chunk_count=0`, no Qdrant write. The OCR sweep (PR C `ocr_legal_case.py`) is the recovery path; this script reports them in the manifest's `by_status.ocr_failed` count.
- IngestRunTracker (PR D-pre1) emits exactly one `legal.ingest_runs` row covering the lifecycle, including `manifest_path` and final `status` ∈ {complete, interrupted, error}.
- Privilege-shielded rows (`status='locked_privileged'`) are counted toward `vault_documents_inserted` (visible in UI) but contribute zero Qdrant points.

## Idempotency contract
- `--resume` (default on): files whose `vault_documents` row already has a terminal status (`complete`/`completed`/`ocr_failed`/`locked_privileged`) are skipped.
- Files in `pending`/`vectorizing`/`processing` are re-processed (recovery from interrupted runs).
- Re-running the script after a clean run is a fast no-op.

## Tests
17 cases in `backend/tests/test_vault_ingest_legal_case.py`, all passing:

- clean run processes all files
- second run skips completed
- physical-path dedup over dual-listed subdirs
- OCR-failed classification
- corrupt file logs error and continues
- max-file-size cap skips
- `--dry-run` makes no writes
- lock file prevents concurrent runs
- pre-flight failure leaves no audit row
- KeyboardInterrupt marks tracker `interrupted`
- resume re-processes pending rows
- rollback deletes Postgres + Qdrant
- rollback requires confirmation unless `--force`
- manifest schema is complete (21 keys verified)
- Qdrant-failure leaves rows in `completed` with `vectors_indexed=0` (per design — operators triage by `vectors_indexed`, not by leaving rows in pending)
- privilege filter marks `locked_privileged`
- writes to both fortress_prod AND fortress_db (via `_mirror_row_to_fortress_db`)

## Runbook
`docs/runbooks/legal-vault-ingest.md` — pre-flight gates, dedup model (3 layers), state machine link, manifest field guide, Ctrl-C / OOM / lock recovery, rollback semantics, common errors with fixes, performance tuning, "adding a new case" walkthrough.

## Test plan
- [x] `pytest backend/tests/test_vault_ingest_legal_case.py` — 17/17 pass
- [x] No syntax / type-checker errors beyond pre-existing path resolution noise
- [ ] Apply migration to fortress_shadow_test (still TODO from PR D-pre2 sandbox block)
- [ ] After merge: kick off real 7IL ingestion in background, capture `ingest_run_id` + ETA

## Followups
- Issue #189 — Whisper ASR for 113 mp4 + 2 mov video evidence (out of scope here)
- Issue #194 — vocabulary cleanup (collapse the bilingual processing_status set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)