### PR TITLE
fix(legal): vault_ingest_legal_case writes to fortress_db (LegacySession)

### DIFF
--- a/fortress-guest-platform/backend/scripts/vault_ingest_legal_case.py
+++ b/fortress-guest-platform/backend/scripts/vault_ingest_legal_case.py
@@ -509,7 +509,7 @@ async def _ingest_one_inner(
     mime = detect_mime_type(physical_path)
 
     if resume:
-        existing_status = _check_existing_row("fortress_prod", case_slug, fhash)
+        existing_status = _check_existing_row("fortress_db", case_slug, fhash)
         if existing_status in skip_status_set:
             return FileOutcome(
                 path=str(physical_path), logical_subdir=logical_subdir,
@@ -534,11 +534,14 @@ async def _ingest_one_inner(
             status="failed", error=f"read_failed:{exc!s}",
         )
 
-    from backend.core.database import AsyncSessionLocal
+    # legal.vault_documents lives in fortress_db (LegacySession target),
+    # NOT fortress_shadow (AsyncSessionLocal target). This matches the
+    # call pattern in legal_email_intake._ingest_attachments.
+    from backend.services.ediscovery_agent import LegacySession
     from backend.services.legal_ediscovery import process_vault_upload
 
     try:
-        async with AsyncSessionLocal() as db:
+        async with LegacySession() as db:
             result = await process_vault_upload(
                 db=db,
                 case_slug=case_slug,
@@ -559,7 +562,7 @@ async def _ingest_one_inner(
 
     if status in {"completed", "ocr_failed", "locked_privileged"} and doc_id:
         try:
-            _mirror_row_to_fortress_db(case_slug=case_slug, doc_id=doc_id)
+            _mirror_row_db_to_prod(case_slug=case_slug, doc_id=doc_id)
         except Exception as exc:
             return FileOutcome(
                 path=str(physical_path), logical_subdir=logical_subdir,
@@ -593,10 +596,11 @@ def _check_existing_row(dbname: str, case_slug: str, file_hash: str) -> str | No
         conn.close()
 
 
-def _mirror_row_to_fortress_db(*, case_slug: str, doc_id: str) -> None:
-    """After process_vault_upload writes to fortress_prod, copy the row to
-    fortress_db so the UI's LegacySession reads the same data."""
-    src = _connect("fortress_prod")
+def _mirror_row_db_to_prod(*, case_slug: str, doc_id: str) -> None:
+    """After process_vault_upload writes via LegacySession (fortress_db),
+    copy the row to fortress_prod so consumers reading from prod see the
+    same vault state. Idempotent via ON CONFLICT DO UPDATE."""
+    src = _connect("fortress_db")
     try:
         with src.cursor() as cur:
             cur.execute(
@@ -609,13 +613,13 @@ def _mirror_row_to_fortress_db(*, case_slug: str, doc_id: str) -> None:
             row = cur.fetchone()
         if row is None:
             raise RuntimeError(
-                f"row {doc_id} missing in fortress_prod for case {case_slug!r} "
+                f"row {doc_id} missing in fortress_db for case {case_slug!r} "
                 f"— cannot mirror"
             )
     finally:
         src.close()
 
-    dst = _connect("fortress_db")
+    dst = _connect("fortress_prod")
     try:
         with dst.cursor() as cur:
             cur.execute(

--- a/fortress-guest-platform/backend/tests/test_vault_ingest_legal_case.py
+++ b/fortress-guest-platform/backend/tests/test_vault_ingest_legal_case.py
@@ -376,7 +376,7 @@ def _run_main(
             return False
 
     monkeypatch.setattr(
-        "backend.core.database.AsyncSessionLocal",
+        "backend.services.ediscovery_agent.LegacySession",
         lambda: _FakeAsyncSession(),
     )
     monkeypatch.setattr(
@@ -384,14 +384,13 @@ def _run_main(
         _fake_upload,
     )
 
-    # Mirror writer needs to find the row in fortress_prod after upload — fold
-    # the canonical row into the registry on demand.
+    # Mirror writer is fortress_db → fortress_prod — fake it to record calls.
     inserted_rows: dict[str, tuple] = {}
 
     def _fake_mirror(*, case_slug, doc_id):
         inserted_rows[doc_id] = (case_slug, doc_id)
 
-    monkeypatch.setattr(vil, "_mirror_row_to_fortress_db", _fake_mirror)
+    monkeypatch.setattr(vil, "_mirror_row_db_to_prod", _fake_mirror)
 
     argv = ["--case-slug", case_slug] + (extra_argv or [])
     rc = vil.main(argv)
@@ -870,7 +869,7 @@ def test_privilege_filter_marks_locked_privileged(env, monkeypatch, tmp_path):
 
 
 def test_writes_to_both_fortress_prod_and_fortress_db(env, monkeypatch, tmp_path):
-    """Verify _mirror_row_to_fortress_db is called once per successful upload."""
+    """Verify _mirror_row_db_to_prod is called once per successful upload."""
     case = "dual-db"
     docs = tmp_path / "docs"
     docs.mkdir()


### PR DESCRIPTION
## Summary
Surgical follow-up to PR #195. The vault ingestion script was using \`AsyncSessionLocal\` (→ \`fortress_shadow\`, the runtime VRS/booking DB), which is wrong: the legal pipeline operationally lives in \`fortress_db\` (queried by the UI via \`LegacySession\`, per \`backend/services/ediscovery_agent.py\`). The existing canonical caller \`legal_email_intake._ingest_attachments\` already uses \`LegacySession\`; the script now matches.

Mirror direction flipped to match: source-of-truth is \`fortress_db\` (where \`process_vault_upload\` just wrote), mirrored to \`fortress_prod\` for parity with PR B's case-row distribution. Function renamed \`_mirror_row_to_fortress_db\` → \`_mirror_row_db_to_prod\` to reflect the new direction.

Resume-mode existence check (\`_check_existing_row\`) now reads from \`fortress_db\` for the same reason.

## Test plan
- [x] 17/17 unit tests pass with the new symbols
- [ ] After merge: kick off real 7IL ingestion, confirm rows land in both \`fortress_db\` (UI source) and \`fortress_prod\` (mirror)

🤖 Generated with [Claude Code](https://claude.com/claude-code)