### PR TITLE
feat(legal): 7IL two-case restructure + privileged communications architecture (PR G)

### DIFF
--- a/fortress-guest-platform/apps/command-center/src/__tests__/legal/case-detail-header.test.tsx
+++ b/fortress-guest-platform/apps/command-center/src/__tests__/legal/case-detail-header.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * PR G phase F (UI) — Case Detail header rendering of privilege metadata.
+ *
+ * Tests verify the header section renders:
+ *   - privileged_counsel_domains as one purple badge per domain
+ *   - related_matters as in-app links to the peer case slug
+ *   - case_phase as an outline pill
+ *   - Nothing privileged-related when arrays are empty/null/undefined
+ *
+ * Strategy: render CaseDetailShell with all hooks mocked so render doesn't
+ * cascade. Sub-components that aren't part of the assertion target are
+ * stubbed to no-op divs.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// ── Mock every hook + sub-component case-detail-shell pulls in.
+//    Sub-components are stubbed to keep DOM small + assertions fast.
+vi.mock("@/lib/legal-hooks", () => ({
+  useCaseGraph: () => ({ data: null, isLoading: false }),
+  useCaseDetail: () => ({ data: null, isLoading: false, error: null }),
+  useCaseExtractionPoll: () => ({ data: null, refetch: vi.fn() }),
+  useDiscoveryPacks: () => ({ data: [], isLoading: false }),
+  useGenerateDiscoveryDraftPack: () => ({ mutate: vi.fn(), isPending: false }),
+  useDepositionKillSheets: () => ({ data: [], isLoading: false }),
+  useSanctionsAlerts: () => ({ data: [], isLoading: false }),
+  downloadKillSheetMarkdown: vi.fn(),
+}));
+vi.mock("@/lib/store", () => ({
+  useAppStore: (selector: (state: { user: { id: number; role: string } }) => unknown) =>
+    selector({ user: { id: 1, role: "admin" } }),
+}));
+vi.mock("@/lib/api", () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+vi.mock("@/lib/roles", () => ({
+  canManageLegalOps: () => true,
+}));
+vi.mock("@tanstack/react-query", async () => {
+  const actual: Record<string, unknown> = await vi.importActual("@tanstack/react-query");
+  return { ...actual, useQueryClient: () => ({ invalidateQueries: vi.fn() }) };
+});
+// Stub heavy sub-components to keep tests fast + focused on the header.
+vi.mock("@/app/(dashboard)/legal/cases/[slug]/_components/graph-snapshot-card", () => ({
+  GraphSnapshotCard: () => <div data-testid="graph-snapshot-card" />,
+}));
+vi.mock("@/app/(dashboard)/legal/cases/[slug]/_components/master-timeline", () => ({
+  MasterTimeline: () => <div data-testid="master-timeline" />,
+}));
+vi.mock("@/app/(dashboard)/legal/cases/[slug]/_components/inference-radar", () => ({
+  InferenceRadar: () => <div data-testid="inference-radar" />,
+}));
+vi.mock("@/app/(dashboard)/legal/cases/[slug]/_components/evidence-upload", () => ({
+  EvidenceUpload: () => <div data-testid="evidence-upload" />,
+}));
+vi.mock("@/app/(dashboard)/legal/cases/[slug]/_components/counsel-threat-matrix", () => ({
+  CounselThreatMatrix: () => <div data-testid="counsel-threat-matrix" />,
+}));
+vi.mock("@/app/(dashboard)/legal/cases/[slug]/_components/discovery-draft-panel", () => ({
+  DiscoveryDraftPanel: () => <div data-testid="discovery-draft-panel" />,
+}));
+vi.mock("@/app/(dashboard)/legal/cases/[slug]/_components/deposition-prep-panel", () => ({
+  DepositionPrepPanel: () => <div data-testid="deposition-prep-panel" />,
+}));
+vi.mock("@/app/(dashboard)/legal/cases/[slug]/_components/sanctions-tripwire-panel", () => ({
+  SanctionsTripwirePanel: () => <div data-testid="sanctions-tripwire-panel" />,
+}));
+vi.mock("@/app/(dashboard)/legal/cases/[slug]/_components/deposition-war-room", () => ({
+  DepositionWarRoomModal: () => <div data-testid="deposition-war-room" />,
+}));
+vi.mock("@/app/(dashboard)/legal/cases/[slug]/_components/jurisprudence-radar", () => ({
+  JurisprudenceRadar: () => <div data-testid="jurisprudence-radar" />,
+}));
+vi.mock("@/app/(dashboard)/legal/cases/[slug]/_components/document-viewer", () => ({
+  DocumentViewer: () => <div data-testid="document-viewer" />,
+}));
+vi.mock("@/app/(dashboard)/legal/cases/[slug]/_components/extraction-panel", () => ({
+  ExtractionPanel: () => <div data-testid="extraction-panel" />,
+}));
+vi.mock("@/app/(dashboard)/legal/cases/[slug]/_components/hitl-deadline-queue", () => ({
+  HitlDeadlineQueue: () => <div data-testid="hitl-deadline-queue" />,
+}));
+vi.mock("@/components/access/role-gated-action", () => ({
+  RoleGatedAction: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { CaseDetailShell } from "@/app/(dashboard)/legal/cases/[slug]/_components/case-detail-shell";
+import * as legalHooks from "@/lib/legal-hooks";
+
+const BASE_CASE_FIELDS = {
+  id: 99,
+  case_slug: "test-case-i",
+  case_number: "1:99-cv-99999-XXX",
+  case_name: "Test Case I",
+  court: "U.S. District Court NDGA",
+  judge: "Hon. Test Judge",
+  case_type: "civil",
+  our_role: "defendant",
+  status: "closed_judgment_against",
+  risk_score: 5,
+  extraction_status: "complete" as const,
+  extracted_entities: { risk_score: 5, parties: [], amounts: [], key_claims: [], deadlines: [] },
+  critical_date: null,
+  critical_note: null,
+  notes: null,
+  our_claim_basis: null,
+  days_remaining: null,
+};
+
+function setUseCaseDetail(caseFields: Record<string, unknown>): void {
+  vi.spyOn(legalHooks, "useCaseDetail").mockReturnValue({
+    data: {
+      case: { ...BASE_CASE_FIELDS, ...caseFields },
+      deadlines: [],
+      recent_actions: [],
+      evidence: [],
+    },
+    isLoading: false,
+    error: null,
+    // Tests don't exercise these but the type expects them; cast through unknown.
+  } as unknown as ReturnType<typeof legalHooks.useCaseDetail>);
+}
+
+describe("CaseDetailShell — privilege metadata in header (PR G)", () => {
+  it("renders one badge per privileged_counsel_domain in the header", () => {
+    setUseCaseDetail({
+      privileged_counsel_domains: ["mhtlegal.com", "fgplaw.com", "dralaw.com"],
+    });
+    render(<CaseDetailShell slug="test-case-i" />);
+    // The "Privileged counsel:" label should be present
+    expect(screen.getByText(/Privileged counsel:/i)).toBeInTheDocument();
+    // One badge per domain
+    expect(screen.getByText("mhtlegal.com")).toBeInTheDocument();
+    expect(screen.getByText("fgplaw.com")).toBeInTheDocument();
+    expect(screen.getByText("dralaw.com")).toBeInTheDocument();
+  });
+
+  it("renders nothing for the privileged-counsel block when the array is empty", () => {
+    setUseCaseDetail({ privileged_counsel_domains: [] });
+    render(<CaseDetailShell slug="test-case-i" />);
+    expect(screen.queryByText(/Privileged counsel:/i)).not.toBeInTheDocument();
+  });
+
+  it("renders nothing for the privileged-counsel block when the field is null/undefined", () => {
+    setUseCaseDetail({ privileged_counsel_domains: null });
+    render(<CaseDetailShell slug="test-case-i" />);
+    expect(screen.queryByText(/Privileged counsel:/i)).not.toBeInTheDocument();
+  });
+
+  it("renders related_matters as anchor links pointing at /legal/cases/<slug>", () => {
+    setUseCaseDetail({
+      related_matters: ["test-case-ii", "test-case-iii"],
+    });
+    render(<CaseDetailShell slug="test-case-i" />);
+    const link1 = screen.getByRole("link", { name: "test-case-ii" });
+    expect(link1).toHaveAttribute("href", "/legal/cases/test-case-ii");
+    const link2 = screen.getByRole("link", { name: "test-case-iii" });
+    expect(link2).toHaveAttribute("href", "/legal/cases/test-case-iii");
+  });
+
+  it("renders nothing for related_matters when the array is empty", () => {
+    setUseCaseDetail({ related_matters: [] });
+    render(<CaseDetailShell slug="test-case-i" />);
+    expect(screen.queryByText(/Related matters:/i)).not.toBeInTheDocument();
+  });
+
+  it("renders case_phase as a badge with underscores transformed to spaces", () => {
+    setUseCaseDetail({ case_phase: "counsel_search" });
+    render(<CaseDetailShell slug="test-case-i" />);
+    // Header pill: "counsel search" (the " " replacement of underscores).
+    expect(screen.getByText("counsel search")).toBeInTheDocument();
+  });
+
+  it("renders nothing for case_phase when null", () => {
+    setUseCaseDetail({ case_phase: null });
+    render(<CaseDetailShell slug="test-case-i" />);
+    // No phase pill — but other content (case_name) still rendered, so smoke-check that.
+    expect(screen.getByText("Test Case I")).toBeInTheDocument();
+    // The phase string we'd expect under the spec ("counsel search") is absent.
+    expect(screen.queryByText(/^counsel search$/)).not.toBeInTheDocument();
+  });
+});

--- a/fortress-guest-platform/apps/command-center/src/__tests__/legal/council-fyeo.test.tsx
+++ b/fortress-guest-platform/apps/command-center/src/__tests__/legal/council-fyeo.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * PR G phase F (UI) — Legal Council page FOR YOUR EYES ONLY warning rendering.
+ *
+ * Tests:
+ *   - Banner does NOT render when contains_privileged=false (default state).
+ *   - Banner renders when the hook flips contains_privileged=true.
+ *   - Banner uses role="alert" + aria-live="polite" for screen readers.
+ *   - Banner falls back to canonical text when the SSE payload didn't ship
+ *     privileged_warning explicitly.
+ *   - Banner uses the SSE-provided text when present.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import LegalCouncilPage from "@/app/(dashboard)/legal/council/page";
+
+// Mock the useCouncilStream hook so we can dial state directly.
+const mockHookState = {
+  jobId: null,
+  sessionId: null,
+  lastEventId: null,
+  connectionState: "idle" as const,
+  isStreaming: false,
+  error: null,
+  events: [],
+  opinions: [],
+  consensus: null,
+  finalResult: null,
+  contextFrozen: null,
+  vaulted: null,
+  containsPrivileged: false,
+  privilegedWarning: null as string | null,
+  hasActiveJob: false,
+  streamLines: [] as Array<{ id: string; label: string; type: string; at: number }>,
+  start: vi.fn(),
+  stop: vi.fn(),
+  reset: vi.fn(),
+};
+vi.mock("@/lib/use-council-stream", () => ({
+  useCouncilStream: () => mockHookState,
+}));
+
+beforeEach(() => {
+  // Reset state to baseline before each test.
+  mockHookState.containsPrivileged = false;
+  mockHookState.privilegedWarning = null;
+});
+
+describe("LegalCouncilPage — FYEO warning banner (PR G)", () => {
+  it("does NOT render the FYEO banner when contains_privileged is false", () => {
+    mockHookState.containsPrivileged = false;
+    render(<LegalCouncilPage />);
+    expect(screen.queryByText(/FOR YOUR EYES ONLY/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("renders the FYEO banner the moment contains_privileged flips true", () => {
+    mockHookState.containsPrivileged = true;
+    render(<LegalCouncilPage />);
+    // Header text + warning body
+    expect(screen.getByText(/FOR YOUR EYES ONLY/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/attorney-client privileged communications/i),
+    ).toBeInTheDocument();
+  });
+
+  it("uses role=alert and aria-live=polite for accessibility (UI must announce when flag flips mid-deliberation)", () => {
+    mockHookState.containsPrivileged = true;
+    render(<LegalCouncilPage />);
+    const banner = screen.getByRole("alert");
+    expect(banner).toBeInTheDocument();
+    expect(banner).toHaveAttribute("aria-live", "polite");
+  });
+
+  it("falls back to canonical warning text when privilegedWarning is null", () => {
+    mockHookState.containsPrivileged = true;
+    mockHookState.privilegedWarning = null;
+    render(<LegalCouncilPage />);
+    expect(
+      screen.getByText(
+        /Do not use this output in court filings, share with opposing parties/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("uses the SSE-provided privileged_warning text when present (so backend can change wording without UI redeploy)", () => {
+    mockHookState.containsPrivileged = true;
+    mockHookState.privilegedWarning =
+      "CUSTOM WARNING TEXT — backend-provided override for testing.";
+    render(<LegalCouncilPage />);
+    expect(
+      screen.getByText(/CUSTOM WARNING TEXT — backend-provided override/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a Privileged badge inside the banner header (visual cue separate from prose)", () => {
+    mockHookState.containsPrivileged = true;
+    render(<LegalCouncilPage />);
+    // Badge text is "Privileged" — exact match, not part of the warning prose.
+    const badges = screen.getAllByText(/^Privileged$/);
+    expect(badges.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/fortress-guest-platform/apps/command-center/src/__tests__/legal/ediscovery-dropzone.test.tsx
+++ b/fortress-guest-platform/apps/command-center/src/__tests__/legal/ediscovery-dropzone.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * PR G phase F (UI) — EdiscoveryDropzone vault-document filter + privileged badge.
+ *
+ * Tests:
+ *   - Filter group defaults to "All".
+ *   - "Privileged" filter shows only locked_privileged docs; counts in pill labels.
+ *   - "Evidence" filter shows everything except privileged.
+ *   - Privileged badge renders adjacent to the filename (not in a corner).
+ *   - Lock icon appears next to the status indicator on privileged docs.
+ *   - Empty filter result shows the "no documents match" message.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+
+import { EdiscoveryDropzone } from "@/app/(dashboard)/legal/cases/[slug]/_components/ediscovery-dropzone";
+
+// Test fixture: 3 evidence docs + 2 privileged docs.
+const FIXTURE_DOCS = [
+  {
+    id: "11111111-1111-1111-1111-111111111111",
+    file_name: "complaint.pdf",
+    mime_type: "application/pdf",
+    file_size_bytes: 12345,
+    chunk_count: 8,
+    processing_status: "completed",
+    error_detail: null,
+    created_at: "2026-04-25T10:00:00Z",
+  },
+  {
+    id: "22222222-2222-2222-2222-222222222222",
+    file_name: "evidence-photo.png",
+    mime_type: "image/png",
+    file_size_bytes: 67890,
+    chunk_count: 0,
+    processing_status: "completed",
+    error_detail: null,
+    created_at: "2026-04-25T10:05:00Z",
+  },
+  {
+    id: "33333333-3333-3333-3333-333333333333",
+    file_name: "scan-no-text.pdf",
+    mime_type: "application/pdf",
+    file_size_bytes: 5000,
+    chunk_count: 0,
+    processing_status: "ocr_failed",
+    error_detail: "image-only PDF",
+    created_at: "2026-04-25T10:10:00Z",
+  },
+  {
+    id: "44444444-4444-4444-4444-444444444444",
+    file_name: "argo-letter.eml",
+    mime_type: "message/rfc822",
+    file_size_bytes: 3210,
+    chunk_count: 4,
+    processing_status: "locked_privileged",
+    error_detail: null,
+    created_at: "2026-04-25T10:15:00Z",
+  },
+  {
+    id: "55555555-5555-5555-5555-555555555555",
+    file_name: "podesta-strategy-memo.pdf",
+    mime_type: "application/pdf",
+    file_size_bytes: 9876,
+    chunk_count: 12,
+    processing_status: "locked_privileged",
+    error_detail: null,
+    created_at: "2026-04-25T10:20:00Z",
+  },
+];
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    get: vi.fn(async () => ({
+      case_slug: "test-case-i",
+      total: FIXTURE_DOCS.length,
+      documents: FIXTURE_DOCS,
+    })),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+async function renderAndWaitForDocs() {
+  render(<EdiscoveryDropzone slug="test-case-i" />);
+  // The component lazy-fetches via setTimeout(loadDocs, 0). Wait for one of
+  // the filenames to land before asserting on filter behavior.
+  await waitFor(() => {
+    expect(screen.getByText("complaint.pdf")).toBeInTheDocument();
+  });
+}
+
+describe("EdiscoveryDropzone — filter + privileged badge (PR G)", () => {
+  it("defaults to the 'All' filter and shows every document with the right count", async () => {
+    await renderAndWaitForDocs();
+    // The All button label includes the total count (5).
+    const allBtn = screen.getByRole("button", { name: /All \(5\)/ });
+    expect(allBtn).toHaveAttribute("aria-pressed", "true");
+    // All 5 filenames are visible.
+    for (const f of [
+      "complaint.pdf",
+      "evidence-photo.png",
+      "scan-no-text.pdf",
+      "argo-letter.eml",
+      "podesta-strategy-memo.pdf",
+    ]) {
+      expect(screen.getByText(f)).toBeInTheDocument();
+    }
+  });
+
+  it("shows the privileged-count and evidence-count in pill labels", async () => {
+    await renderAndWaitForDocs();
+    // Evidence = total − privileged = 5 − 2 = 3
+    expect(screen.getByRole("button", { name: /Evidence \(3\)/ })).toBeInTheDocument();
+    // Privileged button label includes count 2 (regex tolerates the lock icon)
+    expect(screen.getByRole("button", { name: /Privileged \(2\)/ })).toBeInTheDocument();
+  });
+
+  it("clicking 'Privileged' hides non-privileged docs and shows only locked_privileged", async () => {
+    await renderAndWaitForDocs();
+    fireEvent.click(screen.getByRole("button", { name: /Privileged \(2\)/ }));
+
+    // Privileged docs visible
+    expect(screen.getByText("argo-letter.eml")).toBeInTheDocument();
+    expect(screen.getByText("podesta-strategy-memo.pdf")).toBeInTheDocument();
+    // Non-privileged docs hidden
+    expect(screen.queryByText("complaint.pdf")).not.toBeInTheDocument();
+    expect(screen.queryByText("evidence-photo.png")).not.toBeInTheDocument();
+    expect(screen.queryByText("scan-no-text.pdf")).not.toBeInTheDocument();
+  });
+
+  it("clicking 'Evidence' hides privileged docs", async () => {
+    await renderAndWaitForDocs();
+    fireEvent.click(screen.getByRole("button", { name: /Evidence \(3\)/ }));
+
+    expect(screen.getByText("complaint.pdf")).toBeInTheDocument();
+    expect(screen.getByText("evidence-photo.png")).toBeInTheDocument();
+    expect(screen.getByText("scan-no-text.pdf")).toBeInTheDocument();
+    // Privileged docs hidden
+    expect(screen.queryByText("argo-letter.eml")).not.toBeInTheDocument();
+    expect(screen.queryByText("podesta-strategy-memo.pdf")).not.toBeInTheDocument();
+  });
+
+  it("renders a 'Privileged' badge adjacent to the filename on locked_privileged docs", async () => {
+    await renderAndWaitForDocs();
+    // Find the row that contains 'argo-letter.eml'.
+    const filenameSpan = screen.getByText("argo-letter.eml");
+    // The Privileged badge is a sibling element inside the same flex container
+    // (filename + badge are in the same <p>).
+    const filenameContainer = filenameSpan.closest("p")!;
+    const privilegedBadgeInRow = within(filenameContainer).getByText(/^Privileged$/);
+    expect(privilegedBadgeInRow).toBeInTheDocument();
+  });
+
+  it("does NOT render a 'Privileged' badge on completed (non-privileged) docs", async () => {
+    await renderAndWaitForDocs();
+    const filenameSpan = screen.getByText("complaint.pdf");
+    const filenameContainer = filenameSpan.closest("p")!;
+    expect(
+      within(filenameContainer).queryByText(/^Privileged$/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders an empty-state message when filter yields zero docs", async () => {
+    // Mock api.get to return zero privileged docs by overriding the fixture.
+    const apiModule = await import("@/lib/api");
+    (apiModule.api.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      case_slug: "test-case-i",
+      total: 1,
+      documents: [
+        {
+          ...FIXTURE_DOCS[0],
+        },
+      ],
+    });
+    render(<EdiscoveryDropzone slug="test-case-i" />);
+    await waitFor(() => {
+      expect(screen.getByText("complaint.pdf")).toBeInTheDocument();
+    });
+    // Click privileged with zero in the bucket.
+    fireEvent.click(screen.getByRole("button", { name: /Privileged \(0\)/ }));
+    expect(
+      screen.getByText(/No documents match the privileged filter/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/fortress-guest-platform/apps/command-center/src/app/(dashboard)/legal/cases/[slug]/_components/case-detail-shell.tsx
+++ b/fortress-guest-platform/apps/command-center/src/app/(dashboard)/legal/cases/[slug]/_components/case-detail-shell.tsx
@@ -30,6 +30,7 @@ import {
   Clock,
   Eye,
   Loader2,
+  Lock,
   Scale,
   ShieldAlert,
   Swords,
@@ -323,7 +324,47 @@ export function CaseDetailShell({ slug }: { slug: string }) {
               </span>
             </>
           )}
+          {c.case_phase && (
+            <>
+              <span>&middot;</span>
+              <Badge variant="outline" className="text-[10px] capitalize">
+                {c.case_phase.replace(/_/g, " ")}
+              </Badge>
+            </>
+          )}
         </div>
+        {/* PR G — Privileged counsel domains. Each domain = one badge so a
+            quick scan reveals attorney-client relationships without opening
+            the full case detail. */}
+        {Array.isArray(c.privileged_counsel_domains) && c.privileged_counsel_domains.length > 0 && (
+          <div className="flex items-center gap-1.5 flex-wrap text-[10px] pt-1">
+            <Lock className="h-3 w-3 text-purple-400" />
+            <span className="text-zinc-500 uppercase tracking-wider font-semibold">Privileged counsel:</span>
+            {c.privileged_counsel_domains.map((domain) => (
+              <Badge
+                key={domain}
+                variant="outline"
+                className="text-[10px] text-purple-300 border-purple-500/40 bg-purple-500/5"
+              >
+                {domain}
+              </Badge>
+            ))}
+          </div>
+        )}
+        {Array.isArray(c.related_matters) && c.related_matters.length > 0 && (
+          <div className="flex items-center gap-1.5 flex-wrap text-[10px] pt-1 text-zinc-500">
+            <span className="uppercase tracking-wider font-semibold">Related matters:</span>
+            {c.related_matters.map((slug) => (
+              <a
+                key={slug}
+                href={`/legal/cases/${slug}`}
+                className="text-[10px] text-zinc-300 hover:text-zinc-100 underline decoration-dotted underline-offset-2"
+              >
+                {slug}
+              </a>
+            ))}
+          </div>
+        )}
       </div>
 
       {/* ── Three-Tab Command Deck ── */}

--- a/fortress-guest-platform/apps/command-center/src/app/(dashboard)/legal/cases/[slug]/_components/ediscovery-dropzone.tsx
+++ b/fortress-guest-platform/apps/command-center/src/app/(dashboard)/legal/cases/[slug]/_components/ediscovery-dropzone.tsx
@@ -4,8 +4,17 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { api } from "@/lib/api";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Archive, CheckCircle, Clock, Loader2, Upload, XCircle } from "lucide-react";
+import { Archive, CheckCircle, Clock, Loader2, Lock, Upload, XCircle } from "lucide-react";
 import { toast } from "sonner";
+
+type ProcessingStatus =
+  | "pending"
+  | "vectorizing"
+  | "completed"
+  | "failed"
+  | "ocr_failed"
+  | "locked_privileged"
+  | "duplicate";
 
 type VaultDocument = {
   id: string;
@@ -13,10 +22,13 @@ type VaultDocument = {
   mime_type: string;
   file_size_bytes: number;
   chunk_count: number;
-  processing_status: "pending" | "vectorizing" | "completed" | "failed";
+  processing_status: ProcessingStatus;
   error_detail?: string | null;
   created_at: string;
 };
+
+// PR G — vault-document filter: which buckets to render in the ledger.
+type VaultFilter = "all" | "evidence" | "privileged";
 
 type VaultListResponse = {
   case_slug: string;
@@ -33,7 +45,19 @@ const STATUS_ICON: Record<string, React.ReactNode> = {
   vectorizing: <Loader2 className="h-3 w-3 text-blue-400 animate-spin" />,
   completed: <CheckCircle className="h-3 w-3 text-emerald-400" />,
   failed: <XCircle className="h-3 w-3 text-red-400" />,
+  ocr_failed: <XCircle className="h-3 w-3 text-amber-400" />,
+  locked_privileged: <Lock className="h-3 w-3 text-purple-400" />,
+  duplicate: <CheckCircle className="h-3 w-3 text-zinc-500" />,
 };
+
+// PR G — distinguish privileged docs from work product. Privileged docs land
+// in legal_privileged_communications (Council retrieves them on the
+// privileged track only). Everything else is evidence / work product.
+const PRIVILEGED_STATUSES = new Set<ProcessingStatus>(["locked_privileged"]);
+
+function isPrivileged(doc: VaultDocument): boolean {
+  return PRIVILEGED_STATUSES.has(doc.processing_status);
+}
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -45,7 +69,16 @@ export function EdiscoveryDropzone({ slug }: EdiscoveryDropzoneProps) {
   const [docs, setDocs] = useState<VaultDocument[]>([]);
   const [uploading, setUploading] = useState(false);
   const [dragOver, setDragOver] = useState(false);
+  const [filter, setFilter] = useState<VaultFilter>("all");
   const inputRef = useRef<HTMLInputElement>(null);
+
+  const visibleDocs = docs.filter((d) => {
+    if (filter === "all") return true;
+    if (filter === "privileged") return isPrivileged(d);
+    return !isPrivileged(d);   // "evidence" — everything except privileged
+  });
+  const privilegedCount = docs.filter(isPrivileged).length;
+  const evidenceCount = docs.length - privilegedCount;
 
   const loadDocs = useCallback(async () => {
     try {
@@ -151,41 +184,97 @@ export function EdiscoveryDropzone({ slug }: EdiscoveryDropzoneProps) {
 
       {docs.length > 0 && (
         <div>
-          <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center justify-between mb-2 gap-2 flex-wrap">
             <p className="text-[10px] uppercase tracking-wider text-zinc-500 font-semibold">Vault Ledger</p>
-            {hasProcessing && (
-              <Badge variant="outline" className="text-[9px] bg-blue-500/10 text-blue-400 border-blue-500/30 animate-pulse">
-                Processing...
-              </Badge>
-            )}
+            <div className="flex items-center gap-2">
+              {/* PR G — show only evidence / only privileged / both */}
+              <div className="flex items-center gap-1 rounded-md bg-zinc-900/60 p-0.5 text-[10px]">
+                {(["all", "evidence", "privileged"] as VaultFilter[]).map((f) => (
+                  <button
+                    key={f}
+                    onClick={() => setFilter(f)}
+                    className={`px-2 py-0.5 rounded transition ${
+                      filter === f
+                        ? "bg-zinc-700 text-zinc-100"
+                        : "text-zinc-400 hover:text-zinc-200"
+                    }`}
+                    aria-pressed={filter === f}
+                  >
+                    {f === "all" && `All (${docs.length})`}
+                    {f === "evidence" && `Evidence (${evidenceCount})`}
+                    {f === "privileged" && (
+                      <span className="inline-flex items-center gap-1">
+                        <Lock className="h-2.5 w-2.5" />
+                        Privileged ({privilegedCount})
+                      </span>
+                    )}
+                  </button>
+                ))}
+              </div>
+              {hasProcessing && (
+                <Badge variant="outline" className="text-[9px] bg-blue-500/10 text-blue-400 border-blue-500/30 animate-pulse">
+                  Processing...
+                </Badge>
+              )}
+            </div>
           </div>
           <ScrollArea className="max-h-48">
             <div className="space-y-1">
-              {docs.map((doc) => (
-                <div key={doc.id} className="rounded border border-zinc-800 bg-zinc-900/50 px-3 py-2 flex items-center gap-3">
-                  {STATUS_ICON[doc.processing_status] ?? STATUS_ICON.pending}
-                  <div className="flex-1 min-w-0">
-                    <p className="text-xs text-zinc-200 truncate">{doc.file_name}</p>
-                    <p className="text-[10px] text-zinc-500">
-                      {formatBytes(doc.file_size_bytes)}
-                      {doc.chunk_count > 0 && ` · ${doc.chunk_count} chunks`}
-                      {doc.error_detail && ` · ${doc.error_detail.slice(0, 60)}`}
-                    </p>
-                  </div>
-                  <Badge
-                    variant="outline"
-                    className={`text-[9px] ${
-                      doc.processing_status === "completed"
-                        ? "text-emerald-400 border-emerald-500/30"
-                        : doc.processing_status === "failed"
-                          ? "text-red-400 border-red-500/30"
-                          : "text-zinc-400 border-zinc-600"
+              {visibleDocs.map((doc) => {
+                const priv = isPrivileged(doc);
+                return (
+                  <div
+                    key={doc.id}
+                    className={`rounded border px-3 py-2 flex items-center gap-3 ${
+                      priv
+                        ? "border-purple-500/40 bg-purple-500/5"
+                        : "border-zinc-800 bg-zinc-900/50"
                     }`}
                   >
-                    {doc.processing_status}
-                  </Badge>
-                </div>
-              ))}
+                    {STATUS_ICON[doc.processing_status] ?? STATUS_ICON.pending}
+                    <div className="flex-1 min-w-0">
+                      <p className="text-xs text-zinc-200 truncate flex items-center gap-1.5">
+                        {doc.file_name}
+                        {priv && (
+                          <Badge
+                            variant="outline"
+                            className="text-[9px] text-purple-300 border-purple-500/40 bg-purple-500/10 gap-0.5"
+                          >
+                            <Lock className="h-2 w-2" />
+                            Privileged
+                          </Badge>
+                        )}
+                      </p>
+                      <p className="text-[10px] text-zinc-500">
+                        {formatBytes(doc.file_size_bytes)}
+                        {doc.chunk_count > 0 && ` · ${doc.chunk_count} chunks`}
+                        {doc.error_detail && ` · ${doc.error_detail.slice(0, 60)}`}
+                      </p>
+                    </div>
+                    <Badge
+                      variant="outline"
+                      className={`text-[9px] ${
+                        doc.processing_status === "completed"
+                          ? "text-emerald-400 border-emerald-500/30"
+                          : doc.processing_status === "failed"
+                            ? "text-red-400 border-red-500/30"
+                            : doc.processing_status === "locked_privileged"
+                              ? "text-purple-300 border-purple-500/40"
+                              : doc.processing_status === "ocr_failed"
+                                ? "text-amber-400 border-amber-500/30"
+                                : "text-zinc-400 border-zinc-600"
+                      }`}
+                    >
+                      {doc.processing_status}
+                    </Badge>
+                  </div>
+                );
+              })}
+              {visibleDocs.length === 0 && (
+                <p className="text-[10px] text-zinc-500 italic px-3 py-2">
+                  No documents match the {filter} filter.
+                </p>
+              )}
             </div>
           </ScrollArea>
         </div>

--- a/fortress-guest-platform/apps/command-center/src/app/(dashboard)/legal/council/page.tsx
+++ b/fortress-guest-platform/apps/command-center/src/app/(dashboard)/legal/council/page.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
-import { Scale, Loader2, CircleStop, Play, Radio } from "lucide-react";
+import { Scale, Loader2, CircleStop, Play, Radio, Lock, ShieldAlert } from "lucide-react";
 import { useCouncilStream } from "@/lib/use-council-stream";
 
 export default function LegalCouncilPage() {
@@ -81,6 +81,38 @@ export default function LegalCouncilPage() {
             <pre className="text-sm text-destructive font-mono whitespace-pre-wrap">
               {council.error}
             </pre>
+          </CardContent>
+        </Card>
+      )}
+
+      {/*
+        PR G — FOR YOUR EYES ONLY warning. Renders the moment any SSE event
+        carries contains_privileged=true, not just at end of deliberation.
+        The `containsPrivileged` flag latches once true (see use-council-stream
+        reducer), so the warning persists for the rest of the deliberation
+        even if some later event omits the flag.
+      */}
+      {council.containsPrivileged && (
+        <Card
+          role="alert"
+          aria-live="polite"
+          className="border-purple-500/60 bg-purple-500/10 ring-1 ring-purple-500/40"
+        >
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm flex items-center gap-2 text-purple-200">
+              <ShieldAlert className="h-4 w-4 text-purple-300" />
+              <span>⚠️ FOR YOUR EYES ONLY ⚠️</span>
+              <Badge variant="outline" className="text-[10px] gap-1 text-purple-200 border-purple-400/50">
+                <Lock className="h-3 w-3" />
+                Privileged
+              </Badge>
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-purple-100 leading-relaxed">
+              {council.privilegedWarning ??
+                "This deliberation included attorney-client privileged communications. Do not use this output in court filings, share with opposing parties, or quote externally without explicit privilege review. Treat as internal work product subject to attorney-client privilege."}
+            </p>
           </CardContent>
         </Card>
       )}

--- a/fortress-guest-platform/apps/command-center/src/lib/legal-types.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/legal-types.ts
@@ -52,6 +52,10 @@ export interface LegalCase {
   notes?: string | null;
   our_claim_basis?: string | null;
   days_remaining?: number | null;
+  // PR G — privilege architecture metadata
+  privileged_counsel_domains?: string[] | null;
+  related_matters?: string[] | null;
+  case_phase?: string | null;
 }
 
 export interface LegalDeadline {

--- a/fortress-guest-platform/apps/command-center/src/lib/use-council-stream.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/use-council-stream.ts
@@ -126,6 +126,11 @@ interface CouncilStreamState {
   finalResult: CouncilDonePayload | null;
   contextFrozen: CouncilContextFrozen | null;
   vaulted: CouncilVaulted | null;
+  // PR G — privilege tracking. The backend wrapper auto-injects
+  // contains_privileged on every SSE event so the UI can flip the warning
+  // banner the moment a privileged chunk is retrieved (not at end of run).
+  containsPrivileged: boolean;
+  privilegedWarning: string | null;
 }
 
 const MAX_EVENTS = 200;
@@ -144,6 +149,8 @@ const INITIAL_STATE: CouncilStreamState = {
   finalResult: null,
   contextFrozen: null,
   vaulted: null,
+  containsPrivileged: false,
+  privilegedWarning: null,
 };
 
 function isBrowser(): boolean {
@@ -393,6 +400,23 @@ export function useCouncilStream(
       };
 
       setState((current) => {
+        // PR G — every SSE event from run_council_deliberation auto-carries
+        // contains_privileged (legal_council.py wraps progress_callback so the
+        // flag is injected even on persona events). Once true, it stays true
+        // for the rest of the deliberation: a single privileged chunk earns
+        // the warning. Picks up privileged_warning from the `done` payload
+        // when present (it's also redundantly appended to consensus_summary
+        // for in-band rendering).
+        const eventContainsPrivileged =
+          payload.contains_privileged === true ||
+          payload.contains_privileged === "true";
+        const nextContainsPrivileged =
+          current.containsPrivileged || eventContainsPrivileged;
+        const nextPrivilegedWarning =
+          typeof payload.privileged_warning === "string"
+            ? payload.privileged_warning
+            : current.privilegedWarning;
+
         let next = {
           ...current,
           lastEventId: eventId ?? current.lastEventId,
@@ -400,6 +424,8 @@ export function useCouncilStream(
             ? String(payload.message ?? "Council stream error")
             : current.error,
           events: [...current.events, nextEvent].slice(-MAX_EVENTS),
+          containsPrivileged: nextContainsPrivileged,
+          privilegedWarning: nextPrivilegedWarning,
         };
 
         if (nextEvent.type === "session_start") {

--- a/fortress-guest-platform/backend/api/legal_cases.py
+++ b/fortress-guest-platform/backend/api/legal_cases.py
@@ -81,6 +81,53 @@ async def _assert_case_exists_if_supported(session, slug: str) -> None:
         raise HTTPException(status_code=404, detail=f"Case '{slug}' not found")
 
 
+async def _resolve_case_slug(session, slug: str) -> str:
+    """Resolve a case_slug, transparently following backward-compat aliases.
+
+    PR G renamed several case slugs (e.g. ``7il-v-knight-ndga`` →
+    ``7il-v-knight-ndga-i``) and recorded the old → new mapping in
+    ``legal.case_slug_aliases``. This helper preserves bookmarks and external
+    links by silently rewriting an old slug to its current canonical form
+    BEFORE downstream queries run. The URL stays at the old slug (no HTTP 301
+    redirect); only the data resolution is rewritten.
+
+    Strategy:
+      1. Fast path — if the slug exists in ``legal.cases``, return it unchanged.
+      2. Otherwise check ``legal.case_slug_aliases``. On a hit, log the
+         (old → new) pair so we can monitor how often legacy slugs are being
+         used after migration, then return the new slug.
+      3. Otherwise return the original slug (caller will 404 it on its own
+         lookup, preserving the existing 404 messaging).
+
+    Resolution is a single small SELECT on each branch. Idempotent: passing a
+    canonical slug returns it unchanged with no extra DB load on the alias
+    table beyond the original cases lookup.
+    """
+    case_r = await session.execute(
+        text("SELECT 1 FROM legal.cases WHERE case_slug = :s"),
+        {"s": slug},
+    )
+    if case_r.fetchone():
+        return slug
+
+    alias_r = await session.execute(
+        text("SELECT new_slug FROM legal.case_slug_aliases WHERE old_slug = :s"),
+        {"s": slug},
+    )
+    row = alias_r.fetchone()
+    if row:
+        new_slug = row[0]
+        logger.info(
+            "case_slug_alias_hit",
+            old_slug=slug,
+            new_slug=new_slug,
+            note="resolved transparently via legal.case_slug_aliases",
+        )
+        return new_slug
+
+    return slug
+
+
 def _compute_days_remaining(critical_date_str: str | None) -> int | None:
     if not critical_date_str:
         return None
@@ -172,6 +219,7 @@ async def list_cases():
 @router.get("/cases/{slug}", summary="Get case detail")
 async def get_case(slug: str):
     async with LegacySession() as session:
+        slug = await _resolve_case_slug(session, slug)
         result = await session.execute(
             text("SELECT * FROM legal.cases WHERE case_slug = :slug"),
             {"slug": slug},
@@ -219,6 +267,7 @@ async def get_case(slug: str):
 @router.get("/cases/{slug}/deadlines", summary="List deadlines for a case")
 async def list_deadlines(slug: str):
     async with LegacySession() as session:
+        slug = await _resolve_case_slug(session, slug)
         case_r = await session.execute(
             text("SELECT id FROM legal.cases WHERE case_slug = :slug"),
             {"slug": slug},
@@ -260,6 +309,7 @@ async def update_deadline(deadline_id: int, body: DeadlineUpdate):
 @router.get("/cases/{slug}/correspondence", summary="List correspondence for a case")
 async def list_correspondence(slug: str):
     async with LegacySession() as session:
+        slug = await _resolve_case_slug(session, slug)
         case_r = await session.execute(
             text("SELECT id FROM legal.cases WHERE case_slug = :slug"),
             {"slug": slug},
@@ -299,6 +349,7 @@ class CorrespondenceCreate(BaseModel):
 @router.post("/cases/{slug}/correspondence", summary="Create correspondence")
 async def create_correspondence(slug: str, body: CorrespondenceCreate):
     async with LegacySession() as session:
+        slug = await _resolve_case_slug(session, slug)
         case_r = await session.execute(
             text("SELECT id FROM legal.cases WHERE case_slug = :slug"),
             {"slug": slug},
@@ -542,6 +593,7 @@ async def download_case_file(slug: str, filename: str):
         raise HTTPException(status_code=400, detail="Invalid filename")
 
     async with LegacySession() as session:
+        slug = await _resolve_case_slug(session, slug)
         case_r = await session.execute(
             text("SELECT id, nas_layout FROM legal.cases WHERE case_slug = :slug"),
             {"slug": slug},
@@ -585,6 +637,7 @@ async def download_case_file(slug: str, filename: str):
 @router.get("/cases/{slug}/files", summary="List all files in a case's NAS vault")
 async def list_case_files(slug: str):
     async with LegacySession() as session:
+        slug = await _resolve_case_slug(session, slug)
         case_r = await session.execute(
             text("SELECT id, nas_layout FROM legal.cases WHERE case_slug = :slug"),
             {"slug": slug},
@@ -617,6 +670,7 @@ async def list_case_files(slug: str):
 @router.get("/cases/{slug}/timeline", summary="Unified case timeline")
 async def get_timeline(slug: str):
     async with LegacySession() as session:
+        slug = await _resolve_case_slug(session, slug)
         case_r = await session.execute(
             text("SELECT id FROM legal.cases WHERE case_slug = :slug"),
             {"slug": slug},
@@ -692,6 +746,7 @@ class WarRoomStateUpdate(BaseModel):
 @router.get("/cases/{slug}/state", summary="Get war room persistent state")
 async def get_war_room_state(slug: str):
     async with LegacySession() as session:
+        slug = await _resolve_case_slug(session, slug)
         result = await session.execute(
             text("SELECT active_brief, active_consensus FROM legal.cases WHERE case_slug = :slug"),
             {"slug": slug},
@@ -730,6 +785,7 @@ async def patch_war_room_state(slug: str, body: WarRoomStateUpdate):
     query = f"UPDATE legal.cases SET {', '.join(sets)} WHERE case_slug = :slug RETURNING id"
 
     async with LegacySession() as session:
+        slug = await _resolve_case_slug(session, slug)
         result = await session.execute(text(query), params)
         row = result.fetchone()
         await session.commit()
@@ -991,6 +1047,7 @@ async def _run_extraction_job(
     correspondence_id: int | None,
 ) -> None:
     async with LegacySession() as session:
+        slug = await _resolve_case_slug(session, slug)
         await session.execute(
             text("""
                 UPDATE legal.cases
@@ -1073,6 +1130,7 @@ async def _run_extraction_job(
 @router.post("/cases/{slug}/extract", summary="Queue entity extraction")
 async def trigger_extraction(slug: str, body: ExtractionRequest, background_tasks: BackgroundTasks):
     async with LegacySession() as session:
+        slug = await _resolve_case_slug(session, slug)
         case_r = await session.execute(
             text("SELECT id, notes FROM legal.cases WHERE case_slug = :slug"),
             {"slug": slug},
@@ -1314,6 +1372,7 @@ class SynthesizeRequest(BaseModel):
 @router.post("/cases/{slug}/synthesize", summary="Generate AI synthesis for a legal case")
 async def synthesize_case(slug: str, body: SynthesizeRequest):
     async with LegacySession() as session:
+        slug = await _resolve_case_slug(session, slug)
         case_r = await session.execute(text("SELECT * FROM legal.cases WHERE case_slug = :slug"), {"slug": slug})
         case_row = case_r.fetchone()
         if not case_row:

--- a/fortress-guest-platform/backend/services/legal_council.py
+++ b/fortress-guest-platform/backend/services/legal_council.py
@@ -1113,6 +1113,34 @@ def _dedupe_top(items: List[str], limit: int) -> List[str]:
 # legal_library has only 3 points (stale/legacy) — use legal_ediscovery for context freezing
 LEGAL_COLLECTION = "legal_ediscovery"
 
+# PR G — Council pulls from this collection in addition to LEGAL_COLLECTION when
+# COUNCIL_INCLUDE_PRIVILEGED_RETRIEVAL is enabled. Privileged chunks are kept
+# physically separate so the storage layer enforces the privileged track, not
+# just a payload tag.
+PRIVILEGED_COLLECTION = "legal_privileged_communications"
+
+# Warning block appended to deliberation output whenever any privileged chunk
+# was retrieved. Wording is exact per PR G spec; if you change it here, also
+# update apps/command-center deliberation-panel rendering and the runbook.
+FOR_YOUR_EYES_ONLY_WARNING = (
+    "⚠️ FOR YOUR EYES ONLY ⚠️\n"
+    "This deliberation included attorney-client privileged communications. "
+    "Do not use this output in court filings, share with opposing parties, "
+    "or quote externally without explicit privilege review. Treat as "
+    "internal work product subject to attorney-client privilege."
+)
+
+
+def _council_retrieval_flags() -> tuple[bool, bool]:
+    """Read COUNCIL_INCLUDE_PRIVILEGED_RETRIEVAL and COUNCIL_INCLUDE_RELATED_MATTERS
+    at *deliberation time* (not at startup). Both default to true. Either env var
+    can be flipped to "false" / "0" / "no" to disable mid-flight without a
+    restart — emergency containment if a privilege issue surfaces."""
+    def _truthy(name: str, default: bool = True) -> bool:
+        v = os.environ.get(name, "true" if default else "false").strip().lower()
+        return v not in ("false", "0", "no", "off", "")
+    return _truthy("COUNCIL_INCLUDE_PRIVILEGED_RETRIEVAL"), _truthy("COUNCIL_INCLUDE_RELATED_MATTERS")
+
 
 async def _embed_text(text: str) -> Optional[List[float]]:
     """Embed via Ollama OpenAI-compatible /v1/embeddings (backend.core.vector_db)."""
@@ -1192,6 +1220,114 @@ async def freeze_context(
         results[0].get("score", 0.0) if results else 0.0,
     )
     return vector_ids, context_chunks
+
+
+async def freeze_privileged_context(
+    case_brief: str,
+    top_k: int = 10,
+    case_slug: Optional[str] = None,
+) -> Tuple[List[str], List[str]]:
+    """PR G — Pillar 2 sibling: retrieve from legal_privileged_communications.
+
+    Mirrors freeze_context() but targets the privileged collection. Privileged
+    chunks are returned with a [PRIVILEGED] header marker so personas (and
+    later vault audits) can tell them apart from work-product chunks at a
+    glance.
+
+    Returns ([], []) on any failure — same fail-safe behavior as freeze_context.
+    """
+    logger.info(
+        "freeze_privileged_context_start  collection=%s  top_k=%d  case_slug=%s",
+        PRIVILEGED_COLLECTION, top_k, case_slug,
+    )
+
+    query_vec = await _embed_text(case_brief)
+    if query_vec is None:
+        return [], []
+
+    headers = {"api-key": _cfg.qdrant_api_key} if _cfg.qdrant_api_key else {}
+    body: Dict[str, Any] = {
+        "vector": query_vec,
+        "limit": top_k,
+        "with_payload": True,
+        "with_vector": False,
+    }
+    if case_slug:
+        body["filter"] = {"must": [{"key": "case_slug", "match": {"value": case_slug}}]}
+
+    try:
+        async with httpx.AsyncClient(timeout=15) as client:
+            resp = await client.post(
+                f"{_cfg.qdrant_url.rstrip('/')}/collections/{PRIVILEGED_COLLECTION}/points/search",
+                json=body,
+                headers=headers,
+            )
+            resp.raise_for_status()
+            results = resp.json().get("result", [])
+    except Exception as e:
+        logger.warning("freeze_privileged_context_qdrant_failed  error=%s", str(e)[:200])
+        return [], []
+
+    vector_ids: List[str] = []
+    context_chunks: List[str] = []
+    for pt in results:
+        point_id = str(pt.get("id", ""))
+        payload = pt.get("payload", {})
+        text = payload.get("text", "")
+        if not (point_id and text):
+            continue
+        vector_ids.append(point_id)
+        source = payload.get("file_name", payload.get("source_file", "unknown"))
+        domain = payload.get("privileged_counsel_domain") or "unknown-counsel"
+        role = payload.get("role") or "unknown-role"
+        # Mark every chunk visibly so personas + vault audits can see at a
+        # glance that this chunk came from the privileged collection.
+        context_chunks.append(
+            f"[PRIVILEGED · {domain} · {role}] [{source}] {text}"
+        )
+
+    logger.info(
+        "freeze_privileged_context_complete  vectors=%d  chunks=%d  case_slug=%s",
+        len(vector_ids), len(context_chunks), case_slug,
+    )
+    return vector_ids, context_chunks
+
+
+async def _resolve_related_matters_slugs(case_slug: str) -> List[str]:
+    """Look up the case's related_matters JSONB array from legal.cases.
+    Returns the list of related case_slug strings (excluding the case itself).
+    Empty list on any failure or when the column is absent / empty."""
+    if not case_slug:
+        return []
+    try:
+        from backend.services.ediscovery_agent import LegacySession
+        from sqlalchemy import text as sa_text
+        async with LegacySession() as db:
+            r = await db.execute(
+                sa_text(
+                    "SELECT related_matters FROM legal.cases WHERE case_slug = :s"
+                ),
+                {"s": case_slug},
+            )
+            row = r.fetchone()
+        if not row or not row[0]:
+            return []
+        raw = row[0]
+        # asyncpg returns JSONB as already-deserialized list/dict
+        if isinstance(raw, list):
+            related = raw
+        elif isinstance(raw, str):
+            try:
+                related = json.loads(raw)
+            except (ValueError, TypeError):
+                return []
+        else:
+            return []
+        return [s for s in related if isinstance(s, str) and s and s != case_slug]
+    except Exception as exc:
+        logger.warning("resolve_related_matters_failed  case=%s  err=%s",
+                       case_slug, str(exc)[:200])
+        return []
 
 
 def _format_caselaw_citation(payload: Dict[str, Any]) -> str:
@@ -1536,12 +1672,60 @@ async def run_council_deliberation(
         caselaw_chunks_raw, evidence_chunks_raw, CONTEXT_BUDGET_TOKENS,
     )
 
+    # ── PR G: privileged retrieval + related_matters expansion ────────
+    # Both flags are read NOW (not at module load) so an operator can flip
+    # them off mid-flight via env var without a backend restart — emergency
+    # containment if a privilege issue surfaces.
+    include_privileged, include_related_matters = _council_retrieval_flags()
+
+    # Expand the case_slug list with related_matters if enabled.
+    case_slugs_for_retrieval: List[str] = [case_slug] if case_slug else []
+    related_slugs: List[str] = []
+    if include_related_matters and case_slug:
+        related_slugs = await _resolve_related_matters_slugs(case_slug)
+        case_slugs_for_retrieval.extend(related_slugs)
+
+    privileged_vector_ids: List[str] = []
+    privileged_chunks: List[str] = []
+    if include_privileged:
+        for slug_for_priv in case_slugs_for_retrieval:
+            v_ids, chunks = await freeze_privileged_context(
+                case_brief, top_k=10, case_slug=slug_for_priv,
+            )
+            privileged_vector_ids.extend(v_ids)
+            privileged_chunks.extend(chunks)
+
+    contains_privileged: bool = len(privileged_chunks) > 0
+
+    # Wrap progress_callback so EVERY downstream event automatically carries
+    # the contains_privileged flag (per PR G spec — UI needs to render the
+    # FOR YOUR EYES ONLY warning the moment a privileged chunk is retrieved,
+    # not just at end-of-deliberation). Existing callback dicts are left
+    # alone; the wrapper only sets the key when not already present.
+    _orig_progress_callback = progress_callback
+    if _orig_progress_callback is not None:
+        async def _privilege_aware_callback(event: Dict[str, Any]) -> None:
+            event.setdefault("contains_privileged", contains_privileged)
+            await _orig_progress_callback(event)
+        progress_callback = _privilege_aware_callback
+
     frozen_context = assemble_frozen_context(caselaw_chunks, evidence_chunks, context)
+    if privileged_chunks:
+        # Append privileged chunks to the frozen context so personas have
+        # them in their working set for this deliberation. They are visibly
+        # marked with [PRIVILEGED · domain · role] tags by
+        # freeze_privileged_context.
+        priv_block = "\n\n".join(privileged_chunks)
+        frozen_context = (
+            f"{frozen_context}\n\n=== PRIVILEGED COMMUNICATIONS ===\n{priv_block}"
+        )
 
     # Vault receives both sets of identifiers so audits can verify citation
     # grounding. Caselaw refs are prefixed "caselaw:{opinion_id}:{chunk_index}".
-    vector_ids = list(evidence_vector_ids) + list(caselaw_refs)
-    context_chunks = list(caselaw_chunks) + list(evidence_chunks)
+    # Privileged vector ids are recorded too — vault is internal to Fortress
+    # and is allowed to know which privileged points fed a deliberation.
+    vector_ids = list(evidence_vector_ids) + list(caselaw_refs) + list(privileged_vector_ids)
+    context_chunks = list(caselaw_chunks) + list(evidence_chunks) + list(privileged_chunks)
 
     if progress_callback:
         await progress_callback({
@@ -1553,6 +1737,13 @@ async def run_council_deliberation(
             "caselaw_chunk_count": len(caselaw_chunks),
             "caselaw_collection": CASELAW_COLLECTION,
             "context_budget_tokens": CONTEXT_BUDGET_TOKENS,
+            # PR G — privileged retrieval + related-matters telemetry
+            "privileged_vector_count": len(privileged_vector_ids),
+            "privileged_chunk_count": len(privileged_chunks),
+            "privileged_collection": PRIVILEGED_COLLECTION,
+            "include_privileged_retrieval": include_privileged,
+            "include_related_matters": include_related_matters,
+            "related_matters_slugs": related_slugs,
         })
 
     # ── Pillar 4: Roster Snapshot ─────────────────────────────────────
@@ -1661,6 +1852,20 @@ async def run_council_deliberation(
         "opinions": [o.to_dict() for o in opinions],
         **consensus,
     }
+
+    # PR G — surface the privilege state on the final result + append the
+    # FOR YOUR EYES ONLY warning block when any privileged chunk was retrieved.
+    # Both the structured flag and the warning text are needed: the structured
+    # flag drives UI rendering, the text block ensures any rendered/exported
+    # surface (PDF, copy-paste, downstream pipeline) carries the warning.
+    result["contains_privileged"] = contains_privileged
+    if contains_privileged:
+        result["privileged_warning"] = FOR_YOUR_EYES_ONLY_WARNING
+        existing_summary = result.get("consensus_summary") or ""
+        result["consensus_summary"] = (
+            (existing_summary + "\n\n" if existing_summary else "")
+            + FOR_YOUR_EYES_ONLY_WARNING
+        )
 
     # ── Pillar 3 + 4: Cryptographic Vault ─────────────────────────────
     event_id = None

--- a/fortress-guest-platform/backend/services/legal_ediscovery.py
+++ b/fortress-guest-platform/backend/services/legal_ediscovery.py
@@ -9,13 +9,16 @@ case graph or Qdrant search index.
 """
 from __future__ import annotations
 
+import email
+import email.policy
 import hashlib
 import json
 import time
 import structlog
 from datetime import datetime, timezone
 from pathlib import Path
-from uuid import uuid4
+from typing import Optional
+from uuid import UUID, uuid4, uuid5
 
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import text
@@ -32,12 +35,33 @@ logger = structlog.get_logger()
 NAS_VAULT_ROOT = Path("/mnt/fortress_nas/legal_vault")
 LOCAL_VAULT_FALLBACK = Path("/home/admin/Fortress-Prime/data/legal_vault")
 QDRANT_COLLECTION = "legal_ediscovery"
+# PR G — privileged communications go to a physically separate collection so
+# Council retrieval can distinguish work product from privileged content at
+# the storage layer, not just by payload tag.
+QDRANT_PRIVILEGED_COLLECTION = "legal_privileged_communications"
 QDRANT_URL = settings.qdrant_url.rstrip("/")
 EMBED_URL = f"{settings.embed_base_url.rstrip('/')}/api/embeddings"
 EMBED_MODEL = settings.embed_model
 
 SWARM_ENDPOINT = f"{settings.ollama_base_url.rstrip('/')}/v1/chat/completions"
 SWARM_MODEL = settings.ollama_fast_model
+
+# UUID5 namespace for deterministic Qdrant point IDs in the privileged
+# collection. Keyed on (file_hash, chunk_index) so re-runs of the same file
+# upsert to the same point IDs (idempotent), and never produce duplicates.
+_QDRANT_PRIVILEGED_NS = UUID("f0a17e55-7c0d-4d1f-8c5a-d3b4f0e9a200")
+
+# Maps a privileged-counsel email domain to its case-specific attorney_role tag.
+# Source of truth: pr_f_classification_rules.md (v6/v7). Update there first.
+_DOMAIN_TO_ROLE: dict[str, str] = {
+    "mhtlegal.com":        "case_i_phase_1_filing_to_depositions",
+    "fgplaw.com":          "case_i_phase_2_trial_and_general_counsel",
+    "masp-lawfirm.com":    "case_i_trial_cocounsel_and_vanderburge_counsel",
+    "dralaw.com":          "post_judgment_closing_counsel",
+    "wilsonhamilton.com":  "original_transaction_closing_counsel",
+    "wilsonpruittlaw.com": "original_transaction_closing_counsel",
+}
+_KNOWN_PRIVILEGED_DOMAINS = tuple(_DOMAIN_TO_ROLE.keys())
 
 
 # ── Pydantic: Privilege Classification ────────────────────────────
@@ -317,6 +341,126 @@ async def _upsert_to_qdrant(
         return 0
 
 
+# ── Privileged-track helpers (PR G) ───────────────────────────────
+
+def _derive_privileged_counsel_domain(
+    file_bytes: bytes,
+    file_name: str,
+    mime_type: str,
+    raw_text: str,
+) -> Optional[str]:
+    """Return the privileged-counsel email domain that this document was sent to or
+    from, if one of _KNOWN_PRIVILEGED_DOMAINS matches. Returns None when no match.
+
+    Strategy:
+      1. If the file is an email (.eml / message/rfc822), parse RFC-822 headers
+         and look for a privileged domain in From/To/Cc.
+      2. Otherwise, scan the first ~16 KB of extracted text for a privileged
+         domain substring. (PDFs, .docx etc. — names + email addresses commonly
+         appear in headers, signatures, recipient blocks.)
+    """
+    is_email = (
+        "rfc822" in (mime_type or "").lower()
+        or file_name.lower().endswith(".eml")
+    )
+    if is_email:
+        try:
+            msg = email.message_from_bytes(
+                file_bytes, policy=email.policy.default
+            )
+            addrs = " ".join(
+                str(msg.get(h, "") or "") for h in ("From", "To", "Cc", "Bcc", "Reply-To")
+            ).lower()
+            for d in _KNOWN_PRIVILEGED_DOMAINS:
+                if d in addrs:
+                    return d
+        except Exception:
+            pass
+
+    sample = (raw_text or "")[:16384].lower()
+    for d in _KNOWN_PRIVILEGED_DOMAINS:
+        if d in sample:
+            return d
+    return None
+
+
+def _role_for_counsel_domain(domain: Optional[str]) -> Optional[str]:
+    """Map a privileged-counsel domain to its case-specific attorney_role tag.
+    Returns None when domain is None or unmapped."""
+    if not domain:
+        return None
+    return _DOMAIN_TO_ROLE.get(domain.lower())
+
+
+async def _upsert_to_qdrant_privileged(
+    *,
+    doc_id: str,
+    case_slug: str,
+    file_name: str,
+    file_hash: str,
+    privileged_counsel_domain: Optional[str],
+    role: Optional[str],
+    privilege_type: Optional[str],
+    chunks: list[str],
+    vectors: list[list[float]],
+) -> int:
+    """Upsert privileged chunks to the legal_privileged_communications collection.
+
+    Point IDs use UUID5 keyed on (file_hash, chunk_index) so re-runs of the
+    same physical file produce the same point IDs (idempotent upsert; never
+    duplicates points across runs).
+
+    Payload schema per PR G spec:
+      case_slug, document_id, file_name, file_hash, chunk_num, chunk_index,
+      text (≤1000 chars), privileged=true, privileged_counsel_domain, role,
+      privilege_type, ingested_at (UTC ISO-8601).
+    """
+    points: list[dict] = []
+    ingested_at = datetime.now(timezone.utc).isoformat()
+    for idx, (chunk, vector) in enumerate(zip(chunks, vectors)):
+        if not vector:
+            continue
+        point_id = str(uuid5(_QDRANT_PRIVILEGED_NS, f"{file_hash}:{idx}"))
+        points.append({
+            "id": point_id,
+            "vector": vector,
+            "payload": {
+                "case_slug": case_slug,
+                "document_id": doc_id,
+                "file_name": file_name,
+                "file_hash": file_hash,
+                "chunk_num": idx,
+                "chunk_index": idx,
+                "text": chunk[:1000],
+                "privileged": True,
+                "privileged_counsel_domain": privileged_counsel_domain,
+                "role": role,
+                "privilege_type": privilege_type,
+                "ingested_at": ingested_at,
+            },
+        })
+
+    if not points:
+        return 0
+
+    try:
+        resp = await shared_client.put(
+            f"{QDRANT_URL}/collections/{QDRANT_PRIVILEGED_COLLECTION}/points",
+            json={"points": points},
+            timeout=60.0,
+        )
+        resp.raise_for_status()
+        return len(points)
+    except Exception as exc:
+        logger.warning(
+            "qdrant_privileged_upsert_failed",
+            error=str(exc)[:200],
+            doc_id=doc_id,
+            case_slug=case_slug,
+        )
+        return 0
+
+
 # ── Main Ingestion Pipeline ──────────────────────────────────────
 
 async def process_vault_upload(
@@ -416,6 +560,7 @@ async def process_vault_upload(
         classification, priv_latency = await _classify_privilege(raw_text, file_name)
 
         if classification.is_privileged and classification.confidence >= 0.7:
+            # 1. Persist the privilege-log row (existing behavior)
             await _log_privilege(
                 db=db,
                 doc_id=doc_id,
@@ -426,6 +571,58 @@ async def process_vault_upload(
                 latency_ms=priv_latency,
                 snippet=raw_text[:2000],
             )
+
+            # 2. PR G — chunk + embed + upsert into the privileged collection.
+            #    Privileged content STILL gets vectorized so privileged Council
+            #    retrieval can surface it ("for-your-eyes-only" track), but the
+            #    physical store is segregated from work-product (legal_ediscovery).
+            counsel_domain = _derive_privileged_counsel_domain(
+                file_bytes=file_bytes,
+                file_name=file_name,
+                mime_type=mime_type,
+                raw_text=raw_text,
+            )
+            role_tag = _role_for_counsel_domain(counsel_domain)
+
+            priv_chunks = _chunk_document(raw_text)
+            priv_vectors = await _embed_chunks(priv_chunks)
+            priv_indexed = await _upsert_to_qdrant_privileged(
+                doc_id=doc_id,
+                case_slug=case_slug,
+                file_name=file_name,
+                file_hash=fhash,
+                privileged_counsel_domain=counsel_domain,
+                role=role_tag,
+                privilege_type=classification.privilege_type,
+                chunks=priv_chunks,
+                vectors=priv_vectors,
+            )
+
+            # 3. Flip the vault_documents row to its terminal locked_privileged
+            #    state with chunk_count populated (parity with the work-product
+            #    'completed' branch below).
+            await db.execute(
+                text(
+                    "UPDATE legal.vault_documents "
+                    "SET processing_status = 'locked_privileged', chunk_count = :cc "
+                    "WHERE id = :id"
+                ),
+                {"id": doc_id, "cc": len(priv_chunks)},
+            )
+            await db.commit()
+
+            logger.info(
+                "vault_upload_locked_privileged",
+                doc_id=doc_id,
+                case_slug=case_slug,
+                file_name=file_name,
+                privilege_type=classification.privilege_type,
+                privileged_counsel_domain=counsel_domain,
+                role=role_tag,
+                chunks=len(priv_chunks),
+                vectors_indexed=priv_indexed,
+            )
+
             return {
                 "status": "locked_privileged",
                 "document_id": doc_id,
@@ -434,6 +631,10 @@ async def process_vault_upload(
                 "privilege_type": classification.privilege_type,
                 "confidence": classification.confidence,
                 "reasoning": classification.reasoning,
+                "privileged_counsel_domain": counsel_domain,
+                "role": role_tag,
+                "chunks": len(priv_chunks),
+                "vectors_indexed": priv_indexed,
             }
 
         # ── Email Threading & Dedupe (CSV email archives) ─────

--- a/fortress-guest-platform/backend/tests/test_legal_7il_restructure.py
+++ b/fortress-guest-platform/backend/tests/test_legal_7il_restructure.py
@@ -1,0 +1,927 @@
+"""PR G — 7IL restructure + privilege architecture tests.
+
+Coverage targets:
+  Schema (legal.cases new columns + legal.case_slug_aliases + FK deferrable):
+    * test_legal_cases_has_new_columns
+    * test_case_slug_aliases_table_present
+    * test_fk_vault_documents_case_slug_now_deferrable
+    * test_related_matters_jsonb_array_round_trip
+    * test_privileged_counsel_domains_jsonb_array_round_trip
+    * test_case_phase_column_round_trip
+    * test_alias_fk_prevents_orphan_new_slug
+
+  Alias resolution (transparent, with telemetry):
+    * test_resolve_case_slug_returns_canonical_when_exists
+    * test_resolve_case_slug_follows_alias_when_old_slug_queried
+    * test_resolve_case_slug_returns_input_when_no_match
+      (this is also "test_alias_resolution_handles_missing_alias")
+    * test_resolve_case_slug_logs_each_alias_hit
+
+  Council retrieval (env-var-gated, related-matters expansion, fail-soft):
+    * test_council_retrieval_flags_default_true
+    * test_council_retrieval_flags_disabled_via_env
+    * test_council_retrieval_flags_read_at_call_time
+    * test_resolve_related_matters_handles_jsonb_list
+    * test_resolve_related_matters_excludes_self_reference
+    * test_resolve_related_matters_handles_null_column
+    * test_resolve_related_matters_handles_malformed_jsonb
+    * test_freeze_privileged_context_targets_correct_collection
+    * test_freeze_privileged_context_filters_by_case_slug
+    * test_freeze_privileged_context_tags_chunks_with_privileged_marker
+    * test_freeze_privileged_context_fail_soft_on_qdrant_error
+      (covers the "what if collection doesn't exist" failure mode)
+
+  Privileged ingestion routing (process_vault_upload):
+    * test_process_vault_upload_routes_privileged_to_separate_collection
+    * test_process_vault_upload_non_privileged_uses_work_product_collection
+    * test_upsert_to_qdrant_privileged_uses_uuid5_deterministic_ids
+    * test_privileged_collection_payload_dual_field_chunk_num_and_chunk_index
+    * test_derive_privileged_counsel_domain_from_eml_headers
+    * test_derive_privileged_counsel_domain_returns_none_when_no_match
+    * test_role_for_counsel_domain_maps_correctly
+
+Tests against fortress_shadow_test only — synthetic case slugs (test-case-i,
+test-case-ii). No production data is read or modified.
+"""
+from __future__ import annotations
+
+import os
+import re
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid5
+
+import psycopg2
+import pytest
+
+import run  # noqa: F401  — registers settings + sys.path
+import backend.services.legal_ediscovery as legal_ediscovery
+from backend.services.legal_ediscovery import (
+    _DOMAIN_TO_ROLE,
+    _QDRANT_PRIVILEGED_NS,
+    QDRANT_COLLECTION,
+    QDRANT_PRIVILEGED_COLLECTION,
+    _derive_privileged_counsel_domain,
+    _role_for_counsel_domain,
+    _upsert_to_qdrant_privileged,
+)
+
+
+# ─── DB connection helpers ──────────────────────────────────────────
+
+
+def _admin_test_dsn() -> dict:
+    """fortress_admin connection (DDL access for schema tests)."""
+    uri = os.environ.get("POSTGRES_ADMIN_URI", "")
+    m = re.match(
+        r"postgresql(?:\+\w+)?://([^:]+):([^@]+)@([^:/]+):?(\d+)?/[^?]+",
+        uri,
+    )
+    if not m:
+        pytest.skip("POSTGRES_ADMIN_URI not set; can't run DDL-required tests")
+    user, pw, host, port = m.groups()
+    return {"host": host, "port": int(port or 5432), "user": user,
+            "password": pw, "dbname": "fortress_shadow_test"}
+
+
+@pytest.fixture
+def shadow_test_conn():
+    """psycopg2 connection to fortress_shadow_test as fortress_admin (DDL access).
+    Yields connection; rolls back at end so tests don't pollute the DB."""
+    conn = psycopg2.connect(**_admin_test_dsn())
+    conn.autocommit = False
+    yield conn
+    try:
+        conn.rollback()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def synthetic_cases(shadow_test_conn):
+    """Insert two synthetic case rows (test-case-i and test-case-ii) inside the
+    test transaction. Auto-cleaned via the parent fixture's rollback."""
+    cur = shadow_test_conn.cursor()
+    # Wipe any leftover rows from prior failed runs — uses the same synthetic
+    # slugs only.
+    cur.execute("""
+        DELETE FROM legal.case_slug_aliases
+         WHERE old_slug IN ('test-old-slug', 'test-case-i') OR new_slug IN ('test-case-i','test-case-ii')
+    """)
+    cur.execute("""
+        DELETE FROM legal.vault_documents
+         WHERE case_slug IN ('test-case-i','test-case-ii')
+    """)
+    cur.execute("""
+        DELETE FROM legal.cases
+         WHERE case_slug IN ('test-case-i','test-case-ii','test-deleted-case')
+    """)
+    cur.execute("""
+        INSERT INTO legal.cases (
+            case_slug, case_number, case_name, case_type, our_role, status,
+            case_phase, related_matters, privileged_counsel_domains
+        ) VALUES
+          ('test-case-i',  '1:99-cv-99999-XXX', 'Test Case I',  'civil',
+           'defendant', 'closed_judgment_against', 'closed',
+           '["test-case-ii"]'::jsonb,
+           '["mhtlegal.com","fgplaw.com"]'::jsonb),
+          ('test-case-ii', '1:99-cv-99998-XXX', 'Test Case II', 'civil',
+           'defendant_pro_se', 'active', 'counsel_search',
+           '["test-case-i"]'::jsonb,
+           '[]'::jsonb)
+    """)
+    shadow_test_conn.commit()    # commit fixtures so other connections (helper queries) can see
+    yield shadow_test_conn
+    cur = shadow_test_conn.cursor()
+    cur.execute("""
+        DELETE FROM legal.case_slug_aliases
+         WHERE old_slug IN ('test-old-slug') OR new_slug IN ('test-case-i','test-case-ii')
+    """)
+    cur.execute("""
+        DELETE FROM legal.vault_documents
+         WHERE case_slug IN ('test-case-i','test-case-ii')
+    """)
+    cur.execute("""
+        DELETE FROM legal.cases
+         WHERE case_slug IN ('test-case-i','test-case-ii','test-deleted-case')
+    """)
+    shadow_test_conn.commit()
+
+
+# ════════════════════════════════════════════════════════════════════
+# Schema migration verification (Phase B)
+# ════════════════════════════════════════════════════════════════════
+
+
+def test_legal_cases_has_new_columns(shadow_test_conn) -> None:
+    """case_phase TEXT, related_matters JSONB, privileged_counsel_domains JSONB."""
+    cur = shadow_test_conn.cursor()
+    cur.execute("""
+        SELECT column_name, data_type
+          FROM information_schema.columns
+         WHERE table_schema='legal' AND table_name='cases'
+           AND column_name IN ('case_phase','related_matters','privileged_counsel_domains')
+         ORDER BY column_name
+    """)
+    rows = cur.fetchall()
+    assert ("case_phase", "text") in rows
+    assert ("privileged_counsel_domains", "jsonb") in rows
+    assert ("related_matters", "jsonb") in rows
+
+
+def test_case_slug_aliases_table_present(shadow_test_conn) -> None:
+    cur = shadow_test_conn.cursor()
+    cur.execute(
+        "SELECT to_regclass('legal.case_slug_aliases') IS NOT NULL"
+    )
+    assert cur.fetchone()[0] is True
+
+    # PK on old_slug + FK on new_slug → legal.cases(case_slug)
+    cur.execute("""
+        SELECT a.attname, c.contype
+          FROM pg_constraint c
+          JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ANY(c.conkey)
+         WHERE c.conrelid = 'legal.case_slug_aliases'::regclass
+         ORDER BY c.contype, a.attname
+    """)
+    rows = cur.fetchall()
+    # Should have a primary key constraint on old_slug and a foreign key on new_slug
+    assert ("old_slug", "p") in rows  # primary
+    assert ("new_slug", "f") in rows  # foreign
+
+
+def test_fk_vault_documents_case_slug_now_deferrable(shadow_test_conn) -> None:
+    """Phase B made the FK deferrable (default-immediate) so the rename
+    transaction in Phase C could SET CONSTRAINTS DEFERRED."""
+    cur = shadow_test_conn.cursor()
+    cur.execute("""
+        SELECT condeferrable
+          FROM pg_constraint
+         WHERE conname = 'fk_vault_documents_case_slug'
+    """)
+    row = cur.fetchone()
+    assert row is not None
+    assert row[0] is True
+
+
+def test_related_matters_jsonb_array_round_trip(synthetic_cases) -> None:
+    """A JSONB list survives INSERT → SELECT round-trip as a Python list."""
+    cur = synthetic_cases.cursor()
+    cur.execute(
+        "SELECT related_matters FROM legal.cases WHERE case_slug=%s",
+        ("test-case-i",),
+    )
+    val = cur.fetchone()[0]
+    # psycopg2 auto-decodes jsonb to Python list/dict
+    assert isinstance(val, list)
+    assert val == ["test-case-ii"]
+
+
+def test_privileged_counsel_domains_jsonb_array_round_trip(synthetic_cases) -> None:
+    cur = synthetic_cases.cursor()
+    cur.execute(
+        "SELECT privileged_counsel_domains FROM legal.cases WHERE case_slug=%s",
+        ("test-case-i",),
+    )
+    val = cur.fetchone()[0]
+    assert isinstance(val, list)
+    assert "mhtlegal.com" in val
+    assert "fgplaw.com" in val
+    assert len(val) == 2
+
+
+def test_case_phase_column_round_trip(synthetic_cases) -> None:
+    cur = synthetic_cases.cursor()
+    cur.execute(
+        "SELECT case_phase FROM legal.cases WHERE case_slug IN ('test-case-i','test-case-ii') ORDER BY case_slug"
+    )
+    rows = [r[0] for r in cur.fetchall()]
+    assert rows == ["closed", "counsel_search"]
+
+
+def test_alias_fk_prevents_orphan_new_slug(synthetic_cases) -> None:
+    """legal.case_slug_aliases.new_slug FK → legal.cases(case_slug) blocks orphans."""
+    cur = synthetic_cases.cursor()
+    with pytest.raises(psycopg2.errors.ForeignKeyViolation):
+        cur.execute(
+            "INSERT INTO legal.case_slug_aliases (old_slug, new_slug) "
+            "VALUES (%s, %s)",
+            ("test-old-slug", "nonexistent-case-slug"),
+        )
+        synthetic_cases.commit()
+    synthetic_cases.rollback()
+
+
+# ════════════════════════════════════════════════════════════════════
+# Alias resolution (legal_cases.py::_resolve_case_slug)
+# ════════════════════════════════════════════════════════════════════
+
+# Import the resolver via the api module
+from backend.api.legal_cases import _resolve_case_slug  # noqa: E402
+
+
+class _FakeResult:
+    """Minimal SQLAlchemy Result stand-in for resolver tests."""
+    def __init__(self, value=None):
+        self._value = value
+    def fetchone(self):
+        return (self._value,) if self._value is not None else None
+
+
+def _make_session(query_results: list):
+    """AsyncMock session whose execute() returns query_results in order."""
+    db = AsyncMock()
+    rs = list(query_results)
+    async def _exec(_stmt, _params=None):
+        return rs.pop(0) if rs else _FakeResult(None)
+    db.execute = _exec
+    return db
+
+
+@pytest.mark.asyncio
+async def test_resolve_case_slug_returns_canonical_when_exists() -> None:
+    """Fast path — slug exists in legal.cases, no alias lookup needed."""
+    db = _make_session([_FakeResult(value=1)])  # SELECT 1 hits the cases row
+    out = await _resolve_case_slug(db, "test-case-i")
+    assert out == "test-case-i"
+
+
+@pytest.mark.asyncio
+async def test_resolve_case_slug_follows_alias_when_old_slug_queried() -> None:
+    """Cases lookup misses → alias lookup hits → return new_slug."""
+    db = _make_session([
+        _FakeResult(value=None),                    # cases miss
+        _FakeResult(value="test-case-i"),           # alias points at -i
+    ])
+    out = await _resolve_case_slug(db, "test-old-slug")
+    assert out == "test-case-i"
+
+
+@pytest.mark.asyncio
+async def test_resolve_case_slug_returns_input_when_no_match() -> None:
+    """Both queries miss → return the original slug unchanged. (Caller will 404.)
+    This exercises the 'alias points at deleted case_slug' edge case too:
+    if the alias row was deleted but the bookmark remained, the resolver
+    returns the original slug and the caller raises 404 on its own SELECT."""
+    db = _make_session([
+        _FakeResult(value=None),  # cases miss
+        _FakeResult(value=None),  # alias miss
+    ])
+    out = await _resolve_case_slug(db, "totally-unknown-slug")
+    assert out == "totally-unknown-slug"
+
+
+@pytest.mark.asyncio
+async def test_resolve_case_slug_logs_each_alias_hit() -> None:
+    """Verify the case_slug_alias_hit log fires (so we can deprecate old slugs
+    once usage drops to zero per spec)."""
+    db = _make_session([
+        _FakeResult(value=None),                     # cases miss
+        _FakeResult(value="test-case-i"),            # alias hit
+    ])
+    with patch("backend.api.legal_cases.logger") as mock_logger:
+        await _resolve_case_slug(db, "test-old-slug")
+        mock_logger.info.assert_called_once()
+        args, kwargs = mock_logger.info.call_args
+        assert args[0] == "case_slug_alias_hit"
+        assert kwargs.get("old_slug") == "test-old-slug"
+        assert kwargs.get("new_slug") == "test-case-i"
+
+
+@pytest.mark.asyncio
+async def test_resolve_case_slug_does_not_log_on_canonical_path() -> None:
+    """Canonical path (no alias used) must NOT emit case_slug_alias_hit
+    or telemetry won't be meaningful."""
+    db = _make_session([_FakeResult(value=1)])
+    with patch("backend.api.legal_cases.logger") as mock_logger:
+        await _resolve_case_slug(db, "test-case-i")
+        for call in mock_logger.info.call_args_list:
+            assert call.args[0] != "case_slug_alias_hit"
+
+
+# ════════════════════════════════════════════════════════════════════
+# Council retrieval flags + related_matters resolution
+# ════════════════════════════════════════════════════════════════════
+
+from backend.services.legal_council import (  # noqa: E402
+    PRIVILEGED_COLLECTION as COUNCIL_PRIV_COLLECTION,
+    _council_retrieval_flags,
+    _resolve_related_matters_slugs,
+    freeze_privileged_context,
+)
+
+
+def test_council_retrieval_flags_default_true(monkeypatch) -> None:
+    """Both flags default to true when env vars are unset."""
+    monkeypatch.delenv("COUNCIL_INCLUDE_PRIVILEGED_RETRIEVAL", raising=False)
+    monkeypatch.delenv("COUNCIL_INCLUDE_RELATED_MATTERS", raising=False)
+    incl_priv, incl_rel = _council_retrieval_flags()
+    assert incl_priv is True
+    assert incl_rel is True
+
+
+def test_council_retrieval_flags_disabled_via_env(monkeypatch) -> None:
+    """false / 0 / no / off all disable the flag (case-insensitive)."""
+    for falsy in ("false", "0", "no", "off", "False", "FALSE", "Off"):
+        monkeypatch.setenv("COUNCIL_INCLUDE_PRIVILEGED_RETRIEVAL", falsy)
+        monkeypatch.setenv("COUNCIL_INCLUDE_RELATED_MATTERS", falsy)
+        incl_priv, incl_rel = _council_retrieval_flags()
+        assert incl_priv is False, f"expected false for {falsy!r}"
+        assert incl_rel is False, f"expected false for {falsy!r}"
+
+
+def test_council_retrieval_flags_read_at_call_time(monkeypatch) -> None:
+    """Per spec — must be readable mid-flight without a restart."""
+    monkeypatch.setenv("COUNCIL_INCLUDE_PRIVILEGED_RETRIEVAL", "true")
+    assert _council_retrieval_flags()[0] is True
+    monkeypatch.setenv("COUNCIL_INCLUDE_PRIVILEGED_RETRIEVAL", "false")
+    assert _council_retrieval_flags()[0] is False
+    monkeypatch.setenv("COUNCIL_INCLUDE_PRIVILEGED_RETRIEVAL", "true")
+    assert _council_retrieval_flags()[0] is True
+
+
+@pytest.mark.asyncio
+async def test_resolve_related_matters_handles_jsonb_list(monkeypatch) -> None:
+    """Happy path — column has a JSON array of slugs, returns the list."""
+    fake_session = AsyncMock()
+    async def _exec(_stmt, _params):
+        return _FakeResult(value=["test-case-ii", "test-case-iii"])
+    fake_session.execute = _exec
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=False)
+
+    monkeypatch.setattr(
+        "backend.services.ediscovery_agent.LegacySession",
+        lambda: fake_session,
+    )
+    out = await _resolve_related_matters_slugs("test-case-i")
+    assert out == ["test-case-ii", "test-case-iii"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_related_matters_excludes_self_reference(monkeypatch) -> None:
+    """A misconfigured row that lists the case's own slug — filtered out."""
+    fake_session = AsyncMock()
+    async def _exec(_stmt, _params):
+        return _FakeResult(value=["test-case-i", "test-case-ii"])
+    fake_session.execute = _exec
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=False)
+    monkeypatch.setattr(
+        "backend.services.ediscovery_agent.LegacySession",
+        lambda: fake_session,
+    )
+    out = await _resolve_related_matters_slugs("test-case-i")
+    assert "test-case-i" not in out
+    assert out == ["test-case-ii"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_related_matters_handles_null_column(monkeypatch) -> None:
+    """NULL or empty JSONB → empty list (not crash)."""
+    fake_session = AsyncMock()
+    async def _exec(_stmt, _params):
+        return _FakeResult(value=None)
+    fake_session.execute = _exec
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=False)
+    monkeypatch.setattr(
+        "backend.services.ediscovery_agent.LegacySession",
+        lambda: fake_session,
+    )
+    out = await _resolve_related_matters_slugs("test-case-i")
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_related_matters_handles_malformed_jsonb(monkeypatch) -> None:
+    """Non-list values (dict, scalar, None-in-list) → empty / filtered, no crash."""
+    for bad_value in ({"not": "a list"}, "scalar string", 42):
+        fake_session = AsyncMock()
+        async def _exec(_stmt, _params, _v=bad_value):
+            return _FakeResult(value=_v)
+        fake_session.execute = _exec
+        fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+        fake_session.__aexit__ = AsyncMock(return_value=False)
+        monkeypatch.setattr(
+            "backend.services.ediscovery_agent.LegacySession",
+            lambda fs=fake_session: fs,
+        )
+        out = await _resolve_related_matters_slugs("test-case-i")
+        assert out == [], f"malformed value {bad_value!r} should yield []"
+
+
+@pytest.mark.asyncio
+async def test_resolve_related_matters_returns_empty_on_db_error(monkeypatch) -> None:
+    """DB connection error → empty list, never propagate, never crash deliberation."""
+    def _broken_session():
+        raise RuntimeError("simulated DB outage")
+    monkeypatch.setattr(
+        "backend.services.ediscovery_agent.LegacySession",
+        _broken_session,
+    )
+    out = await _resolve_related_matters_slugs("test-case-i")
+    assert out == []
+
+
+# ════════════════════════════════════════════════════════════════════
+# freeze_privileged_context — the privileged retrieval helper
+# ════════════════════════════════════════════════════════════════════
+
+
+class _FakeQdrantResp:
+    def __init__(self, points: list):
+        self._points = points
+    def raise_for_status(self):
+        return None
+    def json(self):
+        return {"result": self._points}
+
+
+@pytest.mark.asyncio
+async def test_freeze_privileged_context_targets_correct_collection(monkeypatch) -> None:
+    """URL ends with /collections/legal_privileged_communications/points/search."""
+    seen_url: list[str] = []
+
+    class _FakeClient:
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return None
+        async def post(self, url, **kwargs):
+            seen_url.append(url)
+            return _FakeQdrantResp(points=[])
+
+    monkeypatch.setattr("backend.services.legal_council.httpx.AsyncClient",
+                        lambda timeout=15: _FakeClient())
+    monkeypatch.setattr("backend.services.legal_council._embed_text",
+                        AsyncMock(return_value=[0.1] * 768))
+
+    await freeze_privileged_context("brief", top_k=5, case_slug="test-case-i")
+
+    assert seen_url, "no httpx.post call observed"
+    assert seen_url[0].endswith(
+        f"/collections/{COUNCIL_PRIV_COLLECTION}/points/search"
+    )
+
+
+@pytest.mark.asyncio
+async def test_freeze_privileged_context_filters_by_case_slug(monkeypatch) -> None:
+    """The body must include filter.must with case_slug match."""
+    seen_body: list[dict] = []
+
+    class _FakeClient:
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return None
+        async def post(self, url, **kwargs):
+            seen_body.append(kwargs.get("json"))
+            return _FakeQdrantResp(points=[])
+
+    monkeypatch.setattr("backend.services.legal_council.httpx.AsyncClient",
+                        lambda timeout=15: _FakeClient())
+    monkeypatch.setattr("backend.services.legal_council._embed_text",
+                        AsyncMock(return_value=[0.1] * 768))
+
+    await freeze_privileged_context("brief", top_k=5, case_slug="test-case-i")
+
+    assert len(seen_body) == 1
+    body = seen_body[0]
+    assert "filter" in body
+    must = body["filter"]["must"]
+    assert any(
+        c.get("key") == "case_slug" and c.get("match", {}).get("value") == "test-case-i"
+        for c in must
+    )
+
+
+@pytest.mark.asyncio
+async def test_freeze_privileged_context_tags_chunks_with_privileged_marker(monkeypatch) -> None:
+    """Returned chunks start with `[PRIVILEGED · domain · role] [source] text`."""
+    points = [{
+        "id": "11111111-2222-3333-4444-555555555555",
+        "payload": {
+            "case_slug": "test-case-i",
+            "file_name": "argo-letter.eml",
+            "text": "the body of the privileged communication",
+            "privileged_counsel_domain": "dralaw.com",
+            "role": "post_judgment_closing_counsel",
+            "privileged": True,
+        },
+    }]
+
+    class _FakeClient:
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return None
+        async def post(self, url, **kwargs):
+            return _FakeQdrantResp(points=points)
+
+    monkeypatch.setattr("backend.services.legal_council.httpx.AsyncClient",
+                        lambda timeout=15: _FakeClient())
+    monkeypatch.setattr("backend.services.legal_council._embed_text",
+                        AsyncMock(return_value=[0.1] * 768))
+
+    vector_ids, chunks = await freeze_privileged_context(
+        "brief", top_k=5, case_slug="test-case-i",
+    )
+    assert len(chunks) == 1
+    assert chunks[0].startswith("[PRIVILEGED · dralaw.com · post_judgment_closing_counsel]")
+    assert "[argo-letter.eml]" in chunks[0]
+    assert "the body of the privileged communication" in chunks[0]
+    assert vector_ids == ["11111111-2222-3333-4444-555555555555"]
+
+
+@pytest.mark.asyncio
+async def test_freeze_privileged_context_fail_soft_on_qdrant_error(monkeypatch) -> None:
+    """If the privileged collection doesn't exist or Qdrant is down — return
+    ([], []) and do not crash the deliberation."""
+    class _BoomClient:
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return None
+        async def post(self, url, **kwargs):
+            raise ConnectionError("qdrant unreachable")
+
+    monkeypatch.setattr("backend.services.legal_council.httpx.AsyncClient",
+                        lambda timeout=15: _BoomClient())
+    monkeypatch.setattr("backend.services.legal_council._embed_text",
+                        AsyncMock(return_value=[0.1] * 768))
+
+    vector_ids, chunks = await freeze_privileged_context(
+        "brief", top_k=5, case_slug="test-case-i",
+    )
+    assert vector_ids == []
+    assert chunks == []
+
+
+# ════════════════════════════════════════════════════════════════════
+# process_vault_upload privileged routing
+# ════════════════════════════════════════════════════════════════════
+
+
+def _make_db_session_for_pipeline(execute_side_effect) -> AsyncMock:
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=execute_side_effect)
+    db.commit = AsyncMock()
+    return db
+
+
+def _exec_factory_inserts_succeed():
+    """Side-effect that lets the INSERT 'go through' (returns a fake id)."""
+    state = {"insert_done": False, "fastdup_done": False}
+    def _eff(stmt, *args, **kwargs):
+        sql = str(stmt)
+        if "SELECT id FROM legal.vault_documents" in sql and not state["fastdup_done"]:
+            state["fastdup_done"] = True
+            r = MagicMock()
+            r.fetchone = MagicMock(return_value=None)  # no dup
+            return r
+        if "INSERT INTO legal.vault_documents" in sql and not state["insert_done"]:
+            state["insert_done"] = True
+            r = MagicMock()
+            r.fetchone = MagicMock(return_value=("inserted-id",))
+            return r
+        # Any other (UPDATE, etc.) — pass-through
+        r = MagicMock()
+        r.fetchone = MagicMock(return_value=None)
+        r.mappings = MagicMock(return_value=MagicMock(
+            first=MagicMock(return_value=None),
+        ))
+        return r
+    return _eff
+
+
+@pytest.mark.asyncio
+async def test_process_vault_upload_routes_privileged_to_separate_collection(
+    monkeypatch, tmp_path,
+) -> None:
+    """Privileged path must call _upsert_to_qdrant_privileged and NOT _upsert_to_qdrant."""
+    monkeypatch.setattr(legal_ediscovery, "_resolve_vault_dir",
+                        lambda _slug: tmp_path)
+    monkeypatch.setattr(legal_ediscovery, "_extract_text",
+                        lambda _b, _m, _n: "privileged content from MHT counsel mhtlegal.com")
+    monkeypatch.setattr(
+        legal_ediscovery, "_classify_privilege",
+        AsyncMock(return_value=(MagicMock(
+            is_privileged=True, confidence=0.95,
+            privilege_type="attorney_client", reasoning="counsel match",
+        ), 5)),
+    )
+    monkeypatch.setattr(legal_ediscovery, "_log_privilege",
+                        AsyncMock(return_value=None))
+    monkeypatch.setattr(legal_ediscovery, "_chunk_document",
+                        lambda _t: ["chunk1", "chunk2"])
+    monkeypatch.setattr(
+        legal_ediscovery, "_embed_chunks",
+        AsyncMock(return_value=[[0.1] * 8, [0.2] * 8]),
+    )
+
+    work_product_calls: list = []
+    monkeypatch.setattr(
+        legal_ediscovery, "_upsert_to_qdrant",
+        AsyncMock(side_effect=lambda *a, **kw: work_product_calls.append((a, kw)) or 2),
+    )
+    privileged_calls: list = []
+    monkeypatch.setattr(
+        legal_ediscovery, "_upsert_to_qdrant_privileged",
+        AsyncMock(side_effect=lambda **kw: privileged_calls.append(kw) or 2),
+    )
+    monkeypatch.setattr(legal_ediscovery, "_emit_docket_updated_event",
+                        AsyncMock(return_value=False))
+
+    db = _make_db_session_for_pipeline(_exec_factory_inserts_succeed())
+    result = await legal_ediscovery.process_vault_upload(
+        db=db,
+        case_slug="test-case-i",
+        file_bytes=b"some bytes from a privileged email between Gary and his attorney",
+        file_name="from-mhtlegal.eml",
+        mime_type="message/rfc822",
+    )
+
+    assert result["status"] == "locked_privileged"
+    assert len(privileged_calls) == 1, "privileged upsert must be called once"
+    assert work_product_calls == [], "non-privileged upsert must NOT be called on privileged docs"
+
+
+@pytest.mark.asyncio
+async def test_process_vault_upload_non_privileged_uses_work_product_collection(
+    monkeypatch, tmp_path,
+) -> None:
+    """Mirror test: non-privileged → _upsert_to_qdrant called, privileged not called."""
+    monkeypatch.setattr(legal_ediscovery, "_resolve_vault_dir",
+                        lambda _slug: tmp_path)
+    monkeypatch.setattr(legal_ediscovery, "_extract_text",
+                        lambda _b, _m, _n: "ordinary case correspondence — no counsel")
+    monkeypatch.setattr(
+        legal_ediscovery, "_classify_privilege",
+        AsyncMock(return_value=(MagicMock(
+            is_privileged=False, confidence=0.0,
+            privilege_type=None, reasoning=None,
+        ), 1)),
+    )
+    monkeypatch.setattr(legal_ediscovery, "_chunk_document",
+                        lambda _t: ["chunk1"])
+    monkeypatch.setattr(
+        legal_ediscovery, "_embed_chunks",
+        AsyncMock(return_value=[[0.3] * 8]),
+    )
+
+    work_product_calls: list = []
+    monkeypatch.setattr(
+        legal_ediscovery, "_upsert_to_qdrant",
+        AsyncMock(side_effect=lambda *a, **kw: work_product_calls.append((a, kw)) or 1),
+    )
+    privileged_calls: list = []
+    monkeypatch.setattr(
+        legal_ediscovery, "_upsert_to_qdrant_privileged",
+        AsyncMock(side_effect=lambda **kw: privileged_calls.append(kw) or 1),
+    )
+    monkeypatch.setattr(legal_ediscovery, "_emit_docket_updated_event",
+                        AsyncMock(return_value=False))
+
+    db = _make_db_session_for_pipeline(_exec_factory_inserts_succeed())
+    result = await legal_ediscovery.process_vault_upload(
+        db=db,
+        case_slug="test-case-i",
+        file_bytes=b"non-privileged content",
+        file_name="random.pdf",
+        mime_type="application/pdf",
+    )
+    assert result["status"] == "completed"
+    assert len(work_product_calls) == 1
+    assert privileged_calls == []
+
+
+# ════════════════════════════════════════════════════════════════════
+# _upsert_to_qdrant_privileged — payload shape + UUID5 idempotency
+# ════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_upsert_to_qdrant_privileged_uses_uuid5_deterministic_ids(monkeypatch) -> None:
+    """Same (file_hash, chunk_index) MUST produce the same point id across runs.
+    Re-runs of the same physical file must NOT duplicate Qdrant points."""
+    captured = []
+    class _FakeResp:
+        def raise_for_status(self): return None
+    fake_client = MagicMock()
+    fake_client.put = AsyncMock(side_effect=lambda url, **kw: (captured.append(kw.get("json")), _FakeResp())[1])
+    monkeypatch.setattr(legal_ediscovery, "shared_client", fake_client)
+
+    # First run
+    n1 = await _upsert_to_qdrant_privileged(
+        doc_id="doc-A", case_slug="test-case-i", file_name="x.eml",
+        file_hash="hashAAA", privileged_counsel_domain="mhtlegal.com",
+        role="case_i_phase_1_filing_to_depositions",
+        privilege_type="attorney_client",
+        chunks=["a", "b"],
+        vectors=[[0.1] * 4, [0.2] * 4],
+    )
+    # Second run — *same* file_hash, simulating a re-ingest. doc_id is
+    # different (a new uuid4 from the INSERT) but file_hash + idx are stable.
+    n2 = await _upsert_to_qdrant_privileged(
+        doc_id="doc-B-different",
+        case_slug="test-case-i", file_name="x.eml",
+        file_hash="hashAAA", privileged_counsel_domain="mhtlegal.com",
+        role="case_i_phase_1_filing_to_depositions",
+        privilege_type="attorney_client",
+        chunks=["a", "b"],
+        vectors=[[0.1] * 4, [0.2] * 4],
+    )
+    assert n1 == 2 and n2 == 2
+    ids_run1 = sorted(p["id"] for p in captured[0]["points"])
+    ids_run2 = sorted(p["id"] for p in captured[1]["points"])
+    assert ids_run1 == ids_run2, (
+        "deterministic UUID5 must produce identical point IDs on re-run "
+        "with the same file_hash+chunk_index"
+    )
+
+    # Sanity: ids really come from uuid5
+    expected_a = str(uuid5(_QDRANT_PRIVILEGED_NS, "hashAAA:0"))
+    expected_b = str(uuid5(_QDRANT_PRIVILEGED_NS, "hashAAA:1"))
+    assert set(ids_run1) == {expected_a, expected_b}
+
+
+@pytest.mark.asyncio
+async def test_privileged_collection_payload_dual_field_chunk_num_and_chunk_index(
+    monkeypatch,
+) -> None:
+    """File 1 spec divergence — payload includes BOTH chunk_num and chunk_index
+    so Council retrieval can use either field name. Both must be present and equal."""
+    captured = []
+    class _FakeResp:
+        def raise_for_status(self): return None
+    fake_client = MagicMock()
+    fake_client.put = AsyncMock(side_effect=lambda url, **kw: (captured.append(kw.get("json")), _FakeResp())[1])
+    monkeypatch.setattr(legal_ediscovery, "shared_client", fake_client)
+
+    await _upsert_to_qdrant_privileged(
+        doc_id="d1", case_slug="test-case-i", file_name="x.eml",
+        file_hash="h1", privileged_counsel_domain="fgplaw.com",
+        role="case_i_phase_2_trial_and_general_counsel",
+        privilege_type="attorney_client",
+        chunks=["chunk-zero", "chunk-one", "chunk-two"],
+        vectors=[[0.1] * 4, [0.2] * 4, [0.3] * 4],
+    )
+    points = captured[0]["points"]
+    assert len(points) == 3
+    for i, p in enumerate(points):
+        payload = p["payload"]
+        assert "chunk_num" in payload, f"chunk_num missing from payload[{i}]"
+        assert "chunk_index" in payload, f"chunk_index missing from payload[{i}]"
+        assert payload["chunk_num"] == i
+        assert payload["chunk_index"] == i
+        assert payload["chunk_num"] == payload["chunk_index"]
+        # Spec-listed fields all present:
+        for key in (
+            "case_slug", "document_id", "file_name", "file_hash",
+            "text", "privileged", "privileged_counsel_domain",
+            "role", "privilege_type", "ingested_at",
+        ):
+            assert key in payload, f"required field {key} missing"
+        assert payload["privileged"] is True
+        assert payload["privileged_counsel_domain"] == "fgplaw.com"
+        assert payload["role"] == "case_i_phase_2_trial_and_general_counsel"
+
+
+# ════════════════════════════════════════════════════════════════════
+# Domain → role + counsel-domain extraction helpers
+# ════════════════════════════════════════════════════════════════════
+
+
+def test_role_for_counsel_domain_maps_correctly() -> None:
+    """Every domain in _DOMAIN_TO_ROLE round-trips."""
+    for domain, expected_role in _DOMAIN_TO_ROLE.items():
+        assert _role_for_counsel_domain(domain) == expected_role
+
+
+def test_role_for_counsel_domain_returns_none_for_unknown() -> None:
+    assert _role_for_counsel_domain("unknown-firm.com") is None
+    assert _role_for_counsel_domain("") is None
+    assert _role_for_counsel_domain(None) is None
+
+
+def test_role_for_counsel_domain_is_case_insensitive() -> None:
+    """A domain with mixed case still resolves (defensive against header parsing)."""
+    assert _role_for_counsel_domain("MHTLEGAL.COM") == _DOMAIN_TO_ROLE["mhtlegal.com"]
+    assert _role_for_counsel_domain("MhtLegal.COM") == _DOMAIN_TO_ROLE["mhtlegal.com"]
+
+
+def test_derive_privileged_counsel_domain_from_eml_headers() -> None:
+    """An .eml with mhtlegal.com in From → derived as mhtlegal.com."""
+    eml_bytes = (
+        b"From: Counsel Smith <counsel@mhtlegal.com>\r\n"
+        b"To: Gary Knight <gary@cabin-rentals-of-georgia.com>\r\n"
+        b"Subject: case strategy\r\n"
+        b"\r\n"
+        b"Body of privileged communication.\r\n"
+    )
+    out = _derive_privileged_counsel_domain(
+        file_bytes=eml_bytes,
+        file_name="incoming.eml",
+        mime_type="message/rfc822",
+        raw_text="extracted body",
+    )
+    assert out == "mhtlegal.com"
+
+
+def test_derive_privileged_counsel_domain_from_to_header() -> None:
+    """Outbound — Gary → counsel. domain matches via To header."""
+    eml_bytes = (
+        b"From: Gary Knight <gary@cabin-rentals-of-georgia.com>\r\n"
+        b"To: Frank Podesta <fpodesta@fgplaw.com>\r\n"
+        b"Subject: question about case\r\n"
+        b"\r\n"
+        b"Need your advice.\r\n"
+    )
+    out = _derive_privileged_counsel_domain(
+        file_bytes=eml_bytes,
+        file_name="outbound.eml",
+        mime_type="message/rfc822",
+        raw_text="Need your advice.",
+    )
+    assert out == "fgplaw.com"
+
+
+def test_derive_privileged_counsel_domain_falls_back_to_text_scan() -> None:
+    """Non-email file (PDF) — domain mention in body text triggers detection."""
+    raw = (
+        "Letter from counsel discussing case. Please reply to "
+        "alicia@dralaw.com for further discussion."
+    )
+    out = _derive_privileged_counsel_domain(
+        file_bytes=b"%PDF-1.4 not really pdf",
+        file_name="memo.pdf",
+        mime_type="application/pdf",
+        raw_text=raw,
+    )
+    assert out == "dralaw.com"
+
+
+def test_derive_privileged_counsel_domain_returns_none_when_no_match() -> None:
+    """No known domain anywhere — derivation returns None (caller writes None to payload)."""
+    out = _derive_privileged_counsel_domain(
+        file_bytes=b"nothing about counsel",
+        file_name="random.txt",
+        mime_type="text/plain",
+        raw_text="nothing about counsel — just business correspondence",
+    )
+    assert out is None
+
+
+# ════════════════════════════════════════════════════════════════════
+# Module-level constants — privileged collection name + warning text
+# ════════════════════════════════════════════════════════════════════
+
+
+def test_legal_privileged_communications_collection_constant() -> None:
+    """The new collection name must match Phase C's PUT call exactly."""
+    assert QDRANT_PRIVILEGED_COLLECTION == "legal_privileged_communications"
+    assert COUNCIL_PRIV_COLLECTION == "legal_privileged_communications"
+    # And it must be different from the work-product collection.
+    assert QDRANT_PRIVILEGED_COLLECTION != QDRANT_COLLECTION
+
+
+def test_for_your_eyes_only_warning_text_matches_spec() -> None:
+    """If this string changes, the UI rendering + the in-band consensus_summary
+    warning + the runbook all need to be updated together. Test catches drift."""
+    from backend.services.legal_council import FOR_YOUR_EYES_ONLY_WARNING
+    assert FOR_YOUR_EYES_ONLY_WARNING.startswith("⚠️ FOR YOUR EYES ONLY ⚠️")
+    assert "attorney-client privileged communications" in FOR_YOUR_EYES_ONLY_WARNING
+    assert "court filings" in FOR_YOUR_EYES_ONLY_WARNING
+    assert "internal work product" in FOR_YOUR_EYES_ONLY_WARNING

--- a/fortress-guest-platform/docs/runbooks/legal-privilege-architecture.md
+++ b/fortress-guest-platform/docs/runbooks/legal-privilege-architecture.md
@@ -31,7 +31,7 @@ file_hash + chunk_index is namespaced under
 `f0a17e55-7c0d-4d1f-8c5a-d3b4f0e9a200` (UUID5), so re-ingesting the same
 document upserts to the same Qdrant points and never produces
 duplicates. (The work-product `_upsert_to_qdrant` path still uses
-`uuid4()` and is non-deterministic — Issue #207 tracks the
+`uuid4()` and is non-deterministic — Issue #210 tracks the
 divergence.)
 
 A non-attorney communication (e.g. spousal — see §6) does **not**
@@ -190,7 +190,7 @@ specifically because Knight has elected to put them at issue.
 
 If Knight withdraws the at-issue defense, the privilege snaps back —
 the rows must move back to `legal_privileged_communications` and the
-work-product copies removed. Issue #208 tracks the formal waiver
+work-product copies removed. Issue #211 tracks the formal waiver
 column work.
 
 ---
@@ -341,7 +341,7 @@ log entries** — the audit trail must outlive the data.
    ```
 
 3. **Move chunks Qdrant-side** (manual today; tooling tracked as
-   Issue #209):
+   Issue #212):
 
    ```python
    # Pseudo: scroll privileged collection by case_slug + document_id,
@@ -423,7 +423,7 @@ Apply to both `fortress_prod` and `fortress_db`.
 
 **Coverage limitation:** 11 endpoints with `{slug}` in path do not
 currently use `LegacySession` and therefore don't run alias resolution.
-Tracked as Issue #210; for now, rely on the 12 covered endpoints that
+Tracked as Issue #213; for now, rely on the 12 covered endpoints that
 do (full list in commit `f468f801b`).
 
 **Deprecation path:** when the old-slug telemetry shows zero hits
@@ -542,8 +542,11 @@ SELECT old_slug, new_slug, created_at FROM legal.case_slug_aliases ORDER BY crea
 - `docs/runbooks/legal-vault-documents.md` — vault row state machine
   and dedup contract (the underlying schema this layer assumes)
 - `docs/runbooks/legal-vault-ingest.md` — ingestion pipeline
-- Issue #207 — work-product Qdrant idempotency (UUID4 → UUID5)
-- Issue #208 — formal at-issue waiver column
-- Issue #209 — Qdrant collection migration tooling
-  (privileged → work-product moves)
-- Issue #210 — alias resolution coverage gap (11 endpoints)
+- Issue #209 — `legal.ingest_runs` row lost when case_slug renamed
+  (FK CASCADE on rename); fix via Option C reconstruct + switch to
+  ON DELETE SET NULL going forward
+- Issue #210 — work-product Qdrant idempotency (UUID4 → UUID5)
+- Issue #211 — formal at-issue waiver schema (`privilege_waivers` table)
+- Issue #212 — `migrate_qdrant_chunks.py` (privileged ↔ work-product
+  collection moves)
+- Issue #213 — alias resolution coverage gap (11 endpoints)

--- a/fortress-guest-platform/docs/runbooks/legal-privilege-architecture.md
+++ b/fortress-guest-platform/docs/runbooks/legal-privilege-architecture.md
@@ -1,0 +1,549 @@
+# Runbook: Legal Privilege Architecture
+
+How attorney-client privileged communications are classified, stored,
+retrieved, and audited across the Fortress legal stack. Read this
+before adding new counsel to a case, before responding to a privilege
+challenge, or before flipping any of the Council retrieval flags in
+production.
+
+Owner: Legal Platform. Last updated: PR G (2026-04-25).
+
+---
+
+## 1. Privilege model
+
+**Default rule:** every communication to or from a known counsel email
+domain on a case is treated as attorney-client privileged. The
+privilege bar is high — `confidence >= 0.7` from the classifier (a
+local Qwen2.5 inference, prompt at `legal_ediscovery.PRIVILEGE_SYSTEM_PROMPT`)
+flips a vault row to `processing_status='locked_privileged'`. Lower
+confidence falls through to the work-product track.
+
+The classifier looks for:
+
+- communications between a client and their attorney seeking or
+  providing legal advice
+- attorney mental impressions, strategies, or legal theories
+- joint defense agreement (JDA) material
+
+A privilege match is **deterministic across re-runs** — the document's
+file_hash + chunk_index is namespaced under
+`f0a17e55-7c0d-4d1f-8c5a-d3b4f0e9a200` (UUID5), so re-ingesting the same
+document upserts to the same Qdrant points and never produces
+duplicates. (The work-product `_upsert_to_qdrant` path still uses
+`uuid4()` and is non-deterministic — Issue #207 tracks the
+divergence.)
+
+A non-attorney communication (e.g. spousal — see §6) does **not**
+trigger `locked_privileged` from the counsel-domain match alone. The
+classifier rule is "communication with a known *attorney* domain" — if
+the sender/recipient isn't on the case's `privileged_counsel_domains`
+list, the document goes through the work-product path even if it
+contains personally sensitive content.
+
+---
+
+## 2. Two-collection architecture
+
+Privileged content is **physically separated** from work product at the
+storage layer, not just by a payload tag. This is the "no leak by
+metadata error" guarantee — a misconfigured filter on the work-product
+collection can never accidentally surface privileged chunks because
+they aren't in that collection at all.
+
+| Collection | Purpose | Populated by |
+| --- | --- | --- |
+| `legal_ediscovery` | Work product (filings, evidence, depositions, discovery responses, exhibits) | `legal_ediscovery._upsert_to_qdrant` (the default branch in `process_vault_upload`) |
+| `legal_privileged_communications` | Attorney-client privileged communications, work-product memos by counsel, JDA traffic | `legal_ediscovery._upsert_to_qdrant_privileged` (the privilege-shielded branch in `process_vault_upload`) |
+
+Both collections share the same vector dimensions (768) and distance
+metric (Cosine). Both index the same `case_slug` field for filtering.
+The privileged collection additionally indexes:
+
+- `privileged=true` (sentinel; every point in this collection is true,
+  but the field exists so downstream consumers can sanity-assert)
+- `privileged_counsel_domain` — e.g. `mhtlegal.com`
+- `role` — case-specific attorney role tag (see §7)
+- `privilege_type` — `attorney_client` | `work_product` | `joint_defense`
+
+Postgres is the source of truth for the row state; Qdrant is an
+index. If the two diverge (e.g. Qdrant ahead of Postgres on a partial
+upsert), the row's `processing_status` and `chunk_count` columns are
+authoritative, not the Qdrant point count.
+
+---
+
+## 3. Council retrieval policy
+
+Council deliberation pulls from BOTH collections by default. Two
+environment variables, read **at deliberation time** (not at backend
+startup) so they can be flipped without a backend restart:
+
+| Env var | Default | When to flip false |
+| --- | --- | --- |
+| `COUNCIL_INCLUDE_PRIVILEGED_RETRIEVAL` | `true` | Emergency containment if a privilege issue surfaces — disables the privileged collection entirely so no FYEO chunks reach personas |
+| `COUNCIL_INCLUDE_RELATED_MATTERS` | `true` | When deliberating on a single matter and you want to suppress cross-matter context (e.g. comparing two cases that share counsel but should be treated independently) |
+
+Acceptable false values: `false`, `0`, `no`, `off`, empty string. Any
+other value is treated as true.
+
+When privileged retrieval is enabled, the frozen context for the
+deliberation gets a separate section:
+
+```
+=== PRIVILEGED COMMUNICATIONS ===
+[PRIVILEGED · mhtlegal.com · case_i_phase_1_filing_to_depositions] [Smith Memo.eml] ...
+[PRIVILEGED · fgplaw.com · case_i_phase_2_trial_and_general_counsel] [Trial Strategy.docx] ...
+```
+
+The per-chunk `[PRIVILEGED · domain · role]` tag is intentional — both
+the LLM personas and any human auditing the frozen context can tell at a
+glance which chunks are privileged. The tag is preserved through every
+downstream pipeline (PDF export, copy/paste, search results), so
+privileged content cannot be invisibly mixed into work product.
+
+When `COUNCIL_INCLUDE_RELATED_MATTERS=true` (the default), retrieval
+expands to every slug in the case's `legal.cases.related_matters` JSONB
+column. Both the work-product and privileged collections are queried
+for each related slug. See §10.
+
+---
+
+## 4. FOR YOUR EYES ONLY warning
+
+Whenever any privileged chunk is retrieved during a deliberation, the
+output gets a hard warning. This is enforced two ways:
+
+**Structured flag — drives the UI:**
+
+```json
+{
+  "contains_privileged": true,
+  "privileged_warning": "<full warning text>"
+}
+```
+
+The command-center deliberation panel watches every SSE event for
+`contains_privileged`. The moment it appears, the FYEO Card renders —
+operators see the warning in real time, not at the end of the
+deliberation. (See `apps/command-center/src/lib/use-council-stream.ts`
+for the event reducer.)
+
+**In-band text — survives downstream pipelines:**
+
+The exact warning text is appended to `consensus_summary`:
+
+```
+⚠️ FOR YOUR EYES ONLY ⚠️
+This deliberation included attorney-client privileged communications.
+Do not use this output in court filings, share with opposing parties,
+or quote externally without explicit privilege review. Treat as
+internal work product subject to attorney-client privilege.
+```
+
+The wording is fixed (canonical source: `legal_council.FOR_YOUR_EYES_ONLY_WARNING`).
+**Do not paraphrase.** If a deliberation output appears in a court
+filing, opposing counsel reads the exact wording — paraphrased
+variants weaken the privilege assertion. Any change here must also
+update:
+
+- `apps/command-center` deliberation-panel rendering
+- This runbook
+- The privilege-protocol page in the operator handbook (if separate)
+
+---
+
+## 5. At-issue waiver — Terry Wilson
+
+The `wilsonhamilton.com` and `wilsonpruittlaw.com` domains are Terry
+Wilson's firms — original transaction closing counsel for the Fish
+Trap deal at the heart of 7IL Properties LLC v. Knight. Communications
+to/from these domains are normally privileged (they're attorney-client
+on the underlying real estate transaction).
+
+**At-issue waiver applies** because Knight's defense theory in
+`7il-v-knight-ndga-i` is "I relied on my closing attorney's advice."
+That puts the content of the attorney's advice **into the case-in-chief**
+— the privilege is waived as to communications about the closing,
+specifically because Knight has elected to put them at issue.
+
+**What this means operationally:**
+
+- These rows are still ingested as `locked_privileged` (the default
+  classifier rule based on counsel domain).
+- Council retrieval still treats them as privileged by default — they
+  go to `legal_privileged_communications`, not `legal_ediscovery`.
+- The waiver decision is **not encoded in the schema** today. Treat the
+  Wilson rows as a manual category that Gary and counsel surface
+  selectively per-deposition, per-filing, per-discovery-response. Any
+  systemic waiver (e.g. blanket production of all Wilson emails as
+  exhibits) requires:
+
+  1. Legal review confirming the waiver scope
+  2. Move the rows from privileged to work-product collection (manual
+     scroll + re-upsert; see §8 recovery procedure)
+  3. UPDATE `vault_documents.processing_status='completed'` for the
+     specific rows so they appear in the standard Vault panel
+  4. Audit trail: `legal.privilege_log` row preserved (do not delete);
+     add a `waived_at` timestamp + `waiver_basis` text in a follow-up
+     schema change when the waiver process is formalized.
+
+If Knight withdraws the at-issue defense, the privilege snaps back —
+the rows must move back to `legal_privileged_communications` and the
+work-product copies removed. Issue #208 tracks the formal waiver
+column work.
+
+---
+
+## 6. Spousal communication — Lissa Knight
+
+Lissa Knight is Gary's spouse and a co-defendant on the **Vanderburge
+state case**. She is **not** a co-defendant on `7il-v-knight-ndga-i` or
+`7il-v-knight-ndga-ii`. Communications between Gary and Lissa fall
+under spousal privilege (where applicable jurisdictionally), **not**
+attorney-client privilege.
+
+**Critical distinction:** the classifier and the
+`privileged_counsel_domains` filter only fire on attorney domains. A
+Gary↔Lissa email never matches a counsel domain — so by default these
+documents go through the work-product path (`legal_ediscovery`
+collection) and end up in the standard Vault panel without privilege
+protection.
+
+**Operational rules:**
+
+- **Do not** add a personal email domain (e.g. `garyknight.com`,
+  `lissaknight@gmail.com`) to any case's `privileged_counsel_domains`.
+  That JSONB list is for **attorney** domains only; conflating spousal
+  with attorney-client weakens both privileges.
+- Spousal-privilege handling for the Vanderburge co-defendant matter
+  is out of scope for the Fortress vault layer today. If a Gary↔Lissa
+  communication needs to be privilege-protected for the Vanderburge
+  case, do it via JDA wrapping with co-defense counsel — those
+  attorney-bridged emails will then carry an attorney domain and hit
+  the standard privilege track automatically.
+- For 7IL specifically, the privilege/non-privilege test is "did an
+  attorney write or read this?" — full stop. Lissa's name on a Cc
+  doesn't change a work-product document into a privileged one.
+
+If a deliberation surfaces a Lissa-only or Gary↔Lissa email in a way
+that exposes confidential marital content, that's a **policy issue**
+(documents shouldn't have been ingested at all if marital confidence
+matters), not a privilege issue. Recovery: rollback those specific
+rows via `vault_ingest_legal_case.py --rollback` for the case.
+
+---
+
+## 7. Adding new privileged counsel to a case
+
+When a case engages new counsel (or transitions phases — see
+`case_phase` column), update both the schema and the code. The schema
+is the runtime source of truth; the code is the role-tag lookup that
+labels Qdrant payloads.
+
+### Step 1 — Update the case row
+
+```sql
+-- Example: add fgplaw.com as new co-counsel on case II
+UPDATE legal.cases
+SET privileged_counsel_domains = COALESCE(privileged_counsel_domains, '[]'::jsonb)
+                                 || '["fgplaw.com"]'::jsonb,
+    case_phase = 'counsel_engaged'
+WHERE case_slug = '7il-v-knight-ndga-ii';
+```
+
+Apply on **both** `fortress_prod` and `fortress_db` (the two-DB
+distribution pattern from PR B / PR D). Verify:
+
+```sql
+SELECT case_slug, jsonb_pretty(privileged_counsel_domains)
+FROM legal.cases WHERE case_slug = '7il-v-knight-ndga-ii';
+```
+
+### Step 2 — Update the role map
+
+Edit `_DOMAIN_TO_ROLE` in
+`backend/services/legal_ediscovery.py`:
+
+```python
+_DOMAIN_TO_ROLE: dict[str, str] = {
+    "mhtlegal.com":        "case_i_phase_1_filing_to_depositions",
+    "fgplaw.com":          "case_i_phase_2_trial_and_general_counsel",
+    # ... add new entry ...
+    "newcounsel.com":      "case_ii_lead_counsel",
+}
+```
+
+This dict is the source of the per-chunk `role` tag in
+`legal_privileged_communications` payloads. Source of truth for the
+role taxonomy is `pr_f_classification_rules.md` v6/v7 — update that
+first if introducing a new role category, then mirror here.
+
+### Step 3 — Re-ingest existing files (optional)
+
+If the case already has emails to/from this counsel in the work-product
+collection (e.g. they were ingested before the domain was added),
+re-classify them:
+
+```bash
+# Dry run first to inventory affected rows
+python -m backend.scripts.vault_ingest_legal_case \
+    --case-slug 7il-v-knight-ndga-ii --dry-run
+
+# Then re-process — resume mode skips terminal rows. To force
+# re-classification of already-completed rows, manually flip them
+# back to pending first:
+psql ... -c "UPDATE legal.vault_documents
+             SET processing_status='pending'
+             WHERE case_slug='7il-v-knight-ndga-ii'
+               AND processing_status='completed'
+               AND (file_name LIKE '%newcounsel%' OR ...);"
+
+python -m backend.scripts.vault_ingest_legal_case \
+    --case-slug 7il-v-knight-ndga-ii
+```
+
+The re-ingest will correctly route to `locked_privileged` for any
+file whose extracted text matches the new counsel domain.
+
+### Step 4 — Restart the backend
+
+The role-map dict is loaded at module import. Adding a new domain
+requires a backend restart for the in-memory map to update. The
+schema-level `privileged_counsel_domains` column doesn't drive the
+classifier today — it's metadata for the UI badges. If a future PR
+adds runtime classifier reads from the column, restart will no longer
+be required for the schema-level change (still required for code
+edits).
+
+---
+
+## 8. Privilege-waiver scenarios
+
+When a privilege determination changes (waiver, court order to
+produce, defensive at-issue use), the document needs to move from the
+privileged track to the work-product track. **Never delete privilege
+log entries** — the audit trail must outlive the data.
+
+### Scenario: blanket waiver, doc category produced as exhibit
+
+1. **Confirm with counsel.** Get a written sign-off (email, doc) on
+   the scope of the waiver. Save in `Correspondence/`.
+
+2. **Identify affected rows:**
+
+   ```sql
+   SELECT id, file_name, file_hash
+   FROM legal.vault_documents
+   WHERE case_slug = '7il-v-knight-ndga-i'
+     AND processing_status = 'locked_privileged'
+     AND file_name ILIKE '%[discriminator]%';
+   ```
+
+3. **Move chunks Qdrant-side** (manual today; tooling tracked as
+   Issue #209):
+
+   ```python
+   # Pseudo: scroll privileged collection by case_slug + document_id,
+   # read points, re-upsert to legal_ediscovery with payload.privileged
+   # stripped, then delete from legal_privileged_communications.
+   ```
+
+4. **Update Postgres:**
+
+   ```sql
+   UPDATE legal.vault_documents
+   SET processing_status = 'completed',
+       error_detail = 'waived ' || NOW()::text || ' per ' || :sign_off_ref
+   WHERE id = ANY(:doc_ids);
+   ```
+
+   Apply to both `fortress_prod` and `fortress_db`.
+
+5. **Preserve `legal.privilege_log`.** Do not UPDATE or DELETE
+   existing rows. The audit trail must show the document was
+   classified privileged at ingest time — that's the truth at the
+   time. The waiver is a later event; record it in a future
+   `privilege_waivers` table, not by overwriting the original
+   classification.
+
+### Scenario: court orders production over objection
+
+Same procedure, but counsel's sign-off is replaced by the court order
+PDF in `Correspondence/`. Mark the `error_detail` with the case
+caption and order date.
+
+### Scenario: at-issue waiver (Terry Wilson — see §5)
+
+Don't bulk-move the rows unless and until counsel decides to put a
+specific email into the record. Keep them in
+`legal_privileged_communications` so they aren't accidentally returned
+from a Council deliberation that the privilege gates would otherwise
+have suppressed. When a specific email is put at issue:
+
+1. Move just that document to work-product (steps 3–4 above)
+2. Note in the file: `at_issue_per <deposition or filing>`
+3. The companion files (chains, attachments) often follow — review
+   each.
+
+---
+
+## 9. Backward-compat alias semantics
+
+PR G phase C renamed `7il-v-knight-ndga` to `7il-v-knight-ndga-i` and
+created `7il-v-knight-ndga-ii` for the post-judgment matter. Existing
+URLs (bookmarks, external links, embedded references in older
+deliberation outputs) point to the old slug. The runtime resolves
+those transparently:
+
+- `legal.case_slug_aliases` table stores `(old_slug, new_slug, created_at)`
+  rows.
+- `_resolve_case_slug(session, slug)` in `backend/api/legal_cases.py`
+  is called at the top of every case endpoint:
+  - Fast path: slug exists in `legal.cases` → return unchanged
+  - Else: lookup `case_slug_aliases.new_slug WHERE old_slug = slug` →
+    on hit, log `case_slug_alias_hit` (for telemetry — used to decide
+    when an old slug is safe to deprecate), return the new slug
+  - Else: return original slug, caller proceeds and hits a normal 404
+
+The URL **does not redirect**. `/cases/7il-v-knight-ndga` keeps that
+path in the browser; the data resolves to `7il-v-knight-ndga-i`. This
+preserves bookmark integrity while allowing the canonical slug to be
+the new one.
+
+**Adding an alias** when renaming a case:
+
+```sql
+INSERT INTO legal.case_slug_aliases (old_slug, new_slug)
+VALUES ('legacy-slug', 'new-canonical-slug')
+ON CONFLICT (old_slug) DO UPDATE SET new_slug = EXCLUDED.new_slug;
+```
+
+Apply to both `fortress_prod` and `fortress_db`.
+
+**Coverage limitation:** 11 endpoints with `{slug}` in path do not
+currently use `LegacySession` and therefore don't run alias resolution.
+Tracked as Issue #210; for now, rely on the 12 covered endpoints that
+do (full list in commit `f468f801b`).
+
+**Deprecation path:** when the old-slug telemetry shows zero hits
+over a quarterly window, deprecate the alias by deleting the row.
+External links will start 404'ing — operators get a real signal to fix
+the source.
+
+---
+
+## 10. Cross-matter retrieval — `related_matters`
+
+Some cases share a factual foundation (the underlying transaction, the
+same parties, the same evidence pool). Council deliberation should pull
+context from related matters to avoid blind spots — e.g. discovery in
+case I that's relevant to a question in case II.
+
+**Schema:** `legal.cases.related_matters` is a JSONB array of
+`case_slug` strings. The case itself is **not** included in its own
+`related_matters` (avoid recursive expansion).
+
+For 7IL today:
+
+```
+7il-v-knight-ndga-i:  related_matters = ["7il-v-knight-ndga-ii"]
+7il-v-knight-ndga-ii: related_matters = ["7il-v-knight-ndga-i"]
+```
+
+Two-way reference is intentional — case I's privileged communications
+are the primary attorney-client substrate (closed phase, full counsel
+roster); case II is in `counsel_search` and has no counsel domains
+yet, so a deliberation on case II that doesn't pull case I would miss
+the entire history of attorney advice.
+
+**How retrieval expands:**
+
+When `COUNCIL_INCLUDE_RELATED_MATTERS=true`,
+`run_council_deliberation` resolves `(case_slug + related_matters)` and
+runs both `freeze_context` and `freeze_privileged_context` per
+resolved slug. Results are merged into the frozen context with each
+chunk's source clearly tagged.
+
+**Disabling cross-matter expansion:** set
+`COUNCIL_INCLUDE_RELATED_MATTERS=false` before invoking the
+deliberation. Useful when the operator wants strictly per-case
+retrieval (e.g. responding to a discovery interrogatory that asks
+about case II only — pulling case I context could confuse the
+response).
+
+**Privilege carry-through:** the `[PRIVILEGED · domain · role]` tags
+are preserved across matter expansion. A privileged chunk from case I
+surfaced in a case II deliberation still tags as privileged and still
+triggers the FYEO warning.
+
+**Cycle protection:** `_resolve_related_matters_slugs` reads only the
+direct `related_matters` column — it does not transitively expand
+(case I → case II → case I…). If transitive expansion is ever needed,
+the resolver must be amended to track a visited set; today's pattern
+is one-hop only.
+
+---
+
+## 11. Common operator queries
+
+```sql
+-- 11.1  All privileged rows for a case
+SELECT id, file_name, processing_status, created_at
+FROM legal.vault_documents
+WHERE case_slug = '7il-v-knight-ndga-i'
+  AND processing_status = 'locked_privileged'
+ORDER BY created_at DESC;
+
+-- 11.2  Per-counsel-domain breakdown (parsing privilege_log)
+SELECT classification->>'privilege_type' AS type,
+       count(*) AS rows
+FROM legal.privilege_log
+WHERE case_slug = '7il-v-knight-ndga-i'
+GROUP BY 1
+ORDER BY rows DESC;
+
+-- 11.3  Pending privilege classification
+SELECT case_slug, count(*)
+FROM legal.vault_documents
+WHERE processing_status IN ('pending', 'processing', 'vectorizing')
+GROUP BY case_slug;
+
+-- 11.4  All cases with their counsel + related_matters
+SELECT case_slug, case_phase,
+       jsonb_array_length(privileged_counsel_domains) AS num_counsel,
+       jsonb_array_length(related_matters) AS num_related
+FROM legal.cases
+ORDER BY case_slug;
+
+-- 11.5  Aliases currently active
+SELECT old_slug, new_slug, created_at FROM legal.case_slug_aliases ORDER BY created_at DESC;
+```
+
+---
+
+## 12. Cross-references
+
+- **PR G phase B** — schema migration adding `case_phase`,
+  `privileged_counsel_domains`, `related_matters` JSONB columns and
+  `legal.case_slug_aliases` table
+- **PR G phase C** — data migration: rename + insert + Qdrant payload
+  migration
+- **PR G phase D file 1** — `process_vault_upload` privileged Qdrant
+  path (`backend/services/legal_ediscovery.py`)
+- **PR G phase D file 2** — alias resolution
+  (`backend/api/legal_cases.py`)
+- **PR G phase D file 3** — Council retrieval + FYEO + related_matters
+  (`backend/services/legal_council.py`)
+- **PR G phase E** — UI surfaces (command-center)
+- **PR G phase F** — backend + UI tests (37 + 20)
+- `pr_f_classification_rules.md` v6/v7 — source of truth for the
+  attorney role taxonomy
+- `docs/runbooks/legal-vault-documents.md` — vault row state machine
+  and dedup contract (the underlying schema this layer assumes)
+- `docs/runbooks/legal-vault-ingest.md` — ingestion pipeline
+- Issue #207 — work-product Qdrant idempotency (UUID4 → UUID5)
+- Issue #208 — formal at-issue waiver column
+- Issue #209 — Qdrant collection migration tooling
+  (privileged → work-product moves)
+- Issue #210 — alias resolution coverage gap (11 endpoints)


### PR DESCRIPTION
## Summary

Three coordinated changes shipped across 7 commits:

1. Restructure 7IL into Case I (closed, judgment against) and Case II (active, pro se) with `related_matters` cross-reference
2. Privileged content physically isolated in new `legal_privileged_communications` Qdrant collection
3. Council retrieval respects privilege boundaries with output flagging and FOR YOUR EYES ONLY warnings

## Phases

- **Phase A**: per-case `nas_layout` (already merged in PR #185)
- **Phase B**: schema migration — `related_matters`, `case_phase`, `privileged_counsel_domains` JSONB columns + `case_slug_aliases` table
- **Phase C**: data migration — renamed Case I, inserted Case II, migrated 634 Thor James files to Case II vault, applied to `fortress_prod` and `fortress_db`, Qdrant payload sync
- **Phase D**: code changes (3 files): `legal_ediscovery.py` privileged Qdrant path, `legal_cases.py` alias resolution, `legal_council.py` privileged-track retrieval + FYEO + related_matters
- **Phase E**: UI surfaces (5 files): privileged-counsel domain badges, FYEO warning Card, dropzone filter, lock icon + "Privileged" badge
- **Phase F**: tests — 37 backend pytest cases + 20 UI Vitest cases
- **Phase G**: runbook at `docs/runbooks/legal-privilege-architecture.md` (12 sections, ~550 lines)
- **Phase H**: this PR

## Privileged counsel domains identified for Case I

- `mhtlegal.com` — early counsel, fired (case I phase 1: filing → depositions)
- `fgplaw.com` — Frank Podesta, general counsel + trial (case I phase 2)
- `msp-lawfirm.com` — Jason Sanker, trial co-counsel + Vanderburge counsel
- `wilsonhamilton.com` / `wilsonpruittlaw.com` — Terry Wilson, original closing counsel; **flagged for at-issue waiver review** (Knight's "I relied on closing counsel" defense theory; runbook §5)
- `dralaw.com` — Alicia Argo, post-judgment property closings

Case II currently has empty `privileged_counsel_domains` (counsel-search phase).

## Test coverage

- **Backend** (`backend/tests/test_legal_7il_restructure.py`, 37 tests): schema verification, alias resolution, privileged Qdrant path, role-tag mapping, related_matters cross-matter expansion, FYEO warning emission, env-var flag behavior, vault separation
- **UI** (`apps/command-center/src/__tests__/legal/`, 20 Vitest tests across 3 files): FYEO banner conditional rendering, filter dropdown defaults, badge placement, counsel-domain badge rendering

## Known followups (filed)

- **#209** — `legal.ingest_runs` row lost when case_slug renamed (FK CASCADE on Phase C rename); recommended fix is Option C reconstruct + switch to ON DELETE SET NULL going forward
- **#210** — work-product Qdrant idempotency (UUID4 → UUID5); the privileged path already uses UUID5
- **#211** — formal at-issue waiver schema (`privilege_waivers` table); replaces today's commit-message-only waiver tracking
- **#212** — `migrate_qdrant_chunks.py` for chunk movement between privileged and work-product collections (paired with #211)
- **#213** — alias resolution coverage gap (11 endpoints don't run `_resolve_case_slug`); recommended fix is a FastAPI dependency

There is also a pre-existing Pyright warning on `legal_council.py:1066` (`No overloads for max`) that is **not from this PR** and is intentionally out of scope per the "no quiet scope expansion" Phase D constraint.

## Verification post-merge

- Restart `fortress-backend.service` (single restart, end of Phase H)
- Verify both 7IL cases render at https://crog-ai.com/legal
- Verify Thor James packet appears in Case II vault
- Verify Council deliberation on a 7IL question emits `contains_privileged` flag when retrieving attorney communications
- Verify alias resolution: `GET /api/internal/legal/cases/7il-v-knight-ndga` returns Case I data

## Database state

- `fortress_prod`: schema + data migration applied
- `fortress_db`: schema + data migration applied
- `fortress_shadow_test`: schema migration applied (test DB only)
- `fortress_shadow`: SKIPPED per **#204** chain divergence (orphaned `alembic_version 7a1b2c3d4e5f`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)