### PR TITLE
docs(legal): correct PR G runbook issue cross-references

### DIFF
--- a/fortress-guest-platform/docs/runbooks/legal-privilege-architecture.md
+++ b/fortress-guest-platform/docs/runbooks/legal-privilege-architecture.md
@@ -190,7 +190,7 @@ specifically because Knight has elected to put them at issue.
 
 If Knight withdraws the at-issue defense, the privilege snaps back —
 the rows must move back to `legal_privileged_communications` and the
-work-product copies removed. Issue #211 tracks the formal waiver
+work-product copies removed. Issue #212 tracks the formal waiver
 column work.
 
 ---
@@ -341,7 +341,7 @@ log entries** — the audit trail must outlive the data.
    ```
 
 3. **Move chunks Qdrant-side** (manual today; tooling tracked as
-   Issue #212):
+   Issue #211):
 
    ```python
    # Pseudo: scroll privileged collection by case_slug + document_id,
@@ -423,7 +423,7 @@ Apply to both `fortress_prod` and `fortress_db`.
 
 **Coverage limitation:** 11 endpoints with `{slug}` in path do not
 currently use `LegacySession` and therefore don't run alias resolution.
-Tracked as Issue #213; for now, rely on the 12 covered endpoints that
+Tracked as Issue #208; for now, rely on the 12 covered endpoints that
 do (full list in commit `f468f801b`).
 
 **Deprecation path:** when the old-slug telemetry shows zero hits
@@ -542,11 +542,12 @@ SELECT old_slug, new_slug, created_at FROM legal.case_slug_aliases ORDER BY crea
 - `docs/runbooks/legal-vault-documents.md` — vault row state machine
   and dedup contract (the underlying schema this layer assumes)
 - `docs/runbooks/legal-vault-ingest.md` — ingestion pipeline
+- Issue #208 — alias resolution coverage gap (11 endpoints)
 - Issue #209 — `legal.ingest_runs` row lost when case_slug renamed
   (FK CASCADE on rename); fix via Option C reconstruct + switch to
   ON DELETE SET NULL going forward
 - Issue #210 — work-product Qdrant idempotency (UUID4 → UUID5)
-- Issue #211 — formal at-issue waiver schema (`privilege_waivers` table)
-- Issue #212 — `migrate_qdrant_chunks.py` (privileged ↔ work-product
+- Issue #211 — `migrate_qdrant_chunks.py` (privileged ↔ work-product
   collection moves)
-- Issue #213 — alias resolution coverage gap (11 endpoints)
+- Issue #212 — formal at-issue waiver schema (`privilege_waivers` table)
+- Issue #213 — duplicate of #208; close after merge


### PR DESCRIPTION
## Summary

Surgical follow-up to PR #214 (PR G). Post-merge verification against the live issue tracker surfaced two cross-reference errors in `docs/runbooks/legal-privilege-architecture.md`:

1. **Issues #211 ↔ #212 swapped.** During Phase G's fixup commit, sequential `gh issue create` for the four followups hit an HTTP 400 on the waiver-schema body (backticks-via-heredoc); the retry slotted #212 in a different position than the runbook references. Net effect: §5 says "#211 = waiver" but #211 is the chunks tooling, and §8 says "#212 = chunks tooling" but #212 is the waiver schema.

2. **#213 is a duplicate of pre-existing #208.** I filed #213 for the alias-coverage gap (11 endpoints) without first searching for an existing one. #208 was filed earlier today by another agent or session and covers the exact same scope.

## Corrections

| section | before | after |
| --- | --- | --- |
| §5 (Terry Wilson at-issue) | Issue #211 (waiver) | **Issue #212** (waiver) |
| §8 (waiver scenarios) | Issue #212 (chunks tooling) | **Issue #211** (chunks tooling) |
| §9 (alias coverage limit) | Issue #213 | **Issue #208** |
| §12 (cross-references) | full re-map | now includes #213 marked as a duplicate to close manually |

## Followup outside this PR

**#213 needs to be closed manually as a duplicate of #208** — my PAT scope is create-only (no edit/comment/close). Suggested close comment: "Superseded by #208."

## Test plan

- [x] `grep -nE "Issue #(20[89]|21[0-3])"` shows the corrected mapping
- No code changes; no backend restart needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)