### PR TITLE
fix(legal): correct Sanker domain in _DOMAIN_TO_ROLE — masp → msp

### DIFF
--- a/fortress-guest-platform/backend/services/legal_ediscovery.py
+++ b/fortress-guest-platform/backend/services/legal_ediscovery.py
@@ -56,7 +56,7 @@ _QDRANT_PRIVILEGED_NS = UUID("f0a17e55-7c0d-4d1f-8c5a-d3b4f0e9a200")
 _DOMAIN_TO_ROLE: dict[str, str] = {
     "mhtlegal.com":        "case_i_phase_1_filing_to_depositions",
     "fgplaw.com":          "case_i_phase_2_trial_and_general_counsel",
-    "masp-lawfirm.com":    "case_i_trial_cocounsel_and_vanderburge_counsel",
+    "msp-lawfirm.com":     "case_i_trial_cocounsel_and_vanderburge_counsel",
     "dralaw.com":          "post_judgment_closing_counsel",
     "wilsonhamilton.com":  "original_transaction_closing_counsel",
     "wilsonpruittlaw.com": "original_transaction_closing_counsel",


### PR DESCRIPTION
## Summary

PR G phase D file 1 (commit `ff1623dec`) added Jason Sanker's law firm to `backend/services/legal_ediscovery.py`'s `_DOMAIN_TO_ROLE` map as `masp-lawfirm.com`. The actual domain is `msp-lawfirm.com` (no leading `a`). Confirmed by review of Sanker's actual email address (`jsank@msp-lawfirm.com`).

## Effect of the bug

Privileged emails to/from `msp-lawfirm.com` were not matching `_KNOWN_PRIVILEGED_DOMAINS`, so the classifier's domain match returned None. Those emails would fall through to the work-product track in `legal_ediscovery` instead of being routed to `legal_privileged_communications`.

**No data is corrupted today** — the privileged Qdrant collection has 0 points (no emails have been ingested through this code path yet). The fix is purely forward-looking. Once merged + restarted, future privileged ingestion will route correctly.

## Companion fixes already applied

- `legal.cases.privileged_counsel_domains` JSONB array on `7il-v-knight-ndga-i` updated in **both** `fortress_prod` and `fortress_db` from `masp-lawfirm.com` → `msp-lawfirm.com`. UPDATE was transactional with before/after verification.

## Restart required

Yes — `_DOMAIN_TO_ROLE` is a module-level dict, loaded at import. After merge, single `fortress-backend.service` restart needed.

## Test plan

- [x] DB UPDATE applied + verified before/after on both DBs
- [x] No other code or doc references to `masp-lawfirm` (full-tree grep clean except pending `/tmp/vanderburge-insert.sql` which has been corrected locally)
- [ ] Merge + restart `fortress-backend.service`
- [ ] Smoke: `curl /api/internal/legal/cases/7il-v-knight-ndga-i` shows the corrected domain in the array

## Followups

- Issue (TBD) — broader audit of where the typo'd domain may have leaked into PR/issue bodies, deliberation outputs, or other static assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)