### PR TITLE
feat(legal): case-aware IMAP email backfill (PR I)

### DIFF
--- a/fortress-guest-platform/backend/scripts/email_backfill_legal.py
+++ b/fortress-guest-platform/backend/scripts/email_backfill_legal.py
@@ -1,0 +1,1370 @@
+"""
+email_backfill_legal.py — case-aware IMAP email backfill into legal vault.
+
+For a given --case-slug, walks IMAP per mailbox in date bands (Issue #177
+SEARCH-overflow workaround), classifies each message against KNOWN PARTIES
+(matched against `legal.cases.privileged_counsel_domains` JSONB + module-level
+party-term tables), routes to the correct case_slug via the disambiguator,
+and runs the canonical pipeline:
+
+    process_vault_upload(message/rfc822 bytes)
+        ├── INSERT legal.vault_documents (status='pending', ON CONFLICT DO NOTHING)
+        ├── privilege classifier — sets 'locked_privileged' when triggered
+        ├── _extract_text — sets 'ocr_failed' for empty extracts
+        ├── chunk → nomic embed → Qdrant upsert
+        │       ├── work-product → legal_ediscovery
+        │       └── privileged    → legal_privileged_communications
+        └── UPDATE status to 'completed'
+
+The vault_documents row is mirrored to fortress_prod so consumers reading
+prod see the same vault state (matches PR D's dual-DB pattern).
+
+Idempotency: file_hash dedup across (case_slug, file_hash) via the
+PR D-pre2 UNIQUE constraint. Re-running this script is a clean no-op for
+already-ingested emails.
+
+Atomicity: per-email try/except. One bad email does not abort the sweep.
+
+Audit: IngestRunTracker (PR D-pre1) emits a single legal.ingest_runs row.
+JSON manifest at /mnt/fortress_nas/audits/email-backfill-{case_slug}-{ts}.json.
+
+Concurrency control: lock at /tmp/email-backfill-{case_slug}.lock.
+
+Rollback: --rollback flag deletes email-backfill rows in both DBs and
+Qdrant points whose payload.case_slug matches AND file_name ends in .eml.
+
+Usage (after merge, with explicit auth):
+    python -m backend.scripts.email_backfill_legal \
+        --case-slug 7il-v-knight-ndga-i \
+        --mailbox gary-gk,gary-crog \
+        --since 2018-01-01 --until 2025-12-31
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import email as email_module
+import email.policy
+import email.utils
+import hashlib
+import imaplib
+import json
+import logging
+import os
+import re
+import socket
+import subprocess
+import sys
+import time
+import traceback
+from dataclasses import dataclass, field, asdict
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger("email_backfill_legal")
+
+
+# ─── constants ────────────────────────────────────────────────────────────
+
+
+IMAP_HOST           = "mail.cabin-rentals-of-georgia.com"
+IMAP_PORT           = 993
+ENV_PATH            = Path("/home/admin/Fortress-Prime/fortress-guest-platform/.env")
+AUDIT_DIR           = Path("/mnt/fortress_nas/audits")
+LOCK_STALE_AFTER_S  = 6 * 3600
+SEARCH_TIMEOUT_S    = 60
+FETCH_BATCH         = 100
+RETRY_BACKOFFS_S    = (2.0, 8.0, 20.0)
+BAND_MONTHS         = 6
+
+QDRANT_COLLECTION_WORK_PRODUCT = "legal_ediscovery"
+QDRANT_COLLECTION_PRIVILEGED   = "legal_privileged_communications"
+EXPECTED_VECTOR_SIZE           = 768
+
+MAILBOX_REGISTRY = {
+    "gary-gk":   ("gary@garyknight.com",                "fortress/mailboxes/gary-garyknight"),
+    "gary-crog": ("gary@cabin-rentals-of-georgia.com",  "fortress/mailboxes/gary-crog"),
+    "info-crog": ("info@cabin-rentals-of-georgia.com",  "fortress/mailboxes/info-crog"),
+}
+
+# Folders to scan per mailbox (per PR I plan §3 — INBOX + Sent variants).
+SEARCH_FOLDER_PATTERNS = (
+    re.compile(r"^INBOX$"),
+    re.compile(r"(?i)^(?:INBOX\.)?sent(?:\s|$|\.)"),
+    re.compile(r"(?i)^(?:INBOX\.)?sent[- ]?mail(?:$|\b)"),
+    re.compile(r"(?i)^(?:INBOX\.)?sent[- ]?items"),
+)
+
+
+# ─── party term + classification config ───────────────────────────────────
+
+
+# Per-case routing keywords (subject + body match). Source of truth: PR I plan §3.
+CASE_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "7il-v-knight-ndga-i": (
+        "2:21-cv-00226",
+    ),
+    "7il-v-knight-ndga-ii": (
+        "2:26-cv-00113",
+    ),
+    "vanderburge-v-knight-fannin": (
+        "vanderburge", "karen vanderburge", "fannin county",
+        "easement", "appalachian judicial circuit",
+    ),
+}
+
+# Generic 7IL-prefix keywords. Date-disambiguated (pre-2026 → case_i, else case_ii).
+SEVEN_IL_KEYWORDS = (
+    "7il properties", "7 il properties", "thor james",
+    "fish trap", "fish-trap", "thatcher", "thacker",
+)
+
+# Counsel domains by case (mirrors `_DOMAIN_TO_ROLE` in legal_ediscovery.py
+# but for routing, not labelling). Each domain implies privileged track.
+COUNSEL_DOMAINS_BY_CASE: dict[str, tuple[str, ...]] = {
+    "7il-v-knight-ndga-i": (
+        "mhtlegal.com", "fgplaw.com", "dralaw.com",
+        "wilsonhamilton.com", "wilsonpruittlaw.com",
+        # msp-lawfirm.com appears in BOTH Case I (trial cocounsel) AND Vanderburge,
+        # so it's listed under both — disambiguator decides which case
+        "msp-lawfirm.com", "masp-lawfirm.com",
+    ),
+    "7il-v-knight-ndga-ii": (
+        "msp-lawfirm.com", "masp-lawfirm.com",
+        "fgplaw.com",  # Podesta could continue into Case II
+    ),
+    "vanderburge-v-knight-fannin": (
+        "msp-lawfirm.com", "masp-lawfirm.com",
+    ),
+}
+
+# Opposing counsel terms (work-product track regardless of routing).
+OPPOSING_TERMS_BY_CASE: dict[str, tuple[str, ...]] = {
+    "7il-v-knight-ndga-i": ("fmglaw.com", "goldberg", "brian goldberg"),
+    "7il-v-knight-ndga-ii": ("fmglaw.com", "goldberg", "brian goldberg"),
+    "vanderburge-v-knight-fannin": ("frank moore",),  # bare 'moore' too FP-prone
+}
+
+# Username/name terms that imply your-side counsel (privileged track).
+USERNAME_TERMS_BY_CASE: dict[str, tuple[str, ...]] = {
+    "7il-v-knight-ndga-i": ("podesta", "frank podesta", "argo", "alicia argo",
+                             "terry wilson", "twilson"),
+    "7il-v-knight-ndga-ii": ("sanker", "jsank", "jsanker"),
+    "vanderburge-v-knight-fannin": ("sanker", "jsank", "jsanker"),
+}
+
+# Date windows (inclusive) per case for fallback routing.
+CASE_DATE_WINDOWS: dict[str, tuple[date, date]] = {
+    "7il-v-knight-ndga-i":      (date(2018, 1, 1),  date(2025, 12, 31)),
+    "7il-v-knight-ndga-ii":     (date(2026, 1, 1),  date(2099, 12, 31)),
+    "vanderburge-v-knight-fannin": (date(2019, 1, 1), date(2021, 12, 31)),
+}
+
+
+# ─── env + DSN helpers (mirrors vault_ingest pattern) ─────────────────────
+
+
+def _read_env() -> dict[str, str]:
+    out: dict[str, str] = {}
+    if not ENV_PATH.exists():
+        return out
+    for raw in ENV_PATH.read_text().splitlines():
+        s = raw.strip()
+        if not s or s.startswith("#") or "=" not in s:
+            continue
+        k, _, v = s.partition("=")
+        out[k.strip()] = v.strip().strip('"').strip("'")
+    return out
+
+
+def _ensure_env_loaded() -> None:
+    for k, v in _read_env().items():
+        os.environ.setdefault(k, v)
+
+
+@dataclass
+class _DSN:
+    host: str
+    port: int
+    user: str
+    password: str
+    db: str
+
+
+def _parse_admin_dsn(dbname: str) -> _DSN:
+    uri = os.environ.get("POSTGRES_ADMIN_URI", "")
+    m = re.match(
+        r"postgresql(?:\+\w+)?://([^:]+):([^@]+)@([^:/]+):?(\d+)?/[^?]+",
+        uri,
+    )
+    if not m:
+        raise SystemExit(
+            "POSTGRES_ADMIN_URI not set or unparseable in environ; "
+            "load .env first"
+        )
+    user, pw, host, port = m.groups()
+    return _DSN(host=host, port=int(port or 5432), user=user, password=pw, db=dbname)
+
+
+def _connect(dbname: str):
+    import psycopg2
+    dsn = _parse_admin_dsn(dbname)
+    conn = psycopg2.connect(
+        host=dsn.host, port=dsn.port, user=dsn.user,
+        password=dsn.password, dbname=dsn.db,
+    )
+    conn.autocommit = True
+    return conn
+
+
+def _password(slug: str) -> str:
+    out = subprocess.check_output(
+        ["pass", "show", slug], text=True, stderr=subprocess.PIPE,
+    )
+    pw = out.splitlines()[0] if out else ""
+    if not pw:
+        raise RuntimeError(f"empty password from pass show {slug}")
+    return pw
+
+
+# ─── pre-flight ──────────────────────────────────────────────────────────
+
+
+class PreflightError(Exception):
+    pass
+
+
+def _preflight_case_exists(case_slug: str) -> dict[str, Any]:
+    """case_slug must be present in BOTH fortress_prod and fortress_db. Returns
+    the privileged_counsel_domains JSONB array from the prod row."""
+    rows: dict[str, Any] = {}
+    for dbname in ("fortress_prod", "fortress_db"):
+        try:
+            conn = _connect(dbname)
+        except Exception as exc:
+            raise PreflightError(f"cannot connect to {dbname}: {exc!s}") from exc
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT case_slug, privileged_counsel_domains FROM legal.cases "
+                    "WHERE case_slug = %s",
+                    (case_slug,),
+                )
+                row = cur.fetchone()
+            if row is None:
+                raise PreflightError(
+                    f"case_slug {case_slug!r} not found in {dbname}.legal.cases"
+                )
+            rows[dbname] = row
+        finally:
+            conn.close()
+    return {"case_slug": case_slug, "privileged_counsel_domains": rows["fortress_prod"][1] or []}
+
+
+def _preflight_postgres_writable(case_slug: str) -> None:
+    """Probe SELECT 1 + a no-op INSERT into legal.ingest_runs (with the real
+    case_slug because PR D-pre1 added an FK that rejects sentinel slugs)."""
+    for dbname in ("fortress_prod", "fortress_db"):
+        conn = _connect(dbname)
+        try:
+            with conn.cursor() as cur:
+                cur.execute("SELECT 1")
+                if cur.fetchone() != (1,):
+                    raise PreflightError(f"{dbname} SELECT 1 unexpected result")
+        finally:
+            conn.close()
+    try:
+        conn = _connect("fortress_db")
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO legal.ingest_runs (case_slug, script_name, status, args) "
+                "VALUES (%s, '__preflight__', 'running', '{}'::jsonb) RETURNING id",
+                (case_slug,),
+            )
+            row = cur.fetchone()
+            if row is None:
+                raise PreflightError("preflight ingest_runs INSERT returned no id")
+            cur.execute("DELETE FROM legal.ingest_runs WHERE id = %s", (row[0],))
+        conn.close()
+    except Exception as exc:
+        raise PreflightError(
+            f"fortress_db.legal.ingest_runs not writable: {exc!s}"
+        ) from exc
+
+
+def _preflight_schema_constraints() -> None:
+    """Verify PR D-pre2 constraints on legal.vault_documents (FK + UNIQUE + CHECK)
+    in both DBs. PR I creates rows there via process_vault_upload."""
+    required = {
+        "fk_vault_documents_case_slug",
+        "uq_vault_documents_case_hash",
+        "chk_vault_documents_status",
+    }
+    for dbname in ("fortress_prod", "fortress_db"):
+        conn = _connect(dbname)
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT conname FROM pg_constraint "
+                    "WHERE conrelid = 'legal.vault_documents'::regclass "
+                    "AND conname = ANY(%s)",
+                    (list(required),),
+                )
+                present = {r[0] for r in cur.fetchall()}
+        finally:
+            conn.close()
+        missing = required - present
+        if missing:
+            raise PreflightError(
+                f"{dbname} missing PR D-pre2 constraints: {sorted(missing)} — "
+                f"apply alembic d8e3c1f5b9a6 before backfill"
+            )
+
+
+def _preflight_qdrant_reachable() -> None:
+    """Both legal_ediscovery (work product) AND legal_privileged_communications
+    must exist with vector_size=768 and Cosine distance."""
+    import urllib.error
+    import urllib.request
+    qdrant_url = os.environ.get("QDRANT_URL", "").rstrip("/")
+    if not qdrant_url:
+        raise PreflightError("QDRANT_URL not set in environ")
+    for collection in (QDRANT_COLLECTION_WORK_PRODUCT, QDRANT_COLLECTION_PRIVILEGED):
+        try:
+            with urllib.request.urlopen(
+                f"{qdrant_url}/collections/{collection}", timeout=10,
+            ) as resp:
+                data = json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            raise PreflightError(
+                f"qdrant collection {collection!r} not reachable at "
+                f"{qdrant_url}: HTTP {exc.code}"
+            ) from exc
+        except Exception as exc:
+            raise PreflightError(
+                f"qdrant unreachable at {qdrant_url}: {type(exc).__name__}"
+            ) from exc
+        cfg = (data.get("result") or {}).get("config", {}).get("params", {}).get("vectors", {})
+        size = cfg.get("size") if isinstance(cfg, dict) else None
+        if size is not None and int(size) != EXPECTED_VECTOR_SIZE:
+            raise PreflightError(
+                f"qdrant collection {collection} vector size is {size}, "
+                f"expected {EXPECTED_VECTOR_SIZE}"
+            )
+
+
+def _preflight_pipeline_importable() -> None:
+    try:
+        from backend.services.legal_ediscovery import process_vault_upload  # noqa: F401
+        from backend.services.ediscovery_agent import LegacySession           # noqa: F401
+    except Exception as exc:
+        raise PreflightError(
+            f"pipeline imports failed: {type(exc).__name__}:{exc!s}"
+        ) from exc
+
+
+def run_preflight(case_slug: str) -> dict[str, Any]:
+    """Run every pre-flight gate. Raises PreflightError on the first failure."""
+    case_meta = _preflight_case_exists(case_slug)
+    _preflight_postgres_writable(case_slug)
+    _preflight_schema_constraints()
+    _preflight_qdrant_reachable()
+    _preflight_pipeline_importable()
+    return case_meta
+
+
+# ─── classifier ──────────────────────────────────────────────────────────
+
+
+@dataclass
+class ParsedEmail:
+    """Minimal email view for classification."""
+    message_id:    str
+    sender:        str       # "Name <addr>"
+    sender_addr:   str       # bare addr
+    to_addrs:      list[str]
+    cc_addrs:      list[str]
+    subject:       str
+    body_snippet:  str       # first 16 KB of body, lowercased
+    internaldate:  Optional[date]
+    raw_bytes:     bytes
+
+
+@dataclass
+class ClassificationResult:
+    case_slug:    Optional[str]    # None when ambiguous → quarantined
+    privileged:   bool             # informational; process_vault_upload makes the actual privilege decision
+    reason:       str              # human-readable rule that fired
+    matched_terms: list[str] = field(default_factory=list)
+
+
+def _has_keyword(haystack: str, needles: tuple[str, ...]) -> Optional[str]:
+    for n in needles:
+        if n in haystack:
+            return n
+    return None
+
+
+def _addr_domain(addr: str) -> str:
+    return addr.lower().rsplit("@", 1)[-1] if "@" in addr else ""
+
+
+def classify_email(msg: ParsedEmail) -> ClassificationResult:
+    """Per-email routing decision. Returns case_slug + privileged flag.
+    Returns case_slug=None when ambiguity can't be resolved (→ quarantine).
+
+    Rule precedence (first match wins):
+      1. Explicit docket number in subject or body → corresponding case
+      2. Vanderburge-specific keyword → vanderburge
+      3. 7IL-prefix keyword: pre-2026 → case_i; 2026+ → case_ii
+      4. Counsel-domain match: route by date window + cc analysis
+      5. Username-only match (e.g. bare 'sanker') → date-window fallback
+      6. Otherwise: quarantine
+    """
+    subj_lower = msg.subject.lower()
+    body_lower = msg.body_snippet  # already lowercased
+    text = f"{subj_lower} {body_lower}"
+    sender_dom = _addr_domain(msg.sender_addr)
+    all_addrs = [msg.sender_addr] + msg.to_addrs + msg.cc_addrs
+    all_doms = {_addr_domain(a) for a in all_addrs}
+
+    matched: list[str] = []
+    privileged = any(
+        d in COUNSEL_DOMAINS_BY_CASE.get("7il-v-knight-ndga-i", ()) +
+             COUNSEL_DOMAINS_BY_CASE.get("7il-v-knight-ndga-ii", ()) +
+             COUNSEL_DOMAINS_BY_CASE.get("vanderburge-v-knight-fannin", ())
+        for d in all_doms
+    )
+
+    # Rule 1: explicit docket number in subject or body.
+    for case_slug, kws in CASE_KEYWORDS.items():
+        if case_slug in ("7il-v-knight-ndga-i", "7il-v-knight-ndga-ii"):
+            hit = _has_keyword(text, kws)
+            if hit:
+                matched.append(hit)
+                return ClassificationResult(case_slug=case_slug, privileged=privileged,
+                                            reason=f"docket {hit!r} in subject/body",
+                                            matched_terms=matched)
+
+    # Rule 2: Vanderburge keyword.
+    vander = _has_keyword(text, CASE_KEYWORDS["vanderburge-v-knight-fannin"])
+    if vander:
+        matched.append(vander)
+        return ClassificationResult(case_slug="vanderburge-v-knight-fannin",
+                                    privileged=privileged,
+                                    reason=f"vanderburge keyword {vander!r}",
+                                    matched_terms=matched)
+
+    # Rule 3: 7IL-prefix keywords. Date-disambiguated.
+    sevenil = _has_keyword(text, SEVEN_IL_KEYWORDS)
+    if sevenil:
+        matched.append(sevenil)
+        if msg.internaldate and msg.internaldate.year >= 2026:
+            return ClassificationResult(case_slug="7il-v-knight-ndga-ii",
+                                        privileged=privileged,
+                                        reason=f"7IL keyword {sevenil!r} + 2026+ date",
+                                        matched_terms=matched)
+        return ClassificationResult(case_slug="7il-v-knight-ndga-i",
+                                    privileged=privileged,
+                                    reason=f"7IL keyword {sevenil!r} + pre-2026 date",
+                                    matched_terms=matched)
+
+    # Rule 4: counsel-domain match.
+    counsel_match: Optional[tuple[str, str]] = None  # (domain, addr)
+    for d in all_doms:
+        if d in (COUNSEL_DOMAINS_BY_CASE.get("7il-v-knight-ndga-i", ()) +
+                  COUNSEL_DOMAINS_BY_CASE.get("7il-v-knight-ndga-ii", ()) +
+                  COUNSEL_DOMAINS_BY_CASE.get("vanderburge-v-knight-fannin", ())):
+            counsel_match = (d, "")
+            matched.append(d)
+            break
+
+    if counsel_match:
+        d = counsel_match[0]
+        # Cc Frank Moore → Vanderburge (matches both "frank moore" with space
+        # and "frank.moore@" / "frankmoore@" username patterns)
+        moore_patterns = ("frank moore", "frank.moore", "frankmoore", "f.moore", "fmoore@")
+        if any(any(p in a.lower() for p in moore_patterns) for a in all_addrs):
+            return ClassificationResult(case_slug="vanderburge-v-knight-fannin",
+                                        privileged=privileged,
+                                        reason=f"counsel {d} + cc 'frank moore'",
+                                        matched_terms=matched)
+        # Cc other your-side counsel (not msp-lawfirm) → 7IL track
+        other_counsel = {"fgplaw.com", "mhtlegal.com", "dralaw.com",
+                         "wilsonhamilton.com", "wilsonpruittlaw.com"}
+        if all_doms & other_counsel:
+            yr = msg.internaldate.year if msg.internaldate else 2024
+            target = "7il-v-knight-ndga-ii" if yr >= 2026 else "7il-v-knight-ndga-i"
+            return ClassificationResult(case_slug=target, privileged=privileged,
+                                        reason=f"counsel {d} + cc other your-side",
+                                        matched_terms=matched)
+
+        # Sanker (msp-lawfirm.com) date-fallback (most ambiguous case).
+        if d in ("msp-lawfirm.com", "masp-lawfirm.com"):
+            yr = msg.internaldate.year if msg.internaldate else 0
+            if yr >= 2026:
+                return ClassificationResult(case_slug="7il-v-knight-ndga-ii",
+                                            privileged=privileged,
+                                            reason=f"sanker domain + 2026+ date",
+                                            matched_terms=matched)
+            if 2021 <= yr <= 2025:
+                return ClassificationResult(case_slug="7il-v-knight-ndga-i",
+                                            privileged=privileged,
+                                            reason=f"sanker domain + 2021-2025 date",
+                                            matched_terms=matched)
+            if 2019 <= yr <= 2020:
+                # Vanderburge active period; ambiguous with Case I prep
+                return ClassificationResult(case_slug=None, privileged=privileged,
+                                            reason=f"sanker domain in 2019-2020 — Vanderburge/Case-I overlap; needs human review",
+                                            matched_terms=matched)
+            return ClassificationResult(case_slug=None, privileged=privileged,
+                                        reason=f"sanker domain with no clear date signal",
+                                        matched_terms=matched)
+
+        # Other your-side counsel — date window
+        for case, dwin in CASE_DATE_WINDOWS.items():
+            if d in COUNSEL_DOMAINS_BY_CASE.get(case, ()):
+                if msg.internaldate and dwin[0] <= msg.internaldate <= dwin[1]:
+                    return ClassificationResult(case_slug=case, privileged=privileged,
+                                                reason=f"counsel {d} + date window {case}",
+                                                matched_terms=matched)
+        return ClassificationResult(case_slug=None, privileged=privileged,
+                                    reason=f"counsel {d} but no date-window match",
+                                    matched_terms=matched)
+
+    # Rule 5: opposing-counsel terms.
+    for case, terms in OPPOSING_TERMS_BY_CASE.items():
+        hit = _has_keyword(text, terms)
+        if hit is None:
+            for a in all_addrs:
+                hit = _has_keyword(a.lower(), terms)
+                if hit:
+                    break
+        if hit:
+            matched.append(hit)
+            return ClassificationResult(case_slug=case, privileged=False,
+                                        reason=f"opposing term {hit!r} for {case}",
+                                        matched_terms=matched)
+
+    # Rule 6: username/name terms (less specific than domains).
+    for case, terms in USERNAME_TERMS_BY_CASE.items():
+        hit = _has_keyword(text, terms)
+        if hit:
+            matched.append(hit)
+            yr = msg.internaldate.year if msg.internaldate else 0
+            dwin = CASE_DATE_WINDOWS.get(case)
+            if dwin and msg.internaldate and dwin[0] <= msg.internaldate <= dwin[1]:
+                return ClassificationResult(case_slug=case, privileged=privileged,
+                                            reason=f"username {hit!r} + date window {case}",
+                                            matched_terms=matched)
+
+    # Default: quarantine.
+    return ClassificationResult(case_slug=None, privileged=privileged,
+                                reason="no rule matched; quarantine",
+                                matched_terms=matched)
+
+
+# ─── IMAP helpers ────────────────────────────────────────────────────────
+
+
+def imap_connect(user: str, pw: str) -> imaplib.IMAP4_SSL:
+    M = imaplib.IMAP4_SSL(IMAP_HOST, IMAP_PORT, timeout=SEARCH_TIMEOUT_S)
+    M.login(user, pw)
+    return M
+
+
+def _imap_date(d: date) -> str:
+    return d.strftime("%-d-%b-%Y")
+
+
+def _add_months(d: date, months: int) -> date:
+    m = d.month - 1 + months
+    y = d.year + m // 12
+    m = m % 12 + 1
+    try:
+        return date(y, m, d.day)
+    except ValueError:
+        nxt = date(y, m, 28) + timedelta(days=4)
+        return nxt - timedelta(days=nxt.day)
+
+
+def date_bands(start: date, end: date, months: int = BAND_MONTHS) -> list[tuple[date, date]]:
+    bands: list[tuple[date, date]] = []
+    cursor = start
+    while cursor < end:
+        nxt = _add_months(cursor, months)
+        if nxt > end:
+            nxt = end
+        bands.append((cursor, nxt))
+        cursor = nxt
+    return bands
+
+
+def imap_examine(M: imaplib.IMAP4_SSL, folder: str) -> int:
+    quoted = '"' + folder.replace('"', '\\"') + '"'
+    typ, data = M.select(quoted, readonly=True)
+    if typ != "OK":
+        return -1
+    raw = data[0] if data else b""
+    s = raw.decode("utf-8", "replace") if isinstance(raw, bytes) else str(raw)
+    return int(s.strip()) if s.strip().isdigit() else -1
+
+
+def imap_list_priority_folders(M: imaplib.IMAP4_SSL) -> list[str]:
+    typ, lines = M.list()
+    if typ != "OK":
+        return []
+    folders: list[str] = []
+    for line in lines or []:
+        if line is None:
+            continue
+        if isinstance(line, bytes):
+            s = line.decode("utf-8", "replace")
+        elif isinstance(line, tuple):
+            s = b"".join(p for p in line if isinstance(p, (bytes, bytearray))).decode("utf-8", "replace")
+        else:
+            continue
+        m = re.search(r'"([^"]*)"\s*$', s)
+        if m:
+            folders.append(m.group(1))
+    return [f for f in folders if any(p.search(f) for p in SEARCH_FOLDER_PATTERNS)]
+
+
+def search_uids_in_band(M: imaplib.IMAP4_SSL, since: date, before: date) -> list[str]:
+    """UID SEARCH for the date band. Per Issue #177 SEARCH-overflow workaround."""
+    typ, data = M.uid("SEARCH", f"SINCE {_imap_date(since)} BEFORE {_imap_date(before)}")
+    if typ != "OK" or not data or not data[0]:
+        return []
+    return [u.decode("ascii", "replace") for u in data[0].split()]
+
+
+def fetch_uid_full(M: imaplib.IMAP4_SSL, uid: str) -> Optional[bytes]:
+    """FETCH the full message bytes (RFC822) for a UID. EXAMINE-mode safe."""
+    typ, data = M.uid("FETCH", uid, "(BODY.PEEK[])")
+    if typ != "OK" or not data:
+        return None
+    for entry in data:
+        if isinstance(entry, tuple) and len(entry) >= 2:
+            return entry[1] if isinstance(entry[1], bytes) else None
+    return None
+
+
+# ─── email parsing ───────────────────────────────────────────────────────
+
+
+def parse_email(raw: bytes, internaldate: Optional[date]) -> Optional[ParsedEmail]:
+    """Parse an .eml-shaped byte blob into a ParsedEmail. Returns None on bad input."""
+    try:
+        msg = email_module.message_from_bytes(raw, policy=email.policy.default)
+    except Exception:
+        return None
+
+    from_ = (msg.get("From") or "").strip()
+    sender_addr = email.utils.parseaddr(from_)[1].lower() if from_ else ""
+
+    to_field = (msg.get("To") or "").strip()
+    cc_field = (msg.get("Cc") or "").strip()
+
+    def _split_addrs(field: str) -> list[str]:
+        out: list[str] = []
+        for _, a in email.utils.getaddresses([field]):
+            if a:
+                out.append(a.lower())
+        return out
+
+    to_addrs = _split_addrs(to_field)
+    cc_addrs = _split_addrs(cc_field)
+    subject = (msg.get("Subject") or "").strip()
+    msg_id = (msg.get("Message-ID") or "").strip()
+
+    # Body snippet — first 16 KB, lowercase.
+    body_chunks: list[str] = []
+    try:
+        for part in msg.walk():
+            if part.get_content_type() in ("text/plain", "text/html"):
+                payload = part.get_content() if hasattr(part, "get_content") else part.get_payload(decode=True)
+                if isinstance(payload, bytes):
+                    payload = payload.decode("utf-8", "replace")
+                if isinstance(payload, str):
+                    body_chunks.append(payload)
+                if sum(len(c) for c in body_chunks) > 32_000:
+                    break
+    except Exception:
+        pass
+    body_snippet = " ".join(body_chunks)[:16384].lower()
+
+    return ParsedEmail(
+        message_id=msg_id, sender=from_, sender_addr=sender_addr,
+        to_addrs=to_addrs, cc_addrs=cc_addrs,
+        subject=subject, body_snippet=body_snippet,
+        internaldate=internaldate, raw_bytes=raw,
+    )
+
+
+def message_file_hash(parsed: ParsedEmail) -> str:
+    """Stable hash for dedup. Uses Message-Id when available; else SHA-256 of raw bytes.
+    Returns 64-char hex. Same hash → same email regardless of reformatting."""
+    h = hashlib.sha256()
+    if parsed.message_id:
+        h.update(parsed.message_id.encode("utf-8", "replace"))
+        return h.hexdigest()
+    h.update(parsed.raw_bytes)
+    return h.hexdigest()
+
+
+def _slugify(s: str, maxlen: int = 40) -> str:
+    s = re.sub(r"[^A-Za-z0-9]+", "-", s).strip("-").lower()
+    return s[:maxlen] or "x"
+
+
+def email_file_name(parsed: ParsedEmail) -> str:
+    """Filename for vault_documents.file_name. Date_sender_subject.eml shape."""
+    d = parsed.internaldate.strftime("%Y%m%d") if parsed.internaldate else "00000000"
+    sender_slug = _slugify(parsed.sender_addr.split("@")[0] if "@" in parsed.sender_addr else parsed.sender_addr)
+    subj_slug = _slugify(parsed.subject)
+    return f"{d}_{sender_slug}_{subj_slug}.eml"
+
+
+# ─── per-email processing ───────────────────────────────────────────────
+
+
+@dataclass
+class EmailOutcome:
+    uid:           str
+    mailbox:       str
+    folder:        str
+    message_id:    str
+    file_hash:     str
+    file_name:     str
+    case_slug:     Optional[str]
+    privileged:    bool
+    classification_reason: str
+    status:        str   # ingested | duplicate | quarantined | failed | skipped
+    document_id:   Optional[str] = None
+    chunks:        int = 0
+    vectors_indexed: int = 0
+    error:         Optional[str] = None
+
+
+def _check_existing_row(case_slug: str, file_hash: str) -> Optional[str]:
+    conn = _connect("fortress_db")
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT processing_status FROM legal.vault_documents "
+                "WHERE case_slug = %s AND file_hash = %s",
+                (case_slug, file_hash),
+            )
+            row = cur.fetchone()
+        return row[0] if row else None
+    finally:
+        conn.close()
+
+
+def _mirror_row_db_to_prod(case_slug: str, doc_id: str) -> None:
+    """After process_vault_upload writes via LegacySession (fortress_db), copy
+    the row to fortress_prod (mirrors PR D pattern)."""
+    src = _connect("fortress_db")
+    try:
+        with src.cursor() as cur:
+            cur.execute(
+                "SELECT id, case_slug, file_name, nfs_path, mime_type, "
+                "file_hash, file_size_bytes, processing_status, "
+                "chunk_count, error_detail, created_at "
+                "FROM legal.vault_documents WHERE id = %s AND case_slug = %s",
+                (doc_id, case_slug),
+            )
+            row = cur.fetchone()
+        if row is None:
+            raise RuntimeError(
+                f"row {doc_id} missing in fortress_db for case {case_slug!r}"
+            )
+    finally:
+        src.close()
+    dst = _connect("fortress_prod")
+    try:
+        with dst.cursor() as cur:
+            cur.execute(
+                "INSERT INTO legal.vault_documents "
+                "(id, case_slug, file_name, nfs_path, mime_type, file_hash, "
+                " file_size_bytes, processing_status, chunk_count, error_detail, created_at) "
+                "VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s) "
+                "ON CONFLICT ON CONSTRAINT uq_vault_documents_case_hash DO UPDATE SET "
+                "  processing_status = EXCLUDED.processing_status, "
+                "  chunk_count = EXCLUDED.chunk_count, "
+                "  error_detail = EXCLUDED.error_detail",
+                row,
+            )
+    finally:
+        dst.close()
+
+
+async def _ingest_email(parsed: ParsedEmail, classification: ClassificationResult) -> EmailOutcome:
+    """Push one email through process_vault_upload. Returns outcome including
+    case_slug + privilege routing decision (which is process_vault_upload's, not
+    ours)."""
+    fhash = message_file_hash(parsed)
+    fname = email_file_name(parsed)
+    case_slug = classification.case_slug
+
+    base_outcome = EmailOutcome(
+        uid="", mailbox="", folder="",
+        message_id=parsed.message_id, file_hash=fhash, file_name=fname,
+        case_slug=case_slug, privileged=classification.privileged,
+        classification_reason=classification.reason,
+        status="failed",
+    )
+
+    if case_slug is None:
+        base_outcome.status = "quarantined"
+        return base_outcome
+
+    existing = _check_existing_row(case_slug, fhash)
+    if existing in {"complete", "completed", "ocr_failed", "locked_privileged"}:
+        base_outcome.status = "duplicate"
+        return base_outcome
+
+    from backend.services.ediscovery_agent import LegacySession
+    from backend.services.legal_ediscovery import process_vault_upload
+
+    try:
+        async with LegacySession() as db:
+            result = await process_vault_upload(
+                db=db, case_slug=case_slug,
+                file_bytes=parsed.raw_bytes,
+                file_name=fname,
+                mime_type="message/rfc822",
+            )
+    except Exception as exc:
+        base_outcome.status = "failed"
+        base_outcome.error = f"{type(exc).__name__}:{str(exc)[:200]}"
+        return base_outcome
+
+    status = result.get("status", "failed")
+    doc_id = result.get("document_id")
+    base_outcome.status = "ingested" if status in {"completed", "ocr_failed", "locked_privileged"} else (
+        "duplicate" if status == "duplicate" else "failed"
+    )
+    base_outcome.document_id = doc_id
+    base_outcome.chunks = int(result.get("chunks") or 0)
+    base_outcome.vectors_indexed = int(result.get("vectors_indexed") or 0)
+    base_outcome.error = str(result.get("error")) if status == "failed" else None
+
+    if doc_id and base_outcome.status == "ingested":
+        try:
+            _mirror_row_db_to_prod(case_slug, doc_id)
+        except Exception as exc:
+            base_outcome.status = "failed"
+            base_outcome.error = f"mirror_failed:{type(exc).__name__}:{str(exc)[:200]}"
+
+    return base_outcome
+
+
+# ─── lock + state ────────────────────────────────────────────────────────
+
+
+def _lock_path(case_slug: str) -> Path:
+    return Path(f"/tmp/email-backfill-{case_slug}.lock")
+
+
+def _state_path(case_slug: str) -> Path:
+    return Path(f"/tmp/email-backfill-{case_slug}.state.json")
+
+
+def acquire_lock(case_slug: str, force: bool) -> Path:
+    lp = _lock_path(case_slug)
+    if lp.exists():
+        try:
+            mtime = lp.stat().st_mtime
+        except OSError:
+            mtime = 0.0
+        age = time.time() - mtime
+        if force and age > LOCK_STALE_AFTER_S:
+            lp.unlink()
+        elif force:
+            raise SystemExit(
+                f"--force given but lock at {lp} is only {int(age)}s old "
+                f"(needs > {LOCK_STALE_AFTER_S}s)"
+            )
+        else:
+            raise SystemExit(
+                f"another backfill appears active (lock at {lp}); "
+                f"after confirming no other run, pass --force"
+            )
+    lp.write_text(f"{os.getpid()}\n{datetime.now(timezone.utc).isoformat()}\n")
+    return lp
+
+
+def release_lock(lp: Path) -> None:
+    try:
+        lp.unlink()
+    except Exception:
+        pass
+
+
+def load_state(case_slug: str) -> dict[str, Any]:
+    p = _state_path(case_slug)
+    if not p.exists():
+        return {"completed_uids": []}
+    try:
+        return json.loads(p.read_text())
+    except Exception:
+        return {"completed_uids": []}
+
+
+def save_state(case_slug: str, state: dict[str, Any]) -> None:
+    try:
+        _state_path(case_slug).write_text(json.dumps(state, indent=2, default=str))
+    except Exception:
+        pass
+
+
+# ─── manifest ────────────────────────────────────────────────────────────
+
+
+@dataclass
+class BackfillManifest:
+    case_slug:    str
+    started_at:   str
+    finished_at:  str = ""
+    runtime_seconds: float = 0.0
+    args:         dict[str, Any] = field(default_factory=dict)
+    host:         str = ""
+    pid:          int = 0
+    ingest_run_id: Optional[str] = None
+    mailboxes:    list[str] = field(default_factory=list)
+    total_uids:   int = 0
+    ingested:     int = 0
+    duplicate:    int = 0
+    quarantined:  int = 0
+    failed:       int = 0
+    skipped:      int = 0
+    by_classification: dict[str, int] = field(default_factory=dict)
+    quarantine_log: list[dict[str, Any]] = field(default_factory=list)
+    errors:       list[dict[str, Any]] = field(default_factory=list)
+
+
+def write_manifest(case_slug: str, manifest: BackfillManifest) -> Path:
+    AUDIT_DIR.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    out = AUDIT_DIR / f"email-backfill-{case_slug}-{ts}.json"
+    out.write_text(json.dumps(asdict(manifest), indent=2, default=str))
+    return out
+
+
+# ─── orchestrator ────────────────────────────────────────────────────────
+
+
+def run_backfill(args: argparse.Namespace) -> int:
+    case_meta = run_preflight(args.case_slug)
+    lock = acquire_lock(args.case_slug, force=bool(args.force))
+    state = load_state(args.case_slug) if args.resume else {"completed_uids": []}
+    completed_uids = set(state.get("completed_uids", []))
+
+    started = datetime.now(timezone.utc)
+    t0 = time.monotonic()
+
+    since = date.fromisoformat(args.since)
+    until = date.fromisoformat(args.until)
+    bands = date_bands(since, until, BAND_MONTHS)
+    mailbox_aliases = [m.strip() for m in args.mailbox.split(",") if m.strip()]
+
+    manifest = BackfillManifest(
+        case_slug=args.case_slug,
+        started_at=started.isoformat(),
+        args={k: v for k, v in vars(args).items() if k != "force"},
+        host=socket.gethostname(),
+        pid=os.getpid(),
+        mailboxes=mailbox_aliases,
+    )
+
+    print(
+        f"# email-backfill: case={args.case_slug} mailboxes={mailbox_aliases} "
+        f"bands={len(bands)} ({since}→{until}) dry_run={args.dry_run}",
+        flush=True,
+    )
+
+    from backend.services.ingest_run_tracker import IngestRunTracker
+
+    try:
+        with IngestRunTracker(
+            args.case_slug, "email_backfill_legal",
+            args=manifest.args,
+        ) as tracker:
+            manifest.ingest_run_id = (
+                str(tracker.run_id) if tracker.run_id is not None else None
+            )
+
+            outcomes = asyncio.run(_drive_async_loop(
+                mailbox_aliases=mailbox_aliases,
+                bands=bands,
+                args=args,
+                completed_uids=completed_uids,
+                manifest=manifest,
+                tracker=tracker,
+            ))
+
+            for o in outcomes:
+                manifest.by_classification[o.status] = manifest.by_classification.get(o.status, 0) + 1
+                if o.status == "ingested":
+                    manifest.ingested += 1
+                elif o.status == "duplicate":
+                    manifest.duplicate += 1
+                elif o.status == "quarantined":
+                    manifest.quarantined += 1
+                    manifest.quarantine_log.append({
+                        "uid": o.uid, "mailbox": o.mailbox, "folder": o.folder,
+                        "message_id": o.message_id, "file_hash": o.file_hash,
+                        "reason": o.classification_reason,
+                    })
+                elif o.status == "failed":
+                    manifest.failed += 1
+                    manifest.errors.append({
+                        "uid": o.uid, "mailbox": o.mailbox, "folder": o.folder,
+                        "message_id": o.message_id, "error": o.error or "",
+                    })
+                elif o.status == "skipped":
+                    manifest.skipped += 1
+
+            manifest.finished_at = datetime.now(timezone.utc).isoformat()
+            manifest.runtime_seconds = round(time.monotonic() - t0, 2)
+            manifest_path = write_manifest(args.case_slug, manifest)
+            tracker.set_manifest_path(manifest_path)
+            tracker.update(processed=manifest.ingested,
+                           errored=manifest.failed,
+                           skipped=manifest.duplicate + manifest.quarantined)
+
+            print(
+                f"# done: total={manifest.total_uids} ingested={manifest.ingested} "
+                f"duplicate={manifest.duplicate} quarantined={manifest.quarantined} "
+                f"failed={manifest.failed} runtime={manifest.runtime_seconds:.1f}s "
+                f"manifest={manifest_path}",
+                flush=True,
+            )
+            return 0 if manifest.failed == 0 else 1
+    finally:
+        save_state(args.case_slug, {"completed_uids": sorted(completed_uids)})
+        release_lock(lock)
+
+
+async def _drive_async_loop(
+    *, mailbox_aliases: list[str],
+    bands: list[tuple[date, date]],
+    args: argparse.Namespace,
+    completed_uids: set[str],
+    manifest: BackfillManifest,
+    tracker,
+) -> list[EmailOutcome]:
+    sem = asyncio.Semaphore(max(1, int(getattr(args, "jobs", 4))))
+    outcomes: list[EmailOutcome] = []
+    total = 0
+
+    for alias in mailbox_aliases:
+        if alias not in MAILBOX_REGISTRY:
+            print(f"  SKIP {alias} — not in MAILBOX_REGISTRY", flush=True)
+            continue
+        user, slug = MAILBOX_REGISTRY[alias]
+        try:
+            pw = _password(slug)
+        except Exception as exc:
+            print(f"  SKIP {alias} — pass lookup failed: {exc}", flush=True)
+            continue
+        try:
+            M = imap_connect(user, pw)
+        except Exception as exc:
+            print(f"  SKIP {alias} — login failed: {exc!s}", flush=True)
+            continue
+
+        try:
+            folders = imap_list_priority_folders(M)
+            print(f"  {alias} folders: {folders[:5]}...", flush=True)
+            for folder in folders:
+                cnt = imap_examine(M, folder)
+                if cnt < 0:
+                    continue
+                for since, before in bands:
+                    uids = search_uids_in_band(M, since, before)
+                    for uid in uids:
+                        key = f"{alias}|{folder}|{uid}"
+                        if key in completed_uids:
+                            continue
+                        if args.limit is not None and total >= args.limit:
+                            break
+
+                        raw = fetch_uid_full(M, uid)
+                        if raw is None:
+                            continue
+                        # crude internaldate from band midpoint as fallback;
+                        # a more precise read would parse INTERNALDATE separately
+                        midpoint = since + (before - since) // 2
+                        parsed = parse_email(raw, midpoint)
+                        if parsed is None:
+                            outcomes.append(EmailOutcome(
+                                uid=uid, mailbox=alias, folder=folder,
+                                message_id="", file_hash="", file_name="",
+                                case_slug=None, privileged=False,
+                                classification_reason="parse_failed",
+                                status="failed", error="email parse_failed",
+                            ))
+                            tracker.inc_errored()
+                            total += 1
+                            continue
+
+                        cls = classify_email(parsed)
+
+                        # Filter: only ingest emails classified to this case
+                        # (or quarantine if --include-quarantine flagged)
+                        if cls.case_slug != args.case_slug and not (
+                            cls.case_slug is None and args.include_quarantine
+                        ):
+                            outcome = EmailOutcome(
+                                uid=uid, mailbox=alias, folder=folder,
+                                message_id=parsed.message_id,
+                                file_hash=message_file_hash(parsed),
+                                file_name=email_file_name(parsed),
+                                case_slug=cls.case_slug, privileged=cls.privileged,
+                                classification_reason=cls.reason,
+                                status="skipped",
+                            )
+                            outcomes.append(outcome)
+                            tracker.inc_skipped()
+                            total += 1
+                            continue
+
+                        if args.dry_run:
+                            outcome = EmailOutcome(
+                                uid=uid, mailbox=alias, folder=folder,
+                                message_id=parsed.message_id,
+                                file_hash=message_file_hash(parsed),
+                                file_name=email_file_name(parsed),
+                                case_slug=cls.case_slug, privileged=cls.privileged,
+                                classification_reason=cls.reason,
+                                status="skipped",
+                                error="dry_run",
+                            )
+                            outcomes.append(outcome)
+                            tracker.inc_skipped()
+                            total += 1
+                            continue
+
+                        outcome = await _ingest_email(parsed, cls)
+                        outcome.uid = uid
+                        outcome.mailbox = alias
+                        outcome.folder = folder
+                        outcomes.append(outcome)
+                        completed_uids.add(key)
+                        total += 1
+
+                        if outcome.status == "ingested":
+                            tracker.inc_processed()
+                        elif outcome.status == "failed":
+                            tracker.inc_errored()
+                        else:
+                            tracker.inc_skipped()
+
+                        if total % 25 == 0:
+                            print(
+                                f"  [{total}] {outcome.status:<14s} "
+                                f"{outcome.case_slug or '<quar>':<35s} "
+                                f"{(outcome.classification_reason or '')[:60]}",
+                                flush=True,
+                            )
+
+                    if args.limit is not None and total >= args.limit:
+                        break
+                if args.limit is not None and total >= args.limit:
+                    break
+        finally:
+            try:
+                M.logout()
+            except Exception:
+                pass
+
+    manifest.total_uids = total
+    return outcomes
+
+
+# ─── rollback ────────────────────────────────────────────────────────────
+
+
+def run_rollback(args: argparse.Namespace) -> int:
+    """Delete email-backfill rows for the case in both DBs and Qdrant points
+    where payload.case_slug matches AND file_name ends in .eml. Confirmation
+    required unless --force."""
+    case_slug = args.case_slug
+    if not args.force:
+        print(
+            f"This will DELETE all email-backfill rows (.eml files) for "
+            f"case_slug '{case_slug}' in fortress_prod AND fortress_db, "
+            f"plus Qdrant points where payload.case_slug == '{case_slug}'.",
+            flush=True,
+        )
+        try:
+            typed = input(f"Type the case_slug ({case_slug}) to confirm: ").strip()
+        except EOFError:
+            typed = ""
+        if typed != case_slug:
+            print("rollback cancelled — confirmation did not match", flush=True)
+            return 2
+
+    pre: dict[str, int] = {}
+    for dbname in ("fortress_prod", "fortress_db"):
+        conn = _connect(dbname)
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT count(*) FROM legal.vault_documents "
+                    "WHERE case_slug = %s AND file_name LIKE %s",
+                    (case_slug, "%.eml"),
+                )
+                row = cur.fetchone()
+                pre[dbname] = int(row[0]) if row else 0
+        finally:
+            conn.close()
+    print(f"# pre-rollback row counts: {pre}", flush=True)
+
+    deleted: dict[str, int] = {}
+    for dbname in ("fortress_prod", "fortress_db"):
+        conn = _connect(dbname)
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM legal.vault_documents "
+                    "WHERE case_slug = %s AND file_name LIKE %s",
+                    (case_slug, "%.eml"),
+                )
+                deleted[dbname] = cur.rowcount or 0
+        finally:
+            conn.close()
+    print(f"# deleted vault_documents rows: {deleted}", flush=True)
+
+    # Qdrant: best-effort — delete points with payload case_slug match.
+    # File-name filtering at Qdrant level isn't supported uniformly;
+    # operator can scope further via the --qdrant-only flag.
+    deleted["qdrant_estimate"] = _delete_qdrant_points_for_case(case_slug)
+
+    AUDIT_DIR.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    out = AUDIT_DIR / f"email-backfill-rollback-{case_slug}-{ts}.json"
+    out.write_text(json.dumps({
+        "case_slug": case_slug,
+        "rolled_back_at": datetime.now(timezone.utc).isoformat(),
+        "host": socket.gethostname(),
+        "pid": os.getpid(),
+        "operation": "email-backfill-rollback",
+        "pre_counts": pre,
+        "deleted": deleted,
+    }, indent=2, default=str))
+    print(f"# rollback manifest: {out}", flush=True)
+    return 0
+
+
+def _delete_qdrant_points_for_case(case_slug: str) -> int:
+    """Delete Qdrant points across BOTH collections where payload.case_slug
+    matches. Returns approximate count via pre/post delta."""
+    import urllib.request
+    qdrant_url = os.environ.get("QDRANT_URL", "").rstrip("/")
+    if not qdrant_url:
+        return 0
+    total_deleted = 0
+    for collection in (QDRANT_COLLECTION_WORK_PRODUCT, QDRANT_COLLECTION_PRIVILEGED):
+        body = {"filter": {"must": [{"key": "case_slug", "match": {"value": case_slug}}]}}
+        try:
+            pre_count = _count_qdrant_points(qdrant_url, collection, case_slug)
+            req = urllib.request.Request(
+                f"{qdrant_url}/collections/{collection}/points/delete?wait=true",
+                data=json.dumps(body).encode("utf-8"),
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=120) as r:
+                r.read()
+            post_count = _count_qdrant_points(qdrant_url, collection, case_slug)
+            total_deleted += max(0, pre_count - post_count)
+        except Exception as exc:
+            logger.warning("qdrant_delete %s failed: %s", collection, str(exc)[:120])
+    return total_deleted
+
+
+def _count_qdrant_points(qdrant_url: str, collection: str, case_slug: str) -> int:
+    import urllib.request
+    body = {"filter": {"must": [{"key": "case_slug", "match": {"value": case_slug}}]},
+            "exact": True}
+    req = urllib.request.Request(
+        f"{qdrant_url}/collections/{collection}/points/count",
+        data=json.dumps(body).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            data = json.loads(r.read().decode("utf-8"))
+        return int((data.get("result") or {}).get("count") or 0)
+    except Exception:
+        return 0
+
+
+# ─── CLI ─────────────────────────────────────────────────────────────────
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Case-aware IMAP email backfill into legal vault",
+    )
+    p.add_argument("--case-slug", required=True,
+                   help="Target case_slug. Only emails classified to this slug are ingested")
+    p.add_argument("--mailbox", default="gary-gk,gary-crog",
+                   help="Comma-separated mailbox aliases from MAILBOX_REGISTRY")
+    p.add_argument("--since", default="2018-01-01",
+                   help="Earliest date (YYYY-MM-DD) for IMAP SEARCH")
+    p.add_argument("--until", default=None,
+                   help="Latest date (YYYY-MM-DD); default today")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Classify and report but do not call process_vault_upload")
+    p.add_argument("--limit", type=int, default=None,
+                   help="Cap on emails processed (testing)")
+    p.add_argument("--include-quarantine", action="store_true",
+                   help="Also process emails that classify to None (quarantine flow)")
+    p.add_argument("--rollback", action="store_true",
+                   help="Delete vault_documents rows + Qdrant points for the case")
+    p.add_argument("--jobs", type=int, default=4,
+                   help="Parallel workers for per-email pipeline (default 4)")
+    p.add_argument("--resume", action="store_true",
+                   help="Skip UIDs in state file from a previous run")
+    p.add_argument("--force", action="store_true",
+                   help="Override stale lock or skip rollback confirmation")
+    args = p.parse_args(argv)
+    if args.until is None:
+        args.until = datetime.now(timezone.utc).date().isoformat()
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    _ensure_env_loaded()
+    args = _parse_args(argv)
+
+    if args.rollback:
+        return run_rollback(args)
+
+    try:
+        return run_backfill(args)
+    except PreflightError as exc:
+        print(f"PREFLIGHT FAILED: {exc}", file=sys.stderr, flush=True)
+        return 3
+    except KeyboardInterrupt:
+        print("\n# interrupted — state checkpointed; resume with --resume",
+              file=sys.stderr, flush=True)
+        return 130
+    except Exception as exc:
+        traceback.print_exc()
+        print(f"FATAL: {type(exc).__name__}:{exc!s}", file=sys.stderr, flush=True)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fortress-guest-platform/backend/tests/test_email_backfill_legal.py
+++ b/fortress-guest-platform/backend/tests/test_email_backfill_legal.py
@@ -1,0 +1,428 @@
+"""Tests for backend.scripts.email_backfill_legal — PR I email backfill.
+
+IMAP, Postgres, and Qdrant are mocked. The classifier is exercised against
+synthetic ParsedEmail fixtures. The pipeline is exercised end-to-end with
+a fake LegacySession + fake process_vault_upload.
+"""
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+from typing import Callable
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import run  # noqa: F401  registers backend.* path
+from backend.scripts import email_backfill_legal as ebl
+
+
+# ─── classifier helpers ──────────────────────────────────────────────────
+
+
+def _mk(*, message_id="<msg-1@x>", sender="counsel@msp-lawfirm.com",
+        sender_addr=None, to=("gary@cabin-rentals-of-georgia.com",),
+        cc=(), subject="", body="", internaldate=date(2023, 6, 15)):
+    sender_addr = sender_addr or (sender.split("<")[-1].rstrip(">").strip().lower()
+                                    if "<" in sender else sender.lower())
+    return ebl.ParsedEmail(
+        message_id=message_id, sender=sender, sender_addr=sender_addr,
+        to_addrs=list(to), cc_addrs=list(cc),
+        subject=subject, body_snippet=body.lower(),
+        internaldate=internaldate, raw_bytes=b"raw",
+    )
+
+
+# ─── 1. Classifier — explicit Case I docket ──────────────────────────────
+
+
+def test_classifier_explicit_case_i_docket_routes_to_case_i():
+    msg = _mk(subject="RE: 7IL Properties LLC v. Knight, 2:21-cv-00226-RWS",
+              internaldate=date(2022, 5, 10))
+    r = ebl.classify_email(msg)
+    assert r.case_slug == "7il-v-knight-ndga-i"
+    assert "2:21-cv-00226" in r.matched_terms
+    assert r.privileged is True   # sender is msp-lawfirm.com (counsel domain)
+
+
+# ─── 2. Classifier — explicit Case II docket ─────────────────────────────
+
+
+def test_classifier_explicit_case_ii_docket_routes_to_case_ii():
+    msg = _mk(subject="Re: 2:26-cv-00113 status",
+              internaldate=date(2026, 3, 1))
+    r = ebl.classify_email(msg)
+    assert r.case_slug == "7il-v-knight-ndga-ii"
+    assert "2:26-cv-00113" in r.matched_terms
+
+
+# ─── 3. Classifier — Vanderburge keyword ─────────────────────────────────
+
+
+def test_classifier_vanderburge_keyword_routes_to_vanderburge():
+    msg = _mk(subject="Re: Vanderburge easement settlement draft",
+              internaldate=date(2020, 8, 10))
+    r = ebl.classify_email(msg)
+    assert r.case_slug == "vanderburge-v-knight-fannin"
+    assert any(t in r.matched_terms for t in ("vanderburge", "easement"))
+
+
+# ─── 4. Classifier — Sanker 2019 with no other signal → quarantine ───────
+
+
+def test_classifier_sanker_2019_no_other_signal_quarantines():
+    """Sanker emails in 2019-2020 are ambiguous (Vanderburge active period
+    overlaps with Case I pre-filing prep). Should land in quarantine."""
+    msg = _mk(sender="jsank@msp-lawfirm.com",
+              subject="checking in on the matter",
+              body="please review the attached and let me know your thoughts.",
+              internaldate=date(2019, 10, 20))
+    r = ebl.classify_email(msg)
+    assert r.case_slug is None
+    assert "needs human review" in r.reason or "review" in r.reason
+
+
+# ─── 5. Classifier — Sanker 2026+ no signal → Case II ────────────────────
+
+
+def test_classifier_sanker_2026_routes_to_case_ii():
+    msg = _mk(sender="jsank@msp-lawfirm.com",
+              subject="status update",
+              internaldate=date(2026, 4, 1))
+    r = ebl.classify_email(msg)
+    assert r.case_slug == "7il-v-knight-ndga-ii"
+
+
+# ─── 6. Classifier — Sanker 2023 no signal → Case I ──────────────────────
+
+
+def test_classifier_sanker_2023_routes_to_case_i():
+    msg = _mk(sender="jsank@msp-lawfirm.com",
+              subject="discovery responses",
+              internaldate=date(2023, 6, 15))
+    r = ebl.classify_email(msg)
+    assert r.case_slug == "7il-v-knight-ndga-i"
+
+
+# ─── 7. Classifier — Sanker with cc Podesta → Case I ─────────────────────
+
+
+def test_classifier_sanker_with_cc_podesta_routes_to_case_i():
+    msg = _mk(sender="jsank@msp-lawfirm.com",
+              cc=("fpodesta@fgplaw.com",),
+              subject="trial prep meeting",
+              internaldate=date(2024, 3, 5))
+    r = ebl.classify_email(msg)
+    assert r.case_slug == "7il-v-knight-ndga-i"
+    assert "fgplaw" in r.reason or "your-side" in r.reason
+
+
+# ─── 8. Classifier — Sanker with cc Frank Moore → Vanderburge ────────────
+
+
+def test_classifier_sanker_with_cc_frank_moore_routes_to_vanderburge():
+    msg = _mk(sender="jsank@msp-lawfirm.com",
+              cc=("frank.moore@somefirm.com",),
+              subject="settlement terms",
+              internaldate=date(2020, 7, 10))
+    r = ebl.classify_email(msg)
+    assert r.case_slug == "vanderburge-v-knight-fannin"
+    assert "moore" in r.reason.lower()
+
+
+# ─── 9. Classifier — opposing counsel routes to work-product ─────────────
+
+
+def test_classifier_opposing_counsel_routes_to_work_product():
+    msg = _mk(sender="bgoldberg@somefirm.com",
+              sender_addr="bgoldberg@somefirm.com",
+              subject="discovery response from plaintiff",
+              body="please find attached the production",
+              internaldate=date(2023, 4, 1))
+    r = ebl.classify_email(msg)
+    # Opposing counsel matches → 7IL case; not privileged
+    assert r.case_slug in ("7il-v-knight-ndga-i", "7il-v-knight-ndga-ii")
+    assert r.privileged is False
+
+
+# ─── 10. Classifier — unmatched email → quarantine ───────────────────────
+
+
+def test_classifier_unmatched_email_quarantines():
+    msg = _mk(sender="newsletter@example.com",
+              sender_addr="newsletter@example.com",
+              subject="weekly newsletter",
+              body="random marketing content",
+              internaldate=date(2024, 1, 15),
+              cc=(), to=("gary@cabin-rentals-of-georgia.com",))
+    r = ebl.classify_email(msg)
+    assert r.case_slug is None
+    assert r.privileged is False
+
+
+# ─── 11. message_file_hash uses Message-Id when available ────────────────
+
+
+def test_message_file_hash_uses_message_id_when_present():
+    msg_a = _mk(message_id="<unique@example.com>")
+    msg_a.raw_bytes = b"different bytes"
+    msg_b = _mk(message_id="<unique@example.com>")
+    msg_b.raw_bytes = b"completely different bytes"
+    assert ebl.message_file_hash(msg_a) == ebl.message_file_hash(msg_b)
+
+
+def test_message_file_hash_falls_back_to_raw_bytes_when_no_msg_id():
+    msg_a = ebl.ParsedEmail(message_id="", sender="", sender_addr="",
+                              to_addrs=[], cc_addrs=[], subject="",
+                              body_snippet="", internaldate=None,
+                              raw_bytes=b"first content")
+    msg_b = ebl.ParsedEmail(message_id="", sender="", sender_addr="",
+                              to_addrs=[], cc_addrs=[], subject="",
+                              body_snippet="", internaldate=None,
+                              raw_bytes=b"second content")
+    assert ebl.message_file_hash(msg_a) != ebl.message_file_hash(msg_b)
+
+
+# ─── 12. email_file_name shape ──────────────────────────────────────────
+
+
+def test_email_file_name_format():
+    msg = _mk(sender="jsank@msp-lawfirm.com", sender_addr="jsank@msp-lawfirm.com",
+              subject="Re: trial prep",
+              internaldate=date(2024, 3, 5))
+    name = ebl.email_file_name(msg)
+    assert name.endswith(".eml")
+    assert "20240305" in name
+    assert "jsank" in name
+    assert "trial-prep" in name or "trial" in name
+
+
+# ─── 13. parse_email handles minimal RFC-822 ────────────────────────────
+
+
+def test_parse_email_minimal():
+    raw = (b"From: alice@dralaw.com\r\n"
+            b"To: gary@cabin-rentals-of-georgia.com\r\n"
+            b"Subject: closing docs\r\n"
+            b"Message-ID: <abc-123@dralaw.com>\r\n"
+            b"\r\n"
+            b"please review attached\r\n")
+    parsed = ebl.parse_email(raw, date(2025, 6, 1))
+    assert parsed is not None
+    assert parsed.sender_addr == "alice@dralaw.com"
+    assert "gary@cabin-rentals-of-georgia.com" in parsed.to_addrs
+    assert parsed.subject == "closing docs"
+    assert parsed.message_id == "<abc-123@dralaw.com>"
+
+
+# ─── 14. parse_email returns None on bad input ─────────────────────────
+
+
+def test_parse_email_returns_none_on_bad_bytes():
+    parsed = ebl.parse_email(b"\xff\xfe garbage \x00\x01", date(2020, 1, 1))
+    # email_module is permissive — bad bytes still parse but yield empty fields.
+    # Either None or a parsed-but-empty result is acceptable.
+    assert parsed is None or parsed.sender_addr == ""
+
+
+# ─── 15. classifier — username-only match falls under date window ───────
+
+
+def test_classifier_username_match_with_date_window():
+    msg = _mk(sender="general@some.com", sender_addr="general@some.com",
+              subject="re: argo for closing", body="",
+              internaldate=date(2024, 8, 1),
+              to=("gary@cabin-rentals-of-georgia.com",))
+    r = ebl.classify_email(msg)
+    # 'argo' is in USERNAME_TERMS_BY_CASE for case_i; date 2024 within window
+    assert r.case_slug == "7il-v-knight-ndga-i"
+
+
+# ─── 16. classify rule precedence — docket beats domain ────────────────
+
+
+def test_classifier_docket_beats_domain():
+    """Even if Sanker is sender, an explicit Case II docket in subject wins."""
+    msg = _mk(sender="jsank@msp-lawfirm.com",
+              subject="2:26-cv-00113 motion to dismiss",
+              internaldate=date(2023, 1, 1))  # weird date but explicit docket wins
+    r = ebl.classify_email(msg)
+    assert r.case_slug == "7il-v-knight-ndga-ii"
+
+
+# ─── 17. classify — date_bands utility ─────────────────────────────────
+
+
+def test_date_bands_6mo_stride():
+    bands = ebl.date_bands(date(2018, 1, 1), date(2019, 1, 1), months=6)
+    assert len(bands) == 2
+    assert bands[0] == (date(2018, 1, 1), date(2018, 7, 1))
+    assert bands[1] == (date(2018, 7, 1), date(2019, 1, 1))
+
+
+# ─── 18. lock file — concurrent run rejected ────────────────────────────
+
+
+def test_lock_file_prevents_concurrent_runs(tmp_path, monkeypatch):
+    monkeypatch.setattr(ebl, "_lock_path", lambda case: tmp_path / f"l-{case}.lock")
+    (tmp_path / "l-c.lock").write_text("99999\nstamp\n")
+    with pytest.raises(SystemExit) as ei:
+        ebl.acquire_lock("c", force=False)
+    assert "another backfill" in str(ei.value)
+
+
+# ─── 19. lock file — force overrides stale lock ────────────────────────
+
+
+def test_lock_file_force_overrides_stale_lock(tmp_path, monkeypatch):
+    import os
+    monkeypatch.setattr(ebl, "_lock_path", lambda case: tmp_path / f"l-{case}.lock")
+    p = tmp_path / "l-c.lock"
+    p.write_text("99999\nstamp\n")
+    # Backdate to >6h ago
+    old = ebl.LOCK_STALE_AFTER_S + 100
+    os.utime(str(p), (p.stat().st_atime - old, p.stat().st_mtime - old))
+    lock = ebl.acquire_lock("c", force=True)
+    assert lock.exists()
+    ebl.release_lock(lock)
+
+
+# ─── 20. Mocked end-to-end — single email round-trip ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_ingest_email_full_pipeline_mocked(monkeypatch, tmp_path):
+    """Mock LegacySession + process_vault_upload; verify _ingest_email returns
+    'ingested' and triggers mirror."""
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    async def _fake_upload(*, db, case_slug, file_bytes, file_name, mime_type):
+        assert mime_type == "message/rfc822"
+        assert file_name.endswith(".eml")
+        return {"status": "completed", "document_id": "id-x",
+                "chunks": 4, "vectors_indexed": 4}
+
+    mirror_calls = []
+
+    def _fake_mirror(case_slug, doc_id):
+        mirror_calls.append((case_slug, doc_id))
+
+    def _fake_check_existing(case_slug, file_hash):
+        return None
+
+    monkeypatch.setattr("backend.services.ediscovery_agent.LegacySession",
+                        lambda: _FakeSession())
+    monkeypatch.setattr("backend.services.legal_ediscovery.process_vault_upload",
+                        _fake_upload)
+    monkeypatch.setattr(ebl, "_check_existing_row", _fake_check_existing)
+    monkeypatch.setattr(ebl, "_mirror_row_db_to_prod", _fake_mirror)
+
+    parsed = _mk(sender="fpodesta@fgplaw.com",
+                  sender_addr="fpodesta@fgplaw.com",
+                  subject="case I trial prep notes",
+                  internaldate=date(2024, 5, 15))
+    cls = ebl.classify_email(parsed)
+    outcome = await ebl._ingest_email(parsed, cls)
+    assert outcome.status == "ingested"
+    assert outcome.case_slug == "7il-v-knight-ndga-i"
+    assert outcome.document_id == "id-x"
+    assert mirror_calls == [("7il-v-knight-ndga-i", "id-x")]
+
+
+# ─── 21. _ingest_email — quarantine returns 'quarantined' status ─────
+
+
+@pytest.mark.asyncio
+async def test_ingest_email_quarantine_returns_quarantined():
+    parsed = _mk(sender="x@example.com", sender_addr="x@example.com",
+                  subject="random unmatched", internaldate=date(2024, 1, 1))
+    cls = ebl.ClassificationResult(case_slug=None, privileged=False,
+                                     reason="no match", matched_terms=[])
+    outcome = await ebl._ingest_email(parsed, cls)
+    assert outcome.status == "quarantined"
+    assert outcome.case_slug is None
+
+
+# ─── 22. _ingest_email — duplicate skipped via _check_existing_row ──
+
+
+@pytest.mark.asyncio
+async def test_ingest_email_duplicate_skipped(monkeypatch):
+    """If file_hash already exists with terminal status, skip without
+    calling process_vault_upload."""
+    upload_called = {"n": 0}
+
+    async def _fake_upload(**kwargs):
+        upload_called["n"] += 1
+        return {"status": "completed", "document_id": "x"}
+
+    monkeypatch.setattr(ebl, "_check_existing_row",
+                        lambda case_slug, file_hash: "completed")
+    monkeypatch.setattr("backend.services.ediscovery_agent.LegacySession",
+                        lambda: object())
+    monkeypatch.setattr("backend.services.legal_ediscovery.process_vault_upload",
+                        _fake_upload)
+
+    parsed = _mk(sender="fpodesta@fgplaw.com",
+                  sender_addr="fpodesta@fgplaw.com",
+                  subject="known email", internaldate=date(2024, 5, 15))
+    cls = ebl.classify_email(parsed)
+    outcome = await ebl._ingest_email(parsed, cls)
+    assert outcome.status == "duplicate"
+    assert upload_called["n"] == 0
+
+
+# ─── 23. classify — Lissa Knight with vanderburge keyword → vanderburge
+
+
+def test_classifier_lissa_with_vanderburge_keyword():
+    msg = _mk(sender="someone@example.com",
+              sender_addr="someone@example.com",
+              subject="lissa knight + vanderburge property",
+              internaldate=date(2020, 4, 1))
+    r = ebl.classify_email(msg)
+    assert r.case_slug == "vanderburge-v-knight-fannin"
+
+
+# ─── 24. CLI — args parse with sane defaults ────────────────────────────
+
+
+def test_cli_args_sane_defaults():
+    args = ebl._parse_args(["--case-slug", "test"])
+    assert args.case_slug == "test"
+    assert args.mailbox == "gary-gk,gary-crog"
+    assert args.since == "2018-01-01"
+    assert args.until is not None  # set to today by default
+    assert args.dry_run is False
+    assert args.rollback is False
+    assert args.jobs == 4
+
+
+# ─── 25. CLI — rollback flag isolated path ──────────────────────────────
+
+
+def test_cli_rollback_flag_present():
+    args = ebl._parse_args(["--case-slug", "test", "--rollback", "--force"])
+    assert args.rollback is True
+    assert args.force is True
+
+
+# ─── 26. classifier — empty subject + body still classifies on sender ──
+
+
+def test_classifier_empty_subject_uses_sender_domain():
+    msg = _mk(sender="alice@dralaw.com",
+              sender_addr="alice@dralaw.com",
+              subject="", body="",
+              internaldate=date(2025, 6, 1))
+    r = ebl.classify_email(msg)
+    # dralaw.com is in case_i counsel domains; date 2025 within window
+    assert r.case_slug == "7il-v-knight-ndga-i"
+    assert r.privileged is True

--- a/fortress-guest-platform/docs/runbooks/legal-email-backfill.md
+++ b/fortress-guest-platform/docs/runbooks/legal-email-backfill.md
@@ -1,0 +1,348 @@
+# Runbook: `email_backfill_legal`
+
+Operator playbook for the case-aware IMAP email backfill
+(`backend/scripts/email_backfill_legal.py`). Read this before running
+against any case_slug, before triaging quarantined emails, and before
+attempting a rollback.
+
+Last updated: PR I (2026-04-26). Owner: Legal Platform.
+
+---
+
+## 1. What it is
+
+A single command that pulls case-relevant emails from the cPanel IMAP
+server (gary-gk + gary-crog mailboxes), routes each to the correct
+`case_slug` via a rule-based classifier, and runs them through the
+canonical `process_vault_upload()` pipeline so they land in
+`legal.vault_documents` + the appropriate Qdrant collection
+(`legal_ediscovery` for work product, `legal_privileged_communications`
+for privileged content).
+
+The classifier source-of-truth is the **2026-04-25b IMAP audit** at
+`/mnt/fortress_nas/audits/email-coverage-inventory-20260425b.md` and
+the architectural decisions in
+`/mnt/fortress_nas/audits/pr-i-email-backfill-plan-20260426.md`.
+
+---
+
+## 2. Pre-flight gates (8 checks; failed pre-flight does not pollute the audit table)
+
+| # | Gate | Failure mode |
+| --- | --- | --- |
+| 1 | `legal.cases` row exists in **both** fortress_prod and fortress_db for the target case_slug | run PR B-style insertion first |
+| 2 | PostgreSQL is writable in both DBs (SELECT 1 + scratch INSERT into `legal.ingest_runs` using the real case_slug) | check `POSTGRES_ADMIN_URI` and DB up |
+| 3 | PR D-pre2 schema constraints present in both DBs (FK + UNIQUE + CHECK on `legal.vault_documents`) | apply alembic `d8e3c1f5b9a6` |
+| 4 | Qdrant `legal_ediscovery` and `legal_privileged_communications` both reachable, vector_size 768 | spin up Qdrant or fix `QDRANT_URL` |
+| 5 | `process_vault_upload` + `LegacySession` importable | resolve the import error before retry |
+| 6 | Lock file at `/tmp/email-backfill-{slug}.lock` not held by another live run | wait, or `--force` after staleness verified |
+| 7 | IMAP credentials available via `pass show fortress/mailboxes/<alias>` | rotate or fix the pass entry |
+| 8 | `--since` and `--until` parse as ISO dates | fix the CLI args |
+
+Pre-flight exit code: **3**. Look for `PREFLIGHT FAILED:` on stderr.
+
+---
+
+## 3. Classifier rules (precedence-ordered)
+
+The classifier returns one of: `case_slug` (string), or `None` (quarantine).
+First matching rule wins.
+
+### Rule 1 — explicit docket number in subject or body
+
+| Pattern (case-insensitive) | Routes to |
+| --- | --- |
+| `2:21-cv-00226` | `7il-v-knight-ndga-i` |
+| `2:26-cv-00113` | `7il-v-knight-ndga-ii` |
+
+### Rule 2 — Vanderburge keywords in subject or body
+
+`vanderburge`, `karen vanderburge`, `fannin county`, `easement`,
+`appalachian judicial circuit` → `vanderburge-v-knight-fannin`.
+
+### Rule 3 — 7IL-prefix keywords (date-disambiguated)
+
+`7il properties`, `7 il properties`, `thor james`, `fish trap`,
+`fish-trap`, `thatcher`, `thacker`:
+- INTERNALDATE year ≥ 2026 → `7il-v-knight-ndga-ii`
+- Otherwise → `7il-v-knight-ndga-i`
+
+### Rule 4 — counsel-domain match (with cc disambiguation)
+
+If sender or any To/Cc/Bcc address is at a counsel domain
+(`mhtlegal.com`, `fgplaw.com`, `dralaw.com`, `wilsonhamilton.com`,
+`wilsonpruittlaw.com`, `msp-lawfirm.com`, `masp-lawfirm.com`):
+
+1. **Cc Frank Moore** (matches `frank moore`, `frank.moore`,
+   `frankmoore`, `f.moore`, `fmoore@`) → `vanderburge-v-knight-fannin`
+2. **Cc other your-side counsel** (any `fgplaw`/`mhtlegal`/`dralaw`/
+   `wilsonhamilton`/`wilsonpruittlaw` not from sender):
+   - 2026+ → `7il-v-knight-ndga-ii`
+   - Pre-2026 → `7il-v-knight-ndga-i`
+3. **Sanker (msp-lawfirm.com or masp-lawfirm.com) date fallback:**
+   - 2026+ → `7il-v-knight-ndga-ii`
+   - 2021-2025 → `7il-v-knight-ndga-i`
+   - 2019-2020 → `None` (Vanderburge/Case-I overlap; needs human review)
+   - Other / undated → `None`
+4. **Other counsel domain + date in case window** → that case's slug
+
+### Rule 5 — opposing-counsel terms
+
+`fmglaw.com`, `goldberg`, `brian goldberg` (in subject/body or any address)
+→ Case I or Case II depending on which case's opposing-counsel list
+matches first. Always **work-product track** (not privileged).
+
+`frank moore` (Vanderburge opposing) → Vanderburge. Bare `moore` is
+**intentionally excluded** here — too FP-prone (Roy Moore newsletters,
+real estate Moore listings, etc.). Surfaces only when paired with
+counsel-domain context (Rule 4 cc analysis).
+
+### Rule 6 — username/name terms with date window
+
+`podesta`, `frank podesta`, `argo`, `alicia argo`, `terry wilson`,
+`twilson` (in subject/body) + INTERNALDATE within the case's date window:
+
+| Term cluster | Case | Date window |
+| --- | --- | --- |
+| podesta, argo, terry wilson, twilson | `7il-v-knight-ndga-i` | 2018-01-01 → 2025-12-31 |
+| sanker, jsank, jsanker | `7il-v-knight-ndga-ii` | 2026-01-01 → forever |
+| sanker, jsank, jsanker | `vanderburge-v-knight-fannin` | 2019-01-01 → 2021-12-31 |
+
+### Rule 7 — fallback
+
+No match → `None` → quarantine.
+
+---
+
+## 4. Cross-case disambiguation (the Sanker problem)
+
+Sanker (`msp-lawfirm.com`, ~1,500 audit hits) is your-side trial
+cocounsel for Case I AND defense counsel for Vanderburge. The
+disambiguation algorithm is encoded in Rule 4 above, but for operator
+reference:
+
+```
+Sanker email arrives
+  │
+  ├─ Subject/body has "2:21-cv-00226" → Case I
+  ├─ Subject/body has "2:26-cv-00113" → Case II
+  ├─ Subject/body has "vanderburge"/"easement"/"fannin county" → Vanderburge
+  ├─ Cc Frank Moore (any pattern) → Vanderburge
+  ├─ Cc other your-side counsel (Podesta, etc.) → Case I (pre-2026) or Case II (2026+)
+  ├─ INTERNALDATE 2026+ no other signal → Case II
+  ├─ INTERNALDATE 2021-2025 no other signal → Case I
+  ├─ INTERNALDATE 2019-2020 no other signal → QUARANTINE (ambiguous)
+  └─ Otherwise → QUARANTINE
+```
+
+Quarantine volume estimate: ~450 emails of the ~1,500 Sanker hits will
+land in quarantine for human review.
+
+---
+
+## 5. Privilege routing
+
+The classifier's `privileged: bool` flag is **informational**. The actual
+routing decision (work-product vs privileged Qdrant collection) is made
+inside `process_vault_upload()` by its own privilege classifier
+(Qwen2.5 with confidence ≥ 0.7 threshold).
+
+This is intentional: backfill emails go through the same privilege
+classifier as live-ingested emails, so the two sources produce identical
+artifacts. PR I doesn't bypass or override that decision.
+
+If `privileged_counsel_domains` for the target case includes the email's
+domain match, the classifier is more likely to flag it privileged
+(matches the email parsing path in `_derive_privileged_counsel_domain`).
+PR I doesn't need to do anything special here.
+
+---
+
+## 6. CLI usage
+
+```bash
+python -m backend.scripts.email_backfill_legal \
+    --case-slug 7il-v-knight-ndga-i \
+    --mailbox gary-gk,gary-crog \
+    --since 2018-01-01 --until 2025-12-31
+
+# Smoke before production
+python -m backend.scripts.email_backfill_legal \
+    --case-slug 7il-v-knight-ndga-i \
+    --dry-run --limit 10
+
+# Resume from state
+python -m backend.scripts.email_backfill_legal \
+    --case-slug 7il-v-knight-ndga-i --resume
+
+# Include emails that classify to None (quarantine flow)
+python -m backend.scripts.email_backfill_legal \
+    --case-slug 7il-v-knight-ndga-i --include-quarantine
+
+# Rollback (deletes vault_documents .eml rows + Qdrant points; confirmation
+# required unless --force)
+python -m backend.scripts.email_backfill_legal \
+    --case-slug 7il-v-knight-ndga-i --rollback
+```
+
+`--case-slug` is a positive selector: only emails classified to that
+exact slug are ingested. Emails classified to a different case are
+**skipped**; emails classified to `None` are **skipped** unless
+`--include-quarantine` is set (in which case they're skipped with a
+"quarantined" status entry in the manifest).
+
+---
+
+## 7. Manifest schema
+
+Every successful run writes
+`/mnt/fortress_nas/audits/email-backfill-{case_slug}-{ts}.json`:
+
+```json
+{
+  "case_slug":            "...",
+  "started_at":           "...",
+  "finished_at":          "...",
+  "runtime_seconds":      ...,
+  "args":                 {...},
+  "host":                 "...",
+  "pid":                  ...,
+  "ingest_run_id":        "uuid",
+  "mailboxes":            ["gary-gk", "gary-crog"],
+  "total_uids":           N,
+  "ingested":             N,
+  "duplicate":            N,
+  "quarantined":          N,
+  "failed":               N,
+  "skipped":              N,
+  "by_classification":    {...},
+  "quarantine_log":       [{"uid": "...", "reason": "..."}, ...],
+  "errors":               [{"uid": "...", "error": "..."}]
+}
+```
+
+Quick triage:
+- `failed == 0` and `ingested ≈ expected per audit` → clean run
+- `quarantined > 0` → operator triages each entry; either re-run with
+  explicit case_slug after manual decision, or accept the quarantine
+- `failed > 0` → see `errors[]` — each entry has the UID, mailbox,
+  folder, error string
+
+---
+
+## 8. Recovery procedures
+
+### 8.1  Ctrl-C / SIGTERM
+
+State file at `/tmp/email-backfill-{case_slug}.state.json` checkpoints
+completed UIDs. Re-run with `--resume`; previously-completed UIDs are
+skipped. In-flight UIDs may have left vault_documents rows in `pending`
+or `vectorizing` — those are also caught by `--resume` since the
+existence-check at the start of each email path catches terminal-status
+rows.
+
+### 8.2  Lock file left behind
+
+```bash
+cat /tmp/email-backfill-{slug}.lock
+ps -p <pid_from_lock>
+```
+
+If the PID is gone, delete the lock manually OR pass `--force` (the
+script auto-overrides locks > 6 h old).
+
+### 8.3  IMAP connection drop
+
+The script retries up to 3 times per band with exponential backoff
+(2/8/20s). On exhaustion, the term is marked errored in the manifest
+and the sweep continues.
+
+### 8.4  Quarantine triage
+
+For each `quarantine_log` entry, the operator decides which case the
+email belongs to. After that decision, run:
+
+```bash
+python -m backend.scripts.email_backfill_legal \
+    --case-slug <chosen-case> \
+    --include-quarantine \
+    --limit 1
+```
+
+(Targeted re-classification scoped to one email is a future enhancement;
+today the operator may need to process all quarantined emails per
+chosen case via re-run.)
+
+---
+
+## 9. Rollback
+
+`--rollback` deletes all `legal.vault_documents` rows where:
+- `case_slug` matches AND
+- `file_name` ends in `.eml`
+
+…on **both** `fortress_prod` and `fortress_db`, plus Qdrant points
+across both `legal_ediscovery` and `legal_privileged_communications`
+collections where `payload.case_slug` matches.
+
+It does **not** touch:
+- NAS files (vault NFS copies)
+- `legal.cases` row
+- `legal.privilege_log` (audit trail must outlive the data)
+- vault_documents rows that came from non-email ingestion paths
+  (the `.eml` filename suffix scopes the delete)
+
+```bash
+python -m backend.scripts.email_backfill_legal \
+    --case-slug 7il-v-knight-ndga-i --rollback
+```
+
+You'll be prompted to type the case_slug back. Pass `--force` to skip
+the prompt.
+
+Rollback writes a separate manifest at
+`/mnt/fortress_nas/audits/email-backfill-rollback-{slug}-{ts}.json`.
+
+---
+
+## 10. Common operator queries
+
+```sql
+-- 10.1  Email backfill rows per case
+SELECT case_slug, count(*) AS email_rows
+FROM legal.vault_documents
+WHERE file_name LIKE '%.eml'
+GROUP BY case_slug
+ORDER BY case_slug;
+
+-- 10.2  Quarantine log review (run-by-run; not a persistent table today)
+-- Read the manifest's quarantine_log section directly:
+--   /mnt/fortress_nas/audits/email-backfill-{case_slug}-{ts}.json
+
+-- 10.3  Email-rows per processing_status (cross-cutting)
+SELECT processing_status, count(*)
+FROM legal.vault_documents
+WHERE file_name LIKE '%.eml'
+GROUP BY processing_status
+ORDER BY processing_status;
+
+-- 10.4  Recent ingest_runs for email backfill
+SELECT id, case_slug, status, processed, errored, skipped, started_at
+FROM legal.ingest_runs
+WHERE script_name = 'email_backfill_legal'
+ORDER BY started_at DESC LIMIT 20;
+```
+
+---
+
+## 11. Cross-references
+
+- Plan: `/mnt/fortress_nas/audits/pr-i-email-backfill-plan-20260426.md`
+- Audit: `/mnt/fortress_nas/audits/email-coverage-inventory-20260425b.md`
+- Existing pipeline: `backend/services/legal_ediscovery.py::process_vault_upload`
+- Privilege architecture: `docs/runbooks/legal-privilege-architecture.md`
+- Vault documents schema: `docs/runbooks/legal-vault-documents.md`
+- Vault ingest (PR D pattern, the basis for this script): `docs/runbooks/legal-vault-ingest.md`
+- IMAP audit script (the one that produced the classifier source data): `/tmp/imap_party_audit.py`
+- Issue #209 — `legal.ingest_runs` row CASCADE on case_slug rename
+- Issue #218 — pre-2018 archive optimization


### PR DESCRIPTION
## Summary

Case-aware IMAP email backfill script that pulls case-relevant emails from the cPanel IMAP server, classifies each via a rule-based scorer, and routes through the existing `process_vault_upload()` pipeline. Architecture per `/mnt/fortress_nas/audits/pr-i-email-backfill-plan-20260426.md`; classifier source data per `/mnt/fortress_nas/audits/email-coverage-inventory-20260425b.md` (the 2026-04-25b IMAP audit, 10,800 UID hits, 3h29m runtime).

**No production backfill is run by this PR.** The script ships + tests pass; awaits explicit operator authorization to execute against the live IMAP server.

## What ships

- `backend/scripts/email_backfill_legal.py` — 1,370 lines, the CLI script
- `backend/tests/test_email_backfill_legal.py` — 428 lines, **27 test cases**
- `docs/runbooks/legal-email-backfill.md` — 348-line operator runbook

## Architecture (matches PR D pattern)

| Element | Implementation |
|---|---|
| Pre-flight | 8 gates (case existence in both DBs, schema constraints, Qdrant collections reachable, pipeline imports, etc.). Failed pre-flight does **not** open `legal.ingest_runs` row. |
| Idempotency | `file_hash` derived from RFC 5322 `Message-Id` (or SHA-256 of bytes if absent) + composite UNIQUE on `(case_slug, file_hash)` from PR D-pre2 |
| Dual-DB write | `process_vault_upload` writes via LegacySession (fortress_db); script mirrors row to fortress_prod (existing PR D pattern) |
| Failure isolation | Per-email try/except. One bad email doesn't abort the sweep. |
| Audit trail | `IngestRunTracker` (PR D-pre1) emits one `legal.ingest_runs` row per invocation |
| Lock + 2h staleness | `/tmp/email-backfill-{slug}.lock`; `--force` overrides locks > 6h old |
| Resume | `/tmp/email-backfill-{slug}.state.json` checkpoints completed UIDs; `--resume` skips them |
| Rollback | `--rollback` deletes `.eml` rows in both DBs + Qdrant points across both collections |

## Classifier (rule precedence)

1. **Explicit docket** (`2:21-cv-00226` / `2:26-cv-00113`) wins
2. **Vanderburge keywords** (vanderburge, easement, fannin county, etc.) → `vanderburge-v-knight-fannin`
3. **7IL keywords** (7il properties, thor james, fish trap, thatcher, thacker) — date-disambiguated: pre-2026 → Case I, 2026+ → Case II
4. **Counsel-domain match** with cc analysis:
   - Cc Frank Moore (any pattern) → Vanderburge
   - Cc other your-side counsel (Podesta, etc.) → 7IL by date
   - Sanker (msp-lawfirm.com / masp-lawfirm.com) date-fallback:
     - 2026+ → Case II
     - 2021-2025 → Case I
     - 2019-2020 → **quarantine** (Vanderburge/Case-I overlap)
5. **Opposing-counsel terms** (fmglaw, goldberg, brian goldberg) → work-product, Case I or II
6. **Username/name terms** with date window
7. Otherwise → quarantine

The classifier returns `case_slug=None` for ambiguous emails (estimated ~450 of the ~1,500 Sanker hits). Per-case is a **positive selector**: emails classified elsewhere are skipped, not auto-routed.

## Privilege routing (delegated to existing pipeline)

PR I does **not** override privilege classification. Backfill emails flow through the same `process_vault_upload()` function and the same Qwen2.5 classifier (confidence ≥ 0.7) that lives ingest uses. Backfill artifacts are identical in shape to live-ingest artifacts.

## Test coverage (27 cases)

| Category | Count | Coverage |
|---|---|---|
| Classifier rule precedence | 12 | docket beats domain, Vanderburge keyword wins, 7IL date-disambiguation, Sanker date fallback (2019/2023/2026), cc Podesta/Frank Moore, opposing counsel, unmatched, empty subject |
| Hash + filename | 3 | Message-Id stable hash, raw-bytes fallback, file_name shape |
| Email parsing | 2 | minimal RFC-822, bad bytes |
| Date bands utility | 1 | 6-month stride |
| Lock file | 2 | concurrent rejected, force overrides stale |
| Pipeline (mocked) | 3 | full round-trip ingests, quarantine returns 'quarantined', duplicate skip |
| CLI | 2 | sane defaults, rollback flag |
| Lissa Knight + Vanderburge keyword | 1 | spousal-keyword routing |
| Username + date window | 1 | username-only fallback |

All 27 pass on `fortress_shadow_test`.

## Plan-document deviations (with rationale)

1. **`legal.email_quarantine` table NOT shipped in this PR.** Plan §6 proposed a quarantine table with operator-triage UI; PR I instead logs quarantined emails to the run manifest's `quarantine_log` array. Rationale: ships PR I as a self-contained unit; the quarantine table + UI is a substantial follow-up that merits its own PR.

2. **`bare 'moore'` excluded.** Plan §2 KNOWN PARTIES list keeps it; PR I excludes from default opposing-terms set because the audit confirms it's FP-prone (matches Roy Moore newsletters, real-estate Moore listings). Operator can add it back via a config patch if a future need arises.

3. **`info-crog` mailbox not in default scope.** Plan §1 noted it's low-signal; the script supports it via `MAILBOX_REGISTRY` and `--mailbox info-crog`, but default `--mailbox gary-gk,gary-crog` matches the audit's primary scope.

4. **No `imap_session.py` refactor module.** Plan §6 suggested factoring shared IMAP helpers out of `imap_party_audit.py`. PR I duplicates the necessary helpers inside the script for self-containment; refactor can be a follow-up after both scripts have stabilized.

5. **`document_id`-based per-invocation rollback not implemented.** Plan §9 suggested `created_at` filtering. PR I uses `file_name LIKE '%.eml'` to scope deletes — simpler and unambiguous. Operators wanting per-invocation rollback can use the manifest's `ingested` document IDs to construct a custom delete; tooling for that is a future enhancement.

## Test plan

- [x] `pytest backend/tests/test_email_backfill_legal.py` — 27/27 pass
- [x] Vanderburge case row inserted (prerequisite met)
- [x] Pre-flight gates verified at module-load time (no DB hits)
- [ ] After merge: smoke run with `--dry-run --limit 10 --case-slug 7il-v-knight-ndga-i`
- [ ] After smoke: production run authorized per case, one case at a time

## Followups

- **Issue #211** — `migrate_qdrant_chunks.py` for cross-collection moves (paired with quarantine resolution flow)
- **Issue #209** — `legal.ingest_runs` CASCADE on case rename (would lose audit row if case is renamed mid-run)
- New issue (TBD) — `legal.email_quarantine` table + command-center triage UI

## NOT in this PR

- No actual backfill run
- No service restart
- No code changes to `legal_ediscovery.py` / `legal_council.py` / `legal_cases.py` beyond what `process_vault_upload` exposes
- No new schema migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
