### PR TITLE
docs(architecture): ADR-002 locked — shared services placement

### DIFF
--- a/docs/architecture/cross-division/_architectural-decisions.md
+++ b/docs/architecture/cross-division/_architectural-decisions.md
@@ -41,7 +41,7 @@ Format inspired by [Michael Nygard's ADR template](https://cognitect.com/blog/20
 ## ADR-002 — Where do shared services (Captain, Council, Sentinel) live in the target state?
 
 **Date:** 2026-04-26
-**Status:** **OPEN — requires operator input**
+**Status:** **LOCKED 2026-04-26**
 
 **Question:** With ADR-001 locking division ↔ spark as 1:1, where do the cross-cutting shared services run?
 
@@ -74,13 +74,53 @@ Each spark runs its own division-scoped Captain (only that division's mailboxes)
 **Pros:** Maximum blast-radius isolation. Per-division ownership of cross-cutting tooling.
 **Cons:** 4× the operational surface. Email classification spans divisions — Captain by definition sees every mailbox, so dividing it artificially risks miscategorization. Probably wrong for Captain specifically; could work for Sentinel (per-division NAS folders are already well-bounded).
 
-**Recommendation pending operator input:**
+**Decisions (LOCKED 2026-04-26):**
 
-- **Captain:** Option A (Spark 2 permanent) — dividing email by mailbox before classification breaks PR I's cross-case disambiguation
-- **Council:** Option B (dedicated shared) — Council reads across divisions for cross-matter retrieval (PR G); a dedicated spark gives it room without contention
-- **Sentinel:** Option C (per-division replicas) is plausible since each division's NAS scope is already bounded; Option A also fine
+### Captain → **Option A — Spark 2 permanent**
 
-**Status:** **AWAITING OPERATOR DECISION.** When picked, this entry gets amended with the chosen option, the supporting reasoning, and a migration plan. Meanwhile every shared-service doc in `../shared/*.md` notes "Current spark: 2 / Target spark: TBD per ADR-002".
+Cross-mailbox classification IS the value of Captain. Dividing it before classification breaks cross-case disambiguation (PR #225 Sanker routing logic relies on seeing every mailbox to compute date-window fallbacks). Centralization is correct architecture, not a compromise.
+
+### Council → **Option B — Spark 4 dedicated (with co-located intermittent divisions)**
+
+**Refinement of Option B:** rather than provisioning a 5th spark for Council alone, Spark 4 hosts **Council + the planned Acquisitions division + the planned Wealth division**. These three workloads are compatible:
+
+- Council: cross-division read-heavy LLM deliberation, bursty workload (drives spark only when an operator initiates a deliberation)
+- Acquisitions: intermittent deal-pipeline analysis (per-deal bursts)
+- Wealth: lower-frequency intelligence (periodic, not continuous)
+
+Co-locating shared services with intermittent divisions on one spark avoids hardware sprawl while preserving the architectural goal of Council not contending with CROG-VRS guest-traffic peaks.
+
+**New architectural classification:** Spark 4 is the first instance of "shared services + intermittent divisions" — an allowable exception to the strict ADR-001 "one spark per division" rule. Documented in `divisions/_template.md` as a recognized pattern. Future sparks may follow the same pattern if a similar workload-compatibility window appears.
+
+### Sentinel → **Option A — Spark 2 permanent**
+
+Sentinel walks NAS. NAS mounts identically from any spark — there is no per-spark file-system locality benefit. Per-division replicas (Option C) would 4× the file-system traffic on the Synology, 4× the Qdrant collections to sync, 4× the failure modes — for **no architectural benefit** since per-division NAS paths are already cleanly separated by directory tree (`Corporate_Legal/` vs `Business_Prime/` vs `Financial_Ledger/` etc.). Centralization on Spark 2 is correct.
+
+### Updated final architecture (target state)
+
+| Spark | Role | Hosts |
+|---|---|---|
+| **Spark 1** | Single-division | Fortress Legal |
+| **Spark 2** | Multi-purpose: division + shared services | CROG-VRS + **Captain** + **Sentinel** + control plane (Postgres, Qdrant for legal collections, NAS mount, Redis, ARQ, FastAPI) |
+| **Spark 3** | Single-division | Financial — Master Accounting + Market Club replacement |
+| **Spark 4** | Shared services + intermittent divisions | **Council** + Acquisitions + Wealth |
+
+### Migration plan
+
+1. **Stage 1 (gating):** Spark 4 hardware provisioned. Captain + Sentinel remain on Spark 2 forever (no migration needed for them).
+2. **Stage 2:** Stand up Council on Spark 4 as warm-spare (no traffic). Council on Spark 2 keeps serving deliberations.
+3. **Stage 3:** Verification — run Council on both sparks in parallel for one week; compare frozen-context outputs for byte-equality on the same case_slug input. Read-replica latency from Spark 4 → Spark 2's Qdrant must stay under the existing per-deliberation latency budget.
+4. **Stage 4:** Cutover — `apps/command-center` switches its deliberation API endpoint from Spark 2 to Spark 4. Spark 2 Council instance retires after a 7-day soak.
+5. **Stage 5:** Spark 4 onboards Acquisitions and Wealth as the divisions ramp (independent of Council; their schemas may live on Spark 4's Postgres with cross-spark access from Spark 2 if needed).
+
+### Implications already documented downstream
+
+- `shared/captain-email-intake.md` header → Current: Spark 2 / Target: Spark 2 (permanent)
+- `shared/council-deliberation.md` header → Current: Spark 2 / Target: Spark 4 (post-Spark-4 provisioning)
+- `shared/sentinel-nas-walker.md` header → Current: Spark 2 / Target: Spark 2 (permanent)
+- `shared/infrastructure.md` Spark allocation table reflects target state with Spark 4 multi-purpose classification
+- `divisions/_template.md` documents the multi-purpose Spark 4 exception pattern
+- `system-map.md` target diagram + 5-stage migration includes the Spark 4 Council step
 
 ---
 

--- a/docs/architecture/divisions/_template.md
+++ b/docs/architecture/divisions/_template.md
@@ -7,6 +7,27 @@ Spark allocation:
 - **Target:** <Spark N (status) — final home per ADR-001; Same if not migrating>
 Last updated: <YYYY-MM-DD>
 
+> **Allowable exception — multi-purpose Spark pattern.** ADR-001 locks
+> "one spark per division" as the default rule. ADR-002 (LOCKED 2026-04-26)
+> introduced a recognized exception: a single spark may host **one shared
+> service + two or more intermittent divisions** when the workload-
+> compatibility argument is genuine.
+>
+> Live instance of this pattern: **Spark 4** hosts Council (bursty cross-
+> division LLM deliberation) + Acquisitions (intermittent deal-pipeline
+> analysis) + Wealth (lower-frequency intelligence). None of the three
+> sustains continuous load, so co-tenancy avoids hardware sprawl without
+> contention risk.
+>
+> Spark 2 is the other multi-purpose spark — hosting CROG-VRS + Captain +
+> Sentinel — though that pairing is "control-plane shared services + a
+> high-traffic division" rather than the Spark 4 pattern.
+>
+> If you're documenting a division that maps to a multi-purpose spark
+> (Spark 4 today), call out the multi-purpose context explicitly in the
+> "Spark allocation" block. The default for any new division remains
+> "one spark per division."
+
 ## Purpose
 
 One paragraph. What does this division do? Why does it exist? Who is the operator?

--- a/docs/architecture/shared/captain-email-intake.md
+++ b/docs/architecture/shared/captain-email-intake.md
@@ -1,5 +1,9 @@
 # Shared: Captain — Email Intake
 
+Spark allocation:
+- **Current:** Spark 2
+- **Target:** **Spark 2 permanent** (per ADR-002 LOCKED 2026-04-26 — Captain cross-mailbox classification is its core value; centralization is correct)
+
 Last updated: 2026-04-26
 
 ## Technical overview

--- a/docs/architecture/shared/council-deliberation.md
+++ b/docs/architecture/shared/council-deliberation.md
@@ -1,5 +1,9 @@
 # Shared: Council — Deliberation
 
+Spark allocation:
+- **Current:** Spark 2 (tenant of the monorepo)
+- **Target:** **Spark 4** (per ADR-002 LOCKED 2026-04-26 — Spark 4 hosts Council + Acquisitions + Wealth as a "shared services + intermittent divisions" multi-purpose node). Migration is staged after Spark 4 is provisioned: warm-spare → parallel verification week → command-center cutover → 7-day soak → Spark 2 instance retires.
+
 Last updated: 2026-04-26
 
 ## Technical overview

--- a/docs/architecture/shared/infrastructure.md
+++ b/docs/architecture/shared/infrastructure.md
@@ -6,24 +6,28 @@ Last updated: 2026-04-26
 
 Fortress Prime runs on a local NVIDIA DGX Spark cluster (4 nodes). No cloud databases for sovereign data; transient cloud inference is allowed only for non-PII payloads with ephemeral guarantees per CONSTITUTION.md Article I.
 
-### Cluster topology — division allocation (per [ADR-001](../cross-division/_architectural-decisions.md))
+### Cluster topology — division + shared-services allocation (per [ADR-001](../cross-division/_architectural-decisions.md) + [ADR-002](../cross-division/_architectural-decisions.md))
 
-The 2026-04-26 architectural decision: **one spark per division.** Cross-division services (Captain / Council / Sentinel) placement is OPEN per ADR-002.
+The 2026-04-26 architectural decisions:
+- **ADR-001 (LOCKED):** one spark per division (default rule).
+- **ADR-002 (LOCKED):** Captain + Sentinel stay on Spark 2 permanent (control plane). Council moves to Spark 4 alongside Acquisitions + Wealth — "shared services + intermittent divisions" multi-purpose pattern, an explicit allowable exception to ADR-001.
 
-| Spark | Network | Status | Division | Role / what's hosted today |
+| Spark | Network | Status | Role | What's hosted (target state) |
 |---|---|---|---|---|
-| **Spark 1** | `192.168.0.X` | **ACTIVE** | Fortress Legal | Legal email intake, vault ingestion, privileged communications, Council legal retrieval. Also TITAN tier inference (DeepSeek-R1 671B local) + BRAIN tier (NIM Nemotron 49B). |
-| **Spark 2** | `192.168.0.100` (control plane @ `100.80.122.100`); hostname `spark-2` / `spark-node-2` | **ACTIVE** | CROG-VRS — currently double-duty as **temporary Financial host** (Market Club replacement scaffolding) until Spark 3 provisions; **temporary control plane** (Captain / Council / Sentinel) per ADR-002 OPEN | All Postgres DBs (`fortress_prod`, `fortress_db`, `fortress_shadow`, `fortress_shadow_test`), Qdrant (legal collections), NAS mount, Redis, ARQ, FastAPI for storefront + command-center, cron infra. SWARM tier inference (qwen2.5:7b on Ollama). |
-| **Spark 3** | TBD | **PLANNED — not yet provisioned** | Financial (Master Accounting + Market Club replacement) | Will host: `division_a.*`, `hedge_fund.*` schema (migrated from Spark 2), Market Club scoring engine, accounting services, all financial intelligence. Migration plan blocked on provisioning timeline (see ADR-002 + `divisions/financial.md`). |
-| **Spark 4** | TBD | **PLANNED — not yet provisioned** | TBD; likely **Acquisitions** OR **Wealth** | Operator decides which division ramps first. Current `crog` tmux + Track B migration scratch space lives on `spark-4` informally today, but that's a transient state not a division allocation. |
+| **Spark 1** | `192.168.0.X` | **ACTIVE** | Single-division | Fortress Legal — vault ingestion, privileged communications, Council legal retrieval (queries Spark 4's Council post-cutover). TITAN (DeepSeek-R1 671B) + BRAIN (NIM Nemotron 49B). |
+| **Spark 2** | `192.168.0.100` (ctrl @ `100.80.122.100`); hostname `spark-2` / `spark-node-2` | **ACTIVE** | Multi-purpose: division + shared services | CROG-VRS (storefront + command-center FastAPI + Postgres + Qdrant for legal collections + NAS mount + Redis + ARQ + cron) + **Captain (permanent)** + **Sentinel (permanent)** + SWARM tier inference (qwen2.5:7b on Ollama). |
+| **Spark 3** | TBD | **PLANNED — not yet provisioned** | Single-division | Financial — Master Accounting + Market Club replacement scoring engine. Will receive `division_a.*` + `hedge_fund.*` migration from Spark 2. |
+| **Spark 4** | TBD | **PLANNED — not yet provisioned** | Multi-purpose: shared services + intermittent divisions | **Council** (post-Spark-4 cutover from Spark 2) + Acquisitions + Wealth. Council's bursty workload + the two divisions' intermittent compute profile are compatible on one node. |
 
 ### Migration milestones still to schedule
 
 1. Spark 3 hardware acquired and provisioned
-2. `hedge_fund.*` schema migration from Spark 2 → Spark 3 (with dual-write window per Issue-209 lessons learned)
-3. ADR-002 resolved → Captain / Council / Sentinel placement decision
-4. Spark 4 destination (Acquisitions vs Wealth) confirmed
-5. CROG-VRS sheds its tenant duties (Spark 2 becomes single-purpose)
+2. `hedge_fund.*` + `division_a.*` schema migration from Spark 2 → Spark 3 (dual-write window + Issue-209 CASCADE-safety lessons)
+3. Spark 4 hardware acquired and provisioned (gating dependency for Council migration + Acquisitions/Wealth ramp)
+4. Council Spark 2 → Spark 4 migration (warm-spare → parallel verification week → command-center cutover → 7-day soak → Spark 2 instance retires)
+5. Acquisitions division ramps on Spark 4
+6. Wealth division ramps on Spark 4
+7. Spark 2 sheds Financial tenant (after Spark 3 cutover) — Spark 2's permanent role is "CROG-VRS + Captain + Sentinel" multi-purpose by ADR-002 design, not transitional
 
 ### AI inference tiers ("DEFCON modes")
 

--- a/docs/architecture/shared/sentinel-nas-walker.md
+++ b/docs/architecture/shared/sentinel-nas-walker.md
@@ -1,5 +1,9 @@
 # Shared: Sentinel — NAS Walker
 
+Spark allocation:
+- **Current:** Spark 2
+- **Target:** **Spark 2 permanent** (per ADR-002 LOCKED 2026-04-26 — NAS mounts identically from any spark, per-division NAS paths are already cleanly separated by directory tree, centralization avoids 4× sync overhead with no architectural benefit)
+
 Last updated: 2026-04-26
 
 ## Technical overview

--- a/docs/architecture/system-map.md
+++ b/docs/architecture/system-map.md
@@ -91,27 +91,34 @@ This map shows **two states** — what runs today, and what we're migrating towa
    ┌────────────────────────────────────────────────────────────────┐
    │                                                                │
    │   SPARK 1            SPARK 2            SPARK 3        SPARK 4 │
-   │   Fortress           CROG-VRS           Financial      TBD     │
-   │   Legal              (single duty)      (active)       (Acq    │
-   │   ACTIVE             ACTIVE             ACTIVE          or     │
-   │                                                         Wealth)│
+   │   Fortress           CROG-VRS +         Financial      Council │
+   │   Legal              Captain +          (single duty)  + Acq.  │
+   │   (single duty)      Sentinel           ACTIVE         + Wealth│
+   │   ACTIVE             (multi-purpose)                   (multi- │
+   │                      ACTIVE                            purpose)│
    │   ─ Legal vault      ─ Storefront       ─ division_a.* ACTIVE  │
    │   ─ Privileged       ─ Command-center   ─ hedge_fund.*         │
-   │     comms            ─ Properties /     ─ Master Acc           │
-   │   ─ Council legal      Bookings           services             │
-   │   ─ TITAN/BRAIN      ─ Stripe handoff   ─ Market Club          │
-   │                        to Spark 3         scoring              │
-   │                                         ─ Financial NAS        │
+   │     comms            ─ Properties /     ─ Master Acc   ─ Council│
+   │   ─ TITAN/BRAIN        Bookings           services       (cross-│
+   │                      ─ ALL Postgres     ─ Market Club    division│
+   │                      ─ ALL Qdrant         scoring        deliber-│
+   │                      ─ NAS mount        ─ Financial NAS  ation) │
+   │                      ─ Captain                         ─ Acq.  │
+   │                        (cross-mailbox                    deal   │
+   │                         classification)                  pipe   │
+   │                      ─ Sentinel                        ─ Wealth│
+   │                        (NAS walker;                      intel  │
+   │                         per-division                            │
+   │                         folders                                 │
+   │                         already separate)                       │
    │                                                                │
-   │     ┌─────────────────────────────────────────────────────┐   │
-   │     │  SHARED INFRASTRUCTURE — placement OPEN per ADR-002 │   │
-   │     │  Captain / Council / Sentinel / Auth / MCP          │   │
-   │     │                                                      │   │
-   │     │  Option A: stays on Spark 2 (control-plane host)    │   │
-   │     │  Option B: dedicated shared-infra spark (+1 node?)  │   │
-   │     │  Option C: per-division replicas                    │   │
-   │     └─────────────────────────────────────────────────────┘   │
-   │                                                                │
+   │   Locked per ADR-001 + ADR-002 (2026-04-26):                   │
+   │     Spark 1 = single-division (Legal)                          │
+   │     Spark 2 = division + shared svcs (CROG-VRS + Captain +     │
+   │               Sentinel) — multi-purpose pattern               │
+   │     Spark 3 = single-division (Financial)                      │
+   │     Spark 4 = shared svcs + intermittent divs (Council +       │
+   │               Acquisitions + Wealth) — multi-purpose pattern  │
    └────────────────────────────────────────────────────────────────┘
 ```
 
@@ -141,23 +148,31 @@ Patterns to apply (informed by PR G phase C lessons + Issue #209):
 
 ⚠️ Per Issue #209, the FK on `legal.ingest_runs.case_slug → legal.cases.case_slug ON DELETE CASCADE` ate the audit row for the PR D 7IL ingestion when Phase C renamed the slug. The Spark 2→3 migration must NOT trigger similar CASCADEs across `division_a.*` audit tables.
 
-### Stage 3 — ADR-002 resolution (Captain / Council / Sentinel placement)
+### Stage 3 — Council migration to Spark 4 (LOCKED per ADR-002)
 
-Operator picks Option A (stay Spark 2 permanent), Option B (dedicated spark), or Option C (per-division replicas). Decision encoded in `_architectural-decisions.md`. Migration plan written for the chosen option.
+After Spark 4 hardware provisions:
 
-### Stage 4 — Spark 4 destination
+1. Stand up Council on Spark 4 as warm-spare (no traffic; Spark 2 keeps serving)
+2. Parallel verification week — run Council on both sparks against the same case_slug inputs; compare frozen-context outputs for byte-equality
+3. Latency check — Spark 4 → Spark 2 Qdrant read-replica latency must stay under per-deliberation budget
+4. Cutover — `apps/command-center` deliberation API endpoint switches to Spark 4
+5. 7-day soak; Spark 2 Council instance retires
 
-Operator picks: Acquisitions or Wealth gets Spark 4. The other waits.
+Captain + Sentinel **stay on Spark 2 permanently** per ADR-002. No migration for them.
 
-### Stage 5 — Spark 2 sheds tenant duties
+### Stage 4 — Acquisitions + Wealth onboarding on Spark 4
 
-Once Stages 1-4 land, Spark 2 returns to single-purpose CROG-VRS hosting. Resource budget recovers. The "double-duty" warning in the current-state diagram resolves.
+Operator chooses ramp order. Both divisions co-host with Council on Spark 4 per ADR-002 multi-purpose pattern. Postgres schemas may live on Spark 4 with cross-spark access from Spark 2 if needed.
+
+### Stage 5 — Spark 2 sheds Financial tenant
+
+Once Spark 3 cutover (Stage 1+2) lands, Spark 2 sheds the Market Club replacement scaffolding. Spark 2's permanent role is "CROG-VRS + Captain + Sentinel" — multi-purpose by ADR-002 design, not transitional.
 
 ---
 
 ## Cross-references
 
-- [`cross-division/_architectural-decisions.md`](cross-division/_architectural-decisions.md) — ADR-001 (locked: one spark per division) + ADR-002 (open: shared services)
+- [`cross-division/_architectural-decisions.md`](cross-division/_architectural-decisions.md) — ADR-001 (LOCKED: one spark per division) + ADR-002 (LOCKED: Captain/Sentinel stay on Spark 2 permanent; Council moves to Spark 4 multi-purpose with Acquisitions + Wealth)
 - [`shared/infrastructure.md`](shared/infrastructure.md) — Spark allocation table + migration milestones
 - [`divisions/financial.md`](divisions/financial.md) — Spark 3 target details + open questions
 - [`divisions/market-club.md`](divisions/market-club.md) — Spark 3 cutover blocked on operator answers (6 questions)


### PR DESCRIPTION
## Summary

ADR-002 LOCKED 2026-04-26. Captures shared-services placement decisions and cascading updates across 7 docs.

## Per-service decisions

### Captain → **Option A — Spark 2 permanent**
Cross-mailbox classification IS Captain's value. Dividing it before classification breaks PR #225's Sanker cross-case routing. Centralization is correct architecture.

### Council → **Option B — Spark 4 dedicated, multi-purpose** (refined)
Spark 4 hosts Council + Acquisitions + Wealth. Workload compatibility:
- Council: bursty cross-division LLM deliberation
- Acquisitions: intermittent deal-pipeline analysis
- Wealth: lower-frequency intelligence

None sustains continuous load → co-tenancy avoids a 5th-spark deployment.

This introduces a recognized **"shared services + intermittent divisions" multi-purpose pattern** as an allowable exception to ADR-001's strict "one spark per division" default. Documented in `divisions/_template.md`.

### Sentinel → **Option A — Spark 2 permanent**
NAS mounts identically from any spark. Per-division NAS paths already cleanly separated by directory tree. Per-division replicas (Option C) would 4× file-system traffic + Qdrant sync overhead with **zero** architectural benefit.

## Updated final architecture (target state)

| Spark | Role | Hosts |
|---|---|---|
| **Spark 1** | Single-division | Fortress Legal |
| **Spark 2** | Multi-purpose: division + shared services | CROG-VRS + Captain + Sentinel + control plane (Postgres, Qdrant for legal, NAS mount, Redis, ARQ, FastAPI) |
| **Spark 3** | Single-division | Financial — Master Accounting + Market Club replacement |
| **Spark 4** | Multi-purpose: shared services + intermittent divisions | Council + Acquisitions + Wealth |

## Files changed (7 docs, 2 commits)

| Commit | File | Change |
|---|---|---|
| `2bd091ca6` | `cross-division/_architectural-decisions.md` | ADR-002 status flipped OPEN → LOCKED. Per-service decisions + reasoning + 5-stage Council migration plan. |
| `2bd091ca6` | `shared/captain-email-intake.md` | Spark allocation header: Current Spark 2 / Target Spark 2 (permanent). |
| `2bd091ca6` | `shared/council-deliberation.md` | Spark allocation header: Current Spark 2 / Target Spark 4 + staged migration note. |
| `2bd091ca6` | `shared/sentinel-nas-walker.md` | Spark allocation header: Current Spark 2 / Target Spark 2 (permanent). |
| `2bd091ca6` | `system-map.md` | Target-state ASCII diagram updated. Stage 3 = "Council migration to Spark 4" (was "ADR-002 resolution"). Stage 4 = "Acquisitions + Wealth onboarding on Spark 4". Stage 5 reframed (CROG-VRS+Captain+Sentinel multi-purpose is permanent, not transitional). |
| `8427eb7ec` | `shared/infrastructure.md` | Spark allocation table now reflects target state with Spark 4 multi-purpose. 7 migration milestones (was 5; Council migration step inserted). |
| `8427eb7ec` | `divisions/_template.md` | Documents multi-purpose Spark pattern as allowable ADR-001 exception. Spark 4 as live instance. Notes Spark 2 as the other multi-purpose spark (different pairing). |

## Council migration plan (LOCKED)

After Spark 4 hardware provisions:

1. **Stage 1:** Stand up Council on Spark 4 as warm-spare (no traffic; Spark 2 keeps serving)
2. **Stage 2:** Parallel verification week — run Council on both sparks against same case_slug inputs; compare frozen-context outputs for byte-equality
3. **Stage 3:** Latency check — Spark 4 → Spark 2 Qdrant read-replica latency must stay under per-deliberation budget
4. **Stage 4:** Cutover — `apps/command-center` deliberation API endpoint switches to Spark 4
5. **Stage 5:** 7-day soak; Spark 2 Council instance retires

Captain + Sentinel **stay on Spark 2 permanently** — no migration.

## Constraints honored

- ✅ Single PR
- ✅ Docs only — zero code changes, zero schema changes, zero service restarts
- ✅ ADR-002 status flipped from OPEN to LOCKED with full reasoning
- ✅ Cascading updates across 7 docs (every doc that referenced "TBD per ADR-002")
- ✅ Multi-purpose pattern documented as allowable exception to ADR-001
- ✅ Migration plan added to system-map.md and to ADR-002 itself

## Test plan

- [x] All 7 affected docs updated
- [x] No "TBD per ADR-002" / "OPEN per ADR-002" / "Option [ABC] per ADR-002" placeholders remaining for shared services
- [x] system-map.md target-state diagram shows Spark 4 multi-purpose
- [ ] CI green
- [ ] Operator merge authorization (no auto-merge per spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
