### PR TITLE
docs(adr): ADR-003 LOCKED — inference plane shared swarm

### DIFF
--- a/docs/architecture/cross-division/_architectural-decisions.md
+++ b/docs/architecture/cross-division/_architectural-decisions.md
@@ -124,9 +124,82 @@ Sentinel walks NAS. NAS mounts identically from any spark — there is no per-sp
 
 ---
 
+## ADR-003 — Inference plane: shared swarm across all sparks
+
+**Date:** 2026-04-26
+**Status:** **LOCKED 2026-04-26**
+
+**Decision:** Inference compute (LLM + embedding) is a shared cluster-wide resource, distributed across all 4 sparks. Division-owned data and business logic remain isolated per ADR-001. ADR-002 service placement unchanged.
+
+**Data plane / inference plane separation:**
+
+Data plane (per-division, ADR-001 unchanged):
+- Spark 1 owns Legal data, schemas, code
+- Spark 2 owns CROG-VRS data, schemas, code
+- Spark 3 owns Financial data, schemas, code (when provisioned)
+- Spark 4 owns Council deliberation logic + Acquisitions + Wealth (per ADR-002)
+
+Inference plane (cluster-wide, shared):
+- All 4 sparks contribute LLM + embedding capacity
+- LiteLLM proxy (already running on Spark 2) load-balances inference across all endpoints
+- Any division can consume inference from any spark
+- Council deliberation, embedding ingestion, and other LLM workloads route through LiteLLM, not direct endpoint calls
+- 100Gbps ConnectX interconnect makes cross-spark inference calls operationally fine
+
+**Rationale:**
+
+- Maximizes hardware utilization (idle division inference capacity available to busy divisions)
+- Decouples inference scaling from division scaling (add more sparks for compute without restructuring division ownership)
+- Single LiteLLM control point for cost/usage accounting per division (virtual keys per division → per-division usage tracking)
+- Resolves Issue #228 root cause path: parallel embedding dispatch across endpoints reduces per-message latency, currently the Vanderburge ingestion bottleneck
+- Compatible with existing infrastructure (LiteLLM already running, Ollama already on Spark 2)
+
+**Implementation roadmap (NOT executing today, just documenting):**
+
+### Phase 1 — Endpoint multiplication
+- Install Ollama (or vLLM) on Spark 1, Spark 3 when provisioned, Spark 4 when provisioned
+- Each spark hosts its own embedding model (`nomic-embed-text`) + an LLM
+- Register endpoints with LiteLLM proxy
+- Verify inference works from any spark targeting LiteLLM
+
+### Phase 2 — Embedding queue
+- Redis-backed queue (Spark 2 hosts Redis, per ADR-002 control plane location)
+- Worker processes on each spark consume from queue
+- `process_vault_upload` enqueues chunks instead of synchronous embedding calls
+- Workers dispatch to local Ollama endpoint OR via LiteLLM (TBD per implementation)
+
+### Phase 3 — Council load balancing
+- Council deliberation steps route through LiteLLM
+- Multi-LLM deliberation can use different endpoints for different personas in parallel
+
+### Phase 4 — Per-division usage accounting
+- LiteLLM virtual keys per division
+- Cost/token tracking per case_slug, per deliberation, per ingestion
+- Surface in admin dashboard
+
+Each phase is its own PR with explicit operator authorization. ADR-003 LOCKED captures architectural direction; implementation phases are deliberate, gated work.
+
+**Cross-references:**
+
+- ADR-001 (one-spark-per-division) **UNCHANGED**
+- ADR-002 (Captain/Council/Sentinel placement) **UNCHANGED**
+- Council on Spark 4 still owns deliberation logic; ADR-003 just means it can dispatch inference workload to any spark
+- Sentinel on Spark 2 still owns NAS walking; ADR-003 lets it use cluster-wide embedding for indexing
+- Captain on Spark 2 still owns email intake classification; ADR-003 lets it use cluster-wide inference for any LLM-assisted classification
+
+**Open questions deferred to implementation phases:**
+
+- Direct endpoint calls vs. LiteLLM-only routing (worker dispatch pattern)
+- Embedding queue implementation (Redis vs. another queue)
+- Failure semantics when an endpoint is unavailable (retry, circuit-break, degraded mode)
+- Per-division rate limiting via LiteLLM
+- Observability (metrics per endpoint, per division, per workload type)
+
+---
+
 ## How to add an ADR
 
-1. Increment the number (next is ADR-003)
+1. Increment the number (next is ADR-004)
 2. Date it (UTC)
 3. Set status: LOCKED, OPEN, AMENDED, or SUPERSEDED-BY-ADR-N
 4. State the decision in 1-2 sentences

--- a/docs/architecture/divisions/_template.md
+++ b/docs/architecture/divisions/_template.md
@@ -46,6 +46,18 @@ Bulleted list. Each entry: service name + how this division uses it. Cross-link 
 - [Council](../shared/council-deliberation.md) — for case-aware deliberation
 - [Sentinel](../shared/sentinel-nas-walker.md) — for NAS document indexing
 
+## Inference consumers
+
+Per [ADR-003](../cross-division/_architectural-decisions.md) LOCKED 2026-04-26, the inference plane (LLM + embedding) is a shared cluster-wide resource routed through the LiteLLM proxy on Spark 2. Each division documents what inference workloads it generates so the cluster can be sized.
+
+Document for this division:
+
+- **LLM workloads** — what calls does this division make? Examples: classification, summarization, parsing, deliberation. Estimate volume (per day / per case / per booking).
+- **Embedding workloads** — what gets embedded? Vault uploads, NAS walks, search index updates. Estimate volume (chunks per day).
+- **Tier preference** — does this division need TITAN/BRAIN tier (deep reasoning), SWARM tier (fast routing), or either?
+- **Latency budget** — synchronous (user is waiting) vs. async (queueable via ADR-003 Phase 2 embedding queue)?
+- **Per-division accounting tag** — what LiteLLM virtual key does this division use? (ADR-003 Phase 4)
+
 ## Key services exposed
 
 Bulleted list. What other divisions or external systems consume this division's output?

--- a/docs/architecture/shared/captain-email-intake.md
+++ b/docs/architecture/shared/captain-email-intake.md
@@ -4,6 +4,11 @@ Spark allocation:
 - **Current:** Spark 2
 - **Target:** **Spark 2 permanent** (per ADR-002 LOCKED 2026-04-26 — Captain cross-mailbox classification is its core value; centralization is correct)
 
+Inference plane (per [ADR-003](../cross-division/_architectural-decisions.md) LOCKED 2026-04-26):
+- Captain's classification + LLM-assisted parsing routes through the LiteLLM proxy (also on Spark 2).
+- Any spark's LLM endpoint may serve Captain's classification calls — LiteLLM picks.
+- Captain's data plane (mailbox state, capture rows in `public.llm_training_captures`) stays on Spark 2's Postgres; only the inference call is cluster-wide.
+
 Last updated: 2026-04-26
 
 ## Technical overview

--- a/docs/architecture/shared/council-deliberation.md
+++ b/docs/architecture/shared/council-deliberation.md
@@ -4,6 +4,12 @@ Spark allocation:
 - **Current:** Spark 2 (tenant of the monorepo)
 - **Target:** **Spark 4** (per ADR-002 LOCKED 2026-04-26 — Spark 4 hosts Council + Acquisitions + Wealth as a "shared services + intermittent divisions" multi-purpose node). Migration is staged after Spark 4 is provisioned: warm-spare → parallel verification week → command-center cutover → 7-day soak → Spark 2 instance retires.
 
+Inference plane (per [ADR-003](../cross-division/_architectural-decisions.md) LOCKED 2026-04-26):
+- Council deliberation **logic** stays on Spark 4 (per ADR-002).
+- Council deliberation **inference workload** routes through the LiteLLM proxy on Spark 2 — Council dispatches to whichever spark's LLM endpoint LiteLLM selects.
+- Multi-persona deliberation can use different endpoints for different personas in parallel (ADR-003 Phase 3).
+- Direct endpoint calls from Council are deprecated in favor of LiteLLM-routed calls.
+
 Last updated: 2026-04-26
 
 ## Technical overview

--- a/docs/architecture/shared/infrastructure.md
+++ b/docs/architecture/shared/infrastructure.md
@@ -6,18 +6,31 @@ Last updated: 2026-04-26
 
 Fortress Prime runs on a local NVIDIA DGX Spark cluster (4 nodes). No cloud databases for sovereign data; transient cloud inference is allowed only for non-PII payloads with ephemeral guarantees per CONSTITUTION.md Article I.
 
-### Cluster topology — division + shared-services allocation (per [ADR-001](../cross-division/_architectural-decisions.md) + [ADR-002](../cross-division/_architectural-decisions.md))
+### Cluster topology — division + shared-services allocation (per [ADR-001](../cross-division/_architectural-decisions.md) + [ADR-002](../cross-division/_architectural-decisions.md) + [ADR-003](../cross-division/_architectural-decisions.md))
 
 The 2026-04-26 architectural decisions:
 - **ADR-001 (LOCKED):** one spark per division (default rule).
 - **ADR-002 (LOCKED):** Captain + Sentinel stay on Spark 2 permanent (control plane). Council moves to Spark 4 alongside Acquisitions + Wealth — "shared services + intermittent divisions" multi-purpose pattern, an explicit allowable exception to ADR-001.
+- **ADR-003 (LOCKED):** Inference compute (LLM + embedding) is a shared cluster-wide resource. All 4 sparks contribute capacity. LiteLLM proxy on Spark 2 routes workloads. Data plane (per-division) and inference plane (shared) are explicitly separated.
 
-| Spark | Network | Status | Role | What's hosted (target state) |
-|---|---|---|---|---|
-| **Spark 1** | `192.168.0.X` | **ACTIVE** | Single-division | Fortress Legal — vault ingestion, privileged communications, Council legal retrieval (queries Spark 4's Council post-cutover). TITAN (DeepSeek-R1 671B) + BRAIN (NIM Nemotron 49B). |
-| **Spark 2** | `192.168.0.100` (ctrl @ `100.80.122.100`); hostname `spark-2` / `spark-node-2` | **ACTIVE** | Multi-purpose: division + shared services | CROG-VRS (storefront + command-center FastAPI + Postgres + Qdrant for legal collections + NAS mount + Redis + ARQ + cron) + **Captain (permanent)** + **Sentinel (permanent)** + SWARM tier inference (qwen2.5:7b on Ollama). |
-| **Spark 3** | TBD | **PLANNED — not yet provisioned** | Single-division | Financial — Master Accounting + Market Club replacement scoring engine. Will receive `division_a.*` + `hedge_fund.*` migration from Spark 2. |
-| **Spark 4** | TBD | **PLANNED — not yet provisioned** | Multi-purpose: shared services + intermittent divisions | **Council** (post-Spark-4 cutover from Spark 2) + Acquisitions + Wealth. Council's bursty workload + the two divisions' intermittent compute profile are compatible on one node. |
+| Spark | Network | Status | Role | Data plane (target state) | Inference plane contribution |
+|---|---|---|---|---|---|
+| **Spark 1** | `192.168.0.X` | **ACTIVE** | Single-division | Fortress Legal — vault ingestion, privileged communications, Council legal retrieval (queries Spark 4's Council post-cutover). | TITAN (DeepSeek-R1 671B) + BRAIN (NIM Nemotron 49B FP8). Endpoint registered with LiteLLM (Phase 1). |
+| **Spark 2** | `192.168.0.100` (ctrl @ `100.80.122.100`); hostname `spark-2` / `spark-node-2` | **ACTIVE** | Multi-purpose: division + shared services | CROG-VRS (storefront + command-center FastAPI + Postgres + Qdrant for legal collections + NAS mount + Redis + ARQ + cron) + **Captain (permanent)** + **Sentinel (permanent)**. | SWARM tier (Ollama qwen2.5:7b + `nomic-embed-text`). **LiteLLM proxy host** — cluster-wide inference router. |
+| **Spark 3** | TBD | **PLANNED — not yet provisioned** | Single-division | Financial — Master Accounting + Market Club replacement scoring engine. Will receive `division_a.*` + `hedge_fund.*` migration from Spark 2. | Ollama (or vLLM) endpoint with embedding + LLM, registered with LiteLLM (ADR-003 Phase 1). |
+| **Spark 4** | TBD | **PLANNED — not yet provisioned** | Multi-purpose: shared services + intermittent divisions | **Council** (post-Spark-4 cutover from Spark 2) + Acquisitions + Wealth. | Ollama (or vLLM) endpoint with embedding + LLM, registered with LiteLLM (ADR-003 Phase 1). Council deliberation dispatches via LiteLLM (Phase 3). |
+
+### Inference plane (per [ADR-003](../cross-division/_architectural-decisions.md))
+
+Inference compute is **decoupled from division ownership**. Any division can consume inference from any spark via the LiteLLM proxy. This is an architectural separation between the data plane (per-division, ADR-001) and the inference plane (cluster-wide, ADR-003).
+
+- **Router:** LiteLLM proxy on Spark 2 (already running). All LLM + embedding calls from FastAPI, ARQ workers, Captain, Council, and Sentinel route through LiteLLM rather than direct endpoint URLs.
+- **Endpoints:** Each spark hosts its own embedding model (`nomic-embed-text`) + an LLM tier. Endpoints register with LiteLLM as a model pool.
+- **Transport:** 100Gbps ConnectX interconnect; cross-spark inference is operationally fine.
+- **Per-division accounting (ADR-003 Phase 4):** LiteLLM virtual keys per division → cost/token tracking per case_slug, deliberation, ingestion.
+- **Embedding queue (ADR-003 Phase 2):** Redis-backed (Spark 2 hosts Redis); workers on each spark consume from queue; `process_vault_upload` enqueues chunks rather than blocking on synchronous embedding.
+
+Implementation is gated work — each ADR-003 phase is its own PR with operator authorization. Today, only Spark 2 contributes to the inference plane (Ollama qwen2.5:7b + nomic). Spark 1 hosts TITAN/BRAIN for legal-only direct calls. Phase 1 multiplies endpoints across all sparks.
 
 ### Migration milestones still to schedule
 
@@ -30,6 +43,8 @@ The 2026-04-26 architectural decisions:
 7. Spark 2 sheds Financial tenant (after Spark 3 cutover) — Spark 2's permanent role is "CROG-VRS + Captain + Sentinel" multi-purpose by ADR-002 design, not transitional
 
 ### AI inference tiers ("DEFCON modes")
+
+These tiers are **inference-plane resources** per ADR-003 — capacity is shared cluster-wide via LiteLLM, not bound to any one division.
 
 | Tier | Service | Model | Use |
 |---|---|---|---|

--- a/docs/architecture/shared/sentinel-nas-walker.md
+++ b/docs/architecture/shared/sentinel-nas-walker.md
@@ -4,6 +4,11 @@ Spark allocation:
 - **Current:** Spark 2
 - **Target:** **Spark 2 permanent** (per ADR-002 LOCKED 2026-04-26 — NAS mounts identically from any spark, per-division NAS paths are already cleanly separated by directory tree, centralization avoids 4× sync overhead with no architectural benefit)
 
+Inference plane (per [ADR-003](../cross-division/_architectural-decisions.md) LOCKED 2026-04-26):
+- Sentinel's NAS walking + chunking + Qdrant upsert (data plane) stays on Spark 2.
+- Sentinel's **embedding workload** routes through the cluster inference plane via LiteLLM — `nomic-embed-text` calls are dispatched to whichever spark's embedding endpoint has capacity.
+- Once the ADR-003 Phase 2 embedding queue lands, Sentinel enqueues chunks rather than blocking on synchronous embedding; workers on each spark drain the queue in parallel.
+
 Last updated: 2026-04-26
 
 ## Technical overview

--- a/docs/architecture/system-map.md
+++ b/docs/architecture/system-map.md
@@ -39,6 +39,8 @@ This map shows **two states** — what runs today, and what we're migrating towa
    │   ─ BRAIN tier                   ─ NAS mount                    │
    │     (NIM Nemotron 49B FP8)       ─ SWARM tier                   │
    │                                    (Ollama qwen2.5:7b)          │
+   │                                  ─ LiteLLM proxy (cluster-wide │
+   │                                    inference router; ADR-003)   │
    │                                  ─ DOUBLE-DUTY ⚠                │
    │                                    + temp Financial scaffolding │
    │                                    + temp control plane         │
@@ -52,6 +54,14 @@ This map shows **two states** — what runs today, and what we're migrating towa
    │     Master Accounting svc                                       │
    │     Market Club scoring                                         │
    │     Financial NAS                                               │
+   │                                                                │
+   │   ── INFERENCE PLANE (current; ADR-003 LOCKED 2026-04-26) ──   │
+   │   Single-endpoint today: only Spark 2 (Ollama qwen2.5:7b +      │
+   │   nomic-embed-text) participates. LiteLLM proxy already running │
+   │   on Spark 2 but routes to a single backend. Spark 1's          │
+   │   TITAN/BRAIN are direct-call legal-only, not yet behind        │
+   │   LiteLLM. ADR-003 Phase 1 will multiply endpoints across all   │
+   │   sparks.                                                       │
    │                                                                │
    └────────────────────────────────────────────────────────────────┘
                                      │
@@ -119,6 +129,34 @@ This map shows **two states** — what runs today, and what we're migrating towa
    │     Spark 3 = single-division (Financial)                      │
    │     Spark 4 = shared svcs + intermittent divs (Council +       │
    │               Acquisitions + Wealth) — multi-purpose pattern  │
+   │                                                                │
+   │   ── INFERENCE PLANE (target; ADR-003 LOCKED 2026-04-26) ──   │
+   │                                                                │
+   │      ┌──────────────── LiteLLM proxy (Spark 2) ────────────┐ │
+   │      │  Cluster-wide router. Per-division virtual keys.    │ │
+   │      │  Phase 4: cost/token tracking per case_slug,         │ │
+   │      │  deliberation, ingestion.                            │ │
+   │      └────┬──────────┬──────────┬──────────┬───────────────┘ │
+   │           ▼          ▼          ▼          ▼                  │
+   │      Spark 1     Spark 2    Spark 3    Spark 4               │
+   │      Ollama/     Ollama     Ollama     Ollama                 │
+   │      vLLM        qwen2.5    (Phase 1   (Phase 1               │
+   │      + TITAN     + nomic-   when prov.) when prov.)           │
+   │      + BRAIN     embed-text                                   │
+   │                                                                │
+   │   Embedding queue (Redis on Spark 2; ADR-003 Phase 2):        │
+   │      process_vault_upload + Sentinel enqueue chunks;          │
+   │      workers on every spark drain queue in parallel.          │
+   │                                                                │
+   │   Council deliberation (ADR-003 Phase 3):                     │
+   │      Logic stays on Spark 4; persona LLM calls dispatched     │
+   │      via LiteLLM, possibly to different sparks in parallel.   │
+   │                                                                │
+   │   Data plane vs. inference plane:                              │
+   │      Data plane (per-division, ADR-001) — schemas, rows,      │
+   │        files, code stay on the division's spark.              │
+   │      Inference plane (cluster-wide, ADR-003) — LLM +          │
+   │        embedding capacity is fungible across sparks.          │
    └────────────────────────────────────────────────────────────────┘
 ```
 
@@ -168,12 +206,25 @@ Operator chooses ramp order. Both divisions co-host with Council on Spark 4 per 
 
 Once Spark 3 cutover (Stage 1+2) lands, Spark 2 sheds the Market Club replacement scaffolding. Spark 2's permanent role is "CROG-VRS + Captain + Sentinel" — multi-purpose by ADR-002 design, not transitional.
 
+### Stage 6 — Inference plane phases (LOCKED per ADR-003)
+
+ADR-003 LOCKED captures architectural direction; the four phases are deliberate, gated work — each phase ships as its own PR with explicit operator authorization. They run independently of the data-plane stages above (1–5).
+
+1. **Phase 1 — Endpoint multiplication.** Install Ollama (or vLLM) on Spark 1, Spark 3 (when provisioned), Spark 4 (when provisioned). Each spark hosts `nomic-embed-text` + an LLM. Register endpoints with LiteLLM. Verify cross-spark inference works.
+2. **Phase 2 — Embedding queue.** Redis-backed queue (Spark 2 hosts Redis). Workers on each spark consume from queue. `process_vault_upload` enqueues chunks rather than synchronous embedding. Resolves Issue #228 Vanderburge ingestion bottleneck.
+3. **Phase 3 — Council load balancing.** Council deliberation steps route through LiteLLM. Multi-LLM persona deliberation can use different endpoints in parallel.
+4. **Phase 4 — Per-division usage accounting.** LiteLLM virtual keys per division. Cost/token tracking per case_slug, per deliberation, per ingestion. Surface in admin dashboard.
+
 ---
 
 ## Cross-references
 
-- [`cross-division/_architectural-decisions.md`](cross-division/_architectural-decisions.md) — ADR-001 (LOCKED: one spark per division) + ADR-002 (LOCKED: Captain/Sentinel stay on Spark 2 permanent; Council moves to Spark 4 multi-purpose with Acquisitions + Wealth)
-- [`shared/infrastructure.md`](shared/infrastructure.md) — Spark allocation table + migration milestones
+- [`cross-division/_architectural-decisions.md`](cross-division/_architectural-decisions.md) — ADR-001 (LOCKED: one spark per division) + ADR-002 (LOCKED: Captain/Sentinel stay on Spark 2 permanent; Council moves to Spark 4 multi-purpose with Acquisitions + Wealth) + ADR-003 (LOCKED: inference plane is cluster-wide shared via LiteLLM)
+- [`shared/infrastructure.md`](shared/infrastructure.md) — Spark allocation table + inference plane section + migration milestones
+- [`shared/council-deliberation.md`](shared/council-deliberation.md) — Council inference dispatch via LiteLLM (ADR-003)
+- [`shared/captain-email-intake.md`](shared/captain-email-intake.md) — Captain classification via LiteLLM (ADR-003)
+- [`shared/sentinel-nas-walker.md`](shared/sentinel-nas-walker.md) — Sentinel embedding via cluster inference plane (ADR-003)
+- [`divisions/_template.md`](divisions/_template.md) — "Inference consumers" subsection per division
 - [`divisions/financial.md`](divisions/financial.md) — Spark 3 target details + open questions
 - [`divisions/market-club.md`](divisions/market-club.md) — Spark 3 cutover blocked on operator answers (6 questions)
 - [`fortress_atlas.yaml`](../../fortress_atlas.yaml) — runtime sector routing (currently spark-agnostic; future amendment may add per-sector spark allocation)


### PR DESCRIPTION
## Summary

- **ADR-003 LOCKED** — Inference compute (LLM + embedding) is a shared cluster-wide resource. All 4 sparks contribute capacity; LiteLLM proxy on Spark 2 routes workloads. Data plane (per-division per ADR-001) and inference plane (cluster-wide per ADR-003) are explicitly separated.
- **Implementation roadmap** documented across 4 phases (endpoint multiplication → embedding queue → Council load balancing → per-division accounting). Each phase ships as its own PR with explicit operator authorization. ADR-003 itself is direction, not execution.
- **ADR-001 and ADR-002 are unchanged.** Service placement (Captain/Council/Sentinel) and division ↔ spark mapping stand exactly as locked on 2026-04-26.

## Files changed

| File | Purpose |
|---|---|
| `docs/architecture/cross-division/_architectural-decisions.md` | Append ADR-003 entry. Updated "next ADR" pointer to ADR-004. |
| `docs/architecture/shared/infrastructure.md` | New "Inference plane" section. Spark allocation table now has separate "Data plane" and "Inference plane contribution" columns. ADR-003 referenced in topology header. |
| `docs/architecture/shared/council-deliberation.md` | Note Council deliberation logic stays on Spark 4 but inference workload routes through LiteLLM. |
| `docs/architecture/shared/captain-email-intake.md` | Note classification + LLM-assisted parsing routes through LiteLLM. |
| `docs/architecture/shared/sentinel-nas-walker.md` | Note embedding workload routes through cluster inference plane (and Phase 2 embedding queue). |
| `docs/architecture/divisions/_template.md` | New "Inference consumers" subsection — divisions document their LLM/embedding workloads, tier preference, latency budget, and accounting tag. |
| `docs/architecture/system-map.md` | Inference plane layer added to current + target diagrams. New Stage 6 in migration path covering ADR-003's 4 phases. |

## Constraints honored

- Docs-only. No code, infra, or runtime changes.
- All edits live under `docs/architecture/`.
- ADR-001 and ADR-002 entry content untouched (only the "next ADR is N" footer pointer advanced from 003 → 004).
- No auto-merge.

## Test plan

- [ ] Operator review of ADR-003 wording — does the data-plane / inference-plane split match operator's mental model?
- [ ] Confirm "LiteLLM already running on Spark 2" matches current state (cited but not verified by this PR).
- [ ] Confirm Issue #228 reference is the correct issue number for the Vanderburge ingestion bottleneck.
- [ ] Confirm no other architecture docs reference the old "next is ADR-003" pointer.
- [ ] After merge: each ADR-003 phase becomes its own gated PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)