### PR TITLE
fix(infra): per-host NIM cache isolation via systemd %H specifier

### DIFF
--- a/deploy/systemd/fortress-nim-brain.service
+++ b/deploy/systemd/fortress-nim-brain.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Fortress NIM Brain — nvidia/Llama-3.3-Nemotron-Super-49B-v1.5-FP8 on spark-1 (Tier 2 sovereign reasoning)
+Description=Fortress NIM Brain — nvidia/Llama-3.3-Nemotron-Super-49B-v1.5-FP8 on spark-1 / spark-5 / spark-6 (parallel-serving brain fleet, per-host cache via %H)
 Documentation=file:///home/admin/Fortress-Prime/deploy/systemd/fortress-nim-brain.service
 Documentation=https://huggingface.co/nvidia/Llama-3_3-Nemotron-Super-49B-v1_5-FP8
 After=docker.service network-online.target remote-fs.target
@@ -40,7 +40,7 @@ ExecStart=/usr/bin/docker run \
   --shm-size=16g \
   -p 8100:8000 \
   -v /mnt/fortress_nas/nim-cache/hf/nvidia-Llama-3_3-Nemotron-Super-49B-v1_5-FP8:/opt/nim/models/nemotron-super-49b-v1-5-fp8:ro \
-  -v /mnt/fortress_nas/nim-cache/hf/llm-nim-runtime-cache:/opt/nim/.cache \
+  -v /mnt/fortress_nas/nim-cache/hf/llm-nim-runtime-cache/%H:/opt/nim/.cache \
   --env-file /etc/fortress/nim.env \
   -e NIM_MODEL_NAME=/opt/nim/models/nemotron-super-49b-v1-5-fp8 \
   -e NIM_SERVED_MODEL_NAME=nvidia/llama-3.3-nemotron-super-49b-v1.5-fp8 \


### PR DESCRIPTION
## Summary

Each NIM brain node now mounts its own subdirectory under `/mnt/fortress_nas/nim-cache/hf/llm-nim-runtime-cache/` using systemd's `%H` specifier (resolves to short OS hostname). Same unit file works on every node.

## Why

Yesterday's cache-poisoning incident (`docs/audits/handoff-20260424.md`, item #176 — `llm-nim-runtime-cache.poisoned-20260424/`) showed that spark-1 and spark-5 brains writing to the same NAS runtime cache produces cross-contamination — KV cache and torch.compile artifacts from one node corrupt the other.

This PR is the actual fix that was discussed in the 2026-04-24 session but never committed. Discovered during spark-6 deployment pre-flight when the unit file showed the unchanged shared mount.

## Changes

- `deploy/systemd/fortress-nim-brain.service`: 
  - cache mount line: `…/llm-nim-runtime-cache:/opt/nim/.cache` → `…/llm-nim-runtime-cache/%H:/opt/nim/.cache`
  - Description: now references all three brain nodes (spark-1 / spark-5 / spark-6)

## Required follow-up after merge

1. Create `…/llm-nim-runtime-cache/<hostname>/` on the NAS for each brain node
2. Restart `fortress-nim-brain` on spark-1, then spark-5 (sequential — rollback if first fails)
3. Deploy spark-6 against fixed unit

## Hostname caveat

`%H` resolves to OS hostname. spark-1 and spark-2 currently report OS hostnames `spark-node-2` and `spark-node-1` respectively (IP-based identification authoritative; `hostnamectl` cleanup tracked for Phase 2). Per-host cache subdirs are created matching **current** OS hostnames (`spark-node-1`, `spark-node-2`, `spark-5`, `spark-6`) and will be renamed after the hostnamectl cleanup.

## Test plan

- [ ] spark-1 (`spark-node-2`): restart with new unit, confirm `/v1/health/ready` and short-form probe
- [ ] spark-5: restart with new unit, confirm `/v1/health/ready` and short-form probe
- [ ] spark-6: fresh deploy against new unit
- [ ] Per-host cache dirs present and being written into after each restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)