### PR TITLE
feat(flos): Phase 0a-3 CLI + health — operator surface for legal_mail_ingester

### DIFF
--- a/fortress-guest-platform/backend/api/legal_mail_health.py
+++ b/fortress-guest-platform/backend/api/legal_mail_health.py
@@ -1,0 +1,413 @@
+"""
+legal_mail_health.py — programmatic health endpoint for legal_mail_ingester.
+
+Phase 0a-3 implementation per:
+  docs/architecture/cross-division/FLOS-phase-0a-legal-email-ingester-design-v1.1.md
+  §6 (operator surface) + §7 (observability)
+
+GET /api/internal/legal/mail/health
+  Returns per-mailbox status as JSON, same data as
+  `fgp legal mail status` but machine-parseable. Used by ops dashboards,
+  alertmanager probes, and automation.
+
+Auth pattern: matches backend/api/internal_health.py
+  - Authorization: Bearer <internal_api_bearer_token>
+  - X-Fortress-Ingress: command_center
+  - X-Fortress-Tunnel-Signature: <internal_api_bearer_token>
+
+All three required. Internal-only endpoint, never exposed via the public
+storefront tunnel.
+"""
+from __future__ import annotations
+
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Annotated, Literal, Optional, Sequence, cast
+
+from fastapi import APIRouter, Header, HTTPException, status
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import text
+
+from backend.core.config import settings
+from backend.services.ediscovery_agent import LegacySession
+from backend.services.legal_mail_ingester import (
+    INGESTER_VERSIONED,
+    LegalMailboxConfigError,
+    load_legal_mailbox_configs,
+)
+
+router = APIRouter()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Response models
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+MailboxStatus = Literal["ok", "stale", "errored", "paused", "unconfigured"]
+OverallStatus = Literal["ok", "degraded", "disabled"]
+
+
+class MailboxHealth(BaseModel):
+    """Per-mailbox health record."""
+    model_config = ConfigDict(extra="forbid")
+
+    alias: str
+    host: str
+    folder: str
+    routing_tag: str
+    poll_interval_sec: int
+
+    # State row from legal.mail_ingester_state
+    last_patrol_at: Optional[datetime] = None
+    last_success_at: Optional[datetime] = None
+    last_error_at: Optional[datetime] = None
+    last_error: Optional[str] = None
+    messages_ingested_total: int = 0
+    messages_errored_total: int = 0
+
+    # Today's counters from legal.event_log
+    messages_ingested_today: int = 0
+    watchdog_matches_today: int = 0
+
+    # Pause row from legal.mail_ingester_pause
+    paused: bool = False
+    paused_by: Optional[str] = None
+    pause_reason: Optional[str] = None
+    paused_at: Optional[datetime] = None
+
+    # Computed per-mailbox rollup
+    status: MailboxStatus
+
+
+class HealthSummary(BaseModel):
+    """Aggregate counts across all mailboxes."""
+    model_config = ConfigDict(extra="forbid")
+
+    total_mailboxes: int
+    healthy: int
+    paused: int
+    errored: int
+    stale: int
+
+
+class LegalMailHealthResponse(BaseModel):
+    """Top-level response for GET /api/internal/legal/mail/health."""
+    model_config = ConfigDict(extra="forbid")
+
+    service: Literal["legal_mail_ingester"] = "legal_mail_ingester"
+    ingester_versioned: str = Field(min_length=1)
+    ingester_enabled: bool
+    checked_at: datetime
+    overall_status: OverallStatus
+    mailboxes: list[MailboxHealth]
+    summary: HealthSummary
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Auth helpers (mirror internal_health.py)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _secure_equals(presented: str | None, expected: str) -> bool:
+    if not presented or not expected:
+        return False
+    return secrets.compare_digest(presented.strip(), expected.strip())
+
+
+def _enforce_internal_auth(
+    authorization: str | None,
+    x_fortress_ingress: str | None,
+    x_fortress_tunnel_signature: str | None,
+) -> None:
+    """
+    Bearer + ingress + tunnel-signature gate. Same triple-check as
+    internal_health.py — any failure raises HTTPException with the same
+    status codes / details so monitoring tools see consistent error shape.
+    """
+    expected_secret = settings.internal_api_bearer_token
+
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing bearer token.",
+        )
+    bearer_token = authorization[7:].strip()
+    if not _secure_equals(bearer_token, expected_secret):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid bearer token.",
+        )
+    if x_fortress_ingress != "command_center":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid ingress boundary.",
+        )
+    if not _secure_equals(x_fortress_tunnel_signature, expected_secret):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid tunnel signature.",
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Status computation
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+# A mailbox is "stale" if its last successful patrol was longer than this many
+# poll intervals ago. 3× provides slack for transient connectivity blips
+# without flagging a healthy mailbox as stale during a single retry.
+STALE_MULTIPLIER = 3
+
+# Errors older than this are considered resolved (the patrol has succeeded
+# since); stop surfacing them as the per-mailbox status.
+ERROR_FRESHNESS_WINDOW = timedelta(hours=1)
+
+
+def _compute_mailbox_status(
+    *,
+    paused: bool,
+    last_success_at: Optional[datetime],
+    last_error_at: Optional[datetime],
+    poll_interval_sec: int,
+    now: datetime,
+) -> MailboxStatus:
+    """
+    Per-mailbox rollup. Order matters — pause is sticky (operator-explicit
+    signal); errored takes precedence over stale (errored is more actionable);
+    stale only if no recent success.
+    """
+    if paused:
+        return "paused"
+
+    # Errored: there was an error AND the last successful patrol was either
+    # missing or older than the error. Once the patrol succeeds AFTER an
+    # error, the mailbox is no longer "errored" from a monitoring view.
+    if last_error_at is not None:
+        recent_error = (now - last_error_at) < ERROR_FRESHNESS_WINDOW
+        unrecovered = (
+            last_success_at is None
+            or last_success_at < last_error_at
+        )
+        if recent_error and unrecovered:
+            return "errored"
+
+    # Stale: no successful patrol ever, or the last one is much older than
+    # the configured poll interval would expect.
+    if last_success_at is None:
+        return "stale"
+    elapsed = (now - last_success_at).total_seconds()
+    if elapsed > (poll_interval_sec * STALE_MULTIPLIER):
+        return "stale"
+
+    return "ok"
+
+
+def _overall_status(
+    ingester_enabled: bool,
+    mailbox_statuses: Sequence[MailboxStatus],
+) -> OverallStatus:
+    """
+    Top-level rollup. If the flag is off, status is 'disabled' regardless
+    of mailbox state — that lets monitors distinguish "code is inert by
+    design" from "code is running but degraded".
+    """
+    if not ingester_enabled:
+        return "disabled"
+    if any(s in ("errored", "stale") for s in mailbox_statuses):
+        return "degraded"
+    return "ok"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Data fetch
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def _build_mailbox_health(
+    *,
+    alias: str,
+    host: str,
+    folder: str,
+    routing_tag: str,
+    poll_interval_sec: int,
+    today_start_utc: datetime,
+    now: datetime,
+) -> MailboxHealth:
+    """
+    Three queries against fortress_db (same shape the CLI uses):
+      1. legal.mail_ingester_state  — counters + last_patrol/success/error
+      2. legal.mail_ingester_pause  — pause row if present
+      3. legal.event_log            — today's email.received events emitted by us
+    """
+    async with LegacySession() as db:
+        r = await db.execute(
+            text("""
+                SELECT last_patrol_at, last_success_at, last_error_at, last_error,
+                       messages_ingested_total, messages_errored_total
+                FROM legal.mail_ingester_state
+                WHERE mailbox_alias = :alias
+            """),
+            {"alias": alias},
+        )
+        state_row = r.fetchone()
+
+        r = await db.execute(
+            text("""
+                SELECT paused_at, paused_by, reason
+                FROM legal.mail_ingester_pause
+                WHERE mailbox_alias = :alias
+            """),
+            {"alias": alias},
+        )
+        pause_row = r.fetchone()
+
+        r = await db.execute(
+            text("""
+                SELECT
+                    COUNT(*) AS events_today,
+                    COALESCE(SUM(jsonb_array_length(event_payload->'watchdog_matches')), 0)
+                        AS watchdog_matches_today
+                FROM legal.event_log
+                WHERE event_type = 'email.received'
+                  AND emitted_by = :v
+                  AND emitted_at >= :today_start
+                  AND event_payload->>'mailbox' = :alias
+            """),
+            {
+                "v": INGESTER_VERSIONED,
+                "today_start": today_start_utc,
+                "alias": alias,
+            },
+        )
+        counters_row = r.fetchone()
+
+    paused = pause_row is not None
+    last_patrol_at = state_row.last_patrol_at if state_row else None
+    last_success_at = state_row.last_success_at if state_row else None
+    last_error_at = state_row.last_error_at if state_row else None
+    last_error = state_row.last_error if state_row else None
+    messages_ingested_total = int(state_row.messages_ingested_total or 0) if state_row else 0
+    messages_errored_total = int(state_row.messages_errored_total or 0) if state_row else 0
+
+    # COUNT(*) always returns one row, so counters_row is non-None.
+    assert counters_row is not None
+    messages_ingested_today = int(counters_row.events_today or 0)
+    watchdog_matches_today = int(counters_row.watchdog_matches_today or 0)
+
+    mailbox_status = _compute_mailbox_status(
+        paused=paused,
+        last_success_at=last_success_at,
+        last_error_at=last_error_at,
+        poll_interval_sec=poll_interval_sec,
+        now=now,
+    )
+
+    return MailboxHealth(
+        alias=alias,
+        host=host,
+        folder=folder,
+        routing_tag=routing_tag,
+        poll_interval_sec=poll_interval_sec,
+        last_patrol_at=last_patrol_at,
+        last_success_at=last_success_at,
+        last_error_at=last_error_at,
+        last_error=last_error,
+        messages_ingested_total=messages_ingested_total,
+        messages_errored_total=messages_errored_total,
+        messages_ingested_today=messages_ingested_today,
+        watchdog_matches_today=watchdog_matches_today,
+        paused=paused,
+        paused_by=pause_row.paused_by if pause_row else None,
+        pause_reason=pause_row.reason if pause_row else None,
+        paused_at=pause_row.paused_at if pause_row else None,
+        status=mailbox_status,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Endpoint
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@router.get(
+    "/legal/mail/health",
+    response_model=LegalMailHealthResponse,
+    include_in_schema=False,
+)
+async def legal_mail_health(
+    authorization: Annotated[str | None, Header(alias="Authorization")] = None,
+    x_fortress_ingress: Annotated[str | None, Header(alias="X-Fortress-Ingress")] = None,
+    x_fortress_tunnel_signature: Annotated[
+        str | None, Header(alias="X-Fortress-Tunnel-Signature")
+    ] = None,
+) -> LegalMailHealthResponse:
+    """
+    Programmatic health surface for legal_mail_ingester.
+
+    Returns per-mailbox status + aggregate rollup. Designed for ops
+    dashboards and alertmanager probes — same data as
+    `fgp legal mail status`, but JSON-shaped and JWT-protected.
+
+    HTTP semantics:
+      200 — successful response (overall_status in body indicates health)
+      401 — missing or bad bearer token
+      403 — wrong ingress boundary or tunnel signature
+      503 — MAILBOXES_CONFIG malformed (the ingester can't be evaluated)
+    """
+    _enforce_internal_auth(
+        authorization=authorization,
+        x_fortress_ingress=x_fortress_ingress,
+        x_fortress_tunnel_signature=x_fortress_tunnel_signature,
+    )
+
+    try:
+        configs = load_legal_mailbox_configs()
+    except LegalMailboxConfigError as exc:
+        # Configuration error is a service-unavailable signal: the
+        # ingester literally cannot evaluate its own health because
+        # the input it would patrol is malformed.
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"MAILBOXES_CONFIG malformed: {exc}",
+        )
+
+    now = datetime.now(timezone.utc)
+    today_start_utc = now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    mailboxes: list[MailboxHealth] = []
+    for cfg in configs:
+        mh = await _build_mailbox_health(
+            alias=cfg.name,
+            host=cfg.host,
+            folder=cfg.folder,
+            routing_tag=cfg.routing_tag,
+            poll_interval_sec=cfg.poll_interval_sec,
+            today_start_utc=today_start_utc,
+            now=now,
+        )
+        mailboxes.append(mh)
+
+    statuses: list[MailboxStatus] = cast(
+        "list[MailboxStatus]", [m.status for m in mailboxes]
+    )
+    summary = HealthSummary(
+        total_mailboxes=len(mailboxes),
+        healthy=sum(1 for s in statuses if s == "ok"),
+        paused=sum(1 for s in statuses if s == "paused"),
+        errored=sum(1 for s in statuses if s == "errored"),
+        stale=sum(1 for s in statuses if s == "stale"),
+    )
+
+    return LegalMailHealthResponse(
+        ingester_versioned=INGESTER_VERSIONED,
+        ingester_enabled=settings.legal_mail_ingester_enabled,
+        checked_at=now,
+        overall_status=_overall_status(
+            ingester_enabled=settings.legal_mail_ingester_enabled,
+            mailbox_statuses=statuses,
+        ),
+        mailboxes=mailboxes,
+        summary=summary,
+    )

--- a/fortress-guest-platform/backend/main.py
+++ b/fortress-guest-platform/backend/main.py
@@ -102,6 +102,7 @@ from backend.api import system_health as system_health_api
 from backend.api import system_nodes as system_nodes_api
 from backend.api import system_dashboard as system_dashboard_api
 from backend.api import internal_health as internal_health_api
+from backend.api import legal_mail_health as legal_mail_health_api
 from backend.api import ops as ops_api
 from backend.api import vrs_health as vrs_health_api
 from backend.api import vrs_treasury as vrs_treasury_api
@@ -533,6 +534,11 @@ async def health_check():
 # ---------------------------------------------------------------------------
 app.include_router(auth_api.router, prefix="/api/auth", tags=["Authentication"])
 app.include_router(internal_health_api.router, tags=["Internal Health"])
+app.include_router(
+    legal_mail_health_api.router,
+    prefix="/api/internal",
+    tags=["Internal Health — Legal Mail"],
+)
 app.include_router(properties.router, prefix="/api/properties", tags=["Properties"])
 app.include_router(reservations.router, prefix="/api/reservations", tags=["Reservations"])
 app.include_router(guests.router, prefix="/api/guests", tags=["Guests"])

--- a/fortress-guest-platform/backend/scripts/legal_mail_ingester_cli.py
+++ b/fortress-guest-platform/backend/scripts/legal_mail_ingester_cli.py
@@ -19,9 +19,9 @@ is failing, when its last successful patrol was, and what error fired.
 Implemented sub-phases:
   3A: argparse skeleton + `status` subcommand (read-only)
   3B: pause / resume mutators (bilateral write to legal.mail_ingester_pause)
+  3C: poll --dry-run (IMAP credential validation; no DB writes)
 
 Pending sub-phases:
-  3C: poll --dry-run (IMAP credential validation)
   3D: backfill --since (forward-only recovery)
 """
 from __future__ import annotations
@@ -46,6 +46,7 @@ from backend.services.ediscovery_agent import LegacySession  # noqa: E402
 from backend.services.legal_mail_ingester import (  # noqa: E402
     INGESTER_VERSIONED,
     LegalMailboxConfigError,
+    LegalMailIngesterTransport,
     ProdSession,
     load_legal_mailbox_configs,
 )
@@ -447,9 +448,115 @@ async def _cmd_resume(args: argparse.Namespace) -> int:
     return 0
 
 
-async def _cmd_poll(_args: argparse.Namespace) -> int:
-    print("(poll subcommand — implemented in Sub-phase 3C)", file=sys.stderr)
-    return 1
+# ─────────────────────────────────────────────────────────────────────────────
+# `poll --dry-run` subcommand (3C)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def _cmd_poll(args: argparse.Namespace) -> int:
+    """
+    Read-only IMAP credential + connectivity probe for one mailbox.
+
+    Required gate before flipping LEGAL_MAIL_INGESTER_ENABLED=true. The
+    probe connects, runs the same banded SEARCH the patrol uses, and
+    surfaces UID count + a header-only preview of the most recent
+    messages in the band — without touching email_archive, event_log,
+    or the \\Seen flag.
+
+    --dry-run is required (no live polling supported via CLI). The flag
+    is enforced rather than implicit so accidental invocation can never
+    write to email_archive.
+    """
+    if not args.dry_run:
+        print(
+            "ERROR: --dry-run is required. CLI does not support live polling — "
+            "the patrol loop in worker.py is the only path that writes.",
+            file=sys.stderr,
+        )
+        return 4
+
+    alias = _validate_mailbox_alias(args.mailbox)
+    if alias is None:
+        print(
+            f"ERROR: mailbox {args.mailbox!r} is not configured with ingester=legal_mail",
+            file=sys.stderr,
+        )
+        return 3
+
+    try:
+        configs = load_legal_mailbox_configs()
+    except LegalMailboxConfigError as exc:
+        print(f"ERROR: MAILBOXES_CONFIG malformed: {exc}", file=sys.stderr)
+        return 2
+
+    cfg = next((c for c in configs if c.name == alias), None)
+    if cfg is None:
+        print(f"ERROR: mailbox {alias!r} resolved but config missing (race?)",
+              file=sys.stderr)
+        return 3
+
+    if cfg.transport != "imap":
+        print(
+            f"ERROR: mailbox {alias!r} transport={cfg.transport!r}; "
+            "only imap probes are supported",
+            file=sys.stderr,
+        )
+        return 5
+
+    print(f"\nDry-run probe — mailbox={alias!r} ({INGESTER_VERSIONED})")
+    print(f"  host:     {cfg.host}:{cfg.port}")
+    print(f"  folder:   {cfg.folder}")
+    print(f"  band:     UNSEEN SINCE today - {cfg.search_band_days} days")
+    print(f"  max/poll: {cfg.max_messages_per_patrol}")
+    print()
+    print("Connecting…")
+
+    try:
+        transport = LegalMailIngesterTransport(cfg)
+    except (ValueError, LegalMailboxConfigError) as exc:
+        print(f"ERROR: transport setup failed: {exc}", file=sys.stderr)
+        return 6
+
+    # imaplib is sync; offload to a thread so we don't block the event loop.
+    # Probe path is short-lived (one connect / one SEARCH / N header fetches).
+    try:
+        result = await asyncio.to_thread(transport.probe, args.limit)
+    except LegalMailboxConfigError as exc:
+        # Specific signal — credentials_ref unset / empty
+        print(f"ERROR: credential resolution failed: {exc}", file=sys.stderr)
+        print("  Check the credentials_ref entry in MAILBOXES_CONFIG and the matching .env var.",
+              file=sys.stderr)
+        return 7
+    except Exception as exc:
+        # Generic IMAP error — login failure, host unreachable, TLS rejection, etc.
+        # Surface cleanly so the operator sees the actual server response.
+        print(f"ERROR: probe failed: {type(exc).__name__}: {exc}",
+              file=sys.stderr)
+        return 8
+
+    print(f"  ✓ login OK")
+    print(f"  ✓ folder selected (readonly)")
+    print(f"  ✓ SEARCH executed: {result['search_predicate']}")
+    print()
+    print(f"UIDs in band (UNSEEN since {result['since_date']}): {result['uids_in_band']}")
+
+    previews = result.get("recent_subjects") or []
+    if previews:
+        print()
+        print(f"Most recent {len(previews)} subject(s) (header-only fetch — \\Seen NOT mutated):")
+        print("-" * 100)
+        for p in previews:
+            print(f"  uid {p['uid']:>8}  {p['date_header'][:32]:<32}  {p['sender'][:30]:<30}")
+            print(f"             └─ {p['subject']}")
+        print("-" * 100)
+    else:
+        print()
+        print("(no messages currently in band — band is empty or all already \\Seen)")
+
+    print()
+    print("Probe complete. NO writes to email_archive, event_log, or any DB.")
+    print("\\Seen flag NOT mutated — Captain coexistence preserved.")
+    return 0
 
 
 async def _cmd_backfill(_args: argparse.Namespace) -> int:
@@ -503,10 +610,17 @@ def _build_parser() -> argparse.ArgumentParser:
                           help="Mailbox alias (idempotent if not currently paused)")
     p_resume.set_defaults(func=_cmd_resume)
 
-    p_poll = sub.add_parser("poll", help="(3C) Single-shot dry-run poll")
-    p_poll.add_argument("--mailbox", required=True)
+    # poll: read-only IMAP probe (--dry-run required — no live polling via CLI)
+    p_poll = sub.add_parser(
+        "poll",
+        help="Dry-run IMAP probe — connects, runs banded SEARCH, surfaces preview (no DB writes)",
+    )
+    p_poll.add_argument("--mailbox", required=True,
+                        help="Mailbox alias to probe")
     p_poll.add_argument("--dry-run", action="store_true",
-                        help="Required (no live polling supported via CLI)")
+                        help="Required — CLI never performs live polling")
+    p_poll.add_argument("--limit", type=int, default=5,
+                        help="Number of recent subjects to preview (default: 5; header-only fetch)")
     p_poll.set_defaults(func=_cmd_poll)
 
     p_backfill = sub.add_parser("backfill", help="(3D) Forward-only date-banded recovery")

--- a/fortress-guest-platform/backend/scripts/legal_mail_ingester_cli.py
+++ b/fortress-guest-platform/backend/scripts/legal_mail_ingester_cli.py
@@ -20,9 +20,7 @@ Implemented sub-phases:
   3A: argparse skeleton + `status` subcommand (read-only)
   3B: pause / resume mutators (bilateral write to legal.mail_ingester_pause)
   3C: poll --dry-run (IMAP credential validation; no DB writes)
-
-Pending sub-phases:
-  3D: backfill --since (forward-only recovery)
+  3D: backfill --since YYYY-MM-DD (forward-only; hard floor 2026-03-26)
 """
 from __future__ import annotations
 
@@ -31,7 +29,8 @@ import asyncio
 import getpass
 import os
 import sys
-from datetime import datetime, timezone
+import time
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
@@ -44,11 +43,21 @@ from sqlalchemy import text  # noqa: E402
 
 from backend.services.ediscovery_agent import LegacySession  # noqa: E402
 from backend.services.legal_mail_ingester import (  # noqa: E402
+    BACKFILL_HARD_FLOOR,
     INGESTER_VERSIONED,
     LegalMailboxConfigError,
     LegalMailIngesterTransport,
     ProdSession,
+    classify_inbound,
+    emit_email_received_event,
     load_legal_mailbox_configs,
+    parse_message,
+    write_email_archive_bilateral,
+)
+from backend.services.legal_mail_ingester import (  # noqa: E402
+    _is_mailbox_paused,
+    _load_priority_sender_rules,
+    _load_watchdog_rules,
 )
 
 
@@ -559,9 +568,277 @@ async def _cmd_poll(args: argparse.Namespace) -> int:
     return 0
 
 
-async def _cmd_backfill(_args: argparse.Namespace) -> int:
-    print("(backfill subcommand — implemented in Sub-phase 3D)", file=sys.stderr)
-    return 1
+# ─────────────────────────────────────────────────────────────────────────────
+# `backfill --mailbox X --since YYYY-MM-DD` subcommand (3D)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _parse_since(arg: str) -> Optional[date]:
+    """Parse --since as ISO date YYYY-MM-DD. Returns None on malformed."""
+    try:
+        return date.fromisoformat(arg)
+    except ValueError:
+        return None
+
+
+async def _cmd_backfill(args: argparse.Namespace) -> int:
+    """
+    Forward-only date-banded recovery (design v1.1 §6, LOCKED Q3).
+
+    Operator-explicit recovery for the gap between the legacy producer's
+    last write (2026-03-25) and the legal_mail_ingester's first patrol.
+
+    Two modes:
+      - Plan (default, no --confirm):
+        Connects, runs SEARCH SINCE <date>, prints UID count + intent,
+        no DB writes, no body fetches.
+      - Execute (--confirm):
+        Fetches up to --limit messages, parses, classifies, writes
+        bilaterally, emits events. Same idempotency as patrol path
+        (file_path UNIQUE constraint dedups already-ingested messages).
+
+    Hard floor BACKFILL_HARD_FLOOR = 2026-03-26 — any earlier --since is
+    rejected (would re-process Captain-handled messages from before the
+    legacy producer outage). To extend, edit the constant in the service.
+
+    \\Seen flag is NEVER mutated (BODY.PEEK[]) — Captain coexistence holds
+    even during backfill.
+    """
+    # ── 1. Parse --since ─────────────────────────────────────────────────
+    since = _parse_since(args.since)
+    if since is None:
+        print(
+            f"ERROR: --since {args.since!r} is not a valid ISO date (YYYY-MM-DD)",
+            file=sys.stderr,
+        )
+        return 9
+
+    # ── 2. Hard floor enforcement ────────────────────────────────────────
+    if since < BACKFILL_HARD_FLOOR:
+        print(
+            f"ERROR: --since {since.isoformat()} is before BACKFILL_HARD_FLOOR "
+            f"{BACKFILL_HARD_FLOOR.isoformat()}",
+            file=sys.stderr,
+        )
+        print(
+            "  The legacy producer last wrote on 2026-03-25; pre-floor backfill "
+            "would re-process Captain-handled messages.",
+            file=sys.stderr,
+        )
+        print(
+            "  To extend: edit BACKFILL_HARD_FLOOR in backend/services/legal_mail_ingester.py",
+            file=sys.stderr,
+        )
+        return 10
+
+    # ── 3. Future-date rejection ─────────────────────────────────────────
+    today = date.today()
+    if since > today:
+        print(
+            f"ERROR: --since {since.isoformat()} is in the future (today is {today.isoformat()})",
+            file=sys.stderr,
+        )
+        return 11
+
+    # ── 4. Mailbox alias validation ──────────────────────────────────────
+    alias = _validate_mailbox_alias(args.mailbox)
+    if alias is None:
+        print(
+            f"ERROR: mailbox {args.mailbox!r} is not configured with ingester=legal_mail",
+            file=sys.stderr,
+        )
+        return 3
+
+    try:
+        configs = load_legal_mailbox_configs()
+    except LegalMailboxConfigError as exc:
+        print(f"ERROR: MAILBOXES_CONFIG malformed: {exc}", file=sys.stderr)
+        return 2
+
+    cfg = next((c for c in configs if c.name == alias), None)
+    if cfg is None:
+        print(f"ERROR: mailbox {alias!r} resolved but config missing (race?)",
+              file=sys.stderr)
+        return 3
+
+    if cfg.transport != "imap":
+        print(
+            f"ERROR: mailbox {alias!r} transport={cfg.transport!r}; "
+            "only imap backfills are supported",
+            file=sys.stderr,
+        )
+        return 5
+
+    # ── 5. Pause warning (advisory — operator may proceed anyway) ────────
+    paused = await _is_mailbox_paused(alias)
+    if paused:
+        print(
+            f"NOTE: mailbox {alias!r} is currently paused. Backfill will proceed "
+            f"(operator-explicit override) but the patrol loop will continue to skip it "
+            f"until 'fgp legal mail resume --mailbox {alias}'.",
+            file=sys.stderr,
+        )
+
+    # ── 6. Build transport ───────────────────────────────────────────────
+    try:
+        transport = LegalMailIngesterTransport(cfg)
+    except (ValueError, LegalMailboxConfigError) as exc:
+        print(f"ERROR: transport setup failed: {exc}", file=sys.stderr)
+        return 6
+
+    # ── 7. Plan header ───────────────────────────────────────────────────
+    print(f"\nBackfill — mailbox={alias!r} ({INGESTER_VERSIONED})")
+    print(f"  host:        {cfg.host}:{cfg.port}")
+    print(f"  folder:      {cfg.folder}")
+    print(f"  since:       {since.isoformat()} (hard floor {BACKFILL_HARD_FLOOR.isoformat()} ✓)")
+    print(f"  limit:       {args.limit}")
+    print(f"  routing tag: {cfg.routing_tag}")
+    print()
+
+    # ── 8. Plan mode (default — no --confirm) ────────────────────────────
+    if not args.confirm:
+        print("Connecting (plan mode — no body fetch, no DB writes)…")
+        try:
+            count = await asyncio.to_thread(transport.search_count_for_backfill, since)
+        except LegalMailboxConfigError as exc:
+            print(f"ERROR: credential resolution failed: {exc}", file=sys.stderr)
+            return 7
+        except Exception as exc:
+            print(f"ERROR: SEARCH failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+            return 8
+        print(f"  ✓ SEARCH SINCE {since.isoformat()}: {count} messages match")
+        print()
+        print("This is a plan. To execute the backfill (writes to email_archive + event_log):")
+        print(
+            f"  fgp legal mail backfill --mailbox {alias} --since {since.isoformat()} "
+            f"--limit {args.limit} --confirm"
+        )
+        print()
+        print("Backfill will:")
+        print("  - parse each message (header + body)")
+        print("  - classify Stage 1 (priority/case/watchdog)")
+        print("  - write to email_archive (bilateral; deduped via file_path UNIQUE)")
+        print("  - emit email.received event to legal.event_log")
+        print("  - NOT mutate IMAP \\Seen flag (BODY.PEEK[])")
+        return 0
+
+    # ── 9. Execute mode (--confirm) ──────────────────────────────────────
+    print("Connecting (execute mode — bilateral writes will occur)…")
+    try:
+        records = await asyncio.to_thread(
+            transport.fetch_for_backfill, since, args.limit,
+        )
+    except LegalMailboxConfigError as exc:
+        print(f"ERROR: credential resolution failed: {exc}", file=sys.stderr)
+        return 7
+    except Exception as exc:
+        print(f"ERROR: backfill fetch failed: {type(exc).__name__}: {exc}",
+              file=sys.stderr)
+        return 8
+
+    fetched = len(records)
+    print(f"  ✓ fetched {fetched} message(s) (limit was {args.limit})")
+    if fetched == 0:
+        print()
+        print("No messages to ingest. Done.")
+        return 0
+
+    # Load classifier rules once
+    print("  ✓ loading classifier rules…")
+    priority_sender_rules = await _load_priority_sender_rules()
+    watchdog_rules = await _load_watchdog_rules()
+
+    print()
+    print(f"Processing {fetched} messages…")
+    print("-" * 100)
+
+    ingested = 0
+    deduped = 0
+    errored = 0
+    watchdog_matches = 0
+    events_emitted = 0
+    t0 = time.monotonic()
+
+    # Mirror patrol_mailbox()'s per-message loop; idempotency via file_path
+    # UNIQUE handles already-ingested messages (write_email_archive_bilateral
+    # returns the existing id on conflict).
+    for i, record in enumerate(records, start=1):
+        uid = record.get("uid", "?")
+        try:
+            parsed = parse_message(
+                raw_bytes=record["raw_bytes"],
+                source=record,
+                routing_tag=cfg.routing_tag,
+            )
+            if parsed is None:
+                errored += 1
+                print(f"  [{i:>4}/{fetched}]  uid {uid:>8}  PARSE_FAILED")
+                continue
+
+            classify_inbound(parsed, priority_sender_rules, watchdog_rules)
+
+            # Pre-check: does a row with this file_path already exist?
+            # file_path is UNIQUE on email_archive, so this is the
+            # authoritative dedup signal. Doing the check explicitly
+            # (vs inferring from write return value) lets us report
+            # accurate fresh/dedup counts AND avoid emitting a duplicate
+            # email.received event for messages already in email_archive.
+            async with LegacySession() as db:
+                r = await db.execute(
+                    text(
+                        "SELECT id, ingested_from FROM email_archive "
+                        "WHERE file_path = :fp"
+                    ),
+                    {"fp": parsed.file_path},
+                )
+                existing = r.fetchone()
+
+            if existing is not None:
+                deduped += 1
+                tag = f"DEDUPED (id={existing.id}, ingested_from={existing.ingested_from})"
+                print(f"  [{i:>4}/{fetched}]  uid {uid:>8}  {tag}")
+                continue
+
+            # Fresh — perform bilateral write + emit event
+            if parsed.watchdog_matches:
+                watchdog_matches += len(parsed.watchdog_matches)
+
+            email_archive_id = await write_email_archive_bilateral(parsed)
+            if email_archive_id is None:
+                errored += 1
+                print(f"  [{i:>4}/{fetched}]  uid {uid:>8}  WRITE_FAILED")
+                continue
+
+            ingested += 1
+            event_id = await emit_email_received_event(parsed, email_archive_id)
+            if event_id is not None:
+                events_emitted += 1
+            tag = "INGESTED"
+            if parsed.watchdog_matches:
+                tag += f" [+{len(parsed.watchdog_matches)} wd]"
+            print(f"  [{i:>4}/{fetched}]  uid {uid:>8}  {tag}")
+        except Exception as exc:
+            errored += 1
+            print(f"  [{i:>4}/{fetched}]  uid {uid:>8}  ERROR: {type(exc).__name__}: {str(exc)[:80]}")
+
+    duration = time.monotonic() - t0
+
+    print("-" * 100)
+    print()
+    print(f"Backfill complete — mailbox={alias!r}")
+    print(f"  fetched:        {fetched}")
+    print(f"  ingested:       {ingested}")
+    print(f"  deduped:        {deduped}")
+    print(f"  errored:        {errored}")
+    print(f"  watchdog hits:  {watchdog_matches}")
+    print(f"  events emitted: {events_emitted}")
+    print(f"  duration:       {duration:.1f}s")
+    print()
+    if errored == 0:
+        print("All messages processed without errors. \\Seen flag NOT mutated.")
+        return 0
+    print(f"NOTE: {errored} message(s) failed. Check logs for details.")
+    return 0  # backfill is best-effort; partial success is not a CLI failure
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -623,10 +900,19 @@ def _build_parser() -> argparse.ArgumentParser:
                         help="Number of recent subjects to preview (default: 5; header-only fetch)")
     p_poll.set_defaults(func=_cmd_poll)
 
-    p_backfill = sub.add_parser("backfill", help="(3D) Forward-only date-banded recovery")
-    p_backfill.add_argument("--mailbox", required=True)
+    # backfill: forward-only recovery for the legacy producer outage gap
+    p_backfill = sub.add_parser(
+        "backfill",
+        help="Forward-only date-banded recovery (default plan mode; --confirm to execute)",
+    )
+    p_backfill.add_argument("--mailbox", required=True,
+                            help="Mailbox alias to backfill")
     p_backfill.add_argument("--since", required=True,
                             help="ISO date YYYY-MM-DD; hard floor 2026-03-26 per design v1.1 §6")
+    p_backfill.add_argument("--limit", type=int, default=200,
+                            help="Maximum messages to process this invocation (default: 200)")
+    p_backfill.add_argument("--confirm", action="store_true",
+                            help="Required to execute writes; without this flag, plan-only")
     p_backfill.set_defaults(func=_cmd_backfill)
 
     return p

--- a/fortress-guest-platform/backend/scripts/legal_mail_ingester_cli.py
+++ b/fortress-guest-platform/backend/scripts/legal_mail_ingester_cli.py
@@ -1,0 +1,349 @@
+"""
+legal_mail_ingester_cli.py — operator interface for the legal_mail_ingester.
+
+Phase 0a-3 implementation per:
+  docs/architecture/cross-division/FLOS-phase-0a-legal-email-ingester-design-v1.1.md §6
+
+Subcommands:
+  status      — surface per-mailbox ingester state
+  pause       — operator-controlled per-mailbox pause (Sub-phase 3B)
+  resume      — undo pause (Sub-phase 3B)
+  poll        — single-shot dry-run (Sub-phase 3C)
+  backfill    — forward-only date-banded recovery (Sub-phase 3D)
+
+Design intent: the operator never has to query email_archive or the state
+tables directly. The CLI surfaces health. When something looks off, the
+operator runs `fgp legal mail status` and immediately sees which mailbox
+is failing, when its last successful patrol was, and what error fired.
+
+This file (Sub-phase 3A) implements:
+  - argparse skeleton with subcommands
+  - `status` subcommand (read-only)
+  - shared helpers (DB connection, output formatting)
+
+Subsequent sub-phases extend the same file:
+  3B: pause / resume mutators
+  3C: poll --dry-run (IMAP credential validation)
+  3D: backfill --since (forward-only recovery)
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+# Ensure project root + venv are on sys.path so we can import the service
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from sqlalchemy import text  # noqa: E402
+
+from backend.services.ediscovery_agent import LegacySession  # noqa: E402
+from backend.services.legal_mail_ingester import (  # noqa: E402
+    INGESTER_VERSIONED,
+    LegalMailboxConfigError,
+    load_legal_mailbox_configs,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Output formatting helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _fmt_age(ts: Optional[datetime]) -> str:
+    """Time elapsed since `ts` in human-readable form. None → '(never)'."""
+    if ts is None:
+        return "(never)"
+    delta = datetime.now(timezone.utc) - ts.astimezone(timezone.utc)
+    secs = int(delta.total_seconds())
+    if secs < 60:
+        return f"{secs}s ago"
+    if secs < 3600:
+        return f"{secs // 60}m ago"
+    if secs < 86400:
+        return f"{secs // 3600}h ago"
+    return f"{secs // 86400}d ago"
+
+
+def _truncate(s: Optional[str], maxlen: int = 60) -> str:
+    """Truncate long strings (last_error) for table display."""
+    if not s:
+        return ""
+    if len(s) <= maxlen:
+        return s
+    return s[: maxlen - 3] + "..."
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# `status` subcommand — per-mailbox state surface
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def _query_mailbox_state(mailbox_aliases: list[str]) -> list[dict[str, Any]]:
+    """
+    Build the per-mailbox status row by joining mail_ingester_state +
+    mail_ingester_pause + today's counters from event_log.
+
+    For each configured mailbox alias, returns a dict with:
+      mailbox, last_patrol_at, last_success_at, last_error,
+      paused (bool), pause_reason (optional),
+      messages_ingested_today, watchdog_matches_today
+    """
+    if not mailbox_aliases:
+        return []
+
+    today_start_utc = datetime.now(timezone.utc).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+
+    out: list[dict[str, Any]] = []
+    async with LegacySession() as db:
+        # Single round-trip per mailbox (cheap; ≤4 mailboxes typical)
+        for alias in mailbox_aliases:
+            row: dict[str, Any] = {"mailbox": alias}
+
+            # State row
+            r = await db.execute(
+                text("""
+                    SELECT last_patrol_at, last_success_at, last_error_at, last_error,
+                           messages_ingested_total, messages_deduped_total,
+                           messages_errored_total, updated_at
+                    FROM legal.mail_ingester_state
+                    WHERE mailbox_alias = :alias
+                """),
+                {"alias": alias},
+            )
+            state = r.fetchone()
+            if state is not None:
+                row["last_patrol_at"] = state.last_patrol_at
+                row["last_success_at"] = state.last_success_at
+                row["last_error"] = state.last_error
+                row["messages_ingested_total"] = int(state.messages_ingested_total or 0)
+                row["messages_errored_total"] = int(state.messages_errored_total or 0)
+            else:
+                row["last_patrol_at"] = None
+                row["last_success_at"] = None
+                row["last_error"] = None
+                row["messages_ingested_total"] = 0
+                row["messages_errored_total"] = 0
+
+            # Pause row
+            r = await db.execute(
+                text("""
+                    SELECT paused_at, paused_by, reason
+                    FROM legal.mail_ingester_pause
+                    WHERE mailbox_alias = :alias
+                """),
+                {"alias": alias},
+            )
+            pause = r.fetchone()
+            if pause is not None:
+                row["paused"] = True
+                row["pause_reason"] = pause.reason or "(no reason given)"
+                row["paused_at"] = pause.paused_at
+            else:
+                row["paused"] = False
+                row["pause_reason"] = None
+                row["paused_at"] = None
+
+            # Today's counters from event_log (all email.received events emitted by us)
+            r = await db.execute(
+                text("""
+                    SELECT
+                        COUNT(*) AS events_today,
+                        COALESCE(SUM(jsonb_array_length(event_payload->'watchdog_matches')), 0)
+                            AS watchdog_matches_today
+                    FROM legal.event_log
+                    WHERE event_type = 'email.received'
+                      AND emitted_by = :v
+                      AND emitted_at >= :today_start
+                      AND event_payload->>'mailbox' = :alias
+                """),
+                {
+                    "v": INGESTER_VERSIONED,
+                    "today_start": today_start_utc,
+                    "alias": alias,
+                },
+            )
+            counters = r.fetchone()
+            # COUNT(*) always returns exactly one row, so counters is non-None,
+            # but Pyright can't infer that from .fetchone() — assert for type narrowing.
+            assert counters is not None
+            row["messages_ingested_today"] = int(counters.events_today or 0)
+            row["watchdog_matches_today"] = int(counters.watchdog_matches_today or 0)
+
+            out.append(row)
+
+    return out
+
+
+def _print_status_table(rows: list[dict[str, Any]]) -> None:
+    """Render the status output as a fixed-column table."""
+    if not rows:
+        print("(no legal_mail_ingester mailboxes configured — check MAILBOXES_CONFIG)")
+        return
+
+    # Header
+    print(f"\nlegal_mail_ingester ({INGESTER_VERSIONED}) — per-mailbox status")
+    print("=" * 100)
+    cols = (
+        ("mailbox",          15),
+        ("last_patrol",      14),
+        ("last_success",     14),
+        ("paused",            7),
+        ("today_in",          8),
+        ("today_wd",          8),
+        ("error",            30),
+    )
+    print(" ".join(f"{name:<{w}}" for name, w in cols))
+    print("-" * 100)
+
+    for row in rows:
+        paused_str = "PAUSED" if row.get("paused") else "-"
+        line = " ".join([
+            f"{row['mailbox']:<15}",
+            f"{_fmt_age(row.get('last_patrol_at')):<14}",
+            f"{_fmt_age(row.get('last_success_at')):<14}",
+            f"{paused_str:<7}",
+            f"{row.get('messages_ingested_today', 0):<8}",
+            f"{row.get('watchdog_matches_today', 0):<8}",
+            f"{_truncate(row.get('last_error'), 30):<30}",
+        ])
+        print(line)
+        # Surface pause reason on its own indented line if paused
+        if row.get("paused") and row.get("pause_reason"):
+            print(f"    └─ pause reason: {row['pause_reason']}")
+
+    print()
+    # Operator-friendly summary signals
+    paused_count = sum(1 for r in rows if r.get("paused"))
+    has_recent_error = any(
+        r.get("last_error") for r in rows
+    )
+    has_stale = any(
+        r.get("last_success_at") is None for r in rows
+    )
+    if paused_count == 0 and not has_recent_error and not has_stale:
+        print("All mailboxes healthy.")
+    else:
+        if paused_count:
+            print(f"{paused_count} mailbox(es) paused — use 'fgp legal mail resume' to re-enable")
+        if has_recent_error:
+            print("Some mailboxes have recent errors — use --json or check legal.mail_ingester_state")
+        if has_stale:
+            print("Some mailboxes have never had a successful patrol — verify credentials with 'fgp legal mail poll --dry-run'")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Command dispatch
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def _cmd_status(args: argparse.Namespace) -> int:
+    """Read state + pause + today's counters; render table."""
+    try:
+        mailboxes = load_legal_mailbox_configs()
+    except LegalMailboxConfigError as exc:
+        print(f"ERROR: MAILBOXES_CONFIG malformed: {exc}", file=sys.stderr)
+        return 2
+
+    aliases = [m.name for m in mailboxes]
+    rows = await _query_mailbox_state(aliases)
+
+    # If --mailbox filter provided, narrow rows
+    if args.mailbox:
+        rows = [r for r in rows if r["mailbox"] == args.mailbox]
+        if not rows:
+            print(f"ERROR: mailbox {args.mailbox!r} is not configured with ingester=legal_mail",
+                  file=sys.stderr)
+            return 3
+
+    _print_status_table(rows)
+    return 0
+
+
+# Stubs for 3B/3C/3D — filled in subsequent sub-phases
+async def _cmd_pause(_args: argparse.Namespace) -> int:
+    print("(pause subcommand — implemented in Sub-phase 3B)", file=sys.stderr)
+    return 1
+
+
+async def _cmd_resume(_args: argparse.Namespace) -> int:
+    print("(resume subcommand — implemented in Sub-phase 3B)", file=sys.stderr)
+    return 1
+
+
+async def _cmd_poll(_args: argparse.Namespace) -> int:
+    print("(poll subcommand — implemented in Sub-phase 3C)", file=sys.stderr)
+    return 1
+
+
+async def _cmd_backfill(_args: argparse.Namespace) -> int:
+    print("(backfill subcommand — implemented in Sub-phase 3D)", file=sys.stderr)
+    return 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# argparse setup
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="legal_mail_ingester_cli",
+        description=(
+            "Operator interface for the legal_mail_ingester. "
+            "Read backend/services/legal_mail_ingester.py for service details."
+        ),
+    )
+    sub = p.add_subparsers(dest="command", required=True)
+
+    # status
+    p_status = sub.add_parser(
+        "status",
+        help="Show per-mailbox ingester state",
+    )
+    p_status.add_argument(
+        "--mailbox", default=None,
+        help="Narrow output to one mailbox alias (default: all configured)",
+    )
+    p_status.set_defaults(func=_cmd_status)
+
+    # pause / resume / poll / backfill — stubs in 3A
+    p_pause = sub.add_parser("pause", help="(3B) Pause a mailbox")
+    p_pause.add_argument("--mailbox", required=True)
+    p_pause.add_argument("--reason", default=None)
+    p_pause.set_defaults(func=_cmd_pause)
+
+    p_resume = sub.add_parser("resume", help="(3B) Resume a paused mailbox")
+    p_resume.add_argument("--mailbox", required=True)
+    p_resume.set_defaults(func=_cmd_resume)
+
+    p_poll = sub.add_parser("poll", help="(3C) Single-shot dry-run poll")
+    p_poll.add_argument("--mailbox", required=True)
+    p_poll.add_argument("--dry-run", action="store_true",
+                        help="Required (no live polling supported via CLI)")
+    p_poll.set_defaults(func=_cmd_poll)
+
+    p_backfill = sub.add_parser("backfill", help="(3D) Forward-only date-banded recovery")
+    p_backfill.add_argument("--mailbox", required=True)
+    p_backfill.add_argument("--since", required=True,
+                            help="ISO date YYYY-MM-DD; hard floor 2026-03-26 per design v1.1 §6")
+    p_backfill.set_defaults(func=_cmd_backfill)
+
+    return p
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return asyncio.run(args.func(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/fortress-guest-platform/backend/scripts/legal_mail_ingester_cli.py
+++ b/fortress-guest-platform/backend/scripts/legal_mail_ingester_cli.py
@@ -16,13 +16,11 @@ tables directly. The CLI surfaces health. When something looks off, the
 operator runs `fgp legal mail status` and immediately sees which mailbox
 is failing, when its last successful patrol was, and what error fired.
 
-This file (Sub-phase 3A) implements:
-  - argparse skeleton with subcommands
-  - `status` subcommand (read-only)
-  - shared helpers (DB connection, output formatting)
+Implemented sub-phases:
+  3A: argparse skeleton + `status` subcommand (read-only)
+  3B: pause / resume mutators (bilateral write to legal.mail_ingester_pause)
 
-Subsequent sub-phases extend the same file:
-  3B: pause / resume mutators
+Pending sub-phases:
   3C: poll --dry-run (IMAP credential validation)
   3D: backfill --since (forward-only recovery)
 """
@@ -30,6 +28,8 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import getpass
+import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -46,6 +46,7 @@ from backend.services.ediscovery_agent import LegacySession  # noqa: E402
 from backend.services.legal_mail_ingester import (  # noqa: E402
     INGESTER_VERSIONED,
     LegalMailboxConfigError,
+    ProdSession,
     load_legal_mailbox_configs,
 )
 
@@ -267,15 +268,183 @@ async def _cmd_status(args: argparse.Namespace) -> int:
     return 0
 
 
-# Stubs for 3B/3C/3D — filled in subsequent sub-phases
-async def _cmd_pause(_args: argparse.Namespace) -> int:
-    print("(pause subcommand — implemented in Sub-phase 3B)", file=sys.stderr)
-    return 1
+# ─────────────────────────────────────────────────────────────────────────────
+# Mutator helpers (3B)
+# ─────────────────────────────────────────────────────────────────────────────
 
 
-async def _cmd_resume(_args: argparse.Namespace) -> int:
-    print("(resume subcommand — implemented in Sub-phase 3B)", file=sys.stderr)
-    return 1
+def _resolve_operator() -> str:
+    """
+    Resolve the operator identity for the audit trail in mail_ingester_pause.
+
+    Resolution order:
+      1. FLOS_OPERATOR env var (explicit override for ops scripts)
+      2. SUDO_USER (when invoked under sudo)
+      3. USER / LOGNAME / getpass.getuser() (the underlying caller)
+
+    The pause table requires paused_by NOT NULL — so we always return a
+    non-empty string. Defaults to 'unknown' rather than raising; CLI must
+    never fail because of a missing env var, the audit row is more useful
+    than a hard failure.
+    """
+    for var in ("FLOS_OPERATOR", "SUDO_USER", "USER", "LOGNAME"):
+        v = os.environ.get(var)
+        if v:
+            return v
+    try:
+        return getpass.getuser() or "unknown"
+    except Exception:
+        return "unknown"
+
+
+def _validate_mailbox_alias(alias: str) -> Optional[str]:
+    """
+    Confirm `alias` is one of the configured legal mailboxes.
+
+    Returns the canonical alias on match, or None if no match.
+    Returning None lets the caller print a helpful error listing valid
+    aliases instead of silently writing pause rows for nonsense names.
+    """
+    try:
+        configs = load_legal_mailbox_configs()
+    except LegalMailboxConfigError:
+        return None
+    for cfg in configs:
+        if cfg.name == alias:
+            return cfg.name
+    return None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# `pause` and `resume` subcommands (3B)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def _cmd_pause(args: argparse.Namespace) -> int:
+    """
+    Insert (or refresh) a row in legal.mail_ingester_pause for the given
+    mailbox. The patrol loop checks this table every cycle via
+    _is_mailbox_paused() and skips the mailbox while a row exists.
+
+    Bilateral: legacy then prod. Prod failure is logged but doesn't fail
+    the command — pause is a control-plane signal and the patrol loop
+    reads from fortress_db (legacy) anyway. The mirror exists so the prod
+    side has the audit trail.
+    """
+    alias = _validate_mailbox_alias(args.mailbox)
+    if alias is None:
+        print(
+            f"ERROR: mailbox {args.mailbox!r} is not configured with ingester=legal_mail",
+            file=sys.stderr,
+        )
+        try:
+            valid = [c.name for c in load_legal_mailbox_configs()]
+            if valid:
+                print(f"  configured aliases: {', '.join(valid)}", file=sys.stderr)
+        except LegalMailboxConfigError:
+            pass
+        return 3
+
+    operator = _resolve_operator()
+    reason = args.reason or f"operator pause via CLI by {operator}"
+
+    upsert_sql = text("""
+        INSERT INTO legal.mail_ingester_pause
+            (mailbox_alias, paused_by, reason, paused_at)
+        VALUES
+            (:alias, :operator, :reason, NOW())
+        ON CONFLICT (mailbox_alias) DO UPDATE
+        SET paused_by = EXCLUDED.paused_by,
+            reason    = EXCLUDED.reason,
+            paused_at = EXCLUDED.paused_at
+        RETURNING paused_at
+    """)
+    params = {"alias": alias, "operator": operator, "reason": reason}
+
+    # Legacy (canonical) write
+    async with LegacySession() as db:
+        r = await db.execute(upsert_sql, params)
+        row = r.fetchone()
+        await db.commit()
+    paused_at = row.paused_at if row is not None else None
+
+    # Prod mirror — log-but-don't-fail
+    prod_mirrored = True
+    try:
+        async with ProdSession() as prod:
+            await prod.execute(upsert_sql, params)
+            await prod.commit()
+    except Exception as exc:
+        prod_mirrored = False
+        print(
+            f"WARNING: legacy write succeeded but fortress_prod mirror failed: {exc}",
+            file=sys.stderr,
+        )
+
+    print(f"PAUSED mailbox={alias!r}")
+    print(f"  by:     {operator}")
+    print(f"  reason: {reason}")
+    if paused_at is not None:
+        print(f"  at:     {_fmt_age(paused_at)}")
+    if not prod_mirrored:
+        print("  mirror: legacy=ok prod=FAILED (re-run pause to retry mirror)")
+    print()
+    print(f"Patrol loop will skip {alias!r} on its next cycle.")
+    print(f"To resume: fgp legal mail resume --mailbox {alias}")
+    return 0
+
+
+async def _cmd_resume(args: argparse.Namespace) -> int:
+    """
+    Delete the pause row for the given mailbox. If no row exists, this is
+    a no-op and returns 0 (idempotent — operator may run resume defensively).
+
+    Bilateral: legacy then prod. Prod failure logged but doesn't fail.
+    """
+    alias = _validate_mailbox_alias(args.mailbox)
+    if alias is None:
+        print(
+            f"ERROR: mailbox {args.mailbox!r} is not configured with ingester=legal_mail",
+            file=sys.stderr,
+        )
+        return 3
+
+    delete_sql = text("""
+        DELETE FROM legal.mail_ingester_pause
+        WHERE mailbox_alias = :alias
+        RETURNING paused_at, paused_by, reason
+    """)
+    params = {"alias": alias}
+
+    async with LegacySession() as db:
+        r = await db.execute(delete_sql, params)
+        deleted = r.fetchone()
+        await db.commit()
+
+    prod_mirrored = True
+    try:
+        async with ProdSession() as prod:
+            await prod.execute(delete_sql, params)
+            await prod.commit()
+    except Exception as exc:
+        prod_mirrored = False
+        print(
+            f"WARNING: legacy delete succeeded but fortress_prod mirror failed: {exc}",
+            file=sys.stderr,
+        )
+
+    if deleted is None:
+        print(f"NOOP — mailbox {alias!r} was not paused. Nothing to resume.")
+    else:
+        print(f"RESUMED mailbox={alias!r}")
+        print(f"  was paused by:     {deleted.paused_by}")
+        print(f"  was paused reason: {deleted.reason}")
+        print(f"  was paused since:  {_fmt_age(deleted.paused_at)}")
+        if not prod_mirrored:
+            print("  mirror: legacy=ok prod=FAILED (re-run resume to retry mirror)")
+        print()
+        print(f"Patrol loop will resume polling {alias!r} on its next cycle.")
+    return 0
 
 
 async def _cmd_poll(_args: argparse.Namespace) -> int:
@@ -314,14 +483,24 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p_status.set_defaults(func=_cmd_status)
 
-    # pause / resume / poll / backfill — stubs in 3A
-    p_pause = sub.add_parser("pause", help="(3B) Pause a mailbox")
-    p_pause.add_argument("--mailbox", required=True)
-    p_pause.add_argument("--reason", default=None)
+    # pause: write legal.mail_ingester_pause row (bilateral)
+    p_pause = sub.add_parser(
+        "pause",
+        help="Pause a mailbox — patrol loop will skip it next cycle",
+    )
+    p_pause.add_argument("--mailbox", required=True,
+                         help="Mailbox alias (must be configured in MAILBOXES_CONFIG)")
+    p_pause.add_argument("--reason", default=None,
+                         help="Why this mailbox is being paused (recorded in audit trail)")
     p_pause.set_defaults(func=_cmd_pause)
 
-    p_resume = sub.add_parser("resume", help="(3B) Resume a paused mailbox")
-    p_resume.add_argument("--mailbox", required=True)
+    # resume: delete legal.mail_ingester_pause row (bilateral)
+    p_resume = sub.add_parser(
+        "resume",
+        help="Resume a paused mailbox — patrol loop polls it next cycle",
+    )
+    p_resume.add_argument("--mailbox", required=True,
+                          help="Mailbox alias (idempotent if not currently paused)")
     p_resume.set_defaults(func=_cmd_resume)
 
     p_poll = sub.add_parser("poll", help="(3C) Single-shot dry-run poll")

--- a/fortress-guest-platform/backend/services/legal_mail_ingester.py
+++ b/fortress-guest-platform/backend/services/legal_mail_ingester.py
@@ -282,6 +282,94 @@ class LegalMailIngesterTransport:
         except Exception:
             pass
 
+    def probe(self, limit_subjects: int = 5) -> dict[str, Any]:
+        """
+        Read-only IMAP credential + connectivity probe used by the operator
+        CLI dry-run (Phase 0a-3 §6).
+
+        Connects, runs the same banded SEARCH the patrol uses, and returns
+        the UID count plus a small header-only preview of the most recent
+        UIDs in the band. Header-only fetch (BODY.PEEK[HEADER.FIELDS ...])
+        is bandwidth-cheap and preserves \\Seen — Captain coexistence holds
+        even during operator probes.
+
+        Never writes to email_archive, event_log, or any DB. Never marks
+        \\Seen. Per §11 cutover discipline, this is the operator's
+        validation gate before flipping LEGAL_MAIL_INGESTER_ENABLED=true.
+
+        Returns dict:
+          host, folder, since_date (str), search_predicate (str),
+          uids_in_band (int), recent_subjects (list of dicts with
+          uid, subject, sender, date_header)
+        """
+        since_date = (date.today() - timedelta(days=self.mailbox.search_band_days))
+        search_predicate = f"UNSEEN SINCE {_imap_date(since_date)}"
+
+        conn = self._connect()
+        try:
+            typ, data = conn.uid("SEARCH", search_predicate)
+            if typ != "OK" or not data or not data[0]:
+                uids: list[bytes] = []
+            else:
+                uids = data[0].split()
+
+            previews: list[dict[str, Any]] = []
+            # Preview most-recent UIDs first (IMAP returns ascending UIDs;
+            # tail of list is newest)
+            preview_uids = uids[-limit_subjects:] if uids else []
+            for uid_bytes in reversed(preview_uids):
+                uid = uid_bytes.decode("ascii", errors="replace")
+                try:
+                    typ, fetch_data = conn.uid(
+                        "FETCH",
+                        uid,
+                        "(BODY.PEEK[HEADER.FIELDS (SUBJECT FROM DATE)])",
+                    )
+                    if typ != "OK" or not fetch_data:
+                        continue
+                    header_bytes: Optional[bytes] = None
+                    for entry in fetch_data:
+                        if isinstance(entry, tuple) and len(entry) >= 2:
+                            candidate = entry[1]
+                            if isinstance(candidate, (bytes, bytearray)):
+                                header_bytes = bytes(candidate)
+                                break
+                    if header_bytes is None:
+                        continue
+                    msg = email_lib.message_from_bytes(header_bytes)
+                    previews.append({
+                        "uid": uid,
+                        "subject": (msg.get("Subject") or "").strip()[:120],
+                        "sender": (msg.get("From") or "").strip()[:120],
+                        "date_header": (msg.get("Date") or "").strip(),
+                    })
+                except Exception as exc:
+                    logger.warning(
+                        "legal_mail_probe_preview_failed",
+                        mailbox=self.mailbox.name,
+                        uid=uid,
+                        error=str(exc)[:200],
+                    )
+                    continue
+
+            return {
+                "host": self.mailbox.host,
+                "folder": self.mailbox.folder,
+                "since_date": since_date.isoformat(),
+                "search_predicate": search_predicate,
+                "uids_in_band": len(uids),
+                "recent_subjects": previews,
+            }
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+            try:
+                conn.logout()
+            except Exception:
+                pass
+
     def fetch_recent(self) -> list[dict[str, Any]]:
         """
         Fetch UNSEEN messages within the date band, capped at max_messages_per_patrol.

--- a/fortress-guest-platform/backend/services/legal_mail_ingester.py
+++ b/fortress-guest-platform/backend/services/legal_mail_ingester.py
@@ -230,6 +230,13 @@ def _imap_date(d: date) -> str:
 SEARCH_TIMEOUT_S = 60
 RETRY_BACKOFFS_S = (2.0, 8.0)
 
+# Hard floor for forward-only backfill (Phase 0a-3 §6, design v1.1 LOCKED Q3).
+# The legacy multi-mailbox producer last wrote to email_archive on 2026-03-25.
+# Any --since before 2026-03-26 would re-process Captain-handled messages that
+# were already in email_archive (under a different ingested_from); blocking is
+# protective. To extend, operator must edit this constant explicitly.
+BACKFILL_HARD_FLOOR: date = date(2026, 3, 26)
+
 
 class LegalMailIngesterTransport:
     """
@@ -360,6 +367,110 @@ class LegalMailIngesterTransport:
                 "uids_in_band": len(uids),
                 "recent_subjects": previews,
             }
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+            try:
+                conn.logout()
+            except Exception:
+                pass
+
+    def fetch_for_backfill(
+        self,
+        since_date: date,
+        max_messages: int,
+    ) -> list[dict[str, Any]]:
+        """
+        Operator-explicit forward-only backfill fetch (Phase 0a-3 §6).
+
+        Differs from fetch_recent() in two ways:
+          1. SEARCH predicate is `SINCE <date>` only — NOT `UNSEEN SINCE <date>`.
+             The legacy producer outage left messages that Captain marked
+             \\Seen but were never written to email_archive; backfill must
+             see them.
+          2. The date is operator-supplied (with hard floor enforced by the
+             CLI), not derived from search_band_days. The CLI is responsible
+             for rejecting --since values before BACKFILL_HARD_FLOOR.
+
+        Same Captain-coexistence discipline as the patrol path:
+          - readonly=True on SELECT (inherited from _connect())
+          - BODY.PEEK[] on FETCH (does not mutate \\Seen)
+
+        max_messages is the hard cap on returned records to bound any one
+        invocation. Operator can run repeated backfills with different
+        --since windows for larger ranges.
+
+        Returns the same record shape as fetch_recent():
+          uid, raw_bytes, host, folder, mailbox_alias, transport
+        """
+        search_predicate = f"SINCE {_imap_date(since_date)}"
+
+        conn = self._connect()
+        try:
+            typ, data = conn.uid("SEARCH", search_predicate)
+            if typ != "OK" or not data or not data[0]:
+                return []
+            uids = data[0].split()[:max_messages]
+            if not uids:
+                return []
+
+            out: list[dict[str, Any]] = []
+            for uid_bytes in uids:
+                uid = uid_bytes.decode("ascii", errors="replace")
+                try:
+                    typ, fetch_data = conn.uid("FETCH", uid, "(BODY.PEEK[])")
+                    if typ != "OK" or not fetch_data:
+                        continue
+                    raw_bytes: Optional[bytes] = None
+                    for entry in fetch_data:
+                        if isinstance(entry, tuple) and len(entry) >= 2:
+                            candidate = entry[1]
+                            if isinstance(candidate, (bytes, bytearray)):
+                                raw_bytes = bytes(candidate)
+                                break
+                    if raw_bytes is None:
+                        continue
+                    out.append({
+                        "uid": uid,
+                        "raw_bytes": raw_bytes,
+                        "host": self.mailbox.host,
+                        "folder": self.mailbox.folder,
+                        "mailbox_alias": self.mailbox.name,
+                        "transport": self.mailbox.transport,
+                    })
+                except Exception as exc:
+                    logger.warning(
+                        "legal_mail_backfill_message_fetch_failed",
+                        mailbox=self.mailbox.name,
+                        uid=uid,
+                        error=str(exc)[:200],
+                    )
+                    continue
+            return out
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+            try:
+                conn.logout()
+            except Exception:
+                pass
+
+    def search_count_for_backfill(self, since_date: date) -> int:
+        """
+        Cardinality-only probe for backfill plan mode. Connects, runs
+        `SEARCH SINCE <date>`, returns UID count without fetching bodies.
+        """
+        search_predicate = f"SINCE {_imap_date(since_date)}"
+        conn = self._connect()
+        try:
+            typ, data = conn.uid("SEARCH", search_predicate)
+            if typ != "OK" or not data or not data[0]:
+                return 0
+            return len(data[0].split())
         finally:
             try:
                 conn.close()


### PR DESCRIPTION
## Summary

Implements the operator-facing CLI (`backend/scripts/legal_mail_ingester_cli.py`) and the programmatic health endpoint (`backend/api/legal_mail_health.py`) for `legal_mail_ingester`. The third leg of FLOS Phase 0a — operators can now surface health, control pause state, validate credentials, and recover gap-window messages without shelling into the database.

Per [FLOS Phase 0a Design v1.1](docs/architecture/cross-division/FLOS-phase-0a-legal-email-ingester-design-v1.1.md) §6 (operator surface) + §7 (observability) + §11 (cutover sequencing).

**Default OFF preserved.** `LEGAL_MAIL_INGESTER_ENABLED=false` is unchanged. The health endpoint returns a valid response when the flag is off (`overall_status: "disabled"`), so monitors see the expected pre-cutover state without misinterpreting it as broken.

## Stacked PR

This PR stacks on **#246** (Phase 0a-2 service implementation), which itself stacks on **#245** (Phase 0a-1 schema). Merge order: #245 → #246 → this PR.

## Sub-phases (one commit each)

| sub-phase | scope | commit |
|---|---|---|
| 3A | CLI skeleton + `status` command | `c954f67e2` |
| 3B | `pause` / `resume` mutators (bilateral writes to legal.mail_ingester_pause) | `b7ebf9aa6` |
| 3C | `poll --dry-run` IMAP credential validation gate | `33950c356` |
| 3D | `backfill --since` forward-only recovery (hard floor 2026-03-26) | `07201903b` |
| 3E | `GET /api/internal/legal/mail/health` endpoint | `a38c55722` |

## Architectural anchors honored

- **§6 operator surface** — CLI (`fgp legal mail {status,pause,resume,poll,backfill}`) and HTTP health endpoint as twin surfaces. Operator never has to query state tables manually.
- **§7 observability** — surfaces all 5 metric counters + last-known-good state from `legal.mail_ingester_state`, paused state from `legal.mail_ingester_pause`, today's `email.received` event count from `legal.event_log` (filtered by `emitted_by = 'legal_mail_ingester:v1'` so legacy producer rows are excluded).
- **§11 cutover gate** — operator runs `fgp legal mail poll --mailbox X --dry-run` to validate credentials BEFORE flipping `LEGAL_MAIL_INGESTER_ENABLED=true`. Health endpoint confirms `overall_status: "disabled"` until flag flips.
- **§3.4 Captain coexistence** — every IMAP read in this PR uses `BODY.PEEK[]` (probe + backfill). The `\Seen` flag is never mutated by CLI operations; Captain's parallel polling continues to see the same UNSEEN set.
- **§3.2 banded SEARCH** — backfill uses `SINCE <date>` (the date itself bounds the result set, defending against Issue #177's >1MB overflow); probe uses the same `UNSEEN SINCE <today - search_band_days>` predicate as the patrol.
- **§10 bilateral mirror** — pause/resume bilateral writes (legacy + prod). Backfill reuses `write_email_archive_bilateral()` and `emit_email_received_event()` from the service — no parallel write paths.
- **Forward-only floor at code-constant level** — `BACKFILL_HARD_FLOOR: date = date(2026, 3, 26)` lives in the service module. Moving the floor requires a git-tracked code edit, not an env-var flip or a `--ignore-floor` bypass flag. Deliberate floor movement only.

## Files changed

| file | role |
|---|---|
| `backend/scripts/legal_mail_ingester_cli.py` | new — argparse CLI, 5 subcommands, async-internal via asyncio.run() (~930 lines) |
| `backend/api/legal_mail_health.py` | new — FastAPI router, JWT-protected JSON health endpoint (~413 lines) |
| `backend/main.py` | router registration (`/api/internal/legal/mail/health`) — +6 lines |
| `backend/services/legal_mail_ingester.py` | extended — `probe()`, `fetch_for_backfill()`, `search_count_for_backfill()`, `BACKFILL_HARD_FLOOR` constant (~200 added lines) |

Service extensions are scoped to the IMAP transport layer + a module-level constant. No changes to patrol logic, classifiers, or write paths. Single source of IMAP truth maintained.

## CLI command surface

```
fgp legal mail status [--mailbox X]
    Read-only per-mailbox health table. Surfaces last_patrol/success/error,
    paused state, today's ingest + watchdog counts, operator-friendly
    summary signals.

fgp legal mail pause --mailbox X [--reason "..."]
    Insert/upsert into legal.mail_ingester_pause (bilateral). Patrol loop
    skips this mailbox until resumed. paused_by resolved via
    FLOS_OPERATOR > SUDO_USER > USER > LOGNAME > getpass.getuser().

fgp legal mail resume --mailbox X
    Delete pause row (bilateral). Idempotent — NOOP exit 0 if not paused.
    Surfaces previous pause metadata before clearing (audit close-out).

fgp legal mail poll --mailbox X --dry-run [--limit 5]
    Read-only IMAP probe. Connects, runs banded SEARCH, surfaces UID
    count + header-only preview. NEVER writes to email_archive or
    event_log. NEVER mutates \Seen flag.

fgp legal mail backfill --mailbox X --since YYYY-MM-DD [--limit 200] [--confirm]
    Plan-by-default forward-only recovery (terraform-style discipline).
    Hard floor BACKFILL_HARD_FLOOR=2026-03-26 enforced. Pre-checks
    file_path UNIQUE for accurate fresh/dedup counts. Reuses service
    write functions (bilateral mirror).
```

## HTTP endpoint

```
GET /api/internal/legal/mail/health
    Auth: Bearer + X-Fortress-Ingress: command_center
              + X-Fortress-Tunnel-Signature
              (matches backend/api/internal_health.py)

    Responses:
        200 — response delivered (check overall_status body field)
        401 — missing or bad bearer token
        403 — wrong ingress boundary or tunnel signature
        503 — MAILBOXES_CONFIG malformed (service can't evaluate itself)

    Body (Pydantic, extra='forbid'):
        service, ingester_versioned, ingester_enabled, checked_at,
        overall_status: Literal['ok','degraded','disabled'],
        mailboxes[]: per-mailbox health record,
        summary: aggregate counts.

    Per-mailbox status: 'ok' | 'stale' | 'errored' | 'paused'
        - STALE_MULTIPLIER=3 (3× poll_interval_sec triggers stale)
        - ERROR_FRESHNESS_WINDOW=1h (errors older than 1h stop being
          surfaced as 'errored' if no fresh patrol overrides)
```

## Default-OFF posture (unchanged)

This PR does not change the cutover state. `LEGAL_MAIL_INGESTER_ENABLED=false` remains the default.

- The CLI works against the DBs regardless of flag state (status/pause/resume/backfill all use `LegacySession` + `ProdSession` directly)
- The CLI poll dry-run works regardless of flag state (probe is operator-driven)
- The HTTP endpoint returns `overall_status: "disabled"` when flag is off — distinct from `"degraded"`. Pre-cutover monitoring sees the expected state without false-alarming.

## Phase 0a-4 next (separate authorization)

Operator runs the cutover gate sequence:

1. `fgp legal mail poll --mailbox legal-cpanel --dry-run` (validates first mailbox credentials)
2. `fgp legal mail poll --mailbox gary-gk --dry-run` (validates each mailbox)
3. `curl -H "Authorization: Bearer ..." -H "X-Fortress-Ingress: command_center" -H "X-Fortress-Tunnel-Signature: ..." https://internal/api/internal/legal/mail/health` (confirms `overall_status: "disabled"` baseline)
4. Set `LEGAL_MAIL_INGESTER_ENABLED=true` in `.env`
5. Restart `fortress-arq-worker`
6. Confirm `overall_status: "ok"` after first patrol cycle (~120s)

## Phase 0a-5 next (24h soak)

After Phase 0a-4 cutover, 24h validation:
- email_archive ingestion rate ≥ 20/day across legal mailboxes
- `ingested_from = 'legal_mail_ingester:v1'` populated on every new row
- `legal.event_log` accumulates `email.received` events with non-zero count
- Bilateral parity holds (no fortress_db / fortress_prod split-brain)
- `fgp legal mail status` shows all configured mailboxes `ok`
- HTTP health endpoint shows `overall_status: "ok"`, `summary.healthy == total_mailboxes`

## Verification posture (this PR)

This PR does NOT include tests. Per the discipline established in PR #246, tests land as a separate sub-PR after operator approves the surface shape.

What CAN be verified now:
- ✅ All 4 touched files parse (Python syntax)
- ✅ Schema dependency intact (3 query shapes match Phase 0a-1 tables)
- ✅ Service dependency intact (CLI imports match Phase 0a-2 exports)
- ✅ Default OFF — no flag flip in this PR
- ✅ No new alembic migrations (no schema changes)

What's verified by Phase 0a-4 cutover:
- IMAP credentials validate via `poll --dry-run`
- Health endpoint returns `disabled` pre-cutover, `ok` post-cutover
- Pause/resume affect patrol behavior

What's verified by Phase 0a-5 (24h soak):
- Health endpoint stays `ok` over time
- Counters increment (today_in, watchdog_matches_today)
- No false-positive `errored` or `stale` flags from STALE_MULTIPLIER tuning

## Cross-references

- Parent: `FLOS-design-v1.md` (FLOS strategic design)
- Direct: `FLOS-phase-0a-legal-email-ingester-design-v1.1.md` §6, §7, §11
- Stacked on: PR #246 (Phase 0a-2 service)
- Schema: PR #245 (Phase 0a-1 — 5 tables this PR reads from)
- ADR-001 — bilateral mirror discipline (honored: pause/resume + backfill)
- ADR-002 — Captain/Sentinel on Spark 2 permanent (legal_mail_ingester sibling)
- Issue #177 — IMAP SEARCH overflow (defended via banded SEARCH in probe + backfill)
- Issue #204 — alembic chain divergence (no migrations in this PR; respected via 0a-1 dependency)

## Test plan

- [x] All 5 sub-phases committed in order on `feat/flos-phase-0a-3-cli-health`
- [x] Default-OFF posture maintained
- [x] No alembic migrations
- [x] Code parses + Pyright clean (sandbox false-positives on inter-file imports acknowledged)
- [x] Single source of query truth (CLI + HTTP use same SQL shapes against legal.* tables)
- [x] Single source of IMAP truth (CLI + service use same `_connect()` + banded SEARCH discipline)
- [ ] CI green
- [ ] Operator merge authorization (no auto-merge per spec)
- [ ] Phase 0a-4 cutover (separate authorization gate after merge)
- [ ] Phase 0a-5 24h soak validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
