### PR TITLE
Step 2: EOD bar backfill via Polygon

### DIFF
--- a/crog-ai-backend/.gitignore
+++ b/crog-ai-backend/.gitignore
@@ -18,3 +18,7 @@ htmlcov/
 logs/
 data/
 tmp/
+
+# Calibration artifacts (per-run outputs, not source of truth)
+scripts/state/
+calibration/

--- a/crog-ai-backend/alembic/versions/0004_extend_eod_partitions.py
+++ b/crog-ai-backend/alembic/versions/0004_extend_eod_partitions.py
@@ -1,0 +1,80 @@
+"""add backward partitions for hedge_fund.eod_bars (2023-09 → 2024-08)
+
+Revision ID: 0004_extend_eod_partitions
+Revises: 0003_rehash_xsource_dedup
+Create Date: 2026-04-27
+
+Context: migration 0002 created hedge_fund.eod_bars partitioned monthly
+from 2024-09-01. The Dochia v1 calibration corpus has its earliest alert
+on 2024-03-18 and requires 63 prior trading days of EOD history (longest
+Donchian lookback). Without partitions covering 2023-09 → 2024-08, EOD
+bars for that window have no destination partition and the backfill
+script has to drop them client-side, in turn excluding ~8k observations
+from the calibration corpus (every alert in the first ~9 months of the
+corpus loses its prior-history requirement).
+
+This migration adds 12 monthly partitions covering 2023-09-01 through
+2024-08-31, eliminating the gap. After this runs, the same Polygon
+backfill that was filtered down to 2024-09-01 can fetch from 2023-09-01
+without integrity errors.
+
+Pattern matches migration 0002: monthly RANGE partitions with explicit
+[start, next_month_start) bounds. The shared parent index
+ix_eod_bars_date_ticker is automatically applied to new partitions
+(Postgres propagates partitioned-table indexes).
+
+Idempotent: re-running fails on the second CREATE — alembic up/down
+discipline is enforced by the version table, so this is fine.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic
+revision: str = "0004_extend_eod_partitions"
+down_revision: str | None = "0003_rehash_xsource_dedup"
+branch_labels: str | tuple[str, ...] | None = None
+depends_on: str | tuple[str, ...] | None = None
+
+
+# Monthly partitions to add: (year, month) for 2023-09 through 2024-08.
+_BACKWARD_PARTITIONS: list[tuple[int, int]] = [
+    (2023, 9),
+    (2023, 10),
+    (2023, 11),
+    (2023, 12),
+    (2024, 1),
+    (2024, 2),
+    (2024, 3),
+    (2024, 4),
+    (2024, 5),
+    (2024, 6),
+    (2024, 7),
+    (2024, 8),
+]
+
+
+def _next_month(year: int, month: int) -> tuple[int, int]:
+    if month == 12:
+        return year + 1, 1
+    return year, month + 1
+
+
+def upgrade() -> None:
+    for year, month in _BACKWARD_PARTITIONS:
+        next_year, next_month = _next_month(year, month)
+        op.execute(
+            f"""
+            CREATE TABLE hedge_fund.eod_bars_{year}_{month:02d}
+            PARTITION OF hedge_fund.eod_bars
+            FOR VALUES FROM ('{year}-{month:02d}-01')
+                       TO   ('{next_year}-{next_month:02d}-01')
+            """
+        )
+
+
+def downgrade() -> None:
+    # Drop in reverse order so the most recently created goes first.
+    for year, month in reversed(_BACKWARD_PARTITIONS):
+        op.execute(f"DROP TABLE IF EXISTS hedge_fund.eod_bars_{year}_{month:02d}")

--- a/crog-ai-backend/docs/dochia-v1-calibration-report.md
+++ b/crog-ai-backend/docs/dochia-v1-calibration-report.md
@@ -58,17 +58,24 @@ trailing 90-day window. Output written to
 
 Exclusion file pointer: `calibration/excluded_tickers.json`
 
-### Known partition coverage gap
+### Partition coverage
 
-`hedge_fund.eod_bars` is partitioned monthly from **2024-09-01** per
-ADR-0001 D6 / migration 0002. Bars before that date are filtered
-client-side by `backfill_eod_bars.py` (count surfaced as
-`bars_dropped_pre_partition` above). For corpus alerts in approximately
-the first 9 months of 2024-2025 the 63-prior-bar requirement cannot be
-met from the current partition set; those tickers/alerts are surfaced
-as exclusions in `excluded_tickers.json`. Decision needed before
-calibration step 5 begins: backfill earlier partitions, or accept the
-exclusion as a corpus-shape constraint.
+`hedge_fund.eod_bars` is partitioned monthly from **2023-09-01** after
+migration `0004_extend_eod_partitions` (this PR) extended
+coverage backward by 12 months from the original 2024-09-01 floor in
+migration 0002.
+
+**Rationale:** the corpus's earliest alert is 2024-03-18 and the
+longest Donchian lookback is 63 trading days. The original 2024-09-01
+floor would have starved approximately the first 9 months of corpus
+alerts (~8k observations) of prior history. Extending to 2023-09-01
+gives a comfortable margin — every alert in the corpus has at least
+~125 prior trading days of bar history available.
+
+`backfill_eod_bars.py` retains a defense-in-depth client-side
+`PARTITION_FLOOR` of 2023-09-01 in case the migration hasn't been
+applied; after `alembic upgrade head` runs, `bars_dropped_pre_partition`
+should be zero.
 
 ---
 

--- a/crog-ai-backend/docs/dochia-v1-calibration-report.md
+++ b/crog-ai-backend/docs/dochia-v1-calibration-report.md
@@ -1,0 +1,125 @@
+# Dochia v1 Calibration Report
+
+Status: **IN PROGRESS** — populated incrementally as ADR-0003 sprint
+workflow steps complete.
+
+This report mirrors the 11-step sprint workflow in
+[ADR-0003](ADR-0003-dochia-v1-fit-method.md). Each section is filled in
+as that step runs; sections still marked `<TBD>` have not yet executed.
+
+---
+
+## 1. Polygon.io setup
+
+**Status:** complete (2026-04-27)
+
+- Polygon Stocks Starter tier (paid, unlimited rate)
+- `POLYGON_API_KEY` set in `crog-ai-backend/.env`
+- Auth verified against `/v3/reference/tickers/AAPL` (`AUTH SUCCESS`)
+- Fetch wrapper: `scripts/backfill_eod_bars.py` (httpx async client,
+  defensive 429 backoff, no client-side rate limiter per ADR-0003 D5)
+
+---
+
+## 2. EOD bar backfill coverage
+
+**Status:** populated by end-of-run summary from `scripts/backfill_eod_bars.py`
+plus exclusion list from `scripts/audit_corpus_coverage.py`.
+
+### Backfill summary
+
+| Metric                          | Value         |
+|---------------------------------|---------------|
+| Tickers attempted               | `<TBD>`       |
+| Tickers succeeded               | `<TBD>`       |
+| Tickers no-data                 | `<TBD>`       |
+| Tickers failed                  | `<TBD>`       |
+| Bars inserted                   | `<TBD>`       |
+| Bars dropped (pre-partition)    | `<TBD>`       |
+
+State files (gitignored):
+- `scripts/state/backfill_state.json` — completed-ticker checkpoint
+- `scripts/state/backfill_errors.log` — per-ticker error trail
+- `scripts/state/no_data_tickers.json` — tickers Polygon returned 0 bars for
+
+### Coverage exclusions (ADR-0002 D2 / ADR-0003 sprint step 2)
+
+A ticker is excluded from the calibration corpus if **any** of its
+alert dates has fewer than 63 prior trading days of EOD bars within the
+trailing 90-day window. Output written to
+`calibration/excluded_tickers.json` (gitignored).
+
+| Metric                          | Value         |
+|---------------------------------|---------------|
+| Total tickers in corpus         | `<TBD>`       |
+| Kept                            | `<TBD>`       |
+| Excluded                        | `<TBD>`       |
+| Observations dropped            | `<TBD>`       |
+
+Exclusion file pointer: `calibration/excluded_tickers.json`
+
+### Known partition coverage gap
+
+`hedge_fund.eod_bars` is partitioned monthly from **2024-09-01** per
+ADR-0001 D6 / migration 0002. Bars before that date are filtered
+client-side by `backfill_eod_bars.py` (count surfaced as
+`bars_dropped_pre_partition` above). For corpus alerts in approximately
+the first 9 months of 2024-2025 the 63-prior-bar requirement cannot be
+met from the current partition set; those tickers/alerts are surfaced
+as exclusions in `excluded_tickers.json`. Decision needed before
+calibration step 5 begins: backfill earlier partitions, or accept the
+exclusion as a corpus-shape constraint.
+
+---
+
+## 3. Feature extraction
+
+**Status:** `<TBD — sprint step 3>`
+
+---
+
+## 4. Train/test split
+
+**Status:** `<TBD — sprint step 4>`
+
+---
+
+## 5. Hyperparameter search
+
+**Status:** `<TBD — sprint step 5>`
+
+---
+
+## 6. Final fit
+
+**Status:** `<TBD — sprint step 6>`
+
+---
+
+## 7. Normalization fit
+
+**Status:** `<TBD — sprint step 7>`
+
+---
+
+## 8. Test-set evaluation
+
+**Status:** `<TBD — sprint step 8>`
+
+---
+
+## 9. Persistence
+
+**Status:** `<TBD — sprint step 9>`
+
+---
+
+## 10. Reporting
+
+**Status:** `<TBD — sprint step 10>`
+
+---
+
+## 11. Decision
+
+**Status:** `<TBD — sprint step 11>`

--- a/crog-ai-backend/pyproject.toml
+++ b/crog-ai-backend/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "imap-tools>=1.7.0",
     "python-dotenv>=1.0.0",
     "structlog>=24.0.0",
+    "tqdm>=4.66.0",
 ]
 
 [dependency-groups]

--- a/crog-ai-backend/pyproject.toml
+++ b/crog-ai-backend/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "structlog>=24.0.0",
     "tqdm>=4.66.0",
+    "aiolimiter>=1.1.0",
 ]
 
 [dependency-groups]

--- a/crog-ai-backend/scripts/audit_corpus_coverage.py
+++ b/crog-ai-backend/scripts/audit_corpus_coverage.py
@@ -1,0 +1,178 @@
+"""Phase 2 / ADR-0003 step 2: post-backfill corpus coverage audit.
+
+Per ADR-0002 D2 ("Tickers without sufficient history get filtered out
+of the calibration corpus with explicit logging"): for every observation
+in hedge_fund.market_club_observations, count the prior EOD bars
+available within the trailing 90-day window before the alert's
+trading_day. The Donchian D63 feature requires 63 prior trading days.
+
+Exclusion rule (per ADR-0003 D5 sprint workflow item 2):
+    A ticker is excluded if ANY of its alert dates has fewer than
+    63 prior bars in the [trading_day - 90 days, trading_day) window.
+
+Output: calibration/excluded_tickers.json
+{
+  "generated_at": "ISO timestamp",
+  "total_tickers": int,
+  "excluded_count": int,
+  "kept_count": int,
+  "total_observations_excluded": int,
+  "excluded_tickers": [
+    {
+      "ticker": "XYZ",
+      "failing_alerts": [
+        {"alert_date": "YYYY-MM-DD", "prior_bar_count": int},
+        ...
+      ]
+    },
+    ...
+  ]
+}
+
+Usage:
+    cd ~/Fortress-Prime/crog-ai-backend
+    uv run python scripts/audit_corpus_coverage.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections import defaultdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import psycopg
+import structlog
+from dotenv import load_dotenv
+from psycopg.rows import dict_row
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+load_dotenv(PROJECT_ROOT / ".env")
+
+CALIBRATION_DIR = PROJECT_ROOT / "calibration"
+OUTPUT_FILE = CALIBRATION_DIR / "excluded_tickers.json"
+
+MIN_PRIOR_BARS = 63
+LOOKBACK_DAYS = 90
+
+# Per-(ticker, trading_day) prior-bar count over the trailing window.
+# LOOKBACK_DAYS interpolated (code-owned int, not user input).
+COVERAGE_SQL = f"""
+SELECT
+    o.ticker,
+    o.trading_day                     AS alert_date,
+    COUNT(b.bar_date)                 AS prior_bar_count
+FROM hedge_fund.market_club_observations o
+LEFT JOIN hedge_fund.eod_bars b
+  ON  b.ticker  = o.ticker
+  AND b.bar_date < o.trading_day
+  AND b.bar_date >= o.trading_day - INTERVAL '{LOOKBACK_DAYS} days'
+GROUP BY o.ticker, o.trading_day
+ORDER BY o.ticker, o.trading_day
+"""
+
+structlog.configure(
+    processors=[
+        structlog.processors.add_log_level,
+        structlog.processors.TimeStamper(fmt="iso", utc=True),
+        structlog.processors.JSONRenderer(),
+    ]
+)
+log = structlog.get_logger()
+
+
+def database_url() -> str:
+    raw = os.environ.get("DATABASE_URL", "")
+    if not raw:
+        raise RuntimeError("DATABASE_URL not set in .env")
+    return raw.replace("postgresql+psycopg://", "postgresql://", 1)
+
+
+def main() -> int:
+    log.info(
+        "audit_starting",
+        min_prior_bars=MIN_PRIOR_BARS,
+        lookback_days=LOOKBACK_DAYS,
+    )
+
+    failing: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    all_tickers: set[str] = set()
+    observations_in_failing_tickers: dict[str, int] = defaultdict(int)
+
+    with psycopg.connect(database_url()) as conn, conn.cursor(row_factory=dict_row) as cur:
+        # Total observation count per ticker (for the "observations dropped" tally)
+        cur.execute(
+            "SELECT ticker, COUNT(*) AS n "
+            "FROM hedge_fund.market_club_observations GROUP BY ticker"
+        )
+        per_ticker_count = {row["ticker"]: row["n"] for row in cur.fetchall()}
+        all_tickers = set(per_ticker_count.keys())
+
+        cur.execute(COVERAGE_SQL)
+        for row in cur.fetchall():
+            if row["prior_bar_count"] < MIN_PRIOR_BARS:
+                ticker = row["ticker"]
+                failing[ticker].append(
+                    {
+                        "alert_date": row["alert_date"].isoformat(),
+                        "prior_bar_count": int(row["prior_bar_count"]),
+                    }
+                )
+
+    excluded_tickers = sorted(failing.keys())
+    for ticker in excluded_tickers:
+        observations_in_failing_tickers[ticker] = per_ticker_count.get(ticker, 0)
+
+    total_observations_excluded = sum(observations_in_failing_tickers.values())
+
+    output = {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "min_prior_bars": MIN_PRIOR_BARS,
+        "lookback_days": LOOKBACK_DAYS,
+        "total_tickers": len(all_tickers),
+        "excluded_count": len(excluded_tickers),
+        "kept_count": len(all_tickers) - len(excluded_tickers),
+        "total_observations_excluded": total_observations_excluded,
+        "excluded_tickers": [
+            {
+                "ticker": ticker,
+                "total_observations": observations_in_failing_tickers[ticker],
+                "failing_alerts": failing[ticker],
+            }
+            for ticker in excluded_tickers
+        ],
+    }
+
+    CALIBRATION_DIR.mkdir(parents=True, exist_ok=True)
+    OUTPUT_FILE.write_text(json.dumps(output, indent=2, sort_keys=True))
+
+    log.info(
+        "audit_complete",
+        kept_count=output["kept_count"],
+        excluded_count=output["excluded_count"],
+        total_observations_excluded=total_observations_excluded,
+        output=str(OUTPUT_FILE),
+    )
+
+    print()
+    print("=" * 60)
+    print("Corpus coverage audit")
+    print("=" * 60)
+    print(f"  total_tickers................ {output['total_tickers']:>10}")
+    print(f"  kept_count................... {output['kept_count']:>10}")
+    print(f"  excluded_count............... {output['excluded_count']:>10}")
+    print(f"  total_observations_excluded.. {total_observations_excluded:>10}")
+    print()
+    print(f"  output: {OUTPUT_FILE}")
+    print()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/crog-ai-backend/scripts/backfill_eod_bars.py
+++ b/crog-ai-backend/scripts/backfill_eod_bars.py
@@ -1,0 +1,432 @@
+"""Phase 2 / ADR-0003 step 2: EOD bar backfill via Polygon.io.
+
+For every distinct ticker in hedge_fund.market_club_observations, fetch
+daily aggregate bars from Polygon and insert into hedge_fund.eod_bars.
+
+Per ADR-0003 D5 ("trust Polygon adjustments"): we request `adjusted=true`
+and populate BOTH `close` and `adjusted_close` with Polygon's adjusted
+close value. `split_factor` and `dividend_cash` are placeholders (1.0 / 0)
+because v1 does not track corporate actions explicitly — that is a v2
+concern via hedge_fund.corporate_actions.
+
+Architecture:
+- httpx.AsyncClient, no client-side rate limiter (Polygon paid tier)
+- Bounded concurrency (HTTP_CONCURRENCY) so we don't open hundreds of
+  sockets at once. Defensive HTTP 429 backoff up to 60s in case Polygon
+  surprises us with a per-tier limit.
+- Resumable: completed tickers persisted to scripts/state/backfill_state.json.
+  Re-running skips them.
+- Per-ticker isolation: any failure goes to scripts/state/backfill_errors.log
+  and the script continues. Empty result sets go to
+  scripts/state/no_data_tickers.json.
+- Idempotent inserts: ON CONFLICT (ticker, bar_date) DO NOTHING.
+
+Partition coverage gap (known issue):
+hedge_fund.eod_bars is partitioned monthly from 2024-09-01 (per
+ADR-0001 D6). Bars before that date have no destination partition and
+would raise an integrity error if inserted. We filter them client-side
+and report a per-ticker `dropped_pre_partition` count. The downstream
+audit script (audit_corpus_coverage.py) will surface tickers whose
+calibration alerts now lack 63 prior bars — caller must decide whether
+to backfill earlier partitions before fitting begins.
+
+Usage:
+    cd ~/Fortress-Prime/crog-ai-backend
+    uv run python scripts/backfill_eod_bars.py
+    uv run python scripts/backfill_eod_bars.py --tickers AAPL,MSFT
+    uv run python scripts/backfill_eod_bars.py --reset-state
+
+State files (scripts/state/, gitignored):
+    backfill_state.json    completed tickers + run metadata
+    backfill_errors.log    per-ticker error trail
+    no_data_tickers.json   tickers Polygon returned 0 bars for
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import httpx
+import psycopg
+import structlog
+from dotenv import load_dotenv
+from psycopg.rows import dict_row
+from tqdm.asyncio import tqdm
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+load_dotenv(PROJECT_ROOT / ".env")
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+POLYGON_API_KEY = os.environ.get("POLYGON_API_KEY", "")
+POLYGON_BASE = "https://api.polygon.io"
+SOURCE_VENDOR = "polygon"
+
+# Earliest partition in hedge_fund.eod_bars per ADR-0001 D6 / migration 0002.
+PARTITION_FLOOR = date(2024, 9, 1)
+
+# Backfill range. Polygon paid tier returns up to 50,000 bars in one call,
+# so 5 years fits comfortably in a single request per ticker.
+BACKFILL_START = "2024-01-01"
+BACKFILL_END = datetime.now(UTC).date().isoformat()
+
+# Bounded HTTP concurrency. Paid tier has no documented rate cap but we
+# don't need to sustain more than 50 parallel sockets to hit the ~5 min
+# budget on ~700 tickers.
+HTTP_CONCURRENCY = 50
+HTTP_TIMEOUT_SECONDS = 30.0
+MAX_RETRIES = 5
+MAX_BACKOFF_SECONDS = 60.0
+
+STATE_DIR = PROJECT_ROOT / "scripts" / "state"
+STATE_FILE = STATE_DIR / "backfill_state.json"
+ERROR_LOG = STATE_DIR / "backfill_errors.log"
+NO_DATA_FILE = STATE_DIR / "no_data_tickers.json"
+
+INSERT_SQL = """
+INSERT INTO hedge_fund.eod_bars (
+    ticker, bar_date, open, high, low, close, volume, vwap,
+    adjusted_close, split_factor, dividend_cash, source_vendor
+) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+ON CONFLICT (ticker, bar_date) DO NOTHING
+"""
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+structlog.configure(
+    processors=[
+        structlog.processors.add_log_level,
+        structlog.processors.TimeStamper(fmt="iso", utc=True),
+        structlog.processors.JSONRenderer(),
+    ]
+)
+log = structlog.get_logger()
+
+
+# ---------------------------------------------------------------------------
+# State persistence
+# ---------------------------------------------------------------------------
+
+
+def load_state() -> dict[str, Any]:
+    if STATE_FILE.exists():
+        return json.loads(STATE_FILE.read_text())
+    return {"started_at": None, "completed": []}
+
+
+def save_state(state: dict[str, Any]) -> None:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    tmp = STATE_FILE.with_suffix(".tmp")
+    tmp.write_text(json.dumps(state, indent=2, sort_keys=True))
+    tmp.replace(STATE_FILE)
+
+
+def append_error(ticker: str, message: str) -> None:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(UTC).isoformat()
+    with ERROR_LOG.open("a") as f:
+        f.write(f"{ts}\t{ticker}\t{message}\n")
+
+
+def append_no_data(ticker: str) -> None:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    existing: list[str] = []
+    if NO_DATA_FILE.exists():
+        existing = json.loads(NO_DATA_FILE.read_text()).get("no_data", [])
+    if ticker not in existing:
+        existing.append(ticker)
+    NO_DATA_FILE.write_text(json.dumps({"no_data": sorted(existing)}, indent=2))
+
+
+# ---------------------------------------------------------------------------
+# Polygon fetch
+# ---------------------------------------------------------------------------
+
+
+async def fetch_ticker_bars(
+    client: httpx.AsyncClient,
+    ticker: str,
+) -> tuple[list[dict[str, Any]] | None, str | None]:
+    """Fetch daily aggregate bars for one ticker.
+
+    Returns (results, error). On error, results is None. On no-data,
+    results is [].
+    """
+    url = f"{POLYGON_BASE}/v2/aggs/ticker/{ticker}/range/1/day/{BACKFILL_START}/{BACKFILL_END}"
+    params = {
+        "adjusted": "true",
+        "sort": "asc",
+        "limit": 50000,
+        "apiKey": POLYGON_API_KEY,
+    }
+    backoff = 1.0
+    for attempt in range(MAX_RETRIES):
+        try:
+            r = await client.get(url, params=params, timeout=HTTP_TIMEOUT_SECONDS)
+            if r.status_code == 429:
+                wait = min(backoff, MAX_BACKOFF_SECONDS)
+                log.warning("rate_limited", ticker=ticker, attempt=attempt, wait=wait)
+                await asyncio.sleep(wait)
+                backoff *= 2
+                continue
+            r.raise_for_status()
+            payload = r.json()
+            return payload.get("results") or [], None
+        except httpx.HTTPStatusError as e:
+            return None, f"http_{e.response.status_code}: {e.response.text[:200]}"
+        except (httpx.TimeoutException, httpx.NetworkError) as e:
+            if attempt == MAX_RETRIES - 1:
+                return None, f"{type(e).__name__}: {e}"
+            await asyncio.sleep(min(backoff, MAX_BACKOFF_SECONDS))
+            backoff *= 2
+        except Exception as e:
+            return None, f"{type(e).__name__}: {e}"
+    return None, "max_retries_exceeded"
+
+
+# ---------------------------------------------------------------------------
+# Row construction + insert
+# ---------------------------------------------------------------------------
+
+
+def polygon_bar_to_row(ticker: str, bar: dict[str, Any]) -> tuple[Any, ...] | None:
+    """Map a Polygon aggregate bar to an eod_bars insert tuple.
+
+    Returns None if the bar's date is before PARTITION_FLOOR (caller drops it).
+    Polygon `t` is epoch ms.
+    """
+    bar_date = datetime.fromtimestamp(bar["t"] / 1000.0, tz=UTC).date()
+    if bar_date < PARTITION_FLOOR:
+        return None
+
+    adjusted_close = Decimal(str(bar["c"]))
+    vwap = Decimal(str(bar["vw"])) if bar.get("vw") is not None else None
+
+    return (
+        ticker,
+        bar_date,
+        Decimal(str(bar["o"])),
+        Decimal(str(bar["h"])),
+        Decimal(str(bar["l"])),
+        adjusted_close,
+        int(bar["v"]),
+        vwap,
+        adjusted_close,
+        Decimal("1.0"),
+        Decimal("0"),
+        SOURCE_VENDOR,
+    )
+
+
+def insert_rows(conn: psycopg.Connection[Any], rows: list[tuple[Any, ...]]) -> int:
+    """Insert rows for one ticker. Returns number of rows attempted."""
+    if not rows:
+        return 0
+    with conn.cursor() as cur:
+        cur.executemany(INSERT_SQL, rows)
+    conn.commit()
+    return len(rows)
+
+
+# ---------------------------------------------------------------------------
+# Main backfill loop
+# ---------------------------------------------------------------------------
+
+
+def database_url() -> str:
+    raw = os.environ.get("DATABASE_URL", "")
+    if not raw:
+        raise RuntimeError("DATABASE_URL not set in .env")
+    # Strip SQLAlchemy driver tag for raw psycopg.
+    return raw.replace("postgresql+psycopg://", "postgresql://", 1)
+
+
+def fetch_corpus_tickers(conn: psycopg.Connection[Any]) -> list[str]:
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            "SELECT DISTINCT ticker FROM hedge_fund.market_club_observations "
+            "ORDER BY ticker"
+        )
+        return [row["ticker"] for row in cur.fetchall()]
+
+
+async def process_ticker(
+    sem: asyncio.Semaphore,
+    client: httpx.AsyncClient,
+    db_lock: asyncio.Lock,
+    conn: psycopg.Connection[Any],
+    ticker: str,
+) -> dict[str, Any]:
+    """Returns a result dict with status/inserted/dropped/error for the ticker."""
+    async with sem:
+        results, error = await fetch_ticker_bars(client, ticker)
+
+    if error is not None:
+        append_error(ticker, error)
+        log.error("ticker_failed", ticker=ticker, error=error)
+        return {"ticker": ticker, "status": "error", "error": error, "inserted": 0}
+
+    assert results is not None
+    if not results:
+        append_no_data(ticker)
+        log.info("ticker_no_data", ticker=ticker)
+        return {"ticker": ticker, "status": "no_data", "inserted": 0}
+
+    rows: list[tuple[Any, ...]] = []
+    dropped = 0
+    for bar in results:
+        row = polygon_bar_to_row(ticker, bar)
+        if row is None:
+            dropped += 1
+        else:
+            rows.append(row)
+
+    async with db_lock:
+        attempted = await asyncio.to_thread(insert_rows, conn, rows)
+
+    log.info(
+        "ticker_completed",
+        ticker=ticker,
+        bars_returned=len(results),
+        rows_attempted=attempted,
+        dropped_pre_partition=dropped,
+    )
+    return {
+        "ticker": ticker,
+        "status": "ok",
+        "inserted": attempted,
+        "dropped_pre_partition": dropped,
+        "bars_returned": len(results),
+    }
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    if not POLYGON_API_KEY:
+        print("ERROR: POLYGON_API_KEY not set in .env", file=sys.stderr)
+        return 2
+
+    state = load_state()
+    if args.reset_state:
+        state = {"started_at": None, "completed": []}
+
+    completed_set = set(state.get("completed", []))
+
+    with psycopg.connect(database_url()) as conn:
+        if args.tickers:
+            corpus = [t.strip().upper() for t in args.tickers.split(",") if t.strip()]
+        else:
+            corpus = fetch_corpus_tickers(conn)
+
+        todo = [t for t in corpus if t not in completed_set]
+        log.info(
+            "backfill_starting",
+            corpus_size=len(corpus),
+            already_done=len(corpus) - len(todo),
+            todo=len(todo),
+            backfill_start=BACKFILL_START,
+            backfill_end=BACKFILL_END,
+            partition_floor=PARTITION_FLOOR.isoformat(),
+        )
+
+        if state.get("started_at") is None:
+            state["started_at"] = datetime.now(UTC).isoformat()
+            save_state(state)
+
+        sem = asyncio.Semaphore(HTTP_CONCURRENCY)
+        db_lock = asyncio.Lock()
+
+        attempted = 0
+        succeeded = 0
+        no_data = 0
+        failed = 0
+        bars_inserted = 0
+        bars_dropped_pre_partition = 0
+
+        async with httpx.AsyncClient() as client:
+            tasks = [
+                process_ticker(sem, client, db_lock, conn, ticker)
+                for ticker in todo
+            ]
+            for fut in tqdm.as_completed(tasks, total=len(tasks), desc="tickers"):
+                result = await fut
+                attempted += 1
+                ticker = result["ticker"]
+
+                if result["status"] == "ok":
+                    succeeded += 1
+                    bars_inserted += result["inserted"]
+                    bars_dropped_pre_partition += result.get(
+                        "dropped_pre_partition", 0
+                    )
+                    completed_set.add(ticker)
+                elif result["status"] == "no_data":
+                    no_data += 1
+                    completed_set.add(ticker)
+                else:
+                    failed += 1
+
+                # Persist state every 10 tickers so a kill mid-run loses little.
+                if attempted % 10 == 0:
+                    state["completed"] = sorted(completed_set)
+                    save_state(state)
+
+        state["completed"] = sorted(completed_set)
+        state["finished_at"] = datetime.now(UTC).isoformat()
+        save_state(state)
+
+    summary = {
+        "tickers_attempted": attempted,
+        "tickers_succeeded": succeeded,
+        "tickers_no_data": no_data,
+        "tickers_failed": failed,
+        "bars_inserted": bars_inserted,
+        "bars_dropped_pre_partition": bars_dropped_pre_partition,
+    }
+    log.info("backfill_complete", **summary)
+
+    print()
+    print("=" * 60)
+    print("EOD backfill summary")
+    print("=" * 60)
+    for k, v in summary.items():
+        print(f"  {k:.<40} {v:>10}")
+    print()
+    print(f"  state_file......... {STATE_FILE}")
+    print(f"  errors_log......... {ERROR_LOG}")
+    print(f"  no_data_file....... {NO_DATA_FILE}")
+    print()
+
+    return 0 if failed == 0 else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="EOD bar backfill via Polygon.")
+    parser.add_argument(
+        "--tickers",
+        help="Comma-separated ticker subset (default: full corpus from observations)",
+    )
+    parser.add_argument(
+        "--reset-state",
+        action="store_true",
+        help="Ignore prior state file and re-fetch every ticker",
+    )
+    args = parser.parse_args()
+    return asyncio.run(main_async(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/crog-ai-backend/scripts/backfill_eod_bars.py
+++ b/crog-ai-backend/scripts/backfill_eod_bars.py
@@ -48,6 +48,7 @@ import asyncio
 import json
 import os
 import sys
+import time
 from datetime import UTC, date, datetime
 from decimal import Decimal
 from pathlib import Path
@@ -56,6 +57,7 @@ from typing import Any
 import httpx
 import psycopg
 import structlog
+from aiolimiter import AsyncLimiter
 from dotenv import load_dotenv
 from psycopg.rows import dict_row
 from tqdm.asyncio import tqdm
@@ -87,18 +89,40 @@ PARTITION_FLOOR = date(2023, 9, 1)
 BACKFILL_START = "2023-09-01"
 BACKFILL_END = datetime.now(UTC).date().isoformat()
 
-# Bounded HTTP concurrency. Paid tier has no documented rate cap but we
-# don't need to sustain more than 50 parallel sockets to hit the ~5 min
-# budget on ~700 tickers.
-HTTP_CONCURRENCY = 50
+# Polygon Stocks Starter is rate-limited despite being a paid tier — our
+# first backfill attempt at HTTP_CONCURRENCY=50 hit instant 429s on every
+# ticker after the first ~19 succeeded. Empirically we sustained ~20
+# calls/min before throttling kicked in. We now gate at 10 RPS via
+# `_RATE_LIMITER` (below) and keep HTTP_CONCURRENCY low — the limiter is
+# the actual throttle; concurrency only governs how many sockets are open.
+HTTP_CONCURRENCY = 5
 HTTP_TIMEOUT_SECONDS = 30.0
-MAX_RETRIES = 5
+MAX_RETRIES = 10
 MAX_BACKOFF_SECONDS = 60.0
+# Per-ticker total backoff budget at MAX_RETRIES=10 with capped exponential:
+#   1 + 2 + 4 + 8 + 16 + 32 + 60*4 = 303s ≈ 5 minutes
 
 STATE_DIR = PROJECT_ROOT / "scripts" / "state"
 STATE_FILE = STATE_DIR / "backfill_state.json"
 ERROR_LOG = STATE_DIR / "backfill_errors.log"
 NO_DATA_FILE = STATE_DIR / "no_data_tickers.json"
+
+# ---------------------------------------------------------------------------
+# Rate limiting (module-level, shared across coroutines)
+# ---------------------------------------------------------------------------
+#
+# AsyncLimiter is a leaky bucket: max_rate tokens accumulate in a bucket of
+# capacity max_rate, draining at max_rate/time_period per second. With
+# (10, 1.0) the first 10 calls burst, then the remainder are paced at 10/sec.
+# This is conservative under the ~20 calls/min ceiling we observed
+# empirically when the tier started returning 429s. Acquire BEFORE the
+# HTTP call so the limiter actually gates outbound requests (acquiring after
+# would let bursts of unlimited concurrent requests fly).
+_RATE_LIMITER = AsyncLimiter(max_rate=10, time_period=1.0)
+
+# Total HTTP attempts made (including retries). Single-threaded asyncio
+# means a plain int increment is safe.
+_HTTP_CALL_COUNTER = 0
 
 INSERT_SQL = """
 INSERT INTO hedge_fund.eod_bars (
@@ -168,9 +192,16 @@ async def fetch_ticker_bars(
 ) -> tuple[list[dict[str, Any]] | None, str | None]:
     """Fetch daily aggregate bars for one ticker.
 
-    Returns (results, error). On error, results is None. On no-data,
-    results is [].
+    Acquires the module-level rate limiter BEFORE every HTTP call (including
+    retries). Returns (results, error). On error, results is None. On
+    no-data, results is [].
+
+    429 logging policy: log at INFO for the first 1-2 consecutive 429s on
+    a single ticker (expected with the limiter), promote to WARNING from
+    the 3rd consecutive onward (signal of pathology — the limiter alone
+    should be preventing 429s).
     """
+    global _HTTP_CALL_COUNTER
     url = f"{POLYGON_BASE}/v2/aggs/ticker/{ticker}/range/1/day/{BACKFILL_START}/{BACKFILL_END}"
     params = {
         "adjusted": "true",
@@ -179,15 +210,27 @@ async def fetch_ticker_bars(
         "apiKey": POLYGON_API_KEY,
     }
     backoff = 1.0
+    consecutive_429 = 0
     for attempt in range(MAX_RETRIES):
         try:
-            r = await client.get(url, params=params, timeout=HTTP_TIMEOUT_SECONDS)
+            async with _RATE_LIMITER:
+                _HTTP_CALL_COUNTER += 1
+                r = await client.get(url, params=params, timeout=HTTP_TIMEOUT_SECONDS)
             if r.status_code == 429:
+                consecutive_429 += 1
                 wait = min(backoff, MAX_BACKOFF_SECONDS)
-                log.warning("rate_limited", ticker=ticker, attempt=attempt, wait=wait)
+                log_method = log.warning if consecutive_429 >= 3 else log.info
+                log_method(
+                    "rate_limited_429",
+                    ticker=ticker,
+                    attempt=attempt,
+                    consecutive=consecutive_429,
+                    wait=wait,
+                )
                 await asyncio.sleep(wait)
                 backoff *= 2
                 continue
+            consecutive_429 = 0
             r.raise_for_status()
             payload = r.json()
             return payload.get("results") or [], None
@@ -360,6 +403,7 @@ async def main_async(args: argparse.Namespace) -> int:
         failed = 0
         bars_inserted = 0
         bars_dropped_pre_partition = 0
+        wall_start = time.monotonic()
 
         async with httpx.AsyncClient() as client:
             tasks = [
@@ -393,6 +437,10 @@ async def main_async(args: argparse.Namespace) -> int:
         state["finished_at"] = datetime.now(UTC).isoformat()
         save_state(state)
 
+    wall_seconds = time.monotonic() - wall_start
+    effective_rate_per_sec = (
+        _HTTP_CALL_COUNTER / wall_seconds if wall_seconds > 0 else 0.0
+    )
     summary = {
         "tickers_attempted": attempted,
         "tickers_succeeded": succeeded,
@@ -400,6 +448,10 @@ async def main_async(args: argparse.Namespace) -> int:
         "tickers_failed": failed,
         "bars_inserted": bars_inserted,
         "bars_dropped_pre_partition": bars_dropped_pre_partition,
+        "http_calls_made": _HTTP_CALL_COUNTER,
+        "wall_seconds": round(wall_seconds, 2),
+        "effective_rate_per_sec": round(effective_rate_per_sec, 3),
+        "effective_rate_per_min": round(effective_rate_per_sec * 60, 1),
     }
     log.info("backfill_complete", **summary)
 

--- a/crog-ai-backend/scripts/backfill_eod_bars.py
+++ b/crog-ai-backend/scripts/backfill_eod_bars.py
@@ -21,14 +21,13 @@ Architecture:
   scripts/state/no_data_tickers.json.
 - Idempotent inserts: ON CONFLICT (ticker, bar_date) DO NOTHING.
 
-Partition coverage gap (known issue):
-hedge_fund.eod_bars is partitioned monthly from 2024-09-01 (per
-ADR-0001 D6). Bars before that date have no destination partition and
-would raise an integrity error if inserted. We filter them client-side
-and report a per-ticker `dropped_pre_partition` count. The downstream
-audit script (audit_corpus_coverage.py) will surface tickers whose
-calibration alerts now lack 63 prior bars — caller must decide whether
-to backfill earlier partitions before fitting begins.
+Partition coverage:
+hedge_fund.eod_bars is partitioned monthly from 2023-09-01 onward after
+migration 0004_extend_eod_partitions extended coverage backward.
+PARTITION_FLOOR is the defense-in-depth client-side floor — if 0004
+hasn't been applied yet, bars before 2023-09-01 are dropped client-side
+and surfaced as `bars_dropped_pre_partition` rather than triggering a
+Postgres integrity error. After 0004 is applied, drops should be zero.
 
 Usage:
     cd ~/Fortress-Prime/crog-ai-backend
@@ -74,12 +73,18 @@ POLYGON_API_KEY = os.environ.get("POLYGON_API_KEY", "")
 POLYGON_BASE = "https://api.polygon.io"
 SOURCE_VENDOR = "polygon"
 
-# Earliest partition in hedge_fund.eod_bars per ADR-0001 D6 / migration 0002.
-PARTITION_FLOOR = date(2024, 9, 1)
+# Earliest partition in hedge_fund.eod_bars after migration
+# 0004_extend_eod_partitions extends coverage backward to 2023-09.
+# Defense in depth: if 0004 hasn't been applied yet, bars before this
+# floor are still dropped client-side rather than triggering a partition
+# integrity error.
+PARTITION_FLOOR = date(2023, 9, 1)
 
-# Backfill range. Polygon paid tier returns up to 50,000 bars in one call,
-# so 5 years fits comfortably in a single request per ticker.
-BACKFILL_START = "2024-01-01"
+# Backfill range. The corpus's earliest alert (2024-03-18) needs 63
+# prior trading days, so we fetch from 2023-09-01 to give a comfortable
+# margin past 63 trading days. Polygon paid tier returns up to 50,000
+# bars per call, so the full window fits in one request per ticker.
+BACKFILL_START = "2023-09-01"
 BACKFILL_END = datetime.now(UTC).date().isoformat()
 
 # Bounded HTTP concurrency. Paid tier has no documented rate cap but we

--- a/crog-ai-backend/tests/test_backfill_rate_limiter.py
+++ b/crog-ai-backend/tests/test_backfill_rate_limiter.py
@@ -1,0 +1,79 @@
+"""Smoke test that the Polygon backfill's rate limiter actually gates HTTP.
+
+This proves two things:
+  1. The module-level `_RATE_LIMITER` is wired into `fetch_ticker_bars`
+     BEFORE the HTTP call (the common bug is acquiring after, which lets
+     bursts fly unthrottled).
+  2. Concurrent fetches are paced at ≤10/sec sustained.
+
+Test design notes
+-----------------
+The user spec asked for "12 concurrent fetches take ≥1 second." That
+threshold won't hold with `aiolimiter.AsyncLimiter`'s leaky-bucket
+semantics: AsyncLimiter(10, 1.0) lets the first 10 acquisitions burst
+(bucket capacity = 10), then trickles at 10/sec. So 12 calls finish in
+~0.2s.
+
+To meaningfully test gating (i.e., second batch must wait for the leak),
+we use 25 concurrent calls. With burst-then-trickle semantics, the
+last 15 calls have to wait for tokens to leak at 10/sec, which forces
+total elapsed to ≥1.0s. If the limiter were missing or wired AFTER the
+HTTP call, all 25 would complete in ~0s and the assertion would fail.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
+
+import backfill_eod_bars  # noqa: E402
+
+
+async def test_rate_limiter_gates_concurrent_fetches() -> None:
+    """25 concurrent fetches against a stubbed 200-OK endpoint take ≥1.0s."""
+    fake_response = MagicMock(spec=httpx.Response)
+    fake_response.status_code = 200
+    fake_response.json.return_value = {"results": []}
+    fake_response.raise_for_status.return_value = None
+
+    fake_client = MagicMock(spec=httpx.AsyncClient)
+    fake_client.get = AsyncMock(return_value=fake_response)
+
+    n_calls = 25
+    start = time.monotonic()
+    results = await asyncio.gather(
+        *(
+            backfill_eod_bars.fetch_ticker_bars(fake_client, f"T{i:03d}")
+            for i in range(n_calls)
+        )
+    )
+    elapsed = time.monotonic() - start
+
+    # All calls succeeded with empty results (no error).
+    for payload, error in results:
+        assert error is None
+        assert payload == []
+
+    # Limiter is configured at 10 RPS sustained. After the initial burst
+    # of `max_rate` tokens, additional tokens release at 10/sec. So the
+    # 11th-25th calls (15 of them) must wait for token leakage. The
+    # tail-end elapsed time is therefore >= 15/10 = 1.5s; we assert
+    # >= 1.0s for cushion against test-host jitter and aiolimiter
+    # implementation details.
+    assert elapsed >= 1.0, (
+        f"Limiter did not gate: 25 concurrent fetches finished in "
+        f"{elapsed:.3f}s (expected ≥1.0s). The limiter is either missing "
+        f"or applied AFTER the HTTP call."
+    )
+
+    # Spot-check: all 25 calls actually went out (so the limiter isn't
+    # accidentally short-circuiting).
+    assert fake_client.get.await_count == n_calls


### PR DESCRIPTION
Implements [ADR-0003](https://github.com/cabinrentalsofgeorgia-bit/Fortress-Prime/blob/main/crog-ai-backend/docs/ADR-0003-dochia-v1-fit-method.md) sprint workflow item 2: populate `hedge_fund.eod_bars` with daily aggregates from Polygon for every ticker in `market_club_observations`, then audit which tickers/alerts have sufficient prior history for the 63-day Donchian feature.

## Deliverables

### 1. `scripts/backfill_eod_bars.py`
- `httpx.AsyncClient` with bounded concurrency (50), no client-side rate limiter (paid tier)
- Defensive HTTP 429 exponential backoff capped at 60s
- One Polygon call per ticker: `/v2/aggs/ticker/{ticker}/range/1/day/2024-01-01/{today}?adjusted=true&sort=asc&limit=50000`
- Inserts via `executemany` with `ON CONFLICT (ticker, bar_date) DO NOTHING`
- **Per ADR-0003 D5:** `close` and `adjusted_close` both populated from Polygon's adjusted close; `split_factor=1.0`, `dividend_cash=0`, `source_vendor='polygon'`
- **Resumable:** completed tickers persisted to `scripts/state/backfill_state.json` every 10 tickers; restart skips them
- Per-ticker isolation: failures → `scripts/state/backfill_errors.log`, empty responses → `scripts/state/no_data_tickers.json`
- `tqdm.asyncio` progress bar; structured end-of-run summary (tickers attempted/succeeded/failed/no-data, bars inserted, bars dropped)
- Uses `crog_ai_app` DB role from .env (per ADR-0001 D4)

### 2. `scripts/audit_corpus_coverage.py`
- Single SQL pass: for every `(ticker, trading_day)` in `market_club_observations`, count rows in `eod_bars` where `ticker` matches AND `bar_date < trading_day` AND `bar_date >= trading_day - INTERVAL '90 days'`
- A ticker is excluded if **any** of its alert dates has \<63 prior bars
- Output: `calibration/excluded_tickers.json` with per-ticker `failing_alerts` list (date + count) plus aggregate counts (`total_tickers`, `kept_count`, `excluded_count`, `total_observations_excluded`)

### 3. `docs/dochia-v1-calibration-report.md` (stub)
- 11 sections mirroring the ADR-0003 sprint workflow
- Section 1 (Polygon setup) **populated** — auth verified earlier today
- Section 2 (EOD backfill coverage) **templated** — end-of-run summary + audit pointers; numbers are `<TBD>` until operator runs the scripts
- Sections 3-11 stubbed with title only

## Known issue surfaced (not silently handled)

`hedge_fund.eod_bars` is partitioned monthly **from 2024-09-01** per ADR-0001 D6 / migration 0002. Bars before that date have no destination partition and would raise an integrity error. The backfill script filters them client-side and counts them as `bars_dropped_pre_partition`. The audit script will then exclude tickers whose first ~9 months of corpus alerts (March 2024 → ~December 2024) cannot meet the 63-prior-bar requirement.

**Decision point before sprint step 5 begins:** backfill earlier partitions (2023-12 → 2024-08), or accept the exclusion as a corpus-shape constraint. Documented in the report with the same framing.

## Other changes
- `pyproject.toml` — adds `tqdm>=4.66.0`. `httpx` was already a dependency.
- `.gitignore` — adds `scripts/state/` and `calibration/` (per-run outputs, not source of truth)

## Test plan

- [ ] Operator runs `uv sync` to pick up tqdm
- [ ] `uv run python scripts/backfill_eod_bars.py` from tmux on Spark 2 (~5 min wall time on paid tier; should produce summary table)
- [ ] `uv run python scripts/audit_corpus_coverage.py` (writes `calibration/excluded_tickers.json`)
- [ ] Operator updates the calibration report's Section 2 placeholders with actual numbers
- [ ] Operator decides on the partition-coverage gap before sprint step 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)