### PR TITLE
fix(flos-phase-0a-7): UID watermark for legal mail intake (INC-2026-04-28)

### DIFF
--- a/fortress-guest-platform/backend/alembic/versions/s4d5e6f7g8h9_flos_phase_0a_7_uid_watermark.py
+++ b/fortress-guest-platform/backend/alembic/versions/s4d5e6f7g8h9_flos_phase_0a_7_uid_watermark.py
@@ -1,0 +1,61 @@
+"""flos phase 0a-7 — add last_seen_uid watermark to mail_ingester_state.
+
+Revision ID: s4d5e6f7g8h9
+Revises: r3c4d5e6f7g8
+Create Date: 2026-04-28
+
+INC-2026-04-28-flos-silent-intake — root cause fix.
+
+Adds last_seen_uid column to legal.mail_ingester_state so the ingester
+can shift IMAP SEARCH from UNSEEN SINCE <date> (which silently misses
+messages read by webmail/Captain/operator before patrol) to
+UID <last+1>:* SINCE <date>.
+
+The UNSEEN-based design assumed the legal mailbox would be ingester-
+exclusive. In production, anything that reads marks \\Seen, hiding the
+message from the ingester forever. Result: 38-day silent intake gap
+(2026-03-21 -> 2026-04-28) and zero rows in legal.event_log.
+
+Companion code change in legal_mail_ingester.py replaces UNSEEN with
+UID-watermark logic.
+
+Apply via raw psql per Issue #204:
+  psql -d fortress_db   -c "ALTER TABLE legal.mail_ingester_state ADD COLUMN IF NOT EXISTS last_seen_uid TEXT NULL;"
+  psql -d fortress_prod -c "ALTER TABLE legal.mail_ingester_state ADD COLUMN IF NOT EXISTS last_seen_uid TEXT NULL;"
+
+Bilateral mirror discipline (ADR-001): both DBs receive this migration.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "s4d5e6f7g8h9"
+down_revision = "r3c4d5e6f7g8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE legal.mail_ingester_state
+        ADD COLUMN IF NOT EXISTS last_seen_uid TEXT NULL;
+        """
+    )
+    op.execute(
+        """
+        COMMENT ON COLUMN legal.mail_ingester_state.last_seen_uid IS
+        'Highest IMAP UID ingested per mailbox. NULL = no watermark (bootstrap on next patrol). Drives SEARCH UID <last+1>:* without relying on \\Seen flag.';
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE legal.mail_ingester_state
+        DROP COLUMN IF EXISTS last_seen_uid;
+        """
+    )

--- a/fortress-guest-platform/backend/services/legal_mail_ingester.py
+++ b/fortress-guest-platform/backend/services/legal_mail_ingester.py
@@ -482,13 +482,18 @@ class LegalMailIngesterTransport:
             except Exception:
                 pass
 
-    def fetch_recent(self) -> list[dict[str, Any]]:
+    def fetch_recent(
+        self,
+        last_seen_uid: Optional[str] = None,
+    ) -> tuple[list[dict[str, Any]], Optional[str]]:
         """
-        Fetch UNSEEN messages within the date band, capped at max_messages_per_patrol.
+        Fetch new messages since last_seen_uid (or bootstrap with date band
+        if None), capped at max_messages_per_patrol.
 
-        Sub-phase 2A returns an empty list — full implementation lands in 2B.
         Connection retry pattern is in place (mirrors Captain's 2-attempt
         reconnect-on-abort for cPanel keep-alive drops).
+
+        Returns (records, new_last_seen_uid).
         """
         attempts = 0
         last_err: Exception | None = None
@@ -497,7 +502,7 @@ class LegalMailIngesterTransport:
             conn: Optional[imaplib.IMAP4_SSL] = None
             try:
                 conn = self._connect()
-                return self._fetch_with(conn)
+                return self._fetch_with(conn, last_seen_uid)
             except (imaplib.IMAP4.abort, EOFError, OSError, imaplib.IMAP4.error) as exc:
                 last_err = exc
                 if attempts == 1:
@@ -513,7 +518,7 @@ class LegalMailIngesterTransport:
                     mailbox=self.mailbox.name,
                     error=str(exc)[:200],
                 )
-                return []
+                return [], last_seen_uid
             finally:
                 if conn is not None:
                     try:
@@ -531,33 +536,73 @@ class LegalMailIngesterTransport:
                 mailbox=self.mailbox.name,
                 error=str(last_err)[:200],
             )
-        return []
+        return [], last_seen_uid
 
-    def _fetch_with(self, conn: imaplib.IMAP4_SSL) -> list[dict[str, Any]]:
+    def _fetch_with(
+        self,
+        conn: imaplib.IMAP4_SSL,
+        last_seen_uid: Optional[str] = None,
+    ) -> tuple[list[dict[str, Any]], Optional[str]]:
         """
         Banded UID SEARCH + per-UID BODY.PEEK[].
 
-        Per design v1.1 §3.2: never issue an unbounded SEARCH UNSEEN — that's
-        how gary-gk hits Issue #177's >1MB overflow. We always pair UNSEEN with
-        a SINCE date floor (default 30 days back, configurable per-mailbox).
+        Bootstrap (last_seen_uid is None): SEARCH SINCE <date>. Captures
+        all messages in band regardless of \\Seen flag.
+
+        Steady-state (last_seen_uid is set): SEARCH UID <last+1>:*.
+        Captures every new message, doesn't depend on \\Seen.
 
         Per design v1.1 §3.4 (Captain coexistence): use BODY.PEEK[] not
         (RFC822) — preserves the \\Seen flag. Captain marks \\Seen on its own
         cycle; we never mutate server-side state.
 
-        Returns list of dicts each containing:
-          uid, raw_bytes, host, folder, mailbox_alias
+        Returns (records, new_last_seen_uid). new_last_seen_uid is the
+        highest UID seen this patrol, or last_seen_uid if no new messages.
         """
         since_date = (date.today() - timedelta(days=self.mailbox.search_band_days))
-        search_predicate = f"UNSEEN SINCE {_imap_date(since_date)}"
+
+        next_uid: Optional[int] = None
+        if last_seen_uid:
+            # Steady state: anything strictly greater than the watermark.
+            try:
+                next_uid = int(last_seen_uid) + 1
+            except (ValueError, TypeError):
+                # Corrupt watermark — fail safe to bootstrap.
+                logger.warning(
+                    "legal_mail_watermark_invalid",
+                    mailbox=self.mailbox.name,
+                    value=last_seen_uid,
+                )
+                next_uid = None
+                search_predicate = f"SINCE {_imap_date(since_date)}"
+            else:
+                search_predicate = f"UID {next_uid}:*"
+        else:
+            # Bootstrap: date-banded, no UNSEEN.
+            search_predicate = f"SINCE {_imap_date(since_date)}"
 
         typ, data = conn.uid("SEARCH", search_predicate)
         if typ != "OK" or not data or not data[0]:
-            return []
+            return [], last_seen_uid
 
-        uids = data[0].split()[: self.mailbox.max_messages_per_patrol]
+        uid_tokens = data[0].split()
+
+        # IMAP UID quirk: `UID <next>:*` returns at least one UID even if no
+        # messages have UID >= next — the server returns the highest UID
+        # instead. Filter to UIDs strictly >= next_uid.
+        if next_uid is not None:
+            filtered: list[bytes] = []
+            for u in uid_tokens:
+                try:
+                    if int(u) >= next_uid:
+                        filtered.append(u)
+                except (ValueError, TypeError):
+                    continue
+            uid_tokens = filtered
+
+        uids = uid_tokens[: self.mailbox.max_messages_per_patrol]
         if not uids:
-            return []
+            return [], last_seen_uid
 
         out: list[dict[str, Any]] = []
         for uid_bytes in uids:
@@ -599,7 +644,12 @@ class LegalMailIngesterTransport:
                 )
                 continue
 
-        return out
+        # IMAP returns UIDs ascending — last token is highest. If the fetch
+        # loop produced no records but the SEARCH found UIDs, still advance
+        # to the highest UID seen; otherwise hold the prior watermark.
+        new_last_seen_uid = uids[-1].decode("ascii", errors="replace") if uids else last_seen_uid
+
+        return out, new_last_seen_uid
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1392,6 +1442,36 @@ async def _is_mailbox_paused(mailbox_alias: str) -> bool:
         return False
 
 
+async def _load_last_seen_uid(mailbox_alias: str) -> Optional[str]:
+    """Load the last_seen_uid watermark from legal.mail_ingester_state.
+
+    Returns None if no row yet (first patrol) OR if the column is
+    actually NULL OR if the read fails. None signals 'bootstrap mode' —
+    the caller falls back to date-banded SEARCH for one patrol, then
+    establishes the watermark from the highest UID seen.
+    """
+    try:
+        async with LegacySession() as db:
+            result = await db.execute(
+                text(
+                    "SELECT last_seen_uid FROM legal.mail_ingester_state "
+                    "WHERE mailbox_alias = :alias LIMIT 1"
+                ),
+                {"alias": mailbox_alias},
+            )
+            row = result.fetchone()
+            if row is None:
+                return None
+            return row[0]  # may be None even if row exists
+    except Exception as exc:
+        logger.warning(
+            "legal_mail_watermark_load_failed",
+            mailbox=mailbox_alias,
+            error=str(exc)[:200],
+        )
+        return None  # fail-open: bootstrap if read fails
+
+
 async def _update_mailbox_state(
     mailbox_alias: str,
     last_patrol_at: datetime,
@@ -1400,6 +1480,7 @@ async def _update_mailbox_state(
     delta_ingested: int,
     delta_deduped: int,
     delta_errored: int,
+    new_last_seen_uid: Optional[str] = None,
 ) -> None:
     """Upsert legal.mail_ingester_state after each patrol per §7 last-known-good.
 
@@ -1413,11 +1494,11 @@ async def _update_mailbox_state(
                         (mailbox_alias, last_patrol_at, last_success_at,
                          last_error_at, last_error,
                          messages_ingested_total, messages_deduped_total,
-                         messages_errored_total, updated_at)
+                         messages_errored_total, last_seen_uid, updated_at)
                     VALUES
                         (:alias, :patrol_at, :success_at,
                          :error_at, :err,
-                         :delta_in, :delta_dd, :delta_er, NOW())
+                         :delta_in, :delta_dd, :delta_er, :uid, NOW())
                     ON CONFLICT (mailbox_alias) DO UPDATE SET
                         last_patrol_at = EXCLUDED.last_patrol_at,
                         last_success_at = COALESCE(EXCLUDED.last_success_at,
@@ -1433,6 +1514,7 @@ async def _update_mailbox_state(
                         messages_ingested_total = legal.mail_ingester_state.messages_ingested_total + EXCLUDED.messages_ingested_total,
                         messages_deduped_total = legal.mail_ingester_state.messages_deduped_total + EXCLUDED.messages_deduped_total,
                         messages_errored_total = legal.mail_ingester_state.messages_errored_total + EXCLUDED.messages_errored_total,
+                        last_seen_uid = COALESCE(EXCLUDED.last_seen_uid, legal.mail_ingester_state.last_seen_uid),
                         updated_at = NOW()
                 """),
                 {
@@ -1444,6 +1526,7 @@ async def _update_mailbox_state(
                     "delta_in": delta_ingested,
                     "delta_dd": delta_deduped,
                     "delta_er": delta_errored,
+                    "uid": new_last_seen_uid,
                 },
             )
             await db.commit()
@@ -1524,15 +1607,19 @@ async def patrol_mailbox(
         return result
 
     # ── 1. Fetch ───────────────────────────────────────────────────────
+    prior_uid = await _load_last_seen_uid(mailbox.name)
     transport = LegalMailIngesterTransport(mailbox)
     fetched_records: list[dict[str, Any]] = []
+    new_last_seen_uid: Optional[str] = prior_uid
     fetch_error: Optional[str] = None
     try:
         # IMAP fetch is sync (imaplib); offload to thread to avoid blocking
         # the asyncio event loop. Mirror Captain's pattern (run_patrol uses
         # asyncio.to_thread on transport.fetch_unseen).
         import asyncio
-        fetched_records = await asyncio.to_thread(transport.fetch_recent)
+        fetched_records, new_last_seen_uid = await asyncio.to_thread(
+            transport.fetch_recent, prior_uid
+        )
     except Exception as exc:
         # Should not reach here — fetch_recent's retry loop catches IMAP
         # errors internally. Defensive only.
@@ -1621,6 +1708,7 @@ async def patrol_mailbox(
         delta_ingested=result.ingested,
         delta_deduped=result.deduped,
         delta_errored=result.errored,
+        new_last_seen_uid=new_last_seen_uid,
     )
 
     # ── 4. Metrics emission ────────────────────────────────────────────

--- a/fortress-guest-platform/backend/tests/test_legal_mail_ingester_uid_watermark.py
+++ b/fortress-guest-platform/backend/tests/test_legal_mail_ingester_uid_watermark.py
@@ -1,0 +1,139 @@
+"""
+Tests for FLOS Phase 0a-7 UID watermark fix (INC-2026-04-28).
+
+Each test below covers one failure mode of the prior `UNSEEN SINCE <date>`
+SEARCH predicate, which silently dropped any message that anything
+(webmail, Captain, operator) had marked \\Seen before the patrol fired.
+The fix replaces it with a `UID <last+1>:*` watermark + bootstrap fallback.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from unittest.mock import MagicMock
+
+from backend.services.legal_mail_ingester import (
+    LegalMailboxConfig,
+    LegalMailIngesterTransport,
+    _imap_date,
+)
+
+
+def _mailbox() -> LegalMailboxConfig:
+    return LegalMailboxConfig(
+        name="legal-cpanel",
+        transport="imap",
+        address="legal@cabin-rentals-of-georgia.com",
+        routing_tag="legal",
+        host="mail.example.com",
+        port=993,
+        credentials_ref="DUMMY_CRED_REF",
+    )
+
+
+def _conn_returning_uids(uid_list: list[bytes]) -> MagicMock:
+    """Build a mock IMAP conn whose SEARCH returns the given UID bytes list,
+    and whose FETCH returns a minimal RFC822 envelope per UID.
+    """
+    conn = MagicMock()
+    captured = {"search_predicate": None}
+
+    def uid_side_effect(*args):
+        if not args:
+            return ("BAD", [])
+        verb = args[0]
+        if verb == "SEARCH":
+            captured["search_predicate"] = args[1]
+            payload = b" ".join(uid_list) if uid_list else b""
+            return ("OK", [payload])
+        if verb == "FETCH":
+            uid_arg = args[1]
+            envelope = (
+                b"From: sender@example.com\r\n"
+                b"To: legal@cabin-rentals-of-georgia.com\r\n"
+                b"Subject: test\r\n"
+                b"Message-ID: <" + uid_arg.encode("ascii") + b"@test>\r\n"
+                b"Date: Mon, 01 Apr 2026 12:00:00 +0000\r\n"
+                b"\r\n"
+                b"body\r\n"
+            )
+            return ("OK", [(b"1 (UID " + uid_arg.encode("ascii") + b" BODY[] {NN}", envelope), b")"])
+        return ("BAD", [])
+
+    conn.uid = MagicMock(side_effect=uid_side_effect)
+    conn._captured = captured  # type: ignore[attr-defined]
+    return conn
+
+
+def test_fetch_recent_bootstrap_uses_since_band():
+    """First patrol with NULL watermark uses SINCE date band, no UNSEEN."""
+    transport = LegalMailIngesterTransport(_mailbox())
+    conn = _conn_returning_uids([b"7"])
+
+    records, new_uid = transport._fetch_with(conn, last_seen_uid=None)
+
+    expected_since = _imap_date(date.today() - timedelta(days=transport.mailbox.search_band_days))
+    predicate = conn._captured["search_predicate"]
+    assert predicate == f"SINCE {expected_since}"
+    assert "UNSEEN" not in predicate
+    assert len(records) == 1
+    assert new_uid == "7"
+
+
+def test_fetch_recent_steady_state_uses_uid_watermark():
+    """Subsequent patrol uses UID <last+1>:* predicate."""
+    transport = LegalMailIngesterTransport(_mailbox())
+    conn = _conn_returning_uids([b"43", b"44"])
+
+    records, new_uid = transport._fetch_with(conn, last_seen_uid="42")
+
+    assert conn._captured["search_predicate"] == "UID 43:*"
+    assert "UNSEEN" not in conn._captured["search_predicate"]
+    assert "SINCE" not in conn._captured["search_predicate"]
+    assert len(records) == 2
+    assert new_uid == "44"
+
+
+def test_fetch_recent_filters_uid_quirk_at_or_below_watermark():
+    """IMAP UID <next>:* may return a UID below next; filter it.
+
+    The cPanel server returns the highest UID in the mailbox even when no
+    messages have UID >= next. Without filtering we'd re-process old mail
+    or set a phantom watermark.
+    """
+    transport = LegalMailIngesterTransport(_mailbox())
+    # SEARCH UID 43:* returns [40, 50]: 40 must be dropped, 50 kept.
+    conn = _conn_returning_uids([b"40", b"50"])
+
+    records, new_uid = transport._fetch_with(conn, last_seen_uid="42")
+
+    assert conn._captured["search_predicate"] == "UID 43:*"
+    assert len(records) == 1
+    assert records[0]["uid"] == "50"
+    assert new_uid == "50"
+
+
+def test_fetch_recent_no_new_messages_returns_unchanged_watermark():
+    """When SEARCH returns empty, returned new_uid equals input."""
+    transport = LegalMailIngesterTransport(_mailbox())
+    conn = _conn_returning_uids([])
+
+    records, new_uid = transport._fetch_with(conn, last_seen_uid="50")
+
+    assert records == []
+    # Watermark unchanged, NOT None — that would re-bootstrap next patrol.
+    assert new_uid == "50"
+
+
+def test_invalid_watermark_falls_back_to_bootstrap():
+    """Garbage in the watermark column triggers bootstrap, not crash."""
+    transport = LegalMailIngesterTransport(_mailbox())
+    conn = _conn_returning_uids([b"5"])
+
+    records, new_uid = transport._fetch_with(conn, last_seen_uid="NOT_A_NUMBER")
+
+    expected_since = _imap_date(date.today() - timedelta(days=transport.mailbox.search_band_days))
+    predicate = conn._captured["search_predicate"]
+    assert predicate == f"SINCE {expected_since}"
+    assert "UNSEEN" not in predicate
+    assert len(records) == 1
+    assert new_uid == "5"


### PR DESCRIPTION
## Root cause (38-day silent gap)

`legal_mail_ingester` has been silently dropping every legal email since deploy. The `_fetch_with` SEARCH predicate was `UNSEEN SINCE <date>`. In production the legal mailbox is read by webmail, Captain, and operators — anything that touches a message marks `\Seen`, and from that moment forward the ingester's SEARCH could no longer see it. Result: 38 days with zero ingested messages and zero rows in `legal.event_log` (2026-03-21 → 2026-04-28). The original `UNSEEN`-based design assumed exclusive ingester ownership of the mailbox, which never held in production.

## Fix

Replace `UNSEEN SINCE <date>` with a per-mailbox UID watermark backed by `legal.mail_ingester_state.last_seen_uid`:

- **Bootstrap (NULL watermark):** `SEARCH SINCE <today - search_band_days>` — no `UNSEEN` clause, picks up every message in the band exactly once.
- **Steady state:** `SEARCH UID <last+1>:*` — captures every newly-arrived UID regardless of `\Seen` flag. Watermark advances to the highest UID seen each patrol; if no new mail, the prior watermark is held (COALESCE in ON CONFLICT).
- **UID 1 quirk:** cPanel/Dovecot return the highest mailbox UID for `UID <next>:*` even when no UIDs `>= next` exist. Results are filtered in-memory to UIDs `>= next_uid`.
- **Invalid watermark:** non-numeric values fall back to bootstrap, with a structured warning. No crash.

`BODY.PEEK[]` retained — Captain coexistence (no `\Seen` mutation) is unchanged.

## Schema note

Migration `s4d5e6f7g8h9_flos_phase_0a_7_uid_watermark.py` was applied directly via `psql` to both `fortress_db` and `fortress_prod` on 2026-04-28 per Issue #204 (alembic chain divergence). Column presence was verified before code merge. The migration file is committed as a durable record for clean DB restores and new spark deployments — `op.execute` uses `ADD COLUMN IF NOT EXISTS`, so re-application against either DB is a safe no-op.

## Validation steps after merge (operator runs)

1. `sudo systemctl restart fortress-arq-worker`
2. Wait ~3 minutes for the legal-cpanel patrol cycle.
3. Verify watermark + counters:
   ```
   sudo -u postgres psql -d fortress_prod -c \
     "SELECT mailbox_alias, last_seen_uid, messages_ingested_total, last_success_at FROM legal.mail_ingester_state;"
   ```
   Expect a row for `legal-cpanel` with `last_seen_uid` set (likely `5` — the 5 SEEN messages currently in INBOX) and `messages_ingested_total = 5`.
4. Verify email_archive:
   ```
   sudo -u postgres psql -d fortress_prod -c \
     "SELECT ingested_from, COUNT(*) FROM email_archive WHERE ingested_from='legal_mail_ingester:v1' GROUP BY ingested_from;"
   ```
   Expect 5 rows from `legal_mail_ingester:v1`.
5. Verify event log:
   ```
   sudo -u postgres psql -d fortress_prod -c \
     "SELECT COUNT(*) FROM legal.event_log;"
   ```
   Expect 5.
6. Send a test email to `legal@cabin-rentals-of-georgia.com`, wait 3 minutes, confirm a new row lands and `last_seen_uid` advances by 1.

## Tests

5 new tests in `backend/tests/test_legal_mail_ingester_uid_watermark.py`:

- `test_fetch_recent_bootstrap_uses_since_band` — NULL watermark uses `SINCE <date>`, no `UNSEEN`.
- `test_fetch_recent_steady_state_uses_uid_watermark` — watermark `42` produces `UID 43:*`.
- `test_fetch_recent_filters_uid_quirk_at_or_below_watermark` — IMAP returning `[40, 50]` for `UID 43:*` drops UID 40, returns only 50.
- `test_fetch_recent_no_new_messages_returns_unchanged_watermark` — empty SEARCH holds the prior watermark instead of resetting to NULL.
- `test_invalid_watermark_falls_back_to_bootstrap` — `"NOT_A_NUMBER"` falls back to `SINCE <date>` bootstrap, no crash.

All 5 pass. No existing tests called the modified signatures (verified via grep across the repo); only `test_spark1_mirror.py` imports from `legal_mail_ingester`, and it touches only `_write_spark1_mirror`. No call sites elsewhere in the backend or CLI use `transport.fetch_recent` or `_update_mailbox_state`.

## Out of scope (explicitly deferred)

- Tagging `gary-gk` and `gary-crog` with `ingester=legal_mail` in `MAILBOXES_CONFIG` — separate config-only PR after this lands.
- Backfilling missed messages from the 38-day silent window — separate PR after stabilization.
- Worker restart — operator step after merge, **not** auto-applied.

Refs: INC-2026-04-28