### PR TITLE
fix(legal-mail): convert RFC 2822 sent_at to naive UTC (INC-2026-04-28-tz-naive)

### DIFF
--- a/fortress-guest-platform/backend/services/legal_mail_ingester.py
+++ b/fortress-guest-platform/backend/services/legal_mail_ingester.py
@@ -740,7 +740,16 @@ def parse_message(raw_bytes: bytes, source: dict[str, Any], routing_tag: str) ->
     date_header = msg.get("Date")
     if date_header:
         try:
-            sent_at = parsedate_to_datetime(date_header)
+            parsed_dt = parsedate_to_datetime(date_header)
+            # email_archive.sent_at is TIMESTAMP WITHOUT TIME ZONE — convert
+            # to UTC then strip tzinfo to produce a naive datetime asyncpg
+            # will accept. RFC 2822 dates from IMAP carry an offset; without
+            # this conversion asyncpg raises "can't subtract offset-naive
+            # and offset-aware datetimes" on the encoder path.
+            if parsed_dt is not None and parsed_dt.tzinfo is not None:
+                from datetime import timezone as _tz
+                parsed_dt = parsed_dt.astimezone(_tz.utc).replace(tzinfo=None)
+            sent_at = parsed_dt
         except (TypeError, ValueError):
             sent_at = None
 

--- a/fortress-guest-platform/backend/tests/test_legal_mail_ingester_tz_naive.py
+++ b/fortress-guest-platform/backend/tests/test_legal_mail_ingester_tz_naive.py
@@ -1,0 +1,100 @@
+"""
+Tests for FLOS Phase 0a-8 tz-naive sent_at fix (INC-2026-04-28, Bug #2).
+
+email_archive.sent_at is TIMESTAMP WITHOUT TIME ZONE. RFC 2822 Date headers
+delivered by IMAP carry a UTC offset, so parsedate_to_datetime() returns an
+aware datetime. asyncpg refuses to encode an aware datetime into a naive
+column ("can't subtract offset-naive and offset-aware datetimes"), which
+silently dropped every legal mail message during the INC-2026-04-28
+incident. parse_message() now converts to UTC and strips tzinfo.
+"""
+from __future__ import annotations
+
+from backend.services.legal_mail_ingester import parse_message
+
+
+_SOURCE = {
+    "uid": "1",
+    "host": "h",
+    "folder": "INBOX",
+    "mailbox_alias": "test",
+    "transport": "imap",
+}
+
+
+def test_parse_message_strips_tz_aware_sent_at():
+    """RFC 2822 Date headers with TZ offset must produce naive UTC datetime."""
+    raw = (
+        b"Date: Tue, 28 Apr 2026 09:22:54 -0400\r\n"
+        b"From: test@example.com\r\n"
+        b"To: legal@example.com\r\n"
+        b"Subject: Test\r\n"
+        b"Message-ID: <abc@test>\r\n"
+        b"\r\n"
+        b"Body\r\n"
+    )
+
+    parsed = parse_message(raw, source=_SOURCE, routing_tag="legal")
+
+    assert parsed is not None
+    assert parsed.sent_at is not None
+    assert parsed.sent_at.tzinfo is None
+    # 09:22:54 -0400 == 13:22:54 UTC
+    assert parsed.sent_at.hour == 13
+    assert parsed.sent_at.minute == 22
+    assert parsed.sent_at.second == 54
+
+
+def test_parse_message_naive_utc_date_header_passes_through():
+    """A Date header already in UTC (+0000) must also yield naive UTC."""
+    raw = (
+        b"Date: Mon, 01 Apr 2026 12:00:00 +0000\r\n"
+        b"From: a@example.com\r\n"
+        b"To: legal@example.com\r\n"
+        b"Subject: Test\r\n"
+        b"Message-ID: <utc@test>\r\n"
+        b"\r\n"
+        b"Body\r\n"
+    )
+
+    parsed = parse_message(raw, source=_SOURCE, routing_tag="legal")
+
+    assert parsed is not None
+    assert parsed.sent_at is not None
+    assert parsed.sent_at.tzinfo is None
+    assert parsed.sent_at.hour == 12
+
+
+def test_parse_message_missing_date_yields_none_sent_at():
+    """No Date header must not crash; sent_at is None."""
+    raw = (
+        b"From: a@example.com\r\n"
+        b"To: legal@example.com\r\n"
+        b"Subject: Test\r\n"
+        b"Message-ID: <nodate@test>\r\n"
+        b"\r\n"
+        b"Body\r\n"
+    )
+
+    parsed = parse_message(raw, source=_SOURCE, routing_tag="legal")
+
+    assert parsed is not None
+    assert parsed.sent_at is None
+
+
+def test_parse_message_unparseable_date_yields_none_sent_at():
+    """Garbage in Date header must not crash; sent_at is None."""
+    raw = (
+        b"Date: not-a-real-date\r\n"
+        b"From: a@example.com\r\n"
+        b"To: legal@example.com\r\n"
+        b"Subject: Test\r\n"
+        b"Message-ID: <baddate@test>\r\n"
+        b"\r\n"
+        b"Body\r\n"
+    )
+
+    parsed = parse_message(raw, source=_SOURCE, routing_tag="legal")
+
+    assert parsed is not None
+    assert parsed.sent_at is None


### PR DESCRIPTION
## What

Convert tz-aware datetimes from `parsedate_to_datetime()` to naive UTC before passing to asyncpg, so they encode cleanly into `email_archive.sent_at` (TIMESTAMP WITHOUT TIME ZONE).

## Why

INC-2026-04-28-tz-naive — discovered as follow-up to PR #271 (FLOS Phase 0a-7 UID watermark). After PR #271 merged, the patrol successfully fetched all 5 messages from legal-cpanel, but 4 of 5 INSERTs failed with:

> asyncpg.exceptions.DataError: can't subtract offset-naive and offset-aware datetimes

Root cause: every RFC 2822 Date header carries a TZ offset (e.g. \`Tue, 28 Apr 2026 09:22:54 -0400\`). \`parsedate_to_datetime()\` returns a tz-aware \`datetime\`. The DB column is naive. asyncpg refuses to coerce.

## How

In \`parse_message()\`, convert to UTC then strip tzinfo:

\`\`\`python
if parsed_dt is not None and parsed_dt.tzinfo is not None:
    from datetime import timezone as _tz
    parsed_dt = parsed_dt.astimezone(_tz.utc).replace(tzinfo=None)
\`\`\`

UTC chosen so all stored timestamps are comparable regardless of server TZ. Tradeoff: original sender's local time is no longer recoverable from \`sent_at\` alone — acceptable because the original Date header is preserved in the raw message body if needed for forensics.

## Verification

Production patrol at 17:33:44 UTC after this patch + grants applied: \`fetched=5 ingested=5 errored=0 events_emitted=5\`. \`legal-cpanel\` watermark advanced to UID=5. \`email_archive\` rows from \`legal_mail_ingester:v1\` = 5. \`legal.event_log\` rows = 5.

## Related

- PR #271 (FLOS Phase 0a-7 UID watermark — merged earlier today)
- INC-2026-04-28-flos-silent-intake (forthcoming doc, captures this and 4 other compounding bugs)

## Hard constraints honored

- No new tests in this PR — patched in-place during incident response. Test gap to be closed in a follow-up. (Honest admission: this is a deviation from the standard "tests with every fix" rule, made for speed of restoration.)
- Migration not needed — code-only change.
- No auto-merge.