### PR TITLE
Phase A1: spark-1 legal overlays (additive, no schema mutations)

### DIFF
--- a/deploy/systemd/fortress-brain.service
+++ b/deploy/systemd/fortress-brain.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Fortress Prime Brain (Streamlit)
+After=network.target
+
+[Service]
+User=admin
+WorkingDirectory=/home/admin/Fortress-Prime
+ExecStart=/home/admin/Fortress-Prime/venv/bin/streamlit run app.py --server.port 8501 --server.headless true
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/fortress-brain.service.d/10-legacy-path.conf
+++ b/deploy/systemd/fortress-brain.service.d/10-legacy-path.conf
@@ -1,0 +1,4 @@
+[Service]
+ExecStart=
+ExecStart=/home/admin/Fortress-Prime.legacy/venv/bin/python3 -m streamlit run app.py --server.address 127.0.0.1 --server.port 8501 --server.headless true
+WorkingDirectory=/home/admin/Fortress-Prime.legacy

--- a/docs/operational/spark-2-to-spark-1-migration-provenance.md
+++ b/docs/operational/spark-2-to-spark-1-migration-provenance.md
@@ -16,11 +16,11 @@ Until Phase A1, the spark-2 → spark-1 migration lived in operator's head and a
 
 - **2026-04-28 08:02 EDT** — apt bootstrap on spark-1 by `admin` user: `postgresql-16`, `postgresql-contrib-16`, `redis-server`, `build-essential`, `libpq-dev`, `python3-venv`, `python3-dev`, `ocrmypdf`. Postgres 16.13 from Ubuntu repo (not PGDG). Redis from Ubuntu repo. OCR toolchain (`ocrmypdf`, `pikepdf`, `lxml`, etc.) installed alongside.
 - **2026-04-28 ~08:30 EDT** — `~/Fortress-Prime` renamed to `~/Fortress-Prime.legacy`; fresh clone of `cabinrentalsofgeorgia-bit/Fortress-Prime` to `~/Fortress-Prime.new` with symlink `~/Fortress-Prime` → `~/Fortress-Prime.new`.
-- **2026-04-28 10:39 EDT** — `/etc/fortress/admin.env` written by operator (mode 600, `admin:admin`). Contains `POSTGRES_FORTRESS_ADMIN_PASSWORD`, `POSTGRES_FORTRESS_API_PASSWORD`, and a stale `POSTGRES_FORTRESS_APP_PASSWORD` (residual from earlier draft of `spark-1-legal-migration-runbook.md` M2-2 step that referenced `fortress_app` before canonical 004 contract was finalized).
+- **2026-04-28 10:39 EDT** — `/etc/fortress/admin.env` written by operator (mode 600, `admin:admin`). Contains `POSTGRES_FORTRESS_ADMIN_PASSWORD`, `POSTGRES_FORTRESS_API_PASSWORD`, and `POSTGRES_FORTRESS_APP_PASSWORD`. The APP key was pre-staged in anticipation of the M3 runbook's `CREATE USER fortress_app` step (per `docs/runbooks/m3-spark1-mirror-activation.md:42`), but the role itself was never created on spark-1 (M3 hasn't run yet) and does not exist on spark-2 either (spark-2's FGP runtime role is `fgp_app`). Phase A1 (2026-04-29) drops the APP_PASSWORD line because the credential authenticates no role anywhere — see "Known issues" #2 for the unresolved naming reconciliation.
 - **2026-04-28 10:52 EDT** — `postgresql-16-postgis-3` and `postgresql-16-pgvector` installed.
 - **2026-04-28 ~11:13 EDT** — `postgresql.conf` tuned for spark-1's RAM profile (8 GB shared_buffers, 24 GB effective_cache_size, 200 max_connections, `pg_stat_statements` preloaded). `pg_hba.conf` opened for `fortress_admin` from spark-2's LAN IP into `fortress_prod` only.
 - **2026-04-28 11:16 EDT** — `postgresql@16-main.service` started.
-- **2026-04-28 (during the day)** — Roles `fortress_admin` (CREATEDB) and `fortress_api` (login only) created on spark-1; matches canonical 004 Postgres contract. **No `fortress_app` role created** despite admin.env key — explicit choice by operator to follow canonical contract over the older runbook draft.
+- **2026-04-28 (during the day)** — Roles `fortress_admin` (Create role + Create DB, *not* Superuser) and `fortress_api` (login only) created on spark-1. **NOT** created on spark-1: `fortress_app` (referenced by M3 runbook + `.env.example`), `fgp_app` (the canonical FGP runtime role on spark-2), and per-service roles spark-2 has (`crog_ai_app`, `miner_bot`, `trader_bot`). Privilege divergence to surface: spark-2's `fortress_admin` is **Superuser**; spark-1's is **Create role, Create DB**. Whether spark-1 should match spark-2's privilege set is an operator decision tied to the canonical-name question (see "Known issues" #2).
 - **2026-04-28 (during the day)** — Schema dump from spark-2 `fortress_db` loaded into spark-1's `fortress_db`, `fortress_prod`, and `fortress_shadow_test` (the third DB is the CROG-AI shadow-testing convention). All three DBs identical: 13 schemas, 291 tables, 36 MB each, zero application data.
 - **2026-04-28 22:49 EDT** — Original `flos-phase-a1-postgres-spark1-brief.md` saved in `~/`. Brief assumed clean-host install — an assumption that no longer matched reality. Operator paused execution, asked for state capture instead.
 - **2026-04-28 23:30 EDT** — Comprehensive state captured in `docs/operational/spark1-current-state-2026-04-29.md` (this PR also commits that file into the repo for durability).
@@ -47,7 +47,19 @@ Until Phase A1, the spark-2 → spark-1 migration lived in operator's head and a
    
    This blocks M3 activation step 4 (`alembic upgrade head`). Phase A1 (additive overlays) is unblocked. Tracking issue filed by this PR.
 
-2. **Stale `fortress_app` reference in admin.env.** Three password keys exist (`ADMIN`, `APP`, `API`); only `fortress_admin` and `fortress_api` are real DB roles. Zero code references `fortress_app` or `POSTGRES_FORTRESS_APP_PASSWORD` anywhere in the repo (verified via grep over `*.py`, `*.env*`, `*.yaml`, `*.yml`, `*.sh`, `*.toml`, `*.cfg`, `*.ini`, `*.md`). The APP key is dead weight from the earlier runbook draft that named the runtime role `fortress_app` before the canonical 004 contract settled on `fortress_api`. Phase A1 leaves admin.env unchanged because the brief's literal "rename APP→API value-carried-over" would overwrite the working `fortress_api` password (APP and API values differ). The APP key is harmless residual; cleanup is a one-line follow-up if desired.
+2. **`fortress_app` canonical-name reconciliation (operator-owned).** `fortress_app` is referenced in:
+
+   - `fortress-guest-platform/.env.example:195` — the `SPARK1_DATABASE_URL` template
+   - `docs/runbooks/m3-spark1-mirror-activation.md:42-46, 74` — `CREATE USER` + grants + `Environment=SPARK1_DATABASE_URL`
+   - `docs/operational/spark-1-legal-migration-runbook.md:57-58` — M2-2 / M2-3 steps
+
+   …yet the role exists on **neither** spark-1 nor spark-2. Spark-2's runtime role for FGP is `fgp_app`. Three names are floating around for the same conceptual runtime role:
+
+   - canonical 004 contract (per `flos-phase-a1-postgres-spark1-brief.md` Section 3): `fortress_api`, with explicit "DO NOT create `fgp_app`"
+   - spark-2 operational reality: `fgp_app` (which the original brief forbade)
+   - M3 mirror activation runbook + `.env.example`: `fortress_app`
+
+   This naming divergence is unresolved as of Phase A1. Phase A1 (2026-04-29) drops the dead `POSTGRES_FORTRESS_APP_PASSWORD` line from `/etc/fortress/admin.env` because it authenticates no role anywhere. The "which name is canonical for spark-1's runtime role" question follows separately as an operator decision.
 
 ## Authoritative artifacts
 
@@ -66,4 +78,4 @@ Until Phase A1, the spark-2 → spark-1 migration lived in operator's head and a
 - `fortress_admin` — canonical owner role per 004 contract (CREATEDB; for migrations, ownership)
 - `fortress_api` — canonical runtime role per 004 contract (login only; for service authentication)
 
-`fortress_app` is **not** a canonical role — see "Known issues" above.
+`fortress_app` is currently a name without a role on either host — see "Known issues" #2 for the unresolved naming reconciliation. Spark-2's per-service FGP runtime role is `fgp_app`; canonical 004 contract says `fortress_api`; M3 runbook prescribes `fortress_app`. Operator will pick.

--- a/docs/operational/spark-2-to-spark-1-migration-provenance.md
+++ b/docs/operational/spark-2-to-spark-1-migration-provenance.md
@@ -1,0 +1,69 @@
+# Spark-2 → Spark-1 Migration Provenance
+
+**Status:** mid-flight, additive M3 trilateral-write phase pending
+**Initiated:** 2026-04-28 (Postgres bootstrap on spark-1; operator-confirmed deliberate)
+**Driver:** ADR-001 (one spark per division) — Fortress Legal moves to spark-1
+**Owner:** Gary Knight
+**Last updated:** 2026-04-29
+
+---
+
+## Why this document exists
+
+Until Phase A1, the spark-2 → spark-1 migration lived in operator's head and a single in-progress runbook. This document is the durable written record so a fresh session — or a second operator — can pick up context without reconstructing it from `apt history`, file timestamps, and tribal knowledge.
+
+## What's been done
+
+- **2026-04-28 08:02 EDT** — apt bootstrap on spark-1 by `admin` user: `postgresql-16`, `postgresql-contrib-16`, `redis-server`, `build-essential`, `libpq-dev`, `python3-venv`, `python3-dev`, `ocrmypdf`. Postgres 16.13 from Ubuntu repo (not PGDG). Redis from Ubuntu repo. OCR toolchain (`ocrmypdf`, `pikepdf`, `lxml`, etc.) installed alongside.
+- **2026-04-28 ~08:30 EDT** — `~/Fortress-Prime` renamed to `~/Fortress-Prime.legacy`; fresh clone of `cabinrentalsofgeorgia-bit/Fortress-Prime` to `~/Fortress-Prime.new` with symlink `~/Fortress-Prime` → `~/Fortress-Prime.new`.
+- **2026-04-28 10:39 EDT** — `/etc/fortress/admin.env` written by operator (mode 600, `admin:admin`). Contains `POSTGRES_FORTRESS_ADMIN_PASSWORD`, `POSTGRES_FORTRESS_API_PASSWORD`, and a stale `POSTGRES_FORTRESS_APP_PASSWORD` (residual from earlier draft of `spark-1-legal-migration-runbook.md` M2-2 step that referenced `fortress_app` before canonical 004 contract was finalized).
+- **2026-04-28 10:52 EDT** — `postgresql-16-postgis-3` and `postgresql-16-pgvector` installed.
+- **2026-04-28 ~11:13 EDT** — `postgresql.conf` tuned for spark-1's RAM profile (8 GB shared_buffers, 24 GB effective_cache_size, 200 max_connections, `pg_stat_statements` preloaded). `pg_hba.conf` opened for `fortress_admin` from spark-2's LAN IP into `fortress_prod` only.
+- **2026-04-28 11:16 EDT** — `postgresql@16-main.service` started.
+- **2026-04-28 (during the day)** — Roles `fortress_admin` (CREATEDB) and `fortress_api` (login only) created on spark-1; matches canonical 004 Postgres contract. **No `fortress_app` role created** despite admin.env key — explicit choice by operator to follow canonical contract over the older runbook draft.
+- **2026-04-28 (during the day)** — Schema dump from spark-2 `fortress_db` loaded into spark-1's `fortress_db`, `fortress_prod`, and `fortress_shadow_test` (the third DB is the CROG-AI shadow-testing convention). All three DBs identical: 13 schemas, 291 tables, 36 MB each, zero application data.
+- **2026-04-28 22:49 EDT** — Original `flos-phase-a1-postgres-spark1-brief.md` saved in `~/`. Brief assumed clean-host install — an assumption that no longer matched reality. Operator paused execution, asked for state capture instead.
+- **2026-04-28 23:30 EDT** — Comprehensive state captured in `docs/operational/spark1-current-state-2026-04-29.md` (this PR also commits that file into the repo for durability).
+- **2026-04-29 09:16 EDT** — `spark1-phase-a1-reshaped-brief.md` written. New shape: additive overlays only, no schema mutations.
+- **2026-04-29** — Phase A1 (this PR) executes the reshaped brief.
+
+## What remains
+
+| Phase | Description | Owner | Blockers |
+|---|---|---|---|
+| **M3** | Trilateral additive write — spark-2 mirrors writes to spark-1 behind default-OFF flag | TBD | M3 activation step 4 blocks on alembic merge (Issue filed by this PR) |
+| **M3 activation** | Flip the default-OFF flag, run `alembic upgrade head` against `SPARK1_DATABASE_URL` | TBD | Alembic merge on spark-2 must complete first |
+| **M4** | Parity verification — both DBs receive the same writes; row-by-row diff stays clean | TBD | M3 activation must be live |
+| **M5** | Read-source switchover spark-2 → spark-1 | TBD | M4 parity must be verified for soak window |
+| **M6** | Retire spark-2 legal writes (decommission) | TBD | M5 stable for soak window |
+
+## Known issues inherited from the schema dump
+
+1. **Two divergent alembic heads** in all three DBs:
+   - `q2b3c4d5e6f7`
+   - `r3c4d5e6f7g8`
+   
+   Plus the previously-known orphaned head `7a1b2c3d4e5f` (Issue #204).
+   
+   This blocks M3 activation step 4 (`alembic upgrade head`). Phase A1 (additive overlays) is unblocked. Tracking issue filed by this PR.
+
+2. **Stale `fortress_app` reference in admin.env.** Three password keys exist (`ADMIN`, `APP`, `API`); only `fortress_admin` and `fortress_api` are real DB roles. Zero code references `fortress_app` or `POSTGRES_FORTRESS_APP_PASSWORD` anywhere in the repo (verified via grep over `*.py`, `*.env*`, `*.yaml`, `*.yml`, `*.sh`, `*.toml`, `*.cfg`, `*.ini`, `*.md`). The APP key is dead weight from the earlier runbook draft that named the runtime role `fortress_app` before the canonical 004 contract settled on `fortress_api`. Phase A1 leaves admin.env unchanged because the brief's literal "rename APP→API value-carried-over" would overwrite the working `fortress_api` password (APP and API values differ). The APP key is harmless residual; cleanup is a one-line follow-up if desired.
+
+## Authoritative artifacts
+
+- `docs/architecture/cross-division/_architectural-decisions.md` — ADR-001 (one-spark-per-division)
+- `docs/operational/spark-1-legal-migration-runbook.md` — broader migration sprint runbook (M1–M6)
+- `docs/operational/spark1-current-state-2026-04-29.md` — frozen snapshot of spark-1 at the moment Phase A1 began
+- `docs/operational/spark1-phase-a1-runbook.md` — operator runbook for verifying / re-running the Phase A1 overlay steps
+- `docs/runbooks/m3-spark1-mirror-activation.md` — M3 activation runbook (companion)
+- `~/spark1-phase-a1-reshaped-brief.md` (spark-1 only, intentionally not in repo) — the brief this PR executes
+
+## Naming conventions
+
+- `fortress_db` — canonical operational DB on spark-1 (target for legal services per `postgres-schemas.md`)
+- `fortress_prod` — canonical mirror target; receives the same writes as `fortress_db` once M3 is active
+- `fortress_shadow_test` — shadow-testing DB (CROG-AI convention); receives writes during shadow-test runs and is otherwise idle
+- `fortress_admin` — canonical owner role per 004 contract (CREATEDB; for migrations, ownership)
+- `fortress_api` — canonical runtime role per 004 contract (login only; for service authentication)
+
+`fortress_app` is **not** a canonical role — see "Known issues" above.

--- a/docs/operational/spark1-current-state-2026-04-29.md
+++ b/docs/operational/spark1-current-state-2026-04-29.md
@@ -1,0 +1,470 @@
+# Spark-1 Current State Capture — 2026-04-29
+
+**Captured:** 2026-04-28 23:30 EDT (early hours of 2026-04-29)
+**Captured by:** Claude Code (Opus 4.7, 1M ctx) at operator's direction
+**Operator:** Gary Knight
+**Source brief:** `/home/admin/flos-phase-a1-postgres-spark1-brief.md` (last edited 2026-04-28 22:49)
+**Reason for capture:** Phase A1 brief assumed clean-host install. Spark-1 is not clean — application migration from spark-2 is in progress. Capture state, defer A/B/C decision to morning session.
+**Read-only:** No DB / config / service changes were made during capture.
+
+---
+
+## Executive summary
+
+Spark-1 is in the **middle of a spark-2 → spark-1 application migration**. As of this capture:
+
+- **Postgres 16.13** (Ubuntu repo, NOT PGDG) is installed and running. Service started 2026-04-28 11:16 EDT, ~12 hours ago. Cluster `16/main` on `/var/lib/postgresql/16/main`.
+- **Three identical schema-only Postgres databases** exist (`fortress_db`, `fortress_prod`, `fortress_shadow_test`) — full Fortress-Prime schema (13 schemas, 291 tables each), zero application data.
+- **Two roles** (`fortress_admin`, `fortress_api`) — match canonical contract.
+- **`/etc/fortress/admin.env`** holds three Postgres passwords (admin, api, **app**) — `admin:admin 600`, **NOT root-owned** as the Phase A1 brief specifies.
+- **Application code copied to `/home/admin/Fortress-Prime.new/`** (symlinked as `Fortress-Prime`) — last touched today.
+- **No service** on spark-1 currently consumes this Postgres via systemd `EnvironmentFile=`. No client connections. The DB is provisioned but idle.
+- **Inference plane on spark-1 untouched and running:** `fortress-nim-sovereign` container (NIM Llama-3.1-8B), `fortress-ray-worker.service`, `ollama.service`, `fortress-brain.service` (Streamlit on `0.0.0.0:8501`).
+- **Postgres bound:** `127.0.0.1:5432`, `192.168.0.104:5432` (LAN). **NOT** on Tailscale `100.127.241.36`.
+- **pg_hba.conf** has only one host fortress rule: `host fortress_prod fortress_admin 192.168.0.100/32` (spark-2 LAN, admin only). No `fortress_api` rules. No spark-5 rules. No Tailscale rules.
+
+**The Phase A1 brief and the actual state diverge in shape, not just degree.** Brief assumes "install + configure on clean host." Reality is "application migration in flight, Postgres provisioned by a different bootstrap, Phase A1 must layer onto migration, not replace it."
+
+---
+
+## A. Database inventory
+
+### A.1 DB list and sizes
+| DB | Owner | Size | Notes |
+|---|---|---|---|
+| `fortress_db` | fortress_admin | 36 MB | Schema-only |
+| `fortress_prod` | fortress_admin | 36 MB | Schema-only |
+| `fortress_shadow_test` | fortress_admin | 36 MB | Schema-only — **NOT in Phase A1 brief** |
+| `fortress_shadow` | — | — | **Does not exist.** Operator's capture spec asked for it; not present. |
+| `postgres` | postgres | 7.5 MB | Default admin DB |
+| `template0` / `template1` | postgres | ~7.5 MB each | Default templates |
+
+All three fortress DBs are **structurally identical**: 13 schemas, 291 tables, same `alembic_version` pair. Restored from the same dump source.
+
+### A.2 Schemas (identical across all three fortress DBs)
+
+```
+core             (1 table)   — deliberation_logs
+crog_acquisition (6 tables)  — properties, parcels, owners, acquisition_pipeline, intel_events, owner_contacts
+division_a       (7 tables)  — chart_of_accounts, journal_entries, transactions, GL, predictions, etc.
+division_b       (9 tables)  — same shape + escrow, trust_ledger, vendor_payouts
+engineering      (11 tables) — projects, drawings, RFIs, permits, inspections, change_orders, etc.
+finance          (2 tables)  — classification_rules, vendor_classifications
+hedge_fund       (4 tables)  — active_strategies, watchlist, market_signals, extraction_log
+intelligence     (4 tables)  — entities, golden_reasoning, relationships, titan_traces
+iot_schema       (2 tables)  — device_events, digital_twins
+legal            (38 tables) — case_*, dispatcher_*, mail_ingester_*, sanctions_*, vault_documents, event_log, etc.
+legal_cmd        (7 tables)  — attorneys, attorney_scoring, deliberation_events, documents, matters, meetings, timeline
+public           (199 tables, owner=pg_database_owner) — full Fortress-Prime + CROG-AI surface
+verses_schema    (1 table)   — products
+```
+
+### A.3 Row counts (key tables)
+
+| DB | `legal.event_log` | `legal.cases` | `public.email_archive` |
+|---|---|---|---|
+| fortress_db | 0 | 0 | 0 |
+| fortress_prod | 0 | 0 | 0 |
+| fortress_shadow_test | 0 | 0 | 0 |
+
+**Only one table > 100 rows in any DB:** `public.spatial_ref_sys` = 8500 rows — that's PostGIS reference data, populated by the `postgresql-16-postgis-3` install. **No application data** has been loaded into any DB yet.
+
+### A.4 alembic_version (identical across all three DBs)
+
+```
+q2b3c4d5e6f7
+r3c4d5e6f7g8
+```
+
+**Two rows = divergent migration heads.** This is exactly the Issue #204 trap the Phase A1 brief warns about. Whatever schema dump was used had a multi-head alembic state baked in. Future `alembic upgrade head` will fail or branch.
+
+### A.5 Full table list of fortress_db (representative — same in all three DBs)
+
+291 rows total. See `/home/admin/.claude/projects/-home-admin/2ce642cf-93e1-4238-93ee-92149b4275fe/tool-results/byfpwn9cf.txt` for the complete listing if needed (preserved tool-results file). Key clusters:
+
+- **legal.\*** (38): case_actions, case_evidence, case_graph_edges_v2/nodes_v2, case_posture, case_precedents, case_slug_aliases, case_statements, case_statements_v2, case_watchdog, cases, chronology_events, correspondence, deadlines, deposition_kill_sheets_v2, discovery_draft_items_v2/packs_v2, dispatcher_dead_letter, dispatcher_event_attempts, dispatcher_pause, dispatcher_routes, distillation_memory, entities, event_log, expense_intake, filings, ingest_runs, legal_exemplars, mail_ingester_metrics/pause/state, priority_sender_rules, privilege_log, sanctions_alerts_v2, sanctions_tripwire_runs_v2, timeline_events, uploads, vault_documents
+- **legal_cmd.\*** (7): attorney_scoring, attorneys, deliberation_events, documents, matters, meetings, timeline
+- **public.\*** (199): full CROG-AI hospitality surface (reservations, guest_*, property_*, ruebarue_*, etc.) PLUS Fortress-Prime cross-cutting (alembic_version, agent_*, ai_*, intelligence_ledger, legal_clients/docket/intel/matters, etc.)
+
+---
+
+## B. Role inventory
+
+```
+   Role name    |                         Attributes                         
+----------------+------------------------------------------------------------
+ fortress_admin | Create role, Create DB                                     
+ fortress_api   | (login only — no CREATEDB, no superuser, no replication)   
+ postgres       | Superuser, Create role, Create DB, Replication, Bypass RLS 
+```
+
+**Three roles total.** Matches canonical contract: `fortress_admin` + `fortress_api`. **No `fortress_readonly`. No `fortress_app`** — even though `admin.env` has `POSTGRES_FORTRESS_APP_PASSWORD`. The "app" key is orphaned.
+
+### B.1 CONNECT privilege matrix
+
+| DB | postgres | fortress_admin | fortress_api |
+|---|---|---|---|
+| fortress_db | t | t | t |
+| fortress_prod | t | t | t |
+| fortress_shadow_test | t | t | t |
+
+CONNECT is granted everywhere (default for all roles unless revoked). But **no Phase 0a-8 grants** have been applied — `fortress_api` cannot INSERT to `legal.event_log` and cannot UPDATE `legal.event_log_id_seq` (verified earlier in this session, not re-checked here).
+
+---
+
+## C. Active connections
+
+```
+ datname  | usename  | application_name | client_addr | state  |         query_start         
+----------+----------+------------------+-------------+--------+-----------------------------
+ postgres | postgres | psql             |             | active | 2026-04-28 23:30:20.5474-04
+```
+
+**One row, and it's the diagnostic query itself.** Zero application traffic. **Nothing is using this DB right now.**
+
+---
+
+## D. Secrets file
+
+```
+-rw------- 1 admin admin 250 Apr 28 10:39 /etc/fortress/admin.env
+```
+
+**Keys (values not dumped):**
+```
+POSTGRES_FORTRESS_ADMIN_PASSWORD
+POSTGRES_FORTRESS_APP_PASSWORD
+POSTGRES_FORTRESS_API_PASSWORD
+```
+
+**`/etc/fortress/` directory state:**
+```
+drwx------   2 admin admin   4096 Apr 28 10:39 .
+drwxr-xr-x 190 root  root   12288 Apr 28 10:52 ..
+-rw-------   1 admin admin    250 Apr 28 10:39 admin.env
+-rw-------   1 root  root      83 Apr 19 13:04 nim.env  (NGC_API_KEY only)
+```
+
+**Brief expectation vs reality:**
+- Brief wants: `/etc/fortress/spark-1-postgres.env`, root-owned, mode 600
+- Reality: `/etc/fortress/admin.env`, `admin:admin`, mode 600
+- Different filename, different ownership. Brief's path does not exist.
+
+**No other Postgres-credential `.env` files anywhere on the system** (verified via `find / -name "*fortress*.env"`).
+
+---
+
+## E. systemd consumers of admin.env / fortress_db / fortress_prod / fortress_app
+
+```
+$ sudo grep -rl "admin.env\|fortress_db\|fortress_prod\|fortress_app" /etc/systemd/system/
+(no matches)
+```
+
+**Zero systemd units reference any of these.** Confirmed by exhaustive grep.
+
+### E.1 All `EnvironmentFile=` references in systemd
+
+```
+fortress-nim-sovereign.service  → /etc/fortress/nim.env       (NGC_API_KEY only — unrelated to Postgres)
+k3s-agent.service               → /etc/default/k3s-agent etc. (k3s, unrelated)
+dgx-dashboard.service           → /opt/nvidia/dgx-dashboard-service/ports.env
+nvidia-cdi-refresh.service      → /etc/nvidia-container-toolkit/nvidia-cdi-refresh.env
+snap.mesa-2404.component-monitor.service → /etc/environment
+```
+
+**No fortress-app / fortress-api / fortress-brain / fortress-ray-worker service references admin.env.** The Streamlit Brain on 0.0.0.0:8501 is running, but its unit file does not load `admin.env` — meaning either: (a) it does not currently use Postgres, (b) it loads a `.env` from working directory at runtime, or (c) it's wired some other way. **Not investigated further per scope.**
+
+### E.2 Active fortress / inference services
+
+```
+fortress-brain.service           loaded active running   Fortress Prime Brain (Streamlit)  → 0.0.0.0:8501
+fortress-nim-sovereign.service   loaded active running   NIM Llama-3.1-8B (DGX-Spark)       → container only
+fortress-ray-worker.service      loaded active running   Ray worker
+ollama.service                   loaded active running   Ollama (currently only nomic-embed-text resident)
+```
+
+**All four must remain running per Phase A1 brief Section 3.**
+
+---
+
+## F. Cron and timers
+
+### F.1 User crontabs
+- `crontab -l` (admin user): **no crontab**
+- `sudo crontab -l` (root): **no crontab**
+
+### F.2 /etc/cron.\*/
+Only stock Ubuntu jobs (anacron, e2scrub_all, sysstat, apport, apt-compat, dpkg, logrotate, man-db, quota). **No fortress / postgres / backup cron.**
+
+### F.3 systemd timers (notable)
+```
+anacron.timer             — every ~hour, ran 23 min ago
+sysstat-collect.timer     — every 10 min, ran 23 sec ago
+dpkg-db-backup.timer      — daily, next 00:00
+logrotate.timer           — daily, next 00:00
+fwupd-refresh.timer       — daily-ish
+apt-daily.timer           — next 02:14
+ua-timer.timer            — next 04:46
+motd-news.timer           — next 05:50
+apt-daily-upgrade.timer   — next 06:53
+update-notifier-download.timer — next 10:07
+systemd-tmpfiles-clean.timer   — next 10:17
+e2scrub_all.timer         — Sunday weekly
+fstrim.timer              — Monday weekly
+```
+
+**No fortress / postgres / backup timers.** Phase A1 brief's nightly backup timer (`spark1-pg-backup.timer`) is not configured.
+
+---
+
+## G. Existing Postgres config
+
+### G.1 postgresql.conf (non-default values)
+
+The file appears to have been edited beyond defaults — note the override section at the bottom:
+
+```
+# (defaults from PGDG/Ubuntu — abbreviated)
+data_directory       = '/var/lib/postgresql/16/main'
+hba_file             = '/etc/postgresql/16/main/pg_hba.conf'
+port                 = 5432
+max_connections      = 100      ← default
+shared_buffers       = 128MB    ← default
+ssl                  = on (snakeoil cert)
+log_line_prefix      = '%m [%p] %q%u@%d '
+log_timezone         = 'America/New_York'
+timezone             = 'America/New_York'
+
+# Custom overrides (later in file, last value wins):
+shared_buffers           = 8GB
+work_mem                 = 32MB
+maintenance_work_mem     = 1GB
+effective_cache_size     = 24GB
+max_connections          = 200
+wal_level                = replica
+random_page_cost         = 1.1
+shared_preload_libraries = 'pg_stat_statements'
+listen_addresses         = 'localhost,192.168.0.104'
+```
+
+**Important:** The override block is tuned for a heavyweight workload (8 GB shared_buffers, 24 GB effective_cache_size, 200 max_connections, pg_stat_statements preloaded). **The Phase A1 brief's perf block (1 GB / 4 GB / 256 MB / 32 MB / 50 connections) would be a downgrade** if appended naively — and because `postgresql.conf` uses last-value-wins semantics, appending the brief's block would silently cap shared_buffers at 1 GB and cut max_connections in half.
+
+### G.2 pg_hba.conf (effective rules only)
+
+```
+local   all             postgres                                peer
+local   all             all                                     peer
+host    all             all             127.0.0.1/32            scram-sha-256
+host    all             all             ::1/128                 scram-sha-256
+local   replication     all                                     peer
+host    replication     all             127.0.0.1/32            scram-sha-256
+host    replication     all             ::1/128                 scram-sha-256
+host    fortress_prod   fortress_admin  192.168.0.100/32        scram-sha-256
+```
+
+**Only ONE non-default rule: `host fortress_prod fortress_admin 192.168.0.100/32`.**
+- Spark-2's LAN IP (192.168.0.100), admin role, prod DB only.
+- **No fortress_api access from anywhere except localhost.**
+- **No spark-5 access.**
+- **No Tailscale-IP access.**
+
+### G.3 Config file timestamps
+```
+postgresql.conf   Apr 28 11:13   (edited after install — added override block)
+pg_hba.conf       Apr 28 11:13   (edited — added the one fortress_prod rule)
+```
+
+Both edited 3 minutes before service start (11:16). So the bootstrap script wrote these too.
+
+---
+
+## H. Active TCP listeners (full)
+
+| Local Address | Process | Notes |
+|---|---|---|
+| `127.0.0.1:5432` | postgres pid 1315161 | ✓ Postgres loopback |
+| `192.168.0.104:5432` | postgres pid 1315161 | ✓ Postgres LAN |
+| `127.0.0.1:6379` + `[::1]:6379` | redis-server pid 1291591 | Redis from same bootstrap |
+| `0.0.0.0:8501` + `[::]:8501` | streamlit pid 1294025 | **fortress-brain (Streamlit) — publicly bound** |
+| `0.0.0.0:22` | sshd | SSH |
+| `0.0.0.0:8000` + `[::]:8000` | docker-proxy | container port |
+| `*:11434` | ollama pid 1332187 | Ollama API (all interfaces) |
+| `127.0.0.1:42493` | ollama pid 1398400 | Ollama runner (model serving) |
+| `192.168.0.104:36973` | ray::RuntimeEnv | Ray |
+| `127.0.0.1:52365`, `192.168.0.104:52365`, `[::ffff:192.168.0.104]:36457`, `0.0.0.0:39549` | ray::DashboardA | Ray dashboard agent |
+| `*:38261`, `*:37693` | raylet | Ray |
+| `100.127.241.36:49746` + `[fd7a:115c:a1e0::fd39:f124]:45856` | tailscaled | Tailscale |
+| `127.0.0.1:20241` | cloudflared | Cloudflare tunnel |
+| `127.0.0.1:11000` | dashboard-service | DGX dashboard |
+| `127.0.0.1:631` + `[::1]:631` | cupsd | Print spooler (local) |
+| `127.0.0.53%lo:53` + `127.0.0.54:53` | systemd-resolve | DNS |
+| `*:5201` | iperf3 | iperf server (likely from earlier benchmarking) |
+| `*:7946` | dockerd | Docker swarm gossip |
+
+**Postgres NOT bound on Tailscale (`100.127.241.36`).** Streamlit Brain IS publicly bound on `0.0.0.0:8501` — worth noting from a network-sovereignty perspective even though out of Phase A1 scope.
+
+---
+
+## I. apt history — install timeline
+
+All by user `admin (uid 1000)` on 2026-04-28:
+
+```
+Start-Date: 2026-04-28  08:02:32   (17 sec total)
+Command:    apt-get install -y postgresql-16 postgresql-contrib-16 redis-server
+            build-essential libpq-dev python3-venv python3-dev ocrmypdf
+Installed:  postgresql-16 (16.13-0ubuntu0.24.04.1), postgresql-client-16,
+            postgresql-common, redis-server (5:7.0.15-1ubuntu0.24.04.4),
+            libpq-dev, libpq5, ocrmypdf (15.2.0+dfsg1-1), pikepdf, lxml,
+            and ~30 transitive deps (PDF/OCR toolchain + Python deps)
+Upgraded:   libssl3t64 + openssl
+End-Date:   2026-04-28  08:02:49
+
+Start-Date: 2026-04-28  10:52:25   (6 sec total)
+Command:    apt-get install -y postgresql-16-postgis-3
+Installed:  postgresql-16-postgis-3 (3.4.2+dfsg-1ubuntu3) + GDAL/GEOS/PROJ stack
+End-Date:   2026-04-28  10:52:31
+
+Start-Date: 2026-04-28  10:52:47   (instant)
+Command:    apt-get install -y postgresql-16-pgvector
+Installed:  postgresql-16-pgvector (0.6.0-1)
+End-Date:   2026-04-28  10:52:47
+```
+
+**Interpretation:** This is a **CROG-AI / Fortress-Prime application bootstrap**, not a Phase A1 Postgres-only install. The 08:02 batch installed Postgres alongside Redis, the OCR toolchain, and Python build tools. The 10:52 batch added PostGIS + pgvector — extensions Fortress-Prime depends on but the Phase A1 brief does not require.
+
+---
+
+## J. Recent file activity
+
+### J.1 /etc/fortress/
+```
+-rw------- 1 root root  83 Apr 19 13:04 /etc/fortress/nim.env
+-rw------- 1 admin admin 250 Apr 28 10:39 /etc/fortress/admin.env
+```
+admin.env was created at 10:39, between the two install batches.
+
+### J.2 /home/admin/ — recently modified files (last 7 days, top-level)
+
+The application migration is **visible in the file tree:**
+```
+/home/admin/Fortress-Prime  →  /home/admin/Fortress-Prime.new  (symlink, created Apr 28 08:42)
+/home/admin/Fortress-Prime.new/   (directory, mtime Apr 28 08:41)
+  app.py
+  CLAUDE.md
+  CODEBASE_OVERVIEW.md
+  PROJECT_MANIFEST.md
+  Makefile
+  Dockerfile.pulse-agent
+  Dockerfile.refinery-agent
+  docker-compose.local.yml
+  document_miner.py
+  email_miner_maildir.py
+  miner_work.py
+  titan_brain.py
+  fortress_atlas.yaml
+  packages.txt
+  add_safety_valve.sql
+  inspect_zillow.sql
+  verify_cleanup.sql
+  ingest_now.sh
+  debug_body.py
+  ...
+```
+
+Plus:
+```
+/home/admin/Fortress-Prime.legacy/   (older copy, last touched Mar 10)
+/home/admin/flos-phase-a1-postgres-spark1-brief.md   (Apr 28 22:49 — tonight)
+/home/admin/.bashrc                                   (Apr 28 08:26)
+/home/admin/.bash_history                             (Apr 28 22:49)
+/home/admin/hostfile                                  (Apr 25)
+```
+
+**This is unambiguously a live application migration.** `Fortress-Prime.new/` is the spark-2 application code copied over for spark-1 to run.
+
+---
+
+## K. Network state, sessions, uptime
+
+### K.1 Tailscale tailnet (online nodes only)
+```
+100.127.241.36  spark-1                       linux   self
+100.80.122.100  spark-2                       linux   ✓ online
+100.96.13.99    spark-5                       linux   ✓ online
+100.96.44.85    spark-3-1                     linux   ✓ online
+100.125.35.42   spark-4                       linux   ✓ online
+100.71.225.76   spark-6                       linux   ✓ online
+100.112.199.24  fortress-linux                linux   ✓ online
+100.66.180.7    fortresscrog-ai1s-mac-mini    macOS   ✓ online
+100.113.162.72  garys-imac-2                  macOS   ✓ active (relay "mia")
+100.100.118.91  garys-mac-mini-1              macOS   ✓ online
+100.72.106.17   garyscyberpowe                windows ✓ online
+100.77.89.127   iphone172                     iOS     ✓ online
+
+Offline:  spark-3, ds1825-1, garys-mac-mini, garys-macbook-pro-1,
+          garys-macbook-pro, rivers-edge-nuc
+```
+
+### K.2 Active sessions on spark-1
+```
+admin   seat0          2026-04-16 10:01   (login screen, console)
+admin   :1             2026-04-16 10:01   (X session)
+admin   pts/1          2026-04-16 11:17   (100.127.241.36 — spark-1 self)
+admin   pts/2          2026-04-28 22:50   (100.113.162.72 — garys-imac-2, this session probably)
+admin   pts/3          2026-04-23 19:11   (192.168.0.100 — spark-2 LAN, idle 5 days)
+admin   pts/4          2026-04-28 22:50   (tmux 1420509.%0)
+admin   pts/10         2026-04-25 13:36   (192.168.0.109 — unknown LAN host)
+admin   pts/11         2026-04-25 13:36   (192.168.0.104 — spark-1 LAN self)
+```
+
+**6 active SSH/login sessions.** Operator has live work in tmux. **Worth flagging:** wipe-style operations (Path B) could disrupt sessions and any in-progress work.
+
+### K.3 Login history (last 10)
+Active session originated from `100.113.162.72` (garys-imac-2) at 22:50 EDT. Multiple recent connections from imac-2 and spark-1 LAN IPs throughout 2026-04-28. wtmp goes back to 2026-02-04.
+
+### K.4 Uptime
+```
+23:30:37 up 12 days, 13:29,  6 users,  load average: 0.21, 0.35, 0.55
+```
+
+Spark-1 has been continuously up since 2026-04-16 ~10:00 EDT. The 08:02 install today happened in the middle of that uptime — service add, not boot.
+
+---
+
+## Synthesis for morning session
+
+### What spark-1 is currently running
+
+Spark-1 is the **inference plane** (NIM Llama-3.1-8B in Docker, Ray worker, Ollama, fortress-brain Streamlit on 8501) that is **also being prepared as a data plane host**. At 08:02 today an `admin`-user bootstrap script installed Postgres 16.13 (Ubuntu repo), Redis, the OCR toolchain, and Python build deps; then provisioned three databases (`fortress_db`, `fortress_prod`, `fortress_shadow_test`) with the full Fortress-Prime schema (13 schemas, 291 tables) and the canonical `fortress_admin`/`fortress_api` role pair, with credentials in `/etc/fortress/admin.env`. PostGIS + pgvector were added at 10:52. The Postgres tuning in `postgresql.conf` is heavyweight (8 GB shared_buffers, 24 GB effective_cache_size, 200 max_connections, pg_stat_statements). Spark-2's application code has been copied to `/home/admin/Fortress-Prime.new/` and symlinked. **Nothing is yet wired to the new Postgres** — no systemd unit references `admin.env`, no client connections exist, and `pg_hba.conf` still allows only `fortress_admin` from spark-2's LAN IP into `fortress_prod`. The Phase A1 brief (drafted assuming clean-host install) was last edited at 22:49 tonight; given the divergence between brief and reality, the operator paused before picking A/B/C and asked for state capture.
+
+### Three things to flag for the morning operator review
+
+1. **The Phase A1 brief is shape-wrong, not just degree-wrong.** It assumes "Postgres-only install on a clean host." Reality is "application migration with Postgres already provisioned by a broader bootstrap (Postgres + Redis + OCR + PostGIS + pgvector + app code), now waiting to be cut over." The right Phase A1 isn't "install" — it's **harden/configure what's there** (Tailscale binding, full pg_hba, Phase 0a-8 grants, firewall, backup, doc) AND/OR **decide what 'Phase A1' even means in a migration context**. The brief's perf block, if appended, would silently downgrade the existing 8 GB tuning to 1 GB. The brief's secrets path (`spark-1-postgres.env` root-owned) conflicts with the existing `admin.env` (admin-owned) — picking one means rewriting whatever consumes the other.
+
+2. **Two divergent alembic heads (`q2b3c4d5e6f7`, `r3c4d5e6f7g8`) are baked into all three DBs.** This is the Issue #204 trap. Whatever schema dump was used had a multi-head state; any future `alembic upgrade head` from spark-2's Fortress-Prime code will fail or branch. Resolving this requires either re-dumping cleanly from spark-2, or running `alembic merge` on spark-2 first and then re-syncing. It is **not** a "leave for later" item — every migration applied to spark-1 from now on inherits this divergence. The morning brief author should decide whether to fix at the source (spark-2) or accept the divergence and document it.
+
+3. **`fortress_app` role is referenced by `admin.env` but does not exist in the database, and the Streamlit Brain is publicly bound on 0.0.0.0:8501.** The `POSTGRES_FORTRESS_APP_PASSWORD` key in `admin.env` has no corresponding pg_role — either it's stale from an older contract draft, or the bootstrap script intends to create it later, or someone has a different role-naming plan than the canonical 004 contract. Worth resolving before any consumer service is wired up. Separately, `fortress-brain.service` is bound on `0.0.0.0:8501` with no apparent firewall — even though it's out of Phase A1 scope, it's a sovereignty item that may want to land on the same morning's review.
+
+### Decision options surfaced (NOT picked tonight)
+
+The morning session's likely framings, in rough order of operator words from this session:
+
+- **"Phase A1 brief is wrong shape — write a new migration-context brief."** Treat the existing install as the migration baseline. Phase A1 becomes "harden and connect": Tailscale listen, full pg_hba (spark-2 fortress_admin + fortress_api, spark-5 fortress_api read-only), Phase 0a-8 grants, root-owned secrets file (consolidate or migrate from admin.env), iptables, backup, doc. **Does NOT** install or wipe.
+- **"Phase A1 brief is right, but additive-not-destructive."** Apply only the parts that don't touch existing state. Skip install, skip role/DB creation. Add Tailscale to listen_addresses (without disturbing the 8 GB perf block), append fortress_api + spark-5 entries to pg_hba, apply Phase 0a-8 grants, configure firewall + backup + doc. Leave admin.env in place.
+- **"Application migration is its own phase; Fortress Legal config layered on top."** Treat the spark-2 → spark-1 application migration as a separate (already-in-flight) project. Phase A1's job is just "the Fortress Legal data-plane config that needs to apply once the migration completes." Brief gets re-scoped to the legal-specific overlays (pg_hba spark-5 read-only access for Phase A5 RAG, legal-table grant verification, legal smoke tests, backup of legal data once it lands).
+- **"Wipe and redo per original brief"** is technically possible (no active connections, zero data, no consumers) but would also discard the 8 GB perf tuning, the postgis/pgvector extensions, the schema dump, and the bootstrap context — and might surprise whoever ran the 08:02 bootstrap if its purpose extends beyond Phase A1.
+
+### What was NOT done tonight
+
+- No DB / role / config / pg_hba / postgresql.conf change.
+- No service start/stop/restart.
+- No file in `/etc/fortress/` modified.
+- No iptables change.
+- No package install or removal.
+- Existing tool-results capture file (raw psql output) is preserved at `/home/admin/.claude/projects/-home-admin/2ce642cf-93e1-4238-93ee-92149b4275fe/tool-results/byfpwn9cf.txt` for forensic reference.
+
+---
+
+**End of state capture.** Next session opens this file and decides forward path. No tool action past this point.

--- a/docs/operational/spark1-phase-a1-runbook.md
+++ b/docs/operational/spark1-phase-a1-runbook.md
@@ -12,7 +12,7 @@
 
 1. Verifies the legal schema is intact on spark-1 (no mutation).
 2. Verifies NAS mount and legal directories.
-3. Resolves the stale `fortress_app` reference (autonomous decision tree).
+3. Surfaces the `fortress_app` contract divergence (canonical 004 vs spark-2 `fgp_app` vs M3 runbook `fortress_app`) and drops the dead `POSTGRES_FORTRESS_APP_PASSWORD` line from admin.env per operator instruction.
 4. Tightens `fortress-brain.service` Streamlit bind from `0.0.0.0` to `127.0.0.1` (sovereignty fix).
 5. Files the alembic-divergence issue that blocks M3 activation.
 6. Writes durable migration provenance.
@@ -22,7 +22,7 @@
 - No `alembic upgrade` on spark-1 (heads divergent — see Issue filed by this PR).
 - No role create / drop / alter on spark-1 (canonical 004 roles already in place).
 - No mutation to `public.*`, `division_a.*`, `hedge_fund.*`, or any `alembic_version` row.
-- No write to admin.env values (rename action proved unsafe — see §3 below).
+- No mutation to admin.env credential values; only the dead `POSTGRES_FORTRESS_APP_PASSWORD` key is removed (see §3).
 - No consumer service wired to spark-1 Postgres (M3 owns first write path).
 - No UFW config change (separate audit follow-up).
 
@@ -39,9 +39,9 @@ sudo ss -tlnp | grep 5432
 Expected:
 - Roles `fortress_admin` (CREATEDB), `fortress_api` (login only).
 - Postgres listening on `127.0.0.1:5432` and `192.168.0.104:5432`.
-- No `fortress_app` role.
+- No `fortress_app` role yet — M3 runbook prescribes its creation later; Phase A1 does not create it.
 
-If a fortress role is missing or `fortress_app` exists: STOP — pre-conditions for Phase A1 not met.
+If `fortress_admin` or `fortress_api` is missing: STOP — pre-conditions for Phase A1 not met.
 
 ## §2 — Legal schema verification (read-only)
 
@@ -87,17 +87,34 @@ grep -rIn "POSTGRES_FORTRESS_APP_PASSWORD" \
   --include="*.sh" --include="*.toml" --include="*.cfg" --include="*.ini"
 ```
 
-**Decision tree:**
+**2026-04-29 grep result (post-pull tree):**
 
-- **No hits anywhere → conclusion 3a (stale).** This is what 2026-04-29 found.
-  
-  Brief's prescribed action is "rename APP → API in admin.env, value carried over." **DO NOT execute this literally** if both APP and API entries already exist with different values — doing so overwrites the working `fortress_api` password.
-  
-  On 2026-04-29 admin.env had three keys: `ADMIN_PASSWORD`, `APP_PASSWORD` (44 chars), `API_PASSWORD` (64 chars). Values differ. **Action taken: no-op.** Document the residual APP key in `spark-2-to-spark-1-migration-provenance.md` and leave the file alone. Cleanup is a one-line `sed` follow-up if operator wants the APP key gone.
+`fortress_app` hits exist in canonical templates and runbook documentation:
 
-- **Hits in service code (`backend/services/*.py`, `backend/core/database.py`, `backend/core/config.py`) → conclusion 3b (intentional third role).** STOP. Surface to operator. Do not create the role.
+- `fortress-guest-platform/.env.example:195` — `SPARK1_DATABASE_URL` template uses `fortress_app`
+- `docs/runbooks/m3-spark1-mirror-activation.md:42-46, 74` — `CREATE USER fortress_app` + grants + `Environment=SPARK1_DATABASE_URL`
+- `docs/operational/spark-1-legal-migration-runbook.md:57-58` — M2-2 / M2-3 reference `fortress_app`
 
-- **Hits in both → 3b with ambiguity.** STOP.
+`POSTGRES_FORTRESS_APP_PASSWORD` only appears in admin.env on spark-1 and in this PR's own descriptive docs. Zero hits in `backend/services/*.py`, `backend/core/*.py`, or `alembic/versions/*.py`.
+
+**Reality across both hosts:**
+
+- spark-1 `\du`: `fortress_admin` (Create role, Create DB), `fortress_api`, `postgres`. **No `fortress_app`.**
+- spark-2 `\du` (canonical source-of-truth): `admin`, `crog_ai_app`, `fgp_app`, `fortress_admin` (Superuser), `fortress_api`, `miner_bot`, `paperclip_admin`, `postgres`, `trader_bot`. **Also no `fortress_app`** — spark-2's FGP runtime role is `fgp_app`.
+
+**Conclusion:** the reshaped brief's clean 3a/3b dichotomy doesn't fit. `fortress_app` is a name in templates and the M3 runbook but a role nowhere in the cluster. Three names are floating around for the same conceptual runtime role: canonical 004 says `fortress_api`, spark-2 reality is `fgp_app`, M3 runbook prescribes `fortress_app`. Resolving "which is canonical for spark-1" is operator's call and out of Phase A1 scope.
+
+**Phase A1 action (per operator decision 2026-04-29):** drop the `POSTGRES_FORTRESS_APP_PASSWORD` line from `/etc/fortress/admin.env`. The credential authenticates no role on any host; it is dead under all four reads of the contract reconciliation question. The naming reconciliation itself follows separately.
+
+```bash
+# inspect before
+grep -E '^[A-Z_]+=' /etc/fortress/admin.env | cut -d= -f1
+# expected: ADMIN, APP, API
+sed -i '/^POSTGRES_FORTRESS_APP_PASSWORD=/d' /etc/fortress/admin.env
+# inspect after
+grep -E '^[A-Z_]+=' /etc/fortress/admin.env | cut -d= -f1
+# expected: ADMIN, API
+```
 
 ## §4 — NAS mount + legal directories (read-only)
 
@@ -170,7 +187,7 @@ See body in `~/spark1-phase-a1-reshaped-brief.md` §9. Labels: `M3-blocker`, `al
 |---|---|---|
 | Legal schema present | `\dt legal.*` against `fortress_db` and `fortress_prod` | 38 tables, 12 spot-checks all return 1 |
 | NAS mount | `mountpoint /mnt/fortress_nas` | "is a mountpoint" |
-| `fortress_app` resolution | grep over repo | 0 hits → 3a no-op (or 3b STOP and surface) |
+| `fortress_app` contract resolution | grep over repo + spark-2 `\du` | hits in templates + M3 runbook, role absent on both hosts → drop dead APP_PASSWORD line, defer naming reconciliation to operator |
 | Streamlit bind | `ss -tlnp \| grep 8501` | `127.0.0.1:8501` (NOT `0.0.0.0`) |
 | Provenance doc | `git log docs/operational/spark-2-to-spark-1-migration-provenance.md` | committed in this branch |
 | State snapshot | `git log docs/operational/spark1-current-state-2026-04-29.md` | committed in this branch |

--- a/docs/operational/spark1-phase-a1-runbook.md
+++ b/docs/operational/spark1-phase-a1-runbook.md
@@ -1,0 +1,179 @@
+# Spark-1 Phase A1 Runbook (Reshaped, Additive)
+
+**Created:** 2026-04-29
+**Source brief:** `~/spark1-phase-a1-reshaped-brief.md` (spark-1 only)
+**Branch:** `feat/spark1-phase-a1-legal-overlays`
+**Owner:** Gary Knight
+**Scope:** verification + minimal-mutation overlays. No schema changes, no role changes (modulo conditional `.env` cleanup), no alembic, no Postgres restart, no UFW changes.
+
+---
+
+## What Phase A1 does
+
+1. Verifies the legal schema is intact on spark-1 (no mutation).
+2. Verifies NAS mount and legal directories.
+3. Resolves the stale `fortress_app` reference (autonomous decision tree).
+4. Tightens `fortress-brain.service` Streamlit bind from `0.0.0.0` to `127.0.0.1` (sovereignty fix).
+5. Files the alembic-divergence issue that blocks M3 activation.
+6. Writes durable migration provenance.
+
+## What Phase A1 does NOT do
+
+- No `alembic upgrade` on spark-1 (heads divergent — see Issue filed by this PR).
+- No role create / drop / alter on spark-1 (canonical 004 roles already in place).
+- No mutation to `public.*`, `division_a.*`, `hedge_fund.*`, or any `alembic_version` row.
+- No write to admin.env values (rename action proved unsafe — see §3 below).
+- No consumer service wired to spark-1 Postgres (M3 owns first write path).
+- No UFW config change (separate audit follow-up).
+
+---
+
+## §1 — Pre-flight (read-only)
+
+```bash
+# DB role + listener sanity
+sudo -u postgres psql -c "\du" | grep fortress
+sudo ss -tlnp | grep 5432
+```
+
+Expected:
+- Roles `fortress_admin` (CREATEDB), `fortress_api` (login only).
+- Postgres listening on `127.0.0.1:5432` and `192.168.0.104:5432`.
+- No `fortress_app` role.
+
+If a fortress role is missing or `fortress_app` exists: STOP — pre-conditions for Phase A1 not met.
+
+## §2 — Legal schema verification (read-only)
+
+```bash
+sudo -u postgres psql -d fortress_db -c "\dt legal.*"
+sudo -u postgres psql -d fortress_db -c "
+  SELECT table_name,
+         (SELECT COUNT(*) FROM information_schema.columns
+          WHERE table_schema='legal' AND table_name=t.table_name) AS col_count
+  FROM information_schema.tables t
+  WHERE table_schema='legal' ORDER BY table_name;"
+
+# Same for fortress_prod
+sudo -u postgres psql -d fortress_prod -c "
+  SELECT table_name,
+         (SELECT COUNT(*) FROM information_schema.columns
+          WHERE table_schema='legal' AND table_name=t.table_name) AS col_count
+  FROM information_schema.tables t
+  WHERE table_schema='legal' ORDER BY table_name;"
+```
+
+Expected: 38 tables (per `\dt`) / 44 rows in `information_schema.tables` (extras are pre-v2 compatibility views: `case_graph_edges`, `case_graph_nodes`, `discovery_draft_items`, `discovery_draft_packs`, `legal_cases`, `sanctions_alerts`).
+
+Spot-checked tables (all confirmed present 2026-04-29):
+`cases`, `vault_documents`, `case_slug_aliases`, `privilege_log`, `ingest_runs`, `correspondence`, `deadlines`, `filings`, `case_actions`, `case_evidence`, `case_watchdog`, `case_precedents`.
+
+If any expected table missing: STOP, surface. Do **not** run alembic to fix — it means the spark-2 schema export was incomplete.
+
+## §3 — fortress_app role disambiguation
+
+Run from `~/Fortress-Prime` on spark-1 (or any local clone):
+
+```bash
+grep -rIn "fortress_app" \
+  --include="*.py" --include="*.env*" --include="*.yaml" --include="*.yml" \
+  --include="*.sh" --include="*.toml" --include="*.cfg" --include="*.ini" \
+  --include="*.md" \
+  | grep -v "spark1-current-state" \
+  | grep -v "\.git/"
+
+grep -rIn "POSTGRES_FORTRESS_APP_PASSWORD" \
+  --include="*.py" --include="*.env*" --include="*.yaml" --include="*.yml" \
+  --include="*.sh" --include="*.toml" --include="*.cfg" --include="*.ini"
+```
+
+**Decision tree:**
+
+- **No hits anywhere → conclusion 3a (stale).** This is what 2026-04-29 found.
+  
+  Brief's prescribed action is "rename APP → API in admin.env, value carried over." **DO NOT execute this literally** if both APP and API entries already exist with different values — doing so overwrites the working `fortress_api` password.
+  
+  On 2026-04-29 admin.env had three keys: `ADMIN_PASSWORD`, `APP_PASSWORD` (44 chars), `API_PASSWORD` (64 chars). Values differ. **Action taken: no-op.** Document the residual APP key in `spark-2-to-spark-1-migration-provenance.md` and leave the file alone. Cleanup is a one-line `sed` follow-up if operator wants the APP key gone.
+
+- **Hits in service code (`backend/services/*.py`, `backend/core/database.py`, `backend/core/config.py`) → conclusion 3b (intentional third role).** STOP. Surface to operator. Do not create the role.
+
+- **Hits in both → 3b with ambiguity.** STOP.
+
+## §4 — NAS mount + legal directories (read-only)
+
+```bash
+mountpoint /mnt/fortress_nas
+ls -ld /mnt/fortress_nas/Corporate_Legal/Business_Legal/
+ls -ld /mnt/fortress_nas/legal_vault/
+ls -1 /mnt/fortress_nas/legal_vault/
+ls -ld /mnt/fortress_nas/audits/
+df -h /mnt/fortress_nas
+```
+
+Expected on 2026-04-29:
+- Mount: active (`192.168.0.113:/volume1/ai-data-new`, 54 TB free).
+- `legal_vault/` subdirs: `7il-v-knight-ndga`, `affidavit-filing`, `fish-trap-suv2026000013`, `vanderburge-v-knight-fannin` (4 directories — note: brief listed 6 expected, actual is 4; consolidation is operator-intended).
+- `Corporate_Legal/Business_Legal/` and `audits/` readable.
+
+If mount missing: STOP. NAS is a hard prerequisite for the legal pipeline.
+
+## §5 — Sovereignty fix: bind fortress-brain Streamlit to loopback
+
+Pre-2026-04-29 state: `fortress-brain.service` Streamlit bound to `0.0.0.0:8501` because the systemd unit's ExecStart did not specify `--server.address` (Streamlit defaults to all interfaces). Audit S-01 (UFW disabled) compounds the exposure. Public-bound Streamlit on a legal data plane spark violates CONSTITUTION.md Article I.
+
+The active configuration is split across:
+- `/etc/systemd/system/fortress-brain.service` (base unit)
+- `/etc/systemd/system/fortress-brain.service.d/10-legacy-path.conf` (drop-in that overrides `ExecStart` to use `Fortress-Prime.legacy/venv/`)
+
+The drop-in's ExecStart is what runs. Edit the drop-in to add `--server.address 127.0.0.1` to the streamlit invocation:
+
+```bash
+sudo sed -i.bak \
+  's|--server.port 8501 --server.headless true|--server.address 127.0.0.1 --server.port 8501 --server.headless true|' \
+  /etc/systemd/system/fortress-brain.service.d/10-legacy-path.conf
+
+sudo systemctl daemon-reload
+sudo systemctl restart fortress-brain.service
+sleep 3
+sudo systemctl is-active fortress-brain.service
+sudo ss -tlnp | grep 8501
+# expected after: 127.0.0.1:8501 (loopback only); NOT 0.0.0.0:8501 / [::]:8501
+```
+
+If the listener is still on `0.0.0.0`: stop, investigate Streamlit version or unit-file precedence (look for any `.service.d/*.conf` other than `10-legacy-path.conf`).
+
+If access from spark-2 or operator workstation is needed, route via Tailscale or SSH tunnel — never re-bind to `0.0.0.0`.
+
+After successful restart, copy the updated unit + drop-in into the repo:
+
+```bash
+mkdir -p /home/admin/Fortress-Prime/deploy/systemd/fortress-brain.service.d
+sudo cat /etc/systemd/system/fortress-brain.service \
+  > /home/admin/Fortress-Prime/deploy/systemd/fortress-brain.service
+sudo cat /etc/systemd/system/fortress-brain.service.d/10-legacy-path.conf \
+  > /home/admin/Fortress-Prime/deploy/systemd/fortress-brain.service.d/10-legacy-path.conf
+```
+
+## §6 — Issue filing
+
+Title: `M3 prereq: merge divergent alembic heads on spark-2 fortress_db`
+
+See body in `~/spark1-phase-a1-reshaped-brief.md` §9. Labels: `M3-blocker`, `alembic`, `postgres`, `spark-1`.
+
+## §7 — Provenance doc
+
+`docs/operational/spark-2-to-spark-1-migration-provenance.md` — written / updated by Phase A1 PR. Treat as the durable migration record going forward.
+
+## §8 — Verification at exit
+
+| Check | How | Pass criterion |
+|---|---|---|
+| Legal schema present | `\dt legal.*` against `fortress_db` and `fortress_prod` | 38 tables, 12 spot-checks all return 1 |
+| NAS mount | `mountpoint /mnt/fortress_nas` | "is a mountpoint" |
+| `fortress_app` resolution | grep over repo | 0 hits → 3a no-op (or 3b STOP and surface) |
+| Streamlit bind | `ss -tlnp \| grep 8501` | `127.0.0.1:8501` (NOT `0.0.0.0`) |
+| Provenance doc | `git log docs/operational/spark-2-to-spark-1-migration-provenance.md` | committed in this branch |
+| State snapshot | `git log docs/operational/spark1-current-state-2026-04-29.md` | committed in this branch |
+| Alembic issue | `gh issue list --label M3-blocker` | issue exists, linked in PR |
+
+PR merge BLOCKED on operator review per brief §10.


### PR DESCRIPTION
## Summary
Phase A1 (reshaped, additive-only) lands the Fortress Legal overlays on spark-1 without mutating any schema, role, or application data inherited from the spark-2 dump. Documents migration provenance, verifies legal pipeline pre-conditions, fixes the public-bound Streamlit on the legal data plane spark, and drops a dead env-var line.

## Brief §10 checklist

### §4 — fortress_app role contract
**Action:** dropped `POSTGRES_FORTRESS_APP_PASSWORD` line from `/etc/fortress/admin.env` on spark-1. Dead config under all four reads (no `fortress_app` role exists on either spark — spark-2's runtime role for FGP is `fgp_app`, canonical 004 contract says `fortress_api`, M3 runbook prescribes `fortress_app`).

**Note:** the `fortress_app` role naming question is **deferred — operator follow-up.** APP_PASSWORD line dropped because dead config (no `fortress_app` role exists on either spark). Three names compete for the same conceptual runtime role; reconciliation is operator-owned and out of Phase A1 scope. See `docs/operational/spark-2-to-spark-1-migration-provenance.md` "Known issues" #2 for the full surface.

### §5 — Legal schema verification
Both `fortress_db` and `fortress_prod` GREEN — 38 tables (`\dt legal.*`), 44 entries in `information_schema.tables` (extras are pre-v2 compatibility views: `case_graph_edges`, `case_graph_nodes`, `discovery_draft_items`, `discovery_draft_packs`, `legal_cases`, `sanctions_alerts`). 12 spot-check tables all present (`cases`, `vault_documents`, `case_slug_aliases`, `privilege_log`, `ingest_runs`, `correspondence`, `deadlines`, `filings`, `case_actions`, `case_evidence`, `case_watchdog`, `case_precedents`).

### §6 — NAS mount + legal directories
`/mnt/fortress_nas` mounted (`192.168.0.113:/volume1/ai-data-new`, 54 TB free). `legal_vault/` has **4 subdirs**: `7il-v-knight-ndga`, `affidavit-filing`, `fish-trap-suv2026000013`, `vanderburge-v-knight-fannin`. Brief listed 6 expected — operator-intended consolidation accounts for the difference. Not a STOP.

### §7 — fortress-brain Streamlit bind (sovereignty fix)
**Before:**
```
LISTEN 0  128  0.0.0.0:8501  ...  streamlit pid=1294025
LISTEN 0  128  [::]:8501     ...  streamlit pid=1294025
```
**After:**
```
LISTEN 0  128  127.0.0.1:8501  ...  python3 pid=1460051
```
Drop-in `10-legacy-path.conf` updated to (a) bind `--server.address 127.0.0.1`, (b) invoke streamlit via `python3 -m streamlit` instead of broken-shebang script (the `bin/streamlit` shebang `#!/home/admin/Fortress-Prime/venv/bin/python3` is broken — `Fortress-Prime → Fortress-Prime.new` and `Fortress-Prime.new/venv` does not exist; Streamlit 1.54.0 site-packages still load via `Fortress-Prime.legacy/venv/bin/python3 -m streamlit`). Repo copies committed at `deploy/systemd/`. Note: this venv-shebang brittleness is a separate follow-up worth tracking.

### §8 — Provenance doc committed
- `docs/operational/spark-2-to-spark-1-migration-provenance.md` (corrected post-pull grep + spark-2 `\du` reality)
- `docs/operational/spark1-phase-a1-runbook.md`
- `docs/operational/spark1-current-state-2026-04-29.md` (frozen diagnostic snapshot)

### §9 — Alembic-divergence issue
**Filed: #279** — https://github.com/cabinrentalsofgeorgia-bit/Fortress-Prime/issues/279. Title `M3 prereq: merge divergent alembic heads on spark-2 fortress_db`, label `M3-blocker`. Body documents the divergent heads (`q2b3c4d5e6f7`, `r3c4d5e6f7g8`) plus prior orphan `7a1b2c3d4e5f` (Issue #204), and notes M3 activation step 4 blocks on resolution at source (alembic merge on spark-2).

### Time elapsed
~80 minutes from reading the reshaped brief to PR opened.

## Test plan
- [ ] Operator confirms `fortress_app` naming reconciliation deferral is acceptable
- [ ] Operator reviews venv-shebang note in §7 (separate brittleness exposed, worth a follow-up)
- [ ] Operator confirms PR scope matches reshaped brief intent
- [ ] **Merge BLOCKED on operator review per brief §10**

🤖 Generated with [Claude Code](https://claude.com/claude-code)