### PR TITLE
F5 root cause investigation surface + W3 workaround codification (ER8411 + Mikrotik fabric topology corrected)

### DIFF
--- a/docs/operational/MASTER-PLAN.md
+++ b/docs/operational/MASTER-PLAN.md
@@ -220,7 +220,7 @@ Maintained tracks. Each updates as items land or shift.
 | NIM ASR ARM64 monitor (SenseVoice replacement trigger) | OPEN issue (P3) |
 | VRS Qdrant migration trigger (fortress-qdrant-vrs on spark-4) | OPEN issue (P5 — monitoring) |
 | Ollama consolidation migration | OPEN issue (P4 — gated on caller migration per `spark-3-4-retained-state-2026-04-29.md`) |
-| F5 cluster egress sustained-transfer failure to xfiles.ngc.nvidia.com | OPEN issue #303 (P3) — operator-side investigation gated on Mikrotik/Tailscale admin access; until F5 lands, **W3 (operator-Mac NIM pulls scp'd to NAS) is the canonical NIM weight-pull procedure** per `docs/operational/runbooks/w3-nim-pull-workaround-runbook.md`. Investigation surface: `docs/operational/briefs/f5-root-cause-investigation-2026-04-29.md`. Implication: TIER 1 batch-pull becomes operator-paced rather than agent-paced. |
+| F5 cluster egress sustained-transfer failure to xfiles.ngc.nvidia.com | OPEN issue #303 (P3) — multi-CDN comparison (Cloudflare / Canonical / Hugging Face / GitHub-Fastly all PASS at 90–110 MB/s through same egress) narrows failure to NGC-only; fix surface is the **TP-Link ER8411 web UI** at `http://192.168.0.1` (Mikrotik switch is fast-fabric only, not in egress path). Until F5 lands, **W3 (operator-Mac NIM pulls scp'd to NAS) is the canonical NIM weight-pull procedure** per `docs/operational/runbooks/w3-nim-pull-workaround-runbook.md`. Investigation surface: `docs/operational/briefs/f5-root-cause-investigation-2026-04-29.md`. Implication: TIER 1 batch-pull becomes operator-paced rather than agent-paced. |
 
 ---
 

--- a/docs/operational/MASTER-PLAN.md
+++ b/docs/operational/MASTER-PLAN.md
@@ -220,6 +220,7 @@ Maintained tracks. Each updates as items land or shift.
 | NIM ASR ARM64 monitor (SenseVoice replacement trigger) | OPEN issue (P3) |
 | VRS Qdrant migration trigger (fortress-qdrant-vrs on spark-4) | OPEN issue (P5 — monitoring) |
 | Ollama consolidation migration | OPEN issue (P4 — gated on caller migration per `spark-3-4-retained-state-2026-04-29.md`) |
+| F5 cluster egress sustained-transfer failure to xfiles.ngc.nvidia.com | OPEN issue #303 (P3) — operator-side investigation gated on Mikrotik/Tailscale admin access; until F5 lands, **W3 (operator-Mac NIM pulls scp'd to NAS) is the canonical NIM weight-pull procedure** per `docs/operational/runbooks/w3-nim-pull-workaround-runbook.md`. Investigation surface: `docs/operational/briefs/f5-root-cause-investigation-2026-04-29.md`. Implication: TIER 1 batch-pull becomes operator-paced rather than agent-paced. |
 
 ---
 

--- a/docs/operational/briefs/f5-issue-303-updated-body-2026-04-29.md
+++ b/docs/operational/briefs/f5-issue-303-updated-body-2026-04-29.md
@@ -1,0 +1,85 @@
+**Priority:** P3
+**Status:** Diagnosis only; fix is operator-side at the **TP-Link ER8411 web UI** (`http://192.168.0.1`).
+
+2026-04-29 llama-nemotron-embed deployment surfaced cluster network defect: small TLS requests work cleanly to NGC; sustained data transfers from `xfiles.ngc.nvidia.com` fail with `DownloadFileSizeMismatch`. Three MTU-related remediations (F1, F2, F4) stacked do NOT fix.
+
+## Topology correction (vs. original brief)
+
+The original F5 brief attributed cluster egress to "Mikrotik". That was wrong. Verified topology:
+
+| Device | Role |
+|---|---|
+| **TP-Link ER8411 Omada Pro VPN Router** at `192.168.0.1` | Internet egress, NAT, DHCP/DNS, firewall, DPI/IPS surface |
+| **Mikrotik CRS812 switch** | Fast fabric only (10.10.10/24 + 10.10.11/24, MTU 9000, BBR, ~93 Gbps verified). Not in egress path. |
+
+Verification: ARP `192.168.0.1 lladdr 98:ba:5f:5c:fe:4a` (OUI = TP-Link Systems Inc.); web UI `/webpages/login.html` = Omada Pro signature.
+
+No active VPN tunnels (Tailscale exit-node ruled out below; OpenVPN deferred for Tailscale).
+
+## Pattern (multi-CDN comparison through ER8411)
+
+| Endpoint | CDN | Bytes | Throughput | Result |
+|---|---|---|---|---|
+| `api.ngc.nvidia.com` (small JSON) | NGC | ~1 KB | n/a | PASS |
+| `nvcr.io` image pull | NGC images | multi-MB layers | n/a | PASS with retries |
+| `speed.cloudflare.com` 50 MB | Cloudflare | 50 MB | 94 MB/s | **PASS** |
+| `releases.ubuntu.com` (range 0-499 MB) | Canonical CDN | 500 MB | 92 MB/s | **PASS** |
+| `huggingface.co` all-mpnet-base-v2 | HF / Cloudflare | 438 MB | 104 MB/s | **PASS** |
+| `huggingface.co` bge-large (range 0-499 MB) | HF / Cloudflare | 500 MB | 111 MB/s | **PASS** |
+| GitHub release tarball 705 MB | Fastly | 705 MB | 70 MB/s | **PASS** |
+| `xfiles.ngc.nvidia.com` (sustained data) | NGC / CloudFront 3.171.171.0/22 | multi-GB | n/a | **FAIL — DownloadFileSizeMismatch** |
+
+**Failure surface = NGC-only.** Cluster sustains 90–110 MB/s through the same ER8411 egress to four other CDNs.
+
+## Candidate root causes (ranked by evidence)
+
+1. **Destination-specific issue at NGC origin / xfiles CloudFront edge** — strongest evidence (multi-CDN PASS rules out generic ER8411 policy)
+2. **ER8411 Application Control / DPI selectively classifying NGC** — moderate (Omada Pro DPI category lists could selectively touch "model distribution"; pattern fits)
+3. **ER8411 IPS rule false-positive on sustained NVIDIA blob downloads** — moderate (sustained-binary heuristic could trip)
+4. **ER8411 Bandwidth Control / QoS application-category throttling** — weaker (broad cap ruled out by multi-CDN; narrow category-specific cap possible)
+5. **Asymmetric routing / IP policy at AWS edge** — moderate (path identical operator-side, divergence at AWS hop 4+)
+6. **MSS double-clamp interaction (ER8411 + spark-2 host clamp)** — weak (no current double-clamp evidence)
+7. ~~Conntrack exhaustion on ER8411~~ — near-ruled-out by multi-CDN PASS
+8. ~~Tailscale exit-node routing~~ — RULED OUT (`ExitNode: False`, no `0.0.0.0/0` via tailnet)
+9. ~~BBR vs CUBIC interaction~~ — RULED OUT by multi-CDN PASS
+
+Dropped from original brief: **Mikrotik DPI** (Mikrotik not in egress path), **VPN tunnel asymmetric routing** (no active tunnels).
+
+## Investigation surface
+
+Full diagnostic plan, captured evidence, MSS/PMTU data: `docs/operational/briefs/f5-root-cause-investigation-2026-04-29.md`
+Until F5 lands, W3 workaround in effect: `docs/operational/runbooks/w3-nim-pull-workaround-runbook.md`
+
+## Required to fix
+
+- **TP-Link ER8411 web UI access** (`http://192.168.0.1`, operator credentials) — primary
+- Operator Mac for traceroute comparison
+- NGC CLI credentials in cluster shell for auth'd tcpdump capture during failing pull
+
+## Recommended next operator action (priority order)
+
+1. **ER8411 web UI inspection** (~15 min):
+   - Application Control → check rules matching source `192.168.0.0/24`; disable for cluster sources or add explicit allow for `3.171.171.0/22` + `*.ngc.nvidia.com`
+   - IPS / Threat Management → Logs → filter for failing-pull window (operator captures wall-clock time before reproducing); look for hits on `xfiles`, `nvidia`, `model-distribution`, sustained-transfer heuristics
+   - Bandwidth Control → confirm no rule throttles cluster sources or `3.171.171.0/22` by application category
+   - Status → Connections → confirm not pegged vs `Max Sessions`
+   - Firewall → ACL / NAT → check for any explicit rule referencing nvidia / xfiles / `3.171.171.0/22`
+   - Capture screenshots / config dump
+2. Different-spark cross-check (~5 min) — try small NGC pull from a different spark; if it works, IP-policy at xfiles destination
+3. Operator Mac-side traceroute comparison
+4. Auth'd tcpdump during real failing pull (RST mid-stream, retransmit walls, ICMP frag-needed, window collapse, RST at consistent byte offset = DPI)
+5. Only if 1–4 inconclusive: BBR→CUBIC sysctl swap (reversible)
+
+## Until F5 fix lands
+
+- All NIM pulls go through W3 (operator pulls on Mac, scp to NAS)
+- Cluster cannot batch-pull TIER 1 NeMo Retriever family autonomously
+- Phase 2 BRAIN cluster expansion blocked on this if multi-NIM deployment becomes urgent
+- TIER 1 batch-pull becomes operator-paced rather than agent-paced
+
+## Cross-references
+
+- F2 fix (TLS handshake MSS clamp, retained): `docs/operational/briefs/iptables-mss-persistence-brief.md`
+- Cluster network topology: `docs/architecture/shared/cluster-network-topology.md`
+- W3 codification: `docs/operational/runbooks/w3-nim-pull-workaround-runbook.md`
+- Investigation surface: `docs/operational/briefs/f5-root-cause-investigation-2026-04-29.md`

--- a/docs/operational/briefs/f5-root-cause-investigation-2026-04-29.md
+++ b/docs/operational/briefs/f5-root-cause-investigation-2026-04-29.md
@@ -1,0 +1,209 @@
+# F5 Root Cause Investigation Surface — Cluster Egress Sustained-Transfer Failure to xfiles.ngc.nvidia.com
+
+**Date:** 2026-04-29
+**Branch:** `chore/f5-root-cause-investigation-2026-04-29`
+**Driver:** 2026-04-29 llama-nemotron-embed deployment surfaced cluster network defect — small TLS to NGC works, sustained transfers from `xfiles.ngc.nvidia.com` fail with `DownloadFileSizeMismatch`. F1 + F2 + F4 stacked do NOT fix.
+**Status:** Diagnosis only. Fix requires Mikrotik admin UI or Tailscale admin console access (operator-side).
+**Tracking:** Issue #303
+**Cross-references:**
+- F2 fix: `docs/operational/briefs/iptables-mss-persistence-brief.md`
+- Cluster network topology: `docs/architecture/shared/cluster-network-topology.md`
+- W3 workaround: `docs/operational/runbooks/w3-nim-pull-workaround-runbook.md`
+
+---
+
+## 1. Mission
+
+Run the §3 diagnostic plan on a cluster spark, capture evidence pointing at one of the 5 candidate root causes, and codify the W3 workaround. Apply no fix in this PR — fix surface is operator-side (Mikrotik admin UI / Tailscale admin console).
+
+## 2. Investigation host
+
+All in-cluster diagnostics ran from the host reachable via SSH alias `spark-2` (per `~/.ssh/config`). Notes on naming:
+- SSH alias `spark-2` → `192.168.0.104`
+- Linux `hostname` on that box: `spark-node-1`
+- Tailscale device name: `spark-1` (Tailscale IP `100.127.241.36`)
+- Memory note `project_spark_network_topology.md` already documents this naming inversion between SSH config and Tailscale.
+
+The brief literal `192.168.0.100` is NOT this host (per `/etc/hosts` it maps to `spark-node-2-mgmt`). Investigation used SSH alias `spark-2` because that is the name the brief refers to colloquially and is the documented operator handle. Operator should verify diagnostics line up with the spark they intended.
+
+## 3. Evidence captured
+
+### 3.1 DNS resolution comparison
+
+| Host | Local resolver | 8.8.8.8 |
+|---|---|---|
+| `api.ngc.nvidia.com` | 52.33.59.115, 184.33.29.243 | 52.33.59.115, 184.33.29.243 |
+| `xfiles.ngc.nvidia.com` | 3.171.171.{52,54,119,128} | 3.171.171.{52,54,119,128} |
+
+ASN lookup (Team Cymru DNS):
+- 52.33.59.115 → AS16509 / 52.32.0.0/14 (Amazon)
+- 184.33.29.243 → AS16509 / 184.32.0.0/14 (Amazon, Akamai-fronted historically but ASN reports Amazon)
+- 3.171.171.0/22 → AS16509 (Amazon CloudFront)
+
+**Finding:** No split-DNS. Both endpoints terminate inside Amazon AS16509. Different /22 prefixes — consistent with different CloudFront PoP / S3 origin clusters but same operator (AWS).
+
+### 3.2 Path comparison (mtr report mode, 3 probes per hop)
+
+`api.ngc.nvidia.com`:
+```
+1. 192.168.0.1     0.0% (Mikrotik)
+2. 69.128.80.1     0.0% (ISP edge)
+3. 69.128.248.142  0.0% (ISP backbone)
+4. 64.50.238.86    0.0%
+5. 108.166.240.72  0.0%
+6. ???           100.0% (target / ICMP-filtered)
+```
+
+`xfiles.ngc.nvidia.com`:
+```
+1. 192.168.0.1     0.0% (Mikrotik)
+2. 69.128.80.1     0.0% (ISP edge)
+3. 69.128.248.142  0.0% (ISP backbone)
+4-8. ???         100.0% (ICMP-filtered)
+9. 3.171.171.119   0.0% (CloudFront PoP)
+```
+
+**Finding:** Hops 1–3 identical. Both endpoints leave the operator's network through the **same Mikrotik gateway and same ISP backbone hop**. Path divergence happens at hop 4+, inside AWS. ICMP filtering on xfiles intermediate hops is normal CDN behavior, not evidence of an operator-side middlebox.
+
+Mac-side comparison: pending operator (out of scope for autonomous investigation).
+
+### 3.3 tcpdump captures
+
+Limitation surfaced in autonomous run: `admin@spark-2` does not have `NGC_CLI_API_KEY` configured. Without auth, the actual `DownloadFileSizeMismatch` failure mode cannot be reproduced from a non-operator shell. **Auth'd capture during a failing weights pull is operator follow-up.** What we did capture:
+
+#### 3.3a Anonymous probes to xfiles (4 sequential connections + 1 range-request attempt, ~5s window)
+
+- 4 SYN / SYN-ACK / clean FIN closures
+- 0 RST mid-stream
+- Server MSS = 1380 (sane post-clamp)
+- 403 responses delivered cleanly (146 byte XML body each)
+- Total 109 packets, flag distribution: `[.]` 48, `[P.]` 44, `[F.]` 8, `[S]` 4, `[S.]` 4, `[R]` 0
+
+#### 3.3b Long-lived idle TLS session to xfiles (60s)
+
+- TLS handshake completed (cert chain validates: `CN=ngc.nvidia.com`, signed by Amazon RSA 2048 M01 → Amazon Root CA 1)
+- 403 served immediately by CloudFront (POP `ATL59-P13`)
+- Connection held open for ~55s idle
+- RST received from `3.171.171.119:443` after ~55s
+
+**Interpretation of 3.3b RST:** Likely normal CloudFront keep-alive idle timeout (CloudFront default 60s). Not strong evidence of operator-side middlebox kill. Without auth'd capture during actual sustained data transfer, we cannot observe consistent-byte-offset RST signatures or window-collapse patterns.
+
+PCAP files NOT committed (per brief hard-constraint, sanitization risk). Stored on spark-2 at `~/f5-investigation-2026-04-29/` for operator review.
+
+### 3.4 Mikrotik admin UI inspection
+
+Out of scope for autonomous investigation (operator-side). Operator action items in §5.
+
+### 3.5 Tailscale state
+
+```
+HostName:        spark-node-1
+TailscaleIPs:    [100.127.241.36, fd7a:115c:a1e0::fd39:f124]
+ExitNode:        False
+ExitNodeOption:  False
+Active:          False
+DERP nearest:    Miami (17.7ms)
+```
+
+Routing table:
+- `default via 192.168.0.1 dev enP7s7 proto static` (primary, wired)
+- `default via 10.0.0.1 dev wlP9s9 proto dhcp metric 600` (WiFi backup, lower priority)
+- `tailscale0` table 52: only `100.x` peer IPs, **no `0.0.0.0/0` via tunnel**
+
+**Finding: Tailscale exit-node routing RULED OUT.** No tunneled internet-bound traffic. NGC-bound packets leave via wired enP7s7 → 192.168.0.1.
+
+### 3.6 Sustained-transfer comparison
+
+| Test | Endpoint | Size | Result | Speed |
+|---|---|---|---|---|
+| Cloudflare control | `speed.cloudflare.com/__down?bytes=10000000` | 10 MB | **PASS** | 44 MB/s |
+| Cloudflare medium | `speed.cloudflare.com/__down?bytes=50000000` | 50 MB | **PASS** | 83 MB/s |
+| AWS CloudFront alt (HF dataset) | `huggingface.co/.../test.jsonl` | 446 KB | PASS | 4 MB/s |
+| Fastly CDN large | `github.com/ollama/ollama/releases/download/v0.1.0/ollama-linux-amd64` | **705 MB** | **PASS** | **70 MB/s** |
+| xfiles unauth | `xfiles.ngc.nvidia.com/` | 146 B 403 | small response only — N/A for sustained |
+| xfiles auth'd weight pull | (operator follow-up) | multi-GB | reported FAIL (DownloadFileSizeMismatch) per brief §2.2 |
+
+**Finding: cluster CAN sustain 705 MB at 70 MB/s** through the same Mikrotik gateway. The failure is NOT a generic sustained-transfer problem.
+
+## 4. Candidate root cause ranking
+
+Ranked by the strength of the evidence in §3:
+
+### Most likely → least likely
+
+#### 1. Destination-specific issue at NGC origin / xfiles CloudFront edge
+
+**Why this rises to #1:** 705 MB Fastly + 50 MB Cloudflare both succeeded through the same Mikrotik path. If the operator's middlebox were applying generic DPI / conntrack / BBR-interaction policy, those would also fail. The failure tracks tightly to `xfiles.ngc.nvidia.com` (3.171.171.0/22).
+
+Possible mechanisms at the destination:
+- Cluster's outbound IP triggered NGC's bot/scraper detection
+- ASN- or prefix-based rate limiting at CloudFront origin policy
+- NGC-side authentication tier delivers truncated bodies for cluster's outbound IP for some classification reason
+- CloudFront signed-URL validity window mismatch (cluster clock skew?)
+
+**How operator confirms:** Re-run the failing pull from the cluster while simultaneously running the same NGC CLI command from a clean-internet machine on the same outbound IP via a SOCKS proxy — if both fail, it's destination-side; if cluster fails and proxy succeeds, it's path-side.
+
+#### 2. Mikrotik selectively filtering on xfiles SNI / hostname / specific destination prefix
+
+**Why mid-rank:** Same Mikrotik passed 705 MB Fastly. For this to be the root cause, the Mikrotik would need a host-specific or prefix-specific filter — possible but unusual. The MTU work (F1/F2/F4) hints PMTU-discovery may be broken on the path to 3.171.171.x specifically, suggesting middlebox involvement of *some* kind.
+
+**How operator confirms:** Mikrotik admin UI → `IP → Firewall → Filter Rules`. Look for any rule referencing `xfiles`, `nvidia`, `3.171.171.0/22`, `dst-port 443` with content matching, or any L7-protocol rule. Also `IP → Firewall → Layer7 Protocols`.
+
+#### 3. Asymmetric routing at AWS edge (cluster-IP-policy at CloudFront)
+
+**Why mid-rank:** Path on operator side is identical to both endpoints. Divergence is at AWS hop 4+. CloudFront may pin xfiles requests to a specific PoP that has a different reachability profile from cluster's IP than the api PoP.
+
+**How operator confirms:** From a different cluster spark (different Tailscale IP / outbound NAT mapping if the Mikrotik does any), retry the failing pull. If a different spark works, it's IP-policy at the destination.
+
+#### 4. Conntrack exhaustion on Mikrotik
+
+**RULED OUT (or near-ruled-out):** A 705 MB sustained transfer through the same Mikrotik succeeded with no observed throttling. Conntrack exhaustion would degrade ANY new connection, not just connections to xfiles.
+
+Operator can still verify: Mikrotik admin → `IP → Firewall → Connections` → check active count vs configured `nf_conntrack_max`. Bump if pegged. But evidence does not point here.
+
+#### 5. BBR vs CUBIC interaction with middlebox
+
+**RULED OUT:** 705 MB Fastly + 50 MB Cloudflare succeeded with the current host congestion-control choice. If BBR were misbehaving with the Mikrotik for sustained streams, we would have seen it in those large transfers. Sysctl swap not warranted by evidence.
+
+## 5. Recommended next operator action (priority order)
+
+1. **Mikrotik admin UI inspection** (15 min): log in to Mikrotik (`192.168.0.1` or Winbox), check `IP → Firewall → Filter Rules`, `Layer7 Protocols`, `Mangle`, `NAT` for any rule referencing nvidia / xfiles / `3.171.171.0/22`. Also check `IP → Firewall → Connections` count vs `/system resource` conntrack max. Capture screenshots / config dump.
+
+2. **Different-spark cross-check** (5 min): from a different spark (different SSH alias, different outbound NAT mapping potentially), attempt a small NGC weights pull. If it works, the issue is IP-specific at xfiles destination — escalate to NGC support with cluster outbound IP.
+
+3. **Operator Mac-side traceroute comparison**: run `traceroute -n -m 20 xfiles.ngc.nvidia.com` from the Mac. If Mac path skips a hop the cluster has, that hop is the suspect.
+
+4. **Auth'd tcpdump capture during real failing pull**: re-run §3.3 with `NGC_CLI_API_KEY` exported and the actual failing `ngc registry model download-version ...` command running. Look for: RST mid-stream, repeated retransmissions hitting a wall, ICMP "fragmentation needed", TCP window collapse to zero, RST at consistent byte offset (DPI signature).
+
+5. **Only if 1–4 inconclusive:** consider sysctl BBR→CUBIC swap (§4.5 of original brief). Reversible.
+
+## 6. What this PR does NOT do
+
+- **No Mikrotik configuration change** (operator-side only)
+- **No Tailscale configuration change** (operator-side only)
+- **No sysctl change** (BBR→CUBIC swap is a candidate fix, not part of investigation)
+- **No revert of F1, F2, F4** (harmless, stay in place)
+- **No service / NIM / LiteLLM / Qdrant modification**
+
+## 7. Workaround in effect
+
+Until F5 lands: **W3 — operator pulls NIM weights on Mac, scp to NAS canonical cache**. See `docs/operational/runbooks/w3-nim-pull-workaround-runbook.md`.
+
+Operational implications:
+- All NIM pulls go through operator Mac
+- Cluster cannot autonomously refresh NIM weights
+- TIER 1 batch-pull becomes operator-paced rather than agent-paced
+- Multi-spark pulls serialized through operator's home internet bandwidth
+- Image pulls (multi-MB nvcr.io) work with retries; weight pulls (multi-GB blobs) require Mac path
+
+## 8. Diagnostic artifacts (not committed)
+
+PCAPs from §3.3 stored on spark-2 at `~/f5-investigation-2026-04-29/`:
+- `f5-xfiles.pcap` (109 packets, anonymous probes)
+- `f5-tls-long.pcap` (22 packets, 60s idle session)
+
+Both are anonymous (no auth headers, no API keys). Operator may inspect with `tcpdump -r` or `wireshark`. They do NOT exercise the failing-pull mode and are kept off-PR per brief sanitization constraint.
+
+---
+
+End of investigation surface.

--- a/docs/operational/briefs/f5-root-cause-investigation-2026-04-29.md
+++ b/docs/operational/briefs/f5-root-cause-investigation-2026-04-29.md
@@ -3,7 +3,7 @@
 **Date:** 2026-04-29
 **Branch:** `chore/f5-root-cause-investigation-2026-04-29`
 **Driver:** 2026-04-29 llama-nemotron-embed deployment surfaced cluster network defect — small TLS to NGC works, sustained transfers from `xfiles.ngc.nvidia.com` fail with `DownloadFileSizeMismatch`. F1 + F2 + F4 stacked do NOT fix.
-**Status:** Diagnosis only. Fix requires Mikrotik admin UI or Tailscale admin console access (operator-side).
+**Status:** Diagnosis only. Fix surface is operator-side at the **TP-Link ER8411 web UI (`http://192.168.0.1`)**. No configuration is changed by this PR.
 **Tracking:** Issue #303
 **Cross-references:**
 - F2 fix: `docs/operational/briefs/iptables-mss-persistence-brief.md`
@@ -14,21 +14,33 @@
 
 ## 1. Mission
 
-Run the §3 diagnostic plan on a cluster spark, capture evidence pointing at one of the 5 candidate root causes, and codify the W3 workaround. Apply no fix in this PR — fix surface is operator-side (Mikrotik admin UI / Tailscale admin console).
+Run the §4 diagnostic plan from a cluster spark, capture evidence pointing at one of the candidate root causes, and codify the W3 workaround. Apply no fix in this PR — fix surface is the **TP-Link ER8411 web UI** (operator-side, after operator review of this investigation).
 
-## 2. Investigation host
+## 2. Topology correction (vs. original brief)
 
-All in-cluster diagnostics ran from the host reachable via SSH alias `spark-2` (per `~/.ssh/config`). Notes on naming:
-- SSH alias `spark-2` → `192.168.0.104`
-- Linux `hostname` on that box: `spark-node-1`
-- Tailscale device name: `spark-1` (Tailscale IP `100.127.241.36`)
-- Memory note `project_spark_network_topology.md` already documents this naming inversion between SSH config and Tailscale.
+The original F5 brief (`/home/admin/f5-root-cause-investigation-brief.md`) attributed the cluster egress middlebox to "Mikrotik". That was incorrect. Verified topology:
 
-The brief literal `192.168.0.100` is NOT this host (per `/etc/hosts` it maps to `spark-node-2-mgmt`). Investigation used SSH alias `spark-2` because that is the name the brief refers to colloquially and is the documented operator handle. Operator should verify diagnostics line up with the spark they intended.
+| Device | Role | Address |
+|---|---|---|
+| **TP-Link ER8411 Omada Pro VPN Router** | Internet egress, NAT, DHCP/DNS, firewall, DPI/IPS surface | `192.168.0.1` (default gw) |
+| **Mikrotik CRS812 switch** | **Fast fabric only** — 100 G ConnectX-6 between sparks (`10.10.10.0/24`, `10.10.11.0/24`, MTU 9000, BBR, ~93 Gbps verified) | not in egress path |
 
-## 3. Evidence captured
+**Verification of ER8411 at `192.168.0.1`:**
+- ARP: `192.168.0.1 dev enP7s7 lladdr 98:ba:5f:5c:fe:4a` — OUI `98:ba:5f` resolves to **TP-Link Systems Inc.** (macvendors.com)
+- Web UI fingerprint: `http://192.168.0.1/` redirects to `/webpages/login.html` — Omada Pro signature path
+- First hop on every external traceroute: `192.168.0.1` (mtr `0.0% loss`, ~0.3 ms)
 
-### 3.1 DNS resolution comparison
+**Mikrotik switch is NOT in the internet-egress path.** No Mikrotik DPI / firewall hypothesis applies to F5.
+
+**No active VPN tunnels** (OpenVPN previously deferred for Tailscale; Tailscale exit-node routing ruled out below). Re-introducing OpenVPN is future work outside F5 scope.
+
+## 3. Investigation host
+
+Diagnostics ran from the spark whose `hostname` is `spark-node-2` (mgmt IP `192.168.0.100`, fabric A `10.10.10.2`, fabric B `10.10.11.2`, Tailscale `100.80.122.100`). The naming inversion between Linux hostname / SSH alias / Tailscale device name is documented in `project_spark_network_topology.md`. Operator should verify diagnostics line up with the spark they intended.
+
+## 4. Evidence captured
+
+### 4.1 DNS resolution comparison
 
 | Host | Local resolver | 8.8.8.8 |
 |---|---|---|
@@ -37,41 +49,43 @@ The brief literal `192.168.0.100` is NOT this host (per `/etc/hosts` it maps to 
 
 ASN lookup (Team Cymru DNS):
 - 52.33.59.115 → AS16509 / 52.32.0.0/14 (Amazon)
-- 184.33.29.243 → AS16509 / 184.32.0.0/14 (Amazon, Akamai-fronted historically but ASN reports Amazon)
+- 184.33.29.243 → AS16509 / 184.32.0.0/14 (Amazon)
 - 3.171.171.0/22 → AS16509 (Amazon CloudFront)
 
 **Finding:** No split-DNS. Both endpoints terminate inside Amazon AS16509. Different /22 prefixes — consistent with different CloudFront PoP / S3 origin clusters but same operator (AWS).
 
-### 3.2 Path comparison (mtr report mode, 3 probes per hop)
+### 4.2 Path comparison (mtr report mode + tracepath)
 
-`api.ngc.nvidia.com`:
+`api.ngc.nvidia.com` (mtr):
 ```
-1. 192.168.0.1     0.0% (Mikrotik)
-2. 69.128.80.1     0.0% (ISP edge)
-3. 69.128.248.142  0.0% (ISP backbone)
+1. 192.168.0.1     0.0%   (TP-Link ER8411 — confirmed via ARP OUI + Omada UI)
+2. 69.128.80.1     0.0%   (ISP edge)
+3. 69.128.248.142  0.0%   (ISP backbone)
 4. 64.50.238.86    0.0%
 5. 108.166.240.72  0.0%
-6. ???           100.0% (target / ICMP-filtered)
+6. ???           100.0%   (target / ICMP-filtered)
 ```
 
-`xfiles.ngc.nvidia.com`:
+`xfiles.ngc.nvidia.com` (mtr):
 ```
-1. 192.168.0.1     0.0% (Mikrotik)
-2. 69.128.80.1     0.0% (ISP edge)
-3. 69.128.248.142  0.0% (ISP backbone)
-4-8. ???         100.0% (ICMP-filtered)
-9. 3.171.171.119   0.0% (CloudFront PoP)
+1. 192.168.0.1     0.0%   (TP-Link ER8411)
+2. 69.128.80.1     0.0%   (ISP edge)
+3. 69.128.248.142  0.0%   (ISP backbone)
+4-8. ???         100.0%   (ICMP-filtered)
+9. 3.171.171.119   0.0%   (CloudFront PoP)
 ```
 
-**Finding:** Hops 1–3 identical. Both endpoints leave the operator's network through the **same Mikrotik gateway and same ISP backbone hop**. Path divergence happens at hop 4+, inside AWS. ICMP filtering on xfiles intermediate hops is normal CDN behavior, not evidence of an operator-side middlebox.
+`tracepath` confirms `pmtu 1420` host-side and same ISP-edge / backbone hops out of ER8411 to both endpoints.
+
+**Finding:** Hops 1–3 identical. Both endpoints leave through the **same TP-Link ER8411 + same ISP backbone hop**. Path divergence happens at hop 4+, inside AWS. ICMP filtering on intermediate xfiles hops is normal CDN behavior.
 
 Mac-side comparison: pending operator (out of scope for autonomous investigation).
 
-### 3.3 tcpdump captures
+### 4.3 tcpdump captures
 
-Limitation surfaced in autonomous run: `admin@spark-2` does not have `NGC_CLI_API_KEY` configured. Without auth, the actual `DownloadFileSizeMismatch` failure mode cannot be reproduced from a non-operator shell. **Auth'd capture during a failing weights pull is operator follow-up.** What we did capture:
+Limitation surfaced in autonomous run: `admin@spark-2` does not have `NGC_CLI_API_KEY` configured. Without auth, the actual `DownloadFileSizeMismatch` failure mode cannot be reproduced from a non-operator shell. **Auth'd capture during a failing weights pull is operator follow-up.** Captured anonymously:
 
-#### 3.3a Anonymous probes to xfiles (4 sequential connections + 1 range-request attempt, ~5s window)
+#### 4.3a Anonymous probes to xfiles (4 sequential connections + 1 range-request attempt, ~5 s window)
 
 - 4 SYN / SYN-ACK / clean FIN closures
 - 0 RST mid-stream
@@ -79,61 +93,83 @@ Limitation surfaced in autonomous run: `admin@spark-2` does not have `NGC_CLI_AP
 - 403 responses delivered cleanly (146 byte XML body each)
 - Total 109 packets, flag distribution: `[.]` 48, `[P.]` 44, `[F.]` 8, `[S]` 4, `[S.]` 4, `[R]` 0
 
-#### 3.3b Long-lived idle TLS session to xfiles (60s)
+#### 4.3b Long-lived idle TLS session to xfiles (60 s)
 
 - TLS handshake completed (cert chain validates: `CN=ngc.nvidia.com`, signed by Amazon RSA 2048 M01 → Amazon Root CA 1)
-- 403 served immediately by CloudFront (POP `ATL59-P13`)
-- Connection held open for ~55s idle
-- RST received from `3.171.171.119:443` after ~55s
+- 403 served immediately by CloudFront (PoP `ATL59-P13`)
+- Connection held open for ~55 s idle
+- RST received from `3.171.171.119:443` after ~55 s
 
-**Interpretation of 3.3b RST:** Likely normal CloudFront keep-alive idle timeout (CloudFront default 60s). Not strong evidence of operator-side middlebox kill. Without auth'd capture during actual sustained data transfer, we cannot observe consistent-byte-offset RST signatures or window-collapse patterns.
+**Interpretation of 4.3b RST:** Likely normal CloudFront keep-alive idle timeout (CloudFront default 60 s). Not strong evidence of an ER8411-side middlebox kill. Without auth'd capture during actual sustained data transfer, we cannot observe consistent-byte-offset RST signatures or window-collapse patterns characteristic of DPI.
 
 PCAP files NOT committed (per brief hard-constraint, sanitization risk). Stored on spark-2 at `~/f5-investigation-2026-04-29/` for operator review.
 
-### 3.4 Mikrotik admin UI inspection
+### 4.4 ER8411 admin UI inspection
 
-Out of scope for autonomous investigation (operator-side). Operator action items in §5.
+Out of scope for autonomous investigation (operator-side). Operator action items in §6.
 
-### 3.5 Tailscale state
+### 4.5 Tailscale state
 
 ```
-HostName:        spark-node-1
+HostName:        spark-node-1   (Tailscale device name; inverted from Linux hostname)
 TailscaleIPs:    [100.127.241.36, fd7a:115c:a1e0::fd39:f124]
 ExitNode:        False
 ExitNodeOption:  False
 Active:          False
-DERP nearest:    Miami (17.7ms)
+DERP nearest:    Miami (17.7 ms)
 ```
 
 Routing table:
-- `default via 192.168.0.1 dev enP7s7 proto static` (primary, wired)
+- `default via 192.168.0.1 dev enP7s7 proto static` (primary, wired through ER8411)
 - `default via 10.0.0.1 dev wlP9s9 proto dhcp metric 600` (WiFi backup, lower priority)
 - `tailscale0` table 52: only `100.x` peer IPs, **no `0.0.0.0/0` via tunnel**
 
-**Finding: Tailscale exit-node routing RULED OUT.** No tunneled internet-bound traffic. NGC-bound packets leave via wired enP7s7 → 192.168.0.1.
+**Finding: Tailscale exit-node routing RULED OUT.** No tunneled internet-bound traffic. NGC-bound packets leave via wired `enP7s7 → 192.168.0.1` (ER8411).
 
-### 3.6 Sustained-transfer comparison
+### 4.6 Sustained-transfer comparison (multi-CDN)
 
-| Test | Endpoint | Size | Result | Speed |
-|---|---|---|---|---|
-| Cloudflare control | `speed.cloudflare.com/__down?bytes=10000000` | 10 MB | **PASS** | 44 MB/s |
-| Cloudflare medium | `speed.cloudflare.com/__down?bytes=50000000` | 50 MB | **PASS** | 83 MB/s |
-| AWS CloudFront alt (HF dataset) | `huggingface.co/.../test.jsonl` | 446 KB | PASS | 4 MB/s |
-| Fastly CDN large | `github.com/ollama/ollama/releases/download/v0.1.0/ollama-linux-amd64` | **705 MB** | **PASS** | **70 MB/s** |
-| xfiles unauth | `xfiles.ngc.nvidia.com/` | 146 B 403 | small response only — N/A for sustained |
-| xfiles auth'd weight pull | (operator follow-up) | multi-GB | reported FAIL (DownloadFileSizeMismatch) per brief §2.2 |
+All curl tests run from spark-2 through ER8411. Caps: 60 s timeout, 500 MB max each (range request used where Content-Length exceeded cap).
 
-**Finding: cluster CAN sustain 705 MB at 70 MB/s** through the same Mikrotik gateway. The failure is NOT a generic sustained-transfer problem.
+| Test | Endpoint / CDN | Bytes transferred | Time | Throughput | Result |
+|---|---|---|---|---|---|
+| Cloudflare 50 MB | `speed.cloudflare.com` (Cloudflare) | 50,000,000 | 0.53 s | **94 MB/s** (≈753 Mbps) | **PASS** |
+| Ubuntu ISO range 0-499 MB | `releases.ubuntu.com/24.04/ubuntu-24.04.4-live-server-amd64.iso` (Canonical CDN) | 500,000,000 | 5.43 s | **92 MB/s** (≈736 Mbps) | **PASS** |
+| HF model — sentence-transformers/all-mpnet-base-v2 | `huggingface.co/.../model.safetensors` (Cloudflare-fronted HF) | 437,971,872 | 4.19 s | **104 MB/s** (≈836 Mbps) | **PASS** |
+| HF model range 0-499 MB — BAAI/bge-large-en-v1.5 | `huggingface.co/.../model.safetensors` | 500,000,000 | 4.49 s | **111 MB/s** (≈892 Mbps) | **PASS** |
+| GitHub/Fastly 705 MB (prior run) | `github.com/ollama/ollama/releases/download/...` (Fastly) | 705,000,000 | ~10 s | **70 MB/s** | **PASS** |
+| `xfiles.ngc.nvidia.com` unauth | (CloudFront 3.171.171.0/22) | 146 B (403 XML) | n/a | small response only — N/A for sustained | n/a |
+| `xfiles.ngc.nvidia.com` auth'd weight pull | (CloudFront, NGC artifacts) | (operator follow-up; reproducible per brief §2.2) | n/a | n/a | **FAIL — DownloadFileSizeMismatch** |
 
-## 4. Candidate root cause ranking
+**Failure surface:** Cluster sustains 90–110 MB/s through ER8411 to **Cloudflare, Canonical, Hugging Face/Cloudflare, and GitHub/Fastly**. Failure is **NGC-only** (specifically `xfiles.ngc.nvidia.com` on `3.171.171.0/22`).
 
-Ranked by the strength of the evidence in §3:
+### 4.7 MSS clamp + PMTU evidence
+
+Spark-2 stack:
+```
+# iptables OUTPUT chain rule 2 (F2):
+TCPMSS  tcp flags:0x06/0x02  TCPMSS clamp to PMTU
+# (active: 1120 packets / 67 KB clamped at observation time)
+
+# Host MTU: 1420 (F4 — set on enP7s7)
+# TCP congestion control: bbr
+# nf_conntrack: 1101 / 655360 (well under spark-2 limit; ER8411 conntrack unknown)
+```
+
+`ping -M do` DF-sweep to xfiles: host stack does not emit packets >1420 (consistent with F4). Larger DF probes show `transmitted 0 received` — local interface refuses, not in-path PMTU drops.
+
+`tracepath -n xfiles.ngc.nvidia.com` reports `pmtu 1420` source-side and no asymmetric reduction along the path. ICMP frag-needed responses are not observed in §4.3 captures, but neither is evidence of double-clamp from ER8411 advertising a smaller MSS than spark-2.
+
+**Finding:** **No double-clamp evidence** in available data. Host-side MSS clamp (F2) is functioning. PMTU is 1420 across the path. Operator follow-up: auth'd tcpdump during failing pull would show ER8411-clamp signatures (if any) on SYN-ACK return.
+
+## 5. Candidate root cause ranking (corrected for ER8411 + no VPN tunnels)
+
+Ranked by strength of evidence in §4. Original brief candidate list reordered for ER8411-as-egress; **Mikrotik DPI** and **VPN tunnel asymmetric routing** removed (no longer applicable).
 
 ### Most likely → least likely
 
 #### 1. Destination-specific issue at NGC origin / xfiles CloudFront edge
 
-**Why this rises to #1:** 705 MB Fastly + 50 MB Cloudflare both succeeded through the same Mikrotik path. If the operator's middlebox were applying generic DPI / conntrack / BBR-interaction policy, those would also fail. The failure tracks tightly to `xfiles.ngc.nvidia.com` (3.171.171.0/22).
+**Why #1 (strong evidence):** Multi-CDN sustained transfers — Cloudflare, Canonical, Hugging Face, GitHub/Fastly — all PASS at 90–110 MB/s through the same ER8411. Failure tracks tightly to `xfiles.ngc.nvidia.com` (3.171.171.0/22) only. If ER8411 were applying generic policy (DPI / IPS / category-throttle / conntrack / BBR-interaction), at least one of the multi-CDN tests would also degrade.
 
 Possible mechanisms at the destination:
 - Cluster's outbound IP triggered NGC's bot/scraper detection
@@ -141,51 +177,87 @@ Possible mechanisms at the destination:
 - NGC-side authentication tier delivers truncated bodies for cluster's outbound IP for some classification reason
 - CloudFront signed-URL validity window mismatch (cluster clock skew?)
 
-**How operator confirms:** Re-run the failing pull from the cluster while simultaneously running the same NGC CLI command from a clean-internet machine on the same outbound IP via a SOCKS proxy — if both fail, it's destination-side; if cluster fails and proxy succeeds, it's path-side.
+**How operator confirms:** Re-run the failing pull from the cluster while simultaneously running the same NGC CLI command from a clean-internet machine on the same outbound IP via SOCKS proxy — if both fail, destination-side; if cluster fails and proxy succeeds, path-side.
 
-#### 2. Mikrotik selectively filtering on xfiles SNI / hostname / specific destination prefix
+#### 2. ER8411 Application Control / DPI selectively classifying NGC
 
-**Why mid-rank:** Same Mikrotik passed 705 MB Fastly. For this to be the root cause, the Mikrotik would need a host-specific or prefix-specific filter — possible but unusual. The MTU work (F1/F2/F4) hints PMTU-discovery may be broken on the path to 3.171.171.x specifically, suggesting middlebox involvement of *some* kind.
+**Why mid-rank (moderate):** TP-Link Omada Pro ER8411 ships with **Application Control** (category-aware DPI) and **IPS** modules. The 705 MB Fastly + multi-CDN HF/Ubuntu/Cloudflare success rules out *generic* DPI throttling — but Application Control category lists could still selectively touch "AI/ML model distribution" or "NVIDIA NGC" if such a category exists in the firmware's signature database. The pattern (small response works, sustained transfer fails mid-stream) is consistent with category-classified DPI.
 
-**How operator confirms:** Mikrotik admin UI → `IP → Firewall → Filter Rules`. Look for any rule referencing `xfiles`, `nvidia`, `3.171.171.0/22`, `dst-port 443` with content matching, or any L7-protocol rule. Also `IP → Firewall → Layer7 Protocols`.
+**How operator confirms:** ER8411 web UI (`http://192.168.0.1`) → **Application Control** → check for any rule matching source `192.168.0.0/24`. Look at category list, application list, and "Application-aware" routing rules. Either:
+- Disable Application Control for source `192.168.0.0/24`, OR
+- Add an explicit allow rule for outbound to `3.171.171.0/22` and `*.ngc.nvidia.com` ahead of any blocking rule.
 
-#### 3. Asymmetric routing at AWS edge (cluster-IP-policy at CloudFront)
+#### 3. ER8411 IPS rule false-positive on sustained NVIDIA blob downloads
 
-**Why mid-rank:** Path on operator side is identical to both endpoints. Divergence is at AWS hop 4+. CloudFront may pin xfiles requests to a specific PoP that has a different reachability profile from cluster's IP than the api PoP.
+**Why mid-rank (moderate):** Same firmware family typically ships **IPS** signatures keyed off TLS SNI / certificate / payload heuristics. Sustained binary blob from a CDN PoP tagged "AI model weights" could plausibly trip a "data-exfiltration" or "binary-over-https" heuristic. The 705 MB Fastly success argues against generic IPS triggering on size, but signature-specific behavior is possible.
 
-**How operator confirms:** From a different cluster spark (different Tailscale IP / outbound NAT mapping if the Mikrotik does any), retry the failing pull. If a different spark works, it's IP-policy at the destination.
+**How operator confirms:** ER8411 web UI → **IPS / Threat Management → Logs**. Filter logs for the failing-pull window (operator: capture wall-clock time of failing `ngc registry model download-version` before reproducing). Any signature hit naming `xfiles`, `nvidia`, `model-distribution`, or sustained-transfer heuristics is the smoking gun. Tune by exempting source `192.168.0.0/24` or destination `3.171.171.0/22`.
 
-#### 4. Conntrack exhaustion on Mikrotik
+#### 4. ER8411 Bandwidth Control / QoS (application-category throttling)
 
-**RULED OUT (or near-ruled-out):** A 705 MB sustained transfer through the same Mikrotik succeeded with no observed throttling. Conntrack exhaustion would degrade ANY new connection, not just connections to xfiles.
+**Why mid-rank (weaker):** Omada Pro **Bandwidth Control** can throttle by application category. If "model distribution" / "NVIDIA NGC" is a separately-managed category from generic file-download, sustained xfiles could see a hard ceiling while Cloudflare/Fastly/HF stay uncapped. Multi-CDN PASS data argues against a *broad* file-download cap; a *narrow* category-specific cap is possible.
 
-Operator can still verify: Mikrotik admin → `IP → Firewall → Connections` → check active count vs configured `nf_conntrack_max`. Bump if pegged. But evidence does not point here.
+**How operator confirms:** ER8411 web UI → **Bandwidth Control** → list rules. Confirm no rule matches NGC traffic specifically. If found, disable for `192.168.0.0/24` or for destination `3.171.171.0/22`.
 
-#### 5. BBR vs CUBIC interaction with middlebox
+#### 5. Asymmetric routing / IP policy at AWS edge (not ER8411-side)
 
-**RULED OUT:** 705 MB Fastly + 50 MB Cloudflare succeeded with the current host congestion-control choice. If BBR were misbehaving with the Mikrotik for sustained streams, we would have seen it in those large transfers. Sysctl swap not warranted by evidence.
+**Why mid-rank (moderate):** Path on operator side is identical to both NGC endpoints. Divergence is at AWS hop 4+. CloudFront may pin xfiles requests to a PoP that has a different reachability profile from cluster's outbound IP than the api PoP.
 
-## 5. Recommended next operator action (priority order)
+**How operator confirms:** From a different cluster spark (different outbound NAT mapping if ER8411 does any), retry the failing pull. If a different spark works, IP-policy at the destination is the cause.
 
-1. **Mikrotik admin UI inspection** (15 min): log in to Mikrotik (`192.168.0.1` or Winbox), check `IP → Firewall → Filter Rules`, `Layer7 Protocols`, `Mangle`, `NAT` for any rule referencing nvidia / xfiles / `3.171.171.0/22`. Also check `IP → Firewall → Connections` count vs `/system resource` conntrack max. Capture screenshots / config dump.
+#### 6. MSS double-clamp interaction (ER8411 + spark-2 host clamp)
 
-2. **Different-spark cross-check** (5 min): from a different spark (different SSH alias, different outbound NAT mapping potentially), attempt a small NGC weights pull. If it works, the issue is IP-specific at xfiles destination — escalate to NGC support with cluster outbound IP.
+**Why mid-rank (weak):** Both spark-2 (F2 OUTPUT chain TCPMSS → PMTU) and ER8411 (default behavior on Omada Pro) likely clamp MSS. Multi-CDN passing argues against a generic double-clamp problem, but a destination-specific PMTU asymmetry to `3.171.171.0/22` is conceivable.
 
-3. **Operator Mac-side traceroute comparison**: run `traceroute -n -m 20 xfiles.ngc.nvidia.com` from the Mac. If Mac path skips a hop the cluster has, that hop is the suspect.
+**How operator confirms:** Auth'd tcpdump during failing pull → inspect SYN/SYN-ACK MSS values and look for ICMP frag-needed not arriving. If MSS dropped to abnormally low value (e.g. 536 / 1280) on xfiles only, double-clamp is implicated.
 
-4. **Auth'd tcpdump capture during real failing pull**: re-run §3.3 with `NGC_CLI_API_KEY` exported and the actual failing `ngc registry model download-version ...` command running. Look for: RST mid-stream, repeated retransmissions hitting a wall, ICMP "fragmentation needed", TCP window collapse to zero, RST at consistent byte offset (DPI signature).
+#### 7. Conntrack exhaustion on ER8411
+
+**RULED OUT (or near-ruled-out):** Multi-CDN sustained transfers at 90–110 MB/s in ~5 s windows succeeded with no observed throttling. Conntrack exhaustion would degrade ANY new connection. spark-2 conntrack is `1101 / 655360` — well under limit on the host side. ER8411 limit unknown but unlikely to be pegged with no active VPN tunnels consuming sessions.
+
+Operator can still verify: ER8411 web UI → **Status → Connections** → check active count vs. configured `Max Sessions`. Bump if pegged. Evidence does not point here.
+
+#### 8. Tailscale exit-node routing on sub-prefix
+
+**RULED OUT.** §4.5 confirms `ExitNode: False`, `Active: False`, no `0.0.0.0/0` via `tailscale0` in any routing table. NGC-bound packets leave via wired `enP7s7 → 192.168.0.1`.
+
+#### 9. BBR vs CUBIC interaction with ER8411
+
+**RULED OUT.** Multi-CDN tests succeeded with current host congestion-control (`bbr`). If BBR were misbehaving with ER8411 for sustained streams, we would have seen it in those large transfers. Sysctl swap not warranted by evidence.
+
+#### Dropped from original brief (no longer applicable)
+
+- **Mikrotik DPI** — Mikrotik is fast-fabric only, not in egress path.
+- **VPN tunnel asymmetric routing** — no active tunnels (Tailscale not exit-noding; OpenVPN deferred).
+
+## 6. Recommended next operator action (priority order)
+
+1. **ER8411 web UI inspection** (~15 min) — log in to `http://192.168.0.1`, then walk:
+   - **Application Control** — check for any rule matching source `192.168.0.0/24`. If present and not deliberately scoped, disable for cluster sources OR add an explicit allow for `3.171.171.0/22` + `*.ngc.nvidia.com` ahead of it.
+   - **IPS / Threat Management → Logs** — filter for the wall-clock window of a known failing pull (operator captures timestamp before reproducing). Any signature hit on `xfiles`, `nvidia`, `model-distribution`, or sustained-transfer heuristics is the smoking gun.
+   - **Bandwidth Control** — confirm no rule throttles `192.168.0.0/24` or destination `3.171.171.0/22` by application category.
+   - **Status → Connections** — read active count vs. `Max Sessions`. Confirm not pegged.
+   - **Firewall → ACL / NAT** — check for any explicit rule referencing `nvidia`, `xfiles`, `3.171.171.0/22`, or NGC.
+   - Capture screenshots / config dump for evidence.
+
+2. **Different-spark cross-check** (~5 min) — from a different spark (different SSH alias, potentially different outbound NAT mapping), attempt a small NGC weights pull. If it works, the issue is IP-specific at xfiles destination — escalate to NGC support with cluster outbound IP.
+
+3. **Operator Mac-side traceroute comparison** — `traceroute -n -m 20 xfiles.ngc.nvidia.com` from the Mac. If Mac path skips a hop the cluster has, that hop is the suspect.
+
+4. **Auth'd tcpdump capture during real failing pull** — re-run §4.3 with `NGC_CLI_API_KEY` exported and the actual failing `ngc registry model download-version ...` command running. Look for: RST mid-stream, repeated retransmissions hitting a wall, ICMP "fragmentation needed", TCP window collapse to zero, RST at consistent byte offset (DPI signature), SYN/SYN-ACK MSS asymmetry (double-clamp).
 
 5. **Only if 1–4 inconclusive:** consider sysctl BBR→CUBIC swap (§4.5 of original brief). Reversible.
 
-## 6. What this PR does NOT do
+## 7. What this PR does NOT do
 
-- **No Mikrotik configuration change** (operator-side only)
-- **No Tailscale configuration change** (operator-side only)
+- **No ER8411 configuration change** (operator-side only)
+- **No Mikrotik configuration change** (irrelevant to F5)
+- **No Tailscale configuration change** (operator-side only; ruled out anyway)
 - **No sysctl change** (BBR→CUBIC swap is a candidate fix, not part of investigation)
 - **No revert of F1, F2, F4** (harmless, stay in place)
 - **No service / NIM / LiteLLM / Qdrant modification**
 
-## 7. Workaround in effect
+## 8. Workaround in effect
 
 Until F5 lands: **W3 — operator pulls NIM weights on Mac, scp to NAS canonical cache**. See `docs/operational/runbooks/w3-nim-pull-workaround-runbook.md`.
 
@@ -196,11 +268,11 @@ Operational implications:
 - Multi-spark pulls serialized through operator's home internet bandwidth
 - Image pulls (multi-MB nvcr.io) work with retries; weight pulls (multi-GB blobs) require Mac path
 
-## 8. Diagnostic artifacts (not committed)
+## 9. Diagnostic artifacts (not committed)
 
-PCAPs from §3.3 stored on spark-2 at `~/f5-investigation-2026-04-29/`:
+PCAPs from §4.3 stored on spark-2 at `~/f5-investigation-2026-04-29/`:
 - `f5-xfiles.pcap` (109 packets, anonymous probes)
-- `f5-tls-long.pcap` (22 packets, 60s idle session)
+- `f5-tls-long.pcap` (22 packets, 60 s idle session)
 
 Both are anonymous (no auth headers, no API keys). Operator may inspect with `tcpdump -r` or `wireshark`. They do NOT exercise the failing-pull mode and are kept off-PR per brief sanitization constraint.
 

--- a/docs/operational/runbooks/w3-nim-pull-workaround-runbook.md
+++ b/docs/operational/runbooks/w3-nim-pull-workaround-runbook.md
@@ -1,0 +1,134 @@
+# W3 — NIM Weight Pull Workaround Runbook
+
+**Purpose:** Canonical procedure for pulling NIM weights into the cluster while F5 (cluster-egress sustained-transfer failure to `xfiles.ngc.nvidia.com`) is unresolved.
+
+**Status:** ACTIVE STANDARD until F5 lands. All NIM weight pulls go through W3.
+**Owner:** Operator (only operator-side internet egress works for sustained NGC weight pulls).
+**Cross-references:**
+- F5 investigation: `docs/operational/briefs/f5-root-cause-investigation-2026-04-29.md`
+- F2 fix (related TLS handshake): `docs/operational/briefs/iptables-mss-persistence-brief.md`
+
+---
+
+## 1. When to use this runbook
+
+Trigger conditions:
+- Any NIM model needs weights resident in `/mnt/fortress_nas/nim-cache/...`
+- Any per-NIM deployment brief calls for weight materialization on NAS
+- TIER 1 NeMo Retriever family batch-pull (until F5 lands, executed sequentially through W3)
+- Cluster-side `ngc registry model download-version` returns `DownloadFileSizeMismatch`
+
+Do NOT trigger if:
+- Weights already on NAS (verify first with `ls /mnt/fortress_nas/nim-cache/<model>/...`)
+- The artifact is an *image* not a weights blob — image pulls from `nvcr.io` work on cluster with retries
+
+## 2. Prerequisites (one-time on operator Mac)
+
+1. NGC CLI installed:
+   ```sh
+   brew install ngc-cli   # or download from ngc.nvidia.com
+   ngc --version
+   ```
+2. NGC CLI configured:
+   ```sh
+   ngc config set
+   # paste API key when prompted; org = `nvidia`; team = `nvidia` (or as scoped)
+   ```
+3. SSH alias to NAS-accessible cluster spark in `~/.ssh/config`:
+   ```sshconfig
+   Host spark-1
+       HostName 10.10.10.2
+   ```
+4. NAS path writable from cluster (already standard): `/mnt/fortress_nas/nim-cache/`
+
+## 3. Procedure
+
+For each NIM weights pull:
+
+### 3.1 On operator Mac — pull from NGC
+
+```sh
+NIM_NAME="<model-short-name>"     # e.g., llama-nemotron-embed
+NIM_VERSION="<org>/<team>/<repo>:<profile>"  # e.g., nim/nvidia/llama-nemotron-embed-1b-v2:cc_12_0-fp16-6d747e0e
+
+mkdir -p ~/Downloads/${NIM_NAME}-weights/
+cd ~/Downloads/${NIM_NAME}-weights/
+
+ngc registry model download-version "${NIM_VERSION}"
+```
+
+Verify the extracted folder contents — should include:
+- `*.safetensors` or `*.bin` weight shards
+- `config.json`, `tokenizer*.json`, `generation_config.json` (HF-style metadata)
+- A `manifest.json` or model card (if NIM-specific)
+
+### 3.2 On operator Mac — scp to NAS canonical cache
+
+```sh
+NAS_CACHE_BASE="/mnt/fortress_nas/nim-cache/nim/<model>/nim-weights-cache/ngc/hub"
+EXTRACTED_DIR=$(ls -d ~/Downloads/${NIM_NAME}-weights/*/ | head -1)
+
+# Create canonical HF-cache layout target on NAS via the cluster spark (NAS is mounted there)
+ssh spark-1 "mkdir -p ${NAS_CACHE_BASE}/<canonical-hf-layout>/"
+
+# scp the extracted contents
+scp -r "${EXTRACTED_DIR}"/* spark-1:${NAS_CACHE_BASE}/<canonical-hf-layout>/
+```
+
+Replace `<canonical-hf-layout>` with the layout the per-NIM deployment brief specifies (typically `models--<org>--<repo>/snapshots/<rev>/` for HF-cache compatibility).
+
+### 3.3 On cluster (spark) — verify and consume
+
+```sh
+ssh spark-1 "ls -la ${NAS_CACHE_BASE}/<canonical-hf-layout>/ | head -10"
+```
+
+Expected: full weight set present, sizes match NGC manifest.
+
+Cluster reads from NAS-mounted cache; the NIM container is configured (per per-NIM deployment brief) to set `HF_HOME` / `NIM_CACHE_PATH` to the NAS path. **No NGC fetch from sparks.** This is the sovereign-cache property — once weights on NAS, cluster is offline-capable for that model.
+
+### 3.4 Cleanup on Mac
+
+```sh
+rm -rf ~/Downloads/${NIM_NAME}-weights/
+```
+
+## 4. Limitations
+
+- **Manual operator step** — does not scale to dozens of NIMs without operator hands-on time
+- **Operator's home internet capacity is the pull bottleneck** — multi-GB downloads pace at home ISP speed
+- **Operator availability blocks fully-automated TIER 1 batch-pull** — no agent can autonomously trigger this
+- **Each pull requires correct HF-cache layout reconstruction on NAS** — operator must know the per-NIM layout convention
+- **No retry-on-failure automation** — if the pull fails midway on Mac (rare, but possible), operator restarts manually
+
+## 5. Advantages
+
+- **Works today** — no infrastructure access required
+- **Bypasses cluster's broken egress entirely** — independent of F5 root cause
+- **Sovereign** — once weights on NAS, cluster never touches NGC again for that model
+- **Cleanly reproducible** — same procedure for any NIM
+- **Auditable** — operator can capture timestamps, file sizes, and SHAs at each step
+
+## 6. When F5 lands
+
+This runbook becomes obsolete (or downgraded to a fallback for environments without internet). All callers — TIER 1 batch-pull brief, per-NIM deployment briefs, master plan §6.5 — should be updated to remove the W3 dependency once F5 fix is verified.
+
+Verification that F5 is fixed:
+```sh
+ssh spark-1 'curl -sS --max-time 60 -o /tmp/test.bin -w "size=%{size_download} time=%{time_total}\n" \
+  -H "Authorization: Bearer $NGC_CLI_API_KEY" \
+  "https://xfiles.ngc.nvidia.com/<known-multi-MB-artifact>"'
+```
+
+If `size` matches expected and no `DownloadFileSizeMismatch`, F5 is resolved. Re-run the TIER 1 batch-pull from the cluster directly to confirm at scale.
+
+## 7. References
+
+- F5 investigation surface: `docs/operational/briefs/f5-root-cause-investigation-2026-04-29.md`
+- F2 fix (TLS handshake MSS clamp, retained): `docs/operational/briefs/iptables-mss-persistence-brief.md`
+- Cluster network topology: `docs/architecture/shared/cluster-network-topology.md`
+- NGC CLI docs: `https://docs.ngc.nvidia.com/cli/`
+
+---
+
+End of runbook.


### PR DESCRIPTION
## Summary

- Investigation surface for F5 (cluster sustained-transfer failure to `xfiles.ngc.nvidia.com`). Diagnosis only — fix surface is operator-side at the **TP-Link ER8411 web UI** (`http://192.168.0.1`).
- Codifies W3 (operator-Mac NIM pull → scp to NAS) as the canonical NIM weight-pull procedure until F5 fix lands.
- Updates MASTER-PLAN.md §6.5 to reference F5 issue #303 and the W3 standard, with corrected ER8411 attribution.

**Merge BLOCKED on operator review.**

Issue: #303 (corrected body staged at `docs/operational/briefs/f5-issue-303-updated-body-2026-04-29.md` for operator to paste — active GH PAT lacks issue-write scope).

## Topology correction (vs. original brief)

The original F5 brief attributed cluster egress to "Mikrotik". That was wrong. Verified topology:

| Device | Role | Address |
|---|---|---|
| **TP-Link ER8411 Omada Pro VPN Router** | Internet egress, NAT, DHCP/DNS, firewall, DPI/IPS surface | `192.168.0.1` (default gw) |
| **Mikrotik CRS812 switch** | Fast fabric only — 100 G ConnectX-6 between sparks (`10.10.10/24`, `10.10.11/24`, MTU 9000, BBR, ~93 Gbps verified) | not in egress path |

Verification: ARP `192.168.0.1 lladdr 98:ba:5f:5c:fe:4a` (OUI = TP-Link Systems Inc.); web UI `/webpages/login.html` = Omada Pro signature. No active VPN tunnels (Tailscale exit-node ruled out below; OpenVPN deferred).

## Evidence summary

Diagnostics ran from spark-node-2 (mgmt `192.168.0.100`, fabric A `10.10.10.2`, fabric B `10.10.11.2`, Tailscale `100.80.122.100`).

| Step | Test | Result |
|---|---|---|
| §4.1 DNS | local resolver vs 8.8.8.8 for api / xfiles | identical; both AS16509 (Amazon) but different /22 prefixes |
| §4.2 mtr | api vs xfiles via cluster | hops 1–3 identical (ER8411 192.168.0.1 → ISP 69.128.80.1 → 69.128.248.142); divergence inside AWS at hop 4+ |
| §4.3 tcpdump | anonymous probes + 60 s idle TLS to xfiles | clean SYN/FIN, 0 RST mid-stream during data; one RST after ~55 s idle (likely normal CloudFront keep-alive timeout, not middlebox kill); auth'd capture during failing pull deferred — `NGC_CLI_API_KEY` not in admin's env |
| §4.5 Tailscale | spark state | `ExitNode: False`, `ExitNodeOption: False`; tunnel routes scoped to `100.x` peer IPs only — no `0.0.0.0/0` via tailnet |
| §4.7 MSS / PMTU | iptables OUTPUT TCPMSS clamp + tracepath | F2 clamp active (1120 packets clamped at observation); host MTU 1420 (F4); tracepath `pmtu 1420` no asymmetric reduction; **no double-clamp evidence** in available data |

## Multi-CDN sustained-transfer comparison through ER8411

| Test | CDN | Bytes | Throughput | Result |
|---|---|---|---|---|
| `speed.cloudflare.com` 50 MB | Cloudflare | 50,000,000 | **94 MB/s** | **PASS** |
| `releases.ubuntu.com` Ubuntu 24.04 ISO range 0-499 MB | Canonical CDN | 500,000,000 | **92 MB/s** | **PASS** |
| `huggingface.co` all-mpnet-base-v2 model.safetensors | HF / Cloudflare | 437,971,872 | **104 MB/s** | **PASS** |
| `huggingface.co` bge-large-en-v1.5 range 0-499 MB | HF / Cloudflare | 500,000,000 | **111 MB/s** | **PASS** |
| `github.com/ollama/ollama/releases/...` 705 MB (prior run) | Fastly | 705,000,000 | **70 MB/s** | **PASS** |
| `xfiles.ngc.nvidia.com` auth'd weight pull | NGC / CloudFront 3.171.171.0/22 | multi-GB | n/a | **FAIL — DownloadFileSizeMismatch** (per brief §2.2) |

**Failure surface = NGC-only.** Cluster sustains 90–110 MB/s through the same ER8411 to four other CDNs.

## Candidate root cause ranking (corrected for ER8411 + no VPN tunnels)

Most likely → least likely:

1. **Destination-specific issue at NGC origin / xfiles CloudFront edge** — strongest. Multi-CDN PASS rules out generic ER8411 policy (DPI / IPS / category-throttle / conntrack / BBR-interaction). Failure tracks tightly to `xfiles.ngc.nvidia.com` (3.171.171.0/22) only. Could be cluster outbound-IP triggering NGC bot detection, ASN-/prefix-based rate limiting at CloudFront origin, NGC-side auth-tier truncation, or signed-URL/clock-skew issue.
2. **ER8411 Application Control / DPI selectively classifying NGC** — moderate. Omada Pro firmware ships category-aware DPI; AI/ML or NVIDIA-NGC category lists could selectively touch xfiles while passing other CDNs.
3. **ER8411 IPS rule false-positive on sustained NVIDIA blob downloads** — moderate. Sustained binary blob from a CDN PoP tagged "AI model weights" could trip a data-exfiltration heuristic. 705 MB Fastly success argues against generic IPS triggers, but signature-specific behavior is possible.
4. **ER8411 Bandwidth Control / QoS application-category throttling** — weaker. Multi-CDN PASS rules out broad cap; narrow category-specific cap still possible.
5. **Asymmetric routing / IP policy at AWS edge** — moderate (path identical operator-side; AWS hop 4+ divergence; cluster outbound IP may pin to a xfiles PoP with reachability differences).
6. **MSS double-clamp interaction (ER8411 + spark-2 host clamp)** — weak (no current double-clamp evidence; auth'd tcpdump can confirm/deny).
7. ~~Conntrack exhaustion on ER8411~~ — RULED OUT by multi-CDN PASS.
8. ~~Tailscale exit-node routing on sub-prefix~~ — RULED OUT (`ExitNode: False`, no `0.0.0.0/0` via tailnet).
9. ~~BBR vs CUBIC interaction~~ — RULED OUT by multi-CDN PASS with `bbr` active.

Dropped from original brief: **Mikrotik DPI** (Mikrotik is fast-fabric only, not in egress path); **VPN tunnel asymmetric routing** (no active tunnels).

## Recommended next operator action (priority order)

1. **ER8411 web UI inspection** (~15 min) at `http://192.168.0.1`:
   - **Application Control** → check rules matching source `192.168.0.0/24`; disable for cluster sources OR add an explicit allow for `3.171.171.0/22` + `*.ngc.nvidia.com` ahead of any blocking rule.
   - **IPS / Threat Management → Logs** → filter for the wall-clock window of a known failing pull (operator captures timestamp before reproducing); look for hits naming `xfiles`, `nvidia`, `model-distribution`, sustained-transfer heuristics.
   - **Bandwidth Control** → confirm no rule throttles cluster sources or `3.171.171.0/22` by application category.
   - **Status → Connections** → confirm not pegged vs. configured `Max Sessions`.
   - **Firewall → ACL / NAT** → check for any explicit rule referencing nvidia / xfiles / `3.171.171.0/22`.
   - Capture screenshots / config dump for evidence.
2. **Different-spark cross-check** (~5 min): try a small NGC pull from a different spark — if it works, IP-policy at xfiles destination.
3. **Operator Mac-side traceroute comparison** for hops Mac skips that cluster includes.
4. **Auth'd tcpdump during real failing pull**: re-run with `NGC_CLI_API_KEY` exported and `ngc registry model download-version ...` running. Look for: RST mid-stream, repeated retransmissions hitting a wall, ICMP frag-needed, window collapse, RST at consistent byte offset (DPI signature), SYN/SYN-ACK MSS asymmetry (double-clamp).
5. Only if 1–4 inconclusive: BBR→CUBIC sysctl swap (reversible, low expected yield).

## What this PR does NOT do

- No ER8411 configuration change (operator-side only)
- No Mikrotik configuration change (irrelevant to F5)
- No Tailscale configuration change (operator-side only; ruled out anyway)
- No sysctl change (BBR→CUBIC is a candidate fix, not part of investigation)
- No revert of F1 / F2 / F4 (harmless, retained)
- No service / NIM / LiteLLM / Qdrant modification

PCAPs from §4.3 NOT committed (per brief sanitization constraint). Stored on spark-2 at `~/f5-investigation-2026-04-29/` for operator review — both anonymous, no auth headers / API keys present.

## Files

- **NEW:** `docs/operational/briefs/f5-root-cause-investigation-2026-04-29.md` — investigation surface (corrected for ER8411 + multi-CDN evidence + MSS/PMTU)
- **NEW:** `docs/operational/runbooks/w3-nim-pull-workaround-runbook.md` — W3 procedure
- **NEW:** `docs/operational/briefs/f5-issue-303-updated-body-2026-04-29.md` — issue #303 corrected body (artifact for operator paste; active PAT lacks issue-write scope)
- **MODIFIED:** `docs/operational/MASTER-PLAN.md` §6.5 — F5 row now attributes egress to TP-Link ER8411 and notes Mikrotik = fast-fabric only

## Test plan

- [x] DNS comparison captured (§4.1)
- [x] Path comparison via mtr captured — first hop confirmed ER8411 192.168.0.1 (§4.2)
- [x] tcpdump captured (§4.3 — anonymous probes; auth'd capture is operator follow-up)
- [x] Tailscale state captured — exit-node ruled out (§4.5)
- [x] Multi-CDN sustained transfer: Cloudflare 50 MB / Ubuntu 500 MB / HF 438 MB + 500 MB / GitHub-Fastly 705 MB all PASS (§4.6) — failure surface narrowed to NGC-only
- [x] MSS clamp + tracepath PMTU captured (§4.7) — no double-clamp evidence
- [x] ER8411 fingerprint confirmed (TP-Link OUI + Omada Pro UI signature)
- [x] Investigation surface document committed (corrected)
- [x] W3 runbook committed
- [x] F5 issue #303 filed (body update staged as artifact for operator paste)
- [x] MASTER-PLAN.md §6.5 updated (ER8411 attribution)
- [ ] Operator pastes corrected #303 body
- [ ] Operator confirms candidate ranking and authorizes next-action
- [ ] Operator runs ER8411 UI walkthrough / different-spark cross-check / auth'd tcpdump
- [ ] Once root cause identified, separate fix PR (not this one)

**Merge BLOCKED on operator review** — operator authorizes next-action sequence, then merge as the surface document for downstream fix work.
