### PR TITLE
Phase B v0.2: synthesizer <think>-block stripping (Pass 1)

### DIFF
--- a/docs/operational/phase-b-v0.2-dry-run-2026-04-29.md
+++ b/docs/operational/phase-b-v0.2-dry-run-2026-04-29.md
@@ -1,0 +1,170 @@
+# Phase B v0.2 Dry-Run — 2026-04-29 (synthesizer ``<think>``-block stripping, Pass 1 only)
+
+**Driver:** Phase B v0.1 dry-run (PR #302) produced Outcome B — pipeline worked end-to-end but output contained 9 leaked ``<think>...</think>`` blocks. v0.2 strips them at the synthesizer level before SectionResult finalize.
+**Stacks on:** PR #302 (v0.1 dry-run), PR #290 (Phase B orchestrator).
+**Branch:** `feat/phase-b-v02-synthesizer-stripping-2026-04-29`.
+**Outputs (dry-run, NOT canonical filings/outgoing/):**
+- `/tmp/phase-b-7il-v-knight-ndga-i/Attorney_Briefing_Package_*.md`
+- Staged at `/mnt/fortress_nas/legal-briefs/7il-v-knight-ndga-i-v3-2026-04-29.md` (md5 `7d2b0c75cd3bc7922bc8839f3c03b0b6`)
+- Outcome-b v3 preserved at `/mnt/fortress_nas/legal-briefs/7il-v-knight-ndga-i-v3-outcome-b-2026-04-29.md` (md5 `bce8484bec36c55095db5a86d8dfa037`)
+
+## Implementation
+
+**`backend/services/case_briefing_synthesizers.py`** — added `strip_reasoning_trace(text: str) -> str`. Single-pass strip + cleanup:
+
+- `<think>...</think>` blocks: non-greedy multiline regex (`re.DOTALL`); anchors on the nearest `</think>`, never document end.
+- Unclosed `<think>` (truncated trace): strip from `<think>` to next blank line OR end of text.
+- Cleanup: collapse 3+ consecutive newlines to 2; trim leading/trailing whitespace.
+- **Pass 2 (first-person planning prose) is intentionally NOT implemented** — deferred per brief; the strategy will likely target synthesizer system prompts upstream rather than post-hoc heuristic filtering.
+
+Integration: `synthesize_synthesis_section()` is the single call site. Strip is applied immediately after streamed-response accumulation, before `_detect_grounding_citations()` and `SectionResult` build.
+
+**8 unit tests** in `backend/tests/test_case_briefing_synthesizers.py` (`TestStripReasoningTrace`):
+
+1. `test_strips_simple_think_block` — basic inline tag pair
+2. `test_strips_multiline_think_block` — real PR #302 §2 fixture
+3. `test_strips_multiple_think_blocks` — three blocks, three closures
+4. `test_handles_unclosed_think_tag` — truncated trace, blank-line terminator
+5. `test_preserves_substantive_body_prose` — clean input no-op
+6. `test_collapses_excess_newlines` — 3+ → 2
+7. `test_idempotent` — running twice equals running once
+8. `test_preserves_first_person_outside_think` — pin Pass 2 not-implemented contract
+
+All 8 pass.
+
+## Execution
+
+| Field | Value |
+|---|---|
+| Started | 2026-04-30T02:39:38Z |
+| Finished | 2026-04-30T03:19:03Z |
+| Total elapsed | **39 min 25 sec** |
+| Sections produced | 10 / 10 |
+
+## HARD PASS gate
+
+| Check | Result |
+|---|---|
+| `<think>` count in new v3 | **0** ✓ |
+| `</think>` count in new v3 | **0** ✓ |
+| 10/10 sections produced | ✓ |
+| §7 defense-counsel exclusion (Underwood, Podesta, FGP, Sanker, Argo, DRAlaw) | **0 hits** ✓ |
+| FYEO marker | **absent** ✓ (Case I has 0 privileged chunks) |
+| Cloud outbound during run (strict — `api.anthropic.com` / `api.openai.com` / `generativelanguage.googleapis.com` / `api.x.ai`) | **0** ✓ |
+| Grounding citations ≥3 per synthesis section | **FAIL — §4 has only 2 citations** (below floor) |
+
+**HARD PASS gate: FAIL.** §4 below ≥3 citation floor.
+
+## Per-section citation counts (vs PR #302 outcome-b)
+
+| Section | Type | v0.2 lines | v0.2 citations | Outcome-b raw | Outcome-b post-strip (body only) |
+|---|---|---:|---:|---:|---:|
+| 1 Case Summary | mechanical | 43 | 0 | 0 | 0 |
+| 2 Critical Timeline | synthesis | 74 | **38** | 18 | 4 |
+| 3 Parties & Counsel | mechanical | 18 | 0 | 0 | 0 |
+| 4 Claims Analysis | synthesis | 24 | **2** ← FLOOR FAIL | 21 | 4 |
+| 5 Key Defenses | synthesis | 38 | **8** | 18 | 7 |
+| 6 Evidence Inventory | mechanical | 26 | 0 | 0 | 0 |
+| 7 Email Intelligence | synthesis | 93 | **40** | 22 | 8 |
+| 8 Financial Exposure | synthesis | 48 | **12** | 28 | 10 |
+| 9 Recommended Strategy | placeholder | 10 | 0 | 0 | 0 |
+| 10 Filing Checklist | mechanical | 23 | 0 | 0 | 0 |
+
+**Critical insight from outcome-b post-strip column:** the apparent "21 citations" in PR #302 §4 was inflated by in-`<think>` reasoning ("Looking at [#13 Joint Preliminary Statement.pdf]..."). The body content of outcome-b §4 had only **4 citations** once `<think>` was stripped retroactively. v0.2's §4 produced only **2 body citations** — run-to-run variance plus mid-sentence truncation (BRAIN's `max_tokens=2000` was hit before §4 finished its second plaintiff count).
+
+In other words: §4 was always thin in body content. v0.2 just makes it visible. The strip is not "eating" citations — citations weren't there.
+
+## Measurement (no gate, report only)
+
+| Metric | Outcome-b | v0.2 | Δ |
+|---|---:|---:|---:|
+| Lines | 557 | 384 | **-31%** |
+| Bytes | 46,097 | 24,950 | **-46%** |
+| Words | 6,683 | 3,532 | **-47%** |
+| First-person planning prose hits (line-start `Let me / I should / I need to / I'll / Now, / Looking at`) | 22 | **6** | **-73%** |
+| `<think>`/`</think>` tag pairs | 9 | **0** | **-100%** |
+
+The 6 surviving first-person hits are all on body lines starting with "Looking at [filename.pdf]..." — the model's natural prose voice when introducing evidence. These are not pure planning ("Let me structure...") but evidence-introducing prose ("Looking at [X.pdf], there's a mention of..."). Pass 2 stripping would risk eating substantive analysis. Per brief, Pass 2 is deferred.
+
+## Cloud egress, sovereignty, and §7 privilege filter
+
+- Cloud egress during run window (22:39:00–23:20:00 EDT): **0 hits** for `api.anthropic.com` / `api.openai.com` / `generativelanguage.googleapis.com` / `api.x.ai`.
+- §7 defense-counsel exclusion: **0 hits** for Underwood, Podesta, FGP, Sanker, Argo, DRAlaw — privilege filter holds.
+- FYEO: correctly absent (Case I has 0 privileged chunks).
+
+## Sample stripped sections (3 examples, trace removed, substantive content preserved)
+
+### Example 1 — §2 Critical Timeline header
+
+**Outcome-b (lines 33-38):**
+
+```
+## 2. Critical Timeline
+
+<think>
+Okay, let's tackle this. The user wants a chronological timeline of dated events for the case, using only the provided evidence. I need to go through each of the CASE EVIDENCE blocks and extract any dates mentioned, then organize them in order.
+
+First, I'll start by scanning each document for dates. Let's go one by one.
+```
+
+**v0.2 (clean):**
+
+```
+## 2. Critical Timeline
+
+| Date | Event | Source |
+|---|---|---|
+```
+
+### Example 2 — §5 Key Defenses, between thinking and substantive prose
+
+**Outcome-b (lines 247-252):**
+
+```
+_Grounding citations: 7_
+
+<think>
+
+So, compiling the list with citations and noting if any are thin. The main defenses are failure of condition precedent, plaintiff's breach, contract expiration, and unjust enrichment...
+</think>
+```
+
+**v0.2 (clean — moves directly to substantive analysis):**
+
+```
+_Grounding citations: 7_
+
+### Affirmative Defenses & Non-Affirmative Theories
+
+#### **1. Failure of Condition Precedent**
+```
+
+### Example 3 — Citations preserved verbatim
+
+Substantive prose with file-reference citations (`[#13 Joint Preliminary Statement.pdf]`, `[5464474_Exhibit_3_GaryKnight(23945080.1).pdf]`) is preserved exactly across both runs. The strip never touches `[*]` regions.
+
+## Recommendation
+
+**Outcome: Pass-1 strip works as specified, but reveals a body-density problem.** The strip itself is correct (8/8 tests pass; tag-only; deterministic). The problem is that BRAIN's `max_tokens=2000` budget was always being half-consumed by `<think>` reasoning, leaving the body short — and §4 of this run truncated mid-sentence (`- **`) before reaching the 3-citation floor.
+
+**Recommended v0.3 scope (separate brief):** target the synthesizer system prompts and/or BRAIN call params:
+
+1. **Reduce reasoning volume** — modify `_SYSTEM_PROMPT` in `case_briefing_synthesizers.py` (currently begins `"detailed thinking on\n\n"` per Nemotron contract) to either omit the trigger phrase or constrain reasoning to N tokens.
+2. **Increase body budget** — bump `synthesize_synthesis_section`'s `max_tokens` from 2000 → 3500 (or split: budget reasoning separately from response).
+3. **Tighten body-output instructions** — current prompt asks for "elements / defense theory / citations"; could be tightened to "MINIMUM 5 citations per count; one paragraph max per element" so the model spends body tokens efficiently.
+
+**Whether to merge this PR:**
+- The stripper is sound — gets shipped on its own merits (8/8 tests, deterministic, idempotent).
+- Merging means accepting that the body-density issue is now visible (and §4 trips the ≥3 floor on this run).
+- Operator decision: merge + iterate on v0.3, OR hold v0.2 until v0.3 lands (so a clean v3 brief is the merge gate).
+
+## Outcome
+
+**B (still issues — body density / max_tokens) → v0.3 prompt-fix recommended before Case II run.**
+
+## Cross-references
+
+- Brief: pasted v0.2 instructions (Pass 1 only) in this session
+- v0.1 dry-run analysis: `docs/operational/phase-b-v0.1-dry-run-2026-04-29.md` (PR #302)
+- Phase B orchestrator: `fortress-guest-platform/backend/services/case_briefing_compose.py` (PR #290)
+- BRAIN model contract: `CLAUDE.md` DEFCON 3 / BRAIN tier ("All callers MUST supply a system prompt e.g. 'detailed thinking on'")

--- a/fortress-guest-platform/backend/services/case_briefing_synthesizers.py
+++ b/fortress-guest-platform/backend/services/case_briefing_synthesizers.py
@@ -34,6 +34,60 @@ from backend.services.case_briefing_compose import (
 logger = logging.getLogger("case_briefing_synthesizers")
 
 
+# ── BRAIN reasoning-trace stripping ──────────────────────────────────────────
+# Nemotron-Super-49B-v1.5 (the BRAIN model) emits <think>...</think> chain-of-
+# thought blocks by design (CLAUDE.md DEFCON 3 note). Phase B v0.1 dry-run on
+# Case I (PR #302) surfaced 9 surviving <think> tag pairs in the assembled
+# brief. v0.2 strips them before SectionResult finalize so the assembled
+# brief reads as analyst output, not model reasoning.
+#
+# Pass 1 only: tag-stripping + whitespace cleanup. First-person planning
+# prose ("Let me structure this...") that survives outside <think> tags is
+# deferred to a follow-up (see PR description) — the strategy will likely
+# target synthesizer system prompts upstream rather than post-hoc filtering.
+
+_THINK_BLOCK_RE = re.compile(r"<think>.*?</think>", flags=re.DOTALL)
+_UNCLOSED_THINK_RE = re.compile(r"<think>.*?(?:\n\n|\Z)", flags=re.DOTALL)
+_EXCESS_NEWLINES_RE = re.compile(r"\n{3,}")
+
+
+def strip_reasoning_trace(text: str) -> str:
+    """Remove BRAIN ``<think>...</think>`` blocks from synthesizer output.
+
+    Single-pass tag-stripping plus whitespace cleanup. Used before any
+    synthesizer text is committed to a `SectionResult`. Designed to be
+    idempotent: running the function on already-clean input is a no-op.
+
+    Strips:
+      * Every closed ``<think>...</think>`` block (multi-line, non-greedy
+        — anchors on the nearest ``</think>``, never document end).
+      * Unclosed ``<think>`` tags (model truncated mid-trace) — strip from
+        ``<think>`` to the next blank line OR end of text.
+
+    Cleans up:
+      * Collapses 3+ consecutive newlines to 2.
+      * Strips leading/trailing whitespace.
+
+    Does NOT strip first-person planning prose, planning patterns, or any
+    other content. That is deferred — Pass 1 is tag-only.
+    """
+    if not text:
+        return text
+
+    # Strip closed <think>...</think> blocks (non-greedy, multiline).
+    out = _THINK_BLOCK_RE.sub("", text)
+    # Handle unclosed <think> (truncated trace from streaming abort) by
+    # stripping to the next blank line or document end.
+    if "<think>" in out:
+        out = _UNCLOSED_THINK_RE.sub("", out)
+
+    # Cleanup whitespace.
+    out = _EXCESS_NEWLINES_RE.sub("\n\n", out)
+    out = out.strip()
+
+    return out
+
+
 _SYSTEM_PROMPT = (
     "detailed thinking on\n\n"
     "You are a meticulous legal analyst supporting Fortress Prime's defense team. "
@@ -246,6 +300,8 @@ async def synthesize_synthesis_section(
     )
     async for chunk in iterator:
         response += chunk
+
+    response = strip_reasoning_trace(response)
 
     grounded_citations, matched_sources = _detect_grounding_citations(
         response,

--- a/fortress-guest-platform/backend/tests/test_case_briefing_synthesizers.py
+++ b/fortress-guest-platform/backend/tests/test_case_briefing_synthesizers.py
@@ -1,0 +1,179 @@
+"""Unit tests for ``backend.services.case_briefing_synthesizers``.
+
+Phase B v0.2 — synthesizer ``<think>``-block stripping (Pass 1 only).
+
+Per-fixture origin: most ``<think>``-block fixtures are real excerpts from
+the PR #302 outcome-b dry-run output at
+``/mnt/fortress_nas/legal-briefs/7il-v-knight-ndga-i-v3-outcome-b-2026-04-29.md``
+(specifically lines 36, 133, 231, 249, 285).
+"""
+from __future__ import annotations
+
+import textwrap
+
+from backend.services.case_briefing_synthesizers import strip_reasoning_trace
+
+
+class TestStripReasoningTrace:
+    """Pass-1 stripper: ``<think>...</think>`` tag removal + whitespace cleanup."""
+
+    def test_strips_simple_think_block(self) -> None:
+        text = "Body before. <think>quick reasoning</think> Body after."
+        out = strip_reasoning_trace(text)
+        assert "<think>" not in out
+        assert "</think>" not in out
+        assert "Body before." in out
+        assert "Body after." in out
+        assert "quick reasoning" not in out
+
+    def test_strips_multiline_think_block(self) -> None:
+        # Real fixture excerpt (PR #302 outcome-b §2 Critical Timeline).
+        text = textwrap.dedent(
+            """\
+            ## 2. Critical Timeline
+
+            <think>
+            Okay, let's tackle this. The user wants a chronological timeline of dated
+            events for the case, using only the provided evidence. I need to go through
+            each of the CASE EVIDENCE blocks and extract any dates mentioned, then
+            organize them in order.
+
+            First, I'll start by scanning each document for dates. Let's go one by one.
+            </think>
+
+            | Date | Event | Source |
+            |---|---|---|
+            | 2021-04-05 | Plaintiff accepted offer | [#13 Joint Preliminary Statement.pdf] |
+            """
+        )
+        out = strip_reasoning_trace(text)
+        assert "<think>" not in out
+        assert "</think>" not in out
+        assert "the user wants" not in out.lower()
+        assert "scanning each document" not in out
+        # substantive content preserved
+        assert "## 2. Critical Timeline" in out
+        assert "[#13 Joint Preliminary Statement.pdf]" in out
+        assert "2021-04-05" in out
+
+    def test_strips_multiple_think_blocks(self) -> None:
+        text = textwrap.dedent(
+            """\
+            ## 4. Claims Analysis
+
+            <think>First reasoning block — model planning the section.</think>
+
+            ### 1. Specific Performance
+
+            <think>
+            Second reasoning block, multi-line, reasoning about the next count.
+            </think>
+
+            ### 2. Breach of Contract
+
+            <think>Third block.</think>
+
+            Body conclusion sentence.
+            """
+        )
+        out = strip_reasoning_trace(text)
+        assert out.count("<think>") == 0
+        assert out.count("</think>") == 0
+        assert "## 4. Claims Analysis" in out
+        assert "### 1. Specific Performance" in out
+        assert "### 2. Breach of Contract" in out
+        assert "Body conclusion sentence." in out
+
+    def test_handles_unclosed_think_tag(self) -> None:
+        # PR #302 outcome-b had 5 <think> opens vs 4 </think> closes; one was
+        # unclosed (model truncated mid-trace). Strip the unclosed reasoning
+        # from <think> to the next blank line.
+        text = textwrap.dedent(
+            """\
+            Body paragraph.
+
+            <think>
+            Reasoning that got cut off because of streaming abort or
+            max_tokens — there is no closing tag.
+
+            More cut-off thinking on the same trace.
+
+            Body paragraph after the blank line acts as the strip terminator.
+            """
+        )
+        out = strip_reasoning_trace(text)
+        assert "<think>" not in out
+        assert "Reasoning that got cut off" not in out
+        # Content after the blank-line terminator is preserved.
+        assert "Body paragraph after the blank line" in out
+        assert "Body paragraph." in out
+
+    def test_preserves_substantive_body_prose(self) -> None:
+        # No-op on clean substantive input. Citations, headers, body prose
+        # all preserved exactly.
+        text = textwrap.dedent(
+            """\
+            ### **1. Specific Performance**
+            **Elements (from evidence):**
+            - Plaintiff alleges Defendant failed to perform under the agreements
+              ([#13 Joint Preliminary Statement.pdf], p. 5).
+            - Plaintiff seeks a judgment ordering specific performance.
+
+            **Defendant's Likely Defense Theory:**
+            - The agreements lapsed due to unmet conditions
+              ([5464474_Exhibit_3_GaryKnight.pdf], paragraph 75).
+            """
+        )
+        out = strip_reasoning_trace(text)
+        assert out.strip() == text.strip()
+
+    def test_collapses_excess_newlines(self) -> None:
+        text = "Para one.\n\n\n\n\nPara two.\n\n\n\nPara three."
+        out = strip_reasoning_trace(text)
+        # 3+ newlines collapse to 2; nothing else changes.
+        assert out == "Para one.\n\nPara two.\n\nPara three."
+
+    def test_idempotent(self) -> None:
+        # Running twice equals running once.
+        text = textwrap.dedent(
+            """\
+            ## Section header
+
+            <think>
+            Reasoning that should be stripped on the first pass.
+            </think>
+
+            Body content with [citation.pdf] preserved.
+            """
+        )
+        once = strip_reasoning_trace(text)
+        twice = strip_reasoning_trace(once)
+        assert once == twice
+        assert "<think>" not in once
+        assert "[citation.pdf]" in once
+
+    def test_preserves_first_person_outside_think(self) -> None:
+        # Pass 2 is intentionally NOT implemented in v0.2. First-person
+        # planning prose that appears OUTSIDE <think> tags is preserved
+        # verbatim — its handling is deferred (likely upstream system-prompt
+        # adjustment). This test pins that contract.
+        text = textwrap.dedent(
+            """\
+            ## Section body
+
+            Let me address the elements one by one.
+
+            I should note the following points about the encroachment.
+
+            Now, structuring the analysis: the issue arose at closing.
+
+            Looking at the evidence, three threads emerge.
+            """
+        )
+        out = strip_reasoning_trace(text)
+        # Tag-stripper has nothing to do — input has no <think> blocks.
+        # All planning prose is preserved (Pass 2 deferred).
+        assert "Let me address" in out
+        assert "I should note" in out
+        assert "Now, structuring" in out
+        assert "Looking at the evidence" in out


### PR DESCRIPTION
## Phase B v0.2 — synthesizer ``<think>``-block stripping (Pass 1 only)

**Driver:** PR #302 dry-run produced Outcome B — pipeline worked end-to-end but output contained 9 leaked ``<think>...</think>`` blocks. v0.2 strips them at the synthesizer integration point before SectionResult finalize.
**Stacks on:** PR #302 (v0.1 dry-run), PR #290 (Phase B orchestrator).
**Doc-only on infra side:** no service/config/Qdrant modifications. Code change is to one synthesizer file plus tests.
**Outputs:** new v3 staged at ``/mnt/fortress_nas/legal-briefs/7il-v-knight-ndga-i-v3-2026-04-29.md`` (md5 ``7d2b0c75cd3bc7922bc8839f3c03b0b6``); outcome-b v3 preserved at ``...-v3-outcome-b-2026-04-29.md`` (md5 ``bce8484bec36c55095db5a86d8dfa037``).

---

### TL;DR

- **Stripper is sound.** 8/8 unit tests pass; deterministic; idempotent; tag-only (no body content stripped).
- **HARD PASS gate FAILS at one spot:** §4 has only **2 grounding citations** (below the ≥3 floor).
- **Root cause is NOT the strip.** Outcome-b's apparent "21 citations" in §4 was inflated by in-``<think>`` reasoning mentions; post-strip body in outcome-b had only **4 citations** there too. v0.2 §4 produced 2 (mid-sentence truncation when BRAIN's ``max_tokens=2000`` ran out).
- **Outcome: B → v0.3 prompt-fix recommended before Case II.** Likely scope: trim ``"detailed thinking on"`` system-prompt trigger or bump max_tokens; tighten body-output instructions.

### Implementation

- **`backend/services/case_briefing_synthesizers.py`** — `strip_reasoning_trace(text)` added; called once in `synthesize_synthesis_section()` immediately after streamed-response accumulation, before `_detect_grounding_citations` and `SectionResult` build.
- Single-pass strip + cleanup: closed `<think>...</think>` non-greedy multiline; unclosed `<think>` stripped to next blank line; 3+ newlines collapsed to 2; trim.
- **Pass 2 (first-person planning prose) intentionally NOT implemented per brief** — deferred; surviving 6 hits are all "Looking at [filename.pdf]..." evidence-introducing prose, not pure planning. Heuristic strip risks eating substantive analysis.

### Tests (8/8 pass)

`backend/tests/test_case_briefing_synthesizers.py::TestStripReasoningTrace`:

1. `test_strips_simple_think_block` ✓
2. `test_strips_multiline_think_block` (real PR #302 §2 fixture) ✓
3. `test_strips_multiple_think_blocks` ✓
4. `test_handles_unclosed_think_tag` (truncated trace, blank-line terminator) ✓
5. `test_preserves_substantive_body_prose` (clean input no-op) ✓
6. `test_collapses_excess_newlines` ✓
7. `test_idempotent` ✓
8. `test_preserves_first_person_outside_think` (Pass 2 not-implemented contract) ✓

### Re-run on Case I

| Field | Value |
|---|---|
| Started | 2026-04-30T02:39:38Z |
| Finished | 2026-04-30T03:19:03Z |
| Total elapsed | **39 min 25 sec** |
| Sections produced | 10 / 10 |

### HARD PASS gate

| Check | Result |
|---|---|
| `<think>` count in new v3 | **0** ✓ |
| `</think>` count in new v3 | **0** ✓ |
| 10/10 sections produced | ✓ |
| §7 defense-counsel exclusion (Underwood, Podesta, FGP, Sanker, Argo, DRAlaw) | **0 hits** ✓ |
| FYEO marker | **absent** ✓ (Case I has 0 privileged chunks) |
| Cloud outbound during run | **0** ✓ |
| Grounding citations ≥3 per synthesis section | **§4 = 2 — FAIL** |

### Per-section citation counts (vs PR #302 baselines)

| Section | Type | v0.2 lines | v0.2 citations | Outcome-b raw | Outcome-b post-strip body |
|---|---|---:|---:|---:|---:|
| 2 Critical Timeline | synthesis | 74 | **38** | 18 | 4 |
| 4 Claims Analysis | synthesis | 24 | **2** ← FLOOR FAIL | 21 | 4 |
| 5 Key Defenses | synthesis | 38 | **8** | 18 | 7 |
| 7 Email Intelligence | synthesis | 93 | **40** | 22 | 8 |
| 8 Financial Exposure | synthesis | 48 | **12** | 28 | 10 |

The "outcome-b post-strip body" column shows what outcome-b would have produced if Pass 1 had been applied retroactively. Note that §4 had only 4 body citations even in outcome-b — the "21" was inflated by `<think>` reasoning mentions. Run-to-run variance brought v0.2 §4 down to 2 (plus mid-sentence truncation: BRAIN hit `max_tokens=2000`).

### Measurement (no gate)

| Metric | Outcome-b | v0.2 | Δ |
|---|---:|---:|---:|
| Lines | 557 | 384 | -31% |
| Bytes | 46,097 | 24,950 | -46% |
| Words | 6,683 | 3,532 | **-47%** |
| First-person planning prose hits (line-start `Let me / I should / I need to / I'll / Now, / Looking at`) | 22 | **6** | -73% |
| `<think>` / `</think>` tag pairs | 9 | **0** | -100% |

The 6 surviving first-person hits are all on body lines beginning with "Looking at [filename.pdf]..." — the model's natural prose voice when introducing evidence. Pass 2 stripping would eat substantive analysis. Per brief, deferred.

### Sample stripped sections

#### Example 1 — §2 Critical Timeline

**Outcome-b:**
```
## 2. Critical Timeline

<think>
Okay, let's tackle this. The user wants a chronological timeline of dated
events for the case, using only the provided evidence. I need to go through
each of the CASE EVIDENCE blocks and extract any dates mentioned, then
organize them in order.

First, I'll start by scanning each document for dates. Let's go one by one.
</think>

| Date | Event | Source |
```

**v0.2 (clean):**
```
## 2. Critical Timeline

| Date | Event | Source |
```

#### Example 2 — §5 Key Defenses transition

**Outcome-b:**
```
_Grounding citations: 7_

<think>
So, compiling the list with citations and noting if any are thin...
</think>

### Affirmative Defenses & Non-Affirmative Theories
```

**v0.2 (clean):**
```
_Grounding citations: 7_

### Affirmative Defenses & Non-Affirmative Theories
```

#### Example 3 — Citations preserved verbatim

`[#13 Joint Preliminary Statement.pdf]`, `[5464474_Exhibit_3_GaryKnight(23945080.1).pdf]`, etc. preserved exactly across both runs. Strip never touches `[*]` regions.

### Recommendation

The stripper is correct and ships on its merits regardless of the §4 floor failure (separate concern, not stripper-caused). Operator decision:

**Option A (recommended) — merge v0.2, draft v0.3 prompt-fix:**
- v0.3 brief targets `_SYSTEM_PROMPT` (currently begins `"detailed thinking on\n\n"`) and/or `synthesize_synthesis_section`'s `max_tokens=2000`. Likely fixes §4 body density.
- Case II run gated on v0.3 PASS, not v0.2.

**Option B — hold v0.2 until v0.3 lands:** combined PR delivers both stripper + prompt-fix. Slower iteration but cleaner merge gate.

### Hard constraints respected (per brief)

- No BRAIN / Vision NIM / embed NIM / inference service modifications ✓
- No LiteLLM gateway config modifications ✓
- No `legal_council.py` / `freeze_context` / retrieval primitive modifications ✓
- No `_v2` collection touches ✓ (Phase A reindex PR #1 owns those — separate session, untouched)
- No `legal_ediscovery` modifications ✓
- No `case_briefing_compose.py` orchestrator modifications ✓ (issue isolated to synthesizers)
- Pass 2 / first-person prose stripping NOT implemented ✓ (deferred per spec)
- Synthesizer system prompts NOT modified ✓ (deferred to v0.3)
- Single PR ✓
- Did NOT run Case II ✓ (gated on v0.2 PASS)

### Files in this PR

- `fortress-guest-platform/backend/services/case_briefing_synthesizers.py` (+56 / -0)
- `fortress-guest-platform/backend/tests/test_case_briefing_synthesizers.py` (+179 / 0, NEW)
- `docs/operational/phase-b-v0.2-dry-run-2026-04-29.md` (+170 / 0, NEW)

3 files / +405 / -0.

**Merge BLOCKED on operator review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)