### PR TITLE
Phase A reindex PR #1: legal-embed cutover for caselaw + privileged + sparse — STOP on privileged quality

### DIFF
--- a/docs/operational/qdrant-reindex-quality-batch1-2026-04-29.md
+++ b/docs/operational/qdrant-reindex-quality-batch1-2026-04-29.md
@@ -140,3 +140,64 @@ ssh admin@192.168.0.100 'python3 /home/admin/Fortress-Prime/src/validate_reindex
     --collection legal_caselaw --n-queries 50 \
     --out /home/admin/Fortress-Prime/docs/operational/reindex-quality/legal_caselaw.json'
 ```
+
+---
+
+## Operator decision (2026-04-30): Option B
+
+**Outcome:** **ACCEPT** `legal_caselaw_v2` and `legal_library_v2` for caller cutover (Phase A PR #2). **DEFER** `legal_privileged_communications_v2` cutover indefinitely.
+
+| Collection | _v2 status | Cutover decision |
+|---|---|---|
+| `legal_caselaw_v2`                  | overlap@5 0.432 (clears 0.300 threshold) | ✅ **ACCEPT** for PR #2 cutover |
+| `legal_library_v2`                  | overlap@5 0.600 (3-pt cap; both encoders return all 3) | ✅ **ACCEPT** for PR #2 cutover |
+| `legal_privileged_communications_v2`| overlap@5 0.136 (below 0.300 threshold)  | 🟡 **DEFER** — _v2 retained on Qdrant, callers stay on legacy |
+| `legal_caselaw_federal_v2`          | empty (schema-only, awaiting federal ingestion) | N/A — no callers yet |
+| `legal_headhunter_memory_v2`        | empty (parity with legacy 0-pt collection) | N/A — no callers |
+
+### Rationale
+
+`legal_privileged_communications_v2` registered overlap@5 = 0.136 vs the 0.300 stop-condition threshold. Encoder disagreement of this magnitude between `nomic-embed-text` (general-purpose, 768-dim) and `legal-embed` (legal-specialized, 2048-dim) is plausible on conversational privileged content — emails, memos, internal communications — without indicating either encoder is wrong. The same harness on legal *case-law* (longer, more structured chunks) cleared the threshold comfortably (0.432); the result on privileged is consistent with the corpus-property hypothesis (high near-duplicate density, ~800-char chunks, domain-specialized vs general encoder geometry) rather than encoder regression.
+
+Operator-side spot-check (Option B in the original menu — manual eyeball of 5–10 known-relevant queries) is **deferred** until one of:
+
+- Case II work specifically demands sovereign-embed privileged retrieval, OR
+- Retrieval-quality evidence emerges that legacy `nomic-embed-text` is hurting privileged-collection work in production.
+
+Until then, **legacy `legal_privileged_communications` (768-dim, nomic-embed-text) stays live** and continues to back caller retrieval.
+
+### Disposition of artifacts
+
+- `legal_privileged_communications_v2` is **retained** on Qdrant. Spending the 2h41m reindex again later is wasteful — the collection is in the can, just unused. If operator returns to this in a future brief, the spot-check can run immediately against the existing _v2 without a re-encode.
+- Legacy `legal_privileged_communications` (768-dim) is **untouched** and remains the production retrieval target.
+- `legal_council.py` and Phase B retrieval primitives are **untouched** by this PR — caller cutover is the scope of Phase A PR #2 (separate brief, will be drafted to cover only `legal_caselaw_v2` + `legal_library_v2`).
+
+### What Phase A PR #2 will and will not include
+
+In scope for PR #2:
+- Cut over caller code paths that hit `legal_caselaw` to read from `legal_caselaw_v2` instead, with `legal-embed input_type=query` at the retrieval site.
+- Same for `legal_library` (~negligible — 3 points).
+
+Out of scope for PR #2:
+- `legal_privileged_communications` cutover (deferred per this decision).
+- `legal_ediscovery` reindex AND cutover (still queued for the separate Phase A reindex PR #2-ediscovery; Phase B v0.1 dry-run is the gate there).
+- `legal_hive_mind_memory` (separate encoder decision — outcome labels not chunks).
+- `legal_caselaw_federal` (no content yet; ingestion brief is upstream).
+
+### Read-only verification at decision time (2026-04-30)
+
+All `_v2` collections present and correctly sized; all legacy collections untouched (point counts match PR #301 audit):
+
+| Collection | Dim | Points | Notes |
+|---|---:|---:|---|
+| `legal_caselaw_v2`                  | 2048 | 2,711   | reindex complete, accepted |
+| `legal_library_v2`                  | 2048 | 3       | reindex complete, accepted |
+| `legal_privileged_communications_v2`| 2048 | 241,167 | reindex complete, deferred (retained) |
+| `legal_caselaw_federal_v2`          | 2048 | 0       | schema-only |
+| `legal_headhunter_memory_v2`        | 2048 | 0       | schema-only |
+| `legal_caselaw`                     | 768  | 2,711   | legacy, unchanged |
+| `legal_library`                     | 768  | 3       | legacy, unchanged |
+| `legal_privileged_communications`   | 768  | 241,167 | legacy, unchanged, **stays in production** |
+| `legal_ediscovery`                  | 768  | 738,918 | legacy, unchanged (Phase A reindex never touched it) |
+| `legal_headhunter_memory`           | 768  | 0       | legacy, unchanged |
+| `legal_hive_mind_memory`            | 768  | 4       | legacy, unchanged |

--- a/docs/operational/qdrant-reindex-quality-batch1-2026-04-29.md
+++ b/docs/operational/qdrant-reindex-quality-batch1-2026-04-29.md
@@ -1,0 +1,78 @@
+# Phase A reindex PR #1 — quality validation
+
+**Date:** 2026-04-29
+**Driver:** Phase A reindex of `legal_*` Qdrant collections from nomic-embed-text (768-dim) to legal-embed (2048-dim, llama-nemotron-embed-1b-v2 on spark-3:8102 — see PR #300).
+**Branch:** `feat/qdrant-legal-reindex-batch1-2026-04-29`
+**Scope:** quality measurements for the three collections reindexed in this PR (`legal_caselaw`, `legal_library`, `legal_privileged_communications`). Empty schema-only `_v2` collections (`legal_caselaw_federal_v2`, `legal_headhunter_memory_v2`) have no content to validate.
+
+## Method
+
+`src/validate_reindex_quality.py`. For each populated collection:
+
+1. Sample N random points from the legacy collection (N=50 unless the collection has fewer points).
+2. For each sample point, take its text field (truncated to 1,200 chars) as a query string.
+3. Embed the query twice:
+   - via `nomic-embed-text` on Ollama spark-2:11434 → search **legacy** collection
+   - via `legal-embed` on the gateway (spark-2:8002, `input_type=query`, `encoding_format=float`) → search **_v2** collection
+4. Take top-N hits from each (N up to 10) and compute:
+   - **top-1 ID match rate**: fraction of queries where both encoders return the same #1 hit (ID-equality).
+   - **mean overlap@k** for k in {1, 3, 5, 10}: |legacy_top_k ∩ v2_top_k| / k, averaged over queries.
+
+Random seed fixed at `20260429` so re-runs reproduce.
+
+The brief's stop condition is **mean overlap@5 ≥ 0.3**. Anything below halts the reindex for operator review.
+
+## Results
+
+### `legal_caselaw` (2,711 → 2,711 pts)
+
+| Metric | Value | Threshold | PASS? |
+|---|---:|---:|:---:|
+| top-1 ID match rate          | **0.940** | informational | — |
+| mean overlap@1               | **0.940** | — | — |
+| mean overlap@3               | 0.440 | — | — |
+| **mean overlap@5**           | **0.432** | **≥ 0.300** | ✅ |
+| mean overlap@10              | 0.364 | — | — |
+| n queries                    | 50 | — | — |
+| validation wall-clock        | 2.83 s | — | — |
+
+Result detail: `docs/operational/reindex-quality/legal_caselaw.json`.
+
+### `legal_library` (3 → 3 pts)
+
+| Metric | Value | Threshold | PASS? |
+|---|---:|---:|:---:|
+| top-1 ID match rate          | **1.000** | informational | — |
+| mean overlap@1               | 1.000 | — | — |
+| mean overlap@3               | 1.000 | — | — |
+| **mean overlap@5**           | **0.600** | **≥ 0.300** | ✅ |
+| mean overlap@10              | 0.300 | — | — |
+| n queries                    | 3 (collection size) | — | — |
+| validation wall-clock        | 0.16 s | — | — |
+
+Note: `legal_library` only has 3 points, so overlap@k for k>3 is artificially capped at 3/k = 0.6 (k=5) and 0.3 (k=10). Both encoders return the full population in their top-5 / top-10 — there are no further documents to disagree about.
+
+### `legal_privileged_communications` (241,167 → 241,167 pts)
+
+Validation deferred to follow-up commit on this PR — runs after the reindex completes (~2.7 h ETA from 2026-04-29 22:38 EDT). Same harness, same thresholds. If overlap@5 < 0.3 the reindex will be halted per the brief's stop condition.
+
+## Interpretation
+
+- **top-1 / overlap@1 of 0.94 on caselaw** is the strongest signal: when both encoders are asked "what's the closest match to this passage?", they agree 94% of the time. The 6% disagreement comes from query truncation (queries are clipped to 1,200 chars; the indexed doc has full text) and tied near-duplicate chunks within caselaw — not encoder mismatch.
+- **overlap@5 of 0.43** means the two encoders agree on ~2.16 of the top-5 per query on average and disagree on the rest. This is **expected** when comparing different encoder geometries on the same corpus — the next-best candidates after the top-1 are sensitive to the encoder's representational space. It does not mean either encoder is "worse"; it means they cluster the corpus differently for the second-tier matches.
+- The threshold of 0.3 was chosen by the brief as the floor below which "the embeddings are semantically incompatible" — a healthy drop-in replacement should score well above it. Caselaw's 0.43 clears that comfortably.
+- The PR #300 §9.7 cosine-sanity test (cos(legal-paraphrase, paraphrase) >> cos(legal-paraphrase, off-domain)) already established the encoder isn't fundamentally broken; this validation confirms it on real corpus data.
+
+## What the validation does NOT measure
+
+- **Recall on hand-labeled queries.** A real retrieval-quality benchmark would use queries authored by a domain expert (e.g., real lawyer search queries, with operator-marked relevant passages) rather than passages-as-queries. The current harness measures *consistency* between encoders on the existing corpus, not *correctness* against ground truth. That's a separate eval and out of scope here.
+- **Asymmetric-encoder gain.** `legal-embed` is asymmetric (`input_type=query` for queries, `=passage` for indexed docs). The validation harness uses `query` for both encoders to keep the comparison apples-to-apples. The downstream win from `legal-embed`'s asymmetric structure will only materialize once `legal_council.py` adopts the asymmetric pattern at the *retrieval* call site — that is the cutover PR (Phase A PR #2), not this one.
+- **Phase B retrieval impact.** `legal_ediscovery` is intentionally unmodified by this PR per the hard constraint, so Phase B retrieval continues against the legacy 768-dim collection.
+
+## Reproducer
+
+```bash
+ssh admin@192.168.0.100 'python3 /home/admin/Fortress-Prime/src/validate_reindex_quality.py \
+    --collection legal_caselaw --n-queries 50 \
+    --out /home/admin/Fortress-Prime/docs/operational/reindex-quality/legal_caselaw.json'
+```

--- a/docs/operational/qdrant-reindex-quality-batch1-2026-04-29.md
+++ b/docs/operational/qdrant-reindex-quality-batch1-2026-04-29.md
@@ -54,7 +54,71 @@ Note: `legal_library` only has 3 points, so overlap@k for k>3 is artificially ca
 
 ### `legal_privileged_communications` (241,167 → 241,167 pts)
 
-Validation deferred to follow-up commit on this PR — runs after the reindex completes (~2.7 h ETA from 2026-04-29 22:38 EDT). Same harness, same thresholds. If overlap@5 < 0.3 the reindex will be halted per the brief's stop condition.
+Reindex completed cleanly:
+
+| Metric | Value |
+|---|---:|
+| points reindexed | 241,167 / 241,167 (exact match) |
+| reindex errors | 0 |
+| reindex wall-clock | 9,664.8 s (~2 h 41 min) |
+| reindex throughput | 25.0 docs/sec sustained (vs caselaw 3.2 — 8× faster, smaller chunks + window pipelining) |
+
+Quality validation:
+
+| Metric | Value | Threshold | PASS? |
+|---|---:|---:|:---:|
+| top-1 ID match rate          | **0.600** | informational | — |
+| mean overlap@1               | 0.600 | — | — |
+| mean overlap@3               | 0.220 | — | — |
+| **mean overlap@5**           | **0.136** | **≥ 0.300** | **❌ FAIL** |
+| mean overlap@10              | 0.086 | — | — |
+| n queries                    | 50 | — | — |
+| validation wall-clock        | 6.40 s | — | — |
+
+Result detail: `docs/operational/reindex-quality/legal_privileged_communications.json`.
+
+#### 🛑 STOP — quality threshold breached
+
+The brief defines the stop condition as: *"Quality validation overlap@5 <0.3 → halt, surface (suggests embedding semantic mismatch, not a reindex bug)."*
+
+The reindex itself is **mechanically correct**: 241,167 source points → 241,167 target points, zero embed errors, vector dim 2048, distance cosine. Round-trip cosine consistency on this NIM was already verified at ~0.999998 in PR #300 §9.5 + the library validation here. The mechanics are fine.
+
+What diverged is the **ranking agreement** between the two encoders:
+- For 60% of queries, both encoders agree on the #1 best match.
+- For the remaining 40%, the #1 hit is different.
+- Beyond #1, agreement collapses fast: only ~14% of top-5 hits overlap on average; only ~9% of top-10 hits overlap.
+- Median overlap@1 is 1.0, min is 0.0 — the failure mode is **bimodal**: many queries match perfectly, and a sizable minority diverge entirely.
+
+#### Why this is plausibly a corpus property, not an encoder failure
+
+`legal_privileged_communications` contains 241k chunks from privileged-counsel email correspondence. Compared with caselaw (which scored overlap@5 = 0.432 on the same harness), this corpus has structural traits that depress ranking agreement between two different encoders even when both are working correctly:
+
+1. **High near-duplicate density.** Privileged email chains have:
+   - recurring email signatures, footers, confidentiality notices
+   - threaded reply chains where successive messages re-quote earlier text
+   - boilerplate privilege-disclosure language at the top/bottom of many docs
+
+   These produce clusters of chunks that are *semantically near-identical*, where any encoder will return one of dozens of equivalent matches as #1. Different encoders, even ones of equal quality, will pick different members of the cluster — and that's enough to drop overlap@5 dramatically without any quality regression.
+2. **Short chunks (~800 chars).** Less context per chunk means less encoder-distinguishable signal between similar chunks. Caselaw's ~5.9k-char chunks are 7× larger and naturally easier to rank-stably across encoders.
+3. **Domain-specialized vs general encoder.** `legal-embed` is trained on legal text; `nomic-embed-text` is general-purpose. On legal-domain email data, they may legitimately rank candidates differently — and `legal-embed` may even be the *better* encoder, but absent ground-truth labels the harness can't tell.
+
+#### What this validation does NOT prove
+
+- It does NOT prove `legal-embed` retrieval on `legal_privileged_communications_v2` is worse than legacy. The harness measures *agreement*, not *correctness*. Without operator-marked ground-truth queries, we cannot distinguish "different rankings, both valid" from "one ranking is wrong."
+- It does NOT block the use of `legal_caselaw_v2` (which passed) or `legal_library_v2` (which passed within its 3-point limit).
+
+#### Operator decision required before cutover (Phase A PR #2)
+
+The brief says halt + surface. **The reindex is in the can — `legal_privileged_communications_v2` exists, has all 241,167 points, dim 2048, no errors.** What is blocked is the *cutover* (Phase A PR #2) for this collection until the operator decides:
+
+| Option | Action | Cost |
+|---|---|---|
+| **A — accept** | Treat overlap@5=0.136 as a corpus property of privileged email (high near-duplicate density), proceed to PR #2 cutover. Justified by the bimodal pattern (median@1=1.0) and the short-chunk hypothesis. | None — proceed. |
+| **B — spot-check** | Operator picks 5–10 representative privileged queries with known-relevant docs, runs both encoders, eyeballs results. If `legal-embed` is at-or-above legacy, accept. | ~30 min of operator time. |
+| **C — defer privileged** | Cut over `legal_caselaw` + trivial collections in PR #2; keep `legal_privileged_communications` on the legacy 768-dim nomic collection until further investigation. | PR #2 scope shrinks; intermediate state where caselaw retrieval uses 2048-dim and privileged uses 768-dim — `legal_council.py` has to branch by collection. |
+| **D — re-encode with different settings** | The reindex used `input_type=passage`. Some asymmetric encoders need different handling for short, conversational chunks. Investigate whether re-running with different settings improves ranking agreement. | New investigation; would re-issue 241k embed calls. |
+
+Recommendation pending operator review. The first reasonable next step is option B — spot-check on 5–10 known-relevant queries before declaring this either an encoder regression or a benign corpus artifact.
 
 ## Interpretation
 

--- a/docs/operational/reindex-quality/legal_caselaw.json
+++ b/docs/operational/reindex-quality/legal_caselaw.json
@@ -1,0 +1,473 @@
+{
+  "summary": {
+    "collection": "legal_caselaw",
+    "target": "legal_caselaw_v2",
+    "n_queries": 50,
+    "top1_id_match_rate": 0.94,
+    "wall_seconds": 2.8315388450864702,
+    "mean_overlap@1": 0.94,
+    "median_overlap@1": 1.0,
+    "min_overlap@1": 0.0,
+    "mean_overlap@3": 0.44,
+    "median_overlap@3": 0.3333333333333333,
+    "min_overlap@3": 0.3333333333333333,
+    "mean_overlap@5": 0.432,
+    "median_overlap@5": 0.4,
+    "min_overlap@5": 0.2,
+    "mean_overlap@10": 0.364,
+    "median_overlap@10": 0.3,
+    "min_overlap@10": 0.1
+  },
+  "detail": [
+    {
+      "q_id": "1bbcadf8-a981-53da-9c46-3a05adc3bb1a",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.2,
+      "top1_legacy": "1bbcadf8-a981-53da-9c46-3a05adc3bb1a",
+      "top1_v2": "1bbcadf8-a981-53da-9c46-3a05adc3bb1a"
+    },
+    {
+      "q_id": "27306c2f-c897-5840-b7cc-dd595ab4ed4d",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.4,
+      "overlap@10": 0.5,
+      "top1_legacy": "27306c2f-c897-5840-b7cc-dd595ab4ed4d",
+      "top1_v2": "27306c2f-c897-5840-b7cc-dd595ab4ed4d"
+    },
+    {
+      "q_id": "1c503276-af34-524c-8667-48d7cc6afc44",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.4,
+      "overlap@10": 0.3,
+      "top1_legacy": "1c503276-af34-524c-8667-48d7cc6afc44",
+      "top1_v2": "1c503276-af34-524c-8667-48d7cc6afc44"
+    },
+    {
+      "q_id": "11e16d87-01e6-546e-830d-678a2922204e",
+      "overlap@1": 1.0,
+      "overlap@3": 0.6666666666666666,
+      "overlap@5": 1.0,
+      "overlap@10": 0.7,
+      "top1_legacy": "9fab758c-b80f-5542-8983-b8edf7823793",
+      "top1_v2": "9fab758c-b80f-5542-8983-b8edf7823793"
+    },
+    {
+      "q_id": "091c2284-1b0e-5768-b42f-815af776564e",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.6,
+      "overlap@10": 0.4,
+      "top1_legacy": "091c2284-1b0e-5768-b42f-815af776564e",
+      "top1_v2": "091c2284-1b0e-5768-b42f-815af776564e"
+    },
+    {
+      "q_id": "0948a0a8-9f84-5673-b625-410fe13730db",
+      "overlap@1": 1.0,
+      "overlap@3": 1.0,
+      "overlap@5": 0.8,
+      "overlap@10": 0.4,
+      "top1_legacy": "0948a0a8-9f84-5673-b625-410fe13730db",
+      "top1_v2": "0948a0a8-9f84-5673-b625-410fe13730db"
+    },
+    {
+      "q_id": "25fcdcdc-2155-5559-9dc7-e02ef62f8f77",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "25fcdcdc-2155-5559-9dc7-e02ef62f8f77",
+      "top1_v2": "25fcdcdc-2155-5559-9dc7-e02ef62f8f77"
+    },
+    {
+      "q_id": "27837c8d-16a5-56eb-8357-6def8c1443f5",
+      "overlap@1": 1.0,
+      "overlap@3": 0.6666666666666666,
+      "overlap@5": 0.6,
+      "overlap@10": 0.7,
+      "top1_legacy": "27837c8d-16a5-56eb-8357-6def8c1443f5",
+      "top1_v2": "27837c8d-16a5-56eb-8357-6def8c1443f5"
+    },
+    {
+      "q_id": "050666de-866d-5db8-af69-5828ee39d8ac",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.4,
+      "overlap@10": 0.2,
+      "top1_legacy": "050666de-866d-5db8-af69-5828ee39d8ac",
+      "top1_v2": "050666de-866d-5db8-af69-5828ee39d8ac"
+    },
+    {
+      "q_id": "2d357e4f-bcd6-5d6a-a68f-1711cbbf11a3",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.4,
+      "top1_legacy": "2d357e4f-bcd6-5d6a-a68f-1711cbbf11a3",
+      "top1_v2": "2d357e4f-bcd6-5d6a-a68f-1711cbbf11a3"
+    },
+    {
+      "q_id": "23628e81-ec8d-582d-87be-e7f4e19ef3ca",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.3,
+      "top1_legacy": "23628e81-ec8d-582d-87be-e7f4e19ef3ca",
+      "top1_v2": "23628e81-ec8d-582d-87be-e7f4e19ef3ca"
+    },
+    {
+      "q_id": "2d6c3e08-c47f-5016-b038-35e6577d1bfa",
+      "overlap@1": 1.0,
+      "overlap@3": 0.6666666666666666,
+      "overlap@5": 0.6,
+      "overlap@10": 0.5,
+      "top1_legacy": "2d6c3e08-c47f-5016-b038-35e6577d1bfa",
+      "top1_v2": "2d6c3e08-c47f-5016-b038-35e6577d1bfa"
+    },
+    {
+      "q_id": "10482758-f4c6-539a-9e61-9e08fd15f077",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.4,
+      "overlap@10": 0.3,
+      "top1_legacy": "10482758-f4c6-539a-9e61-9e08fd15f077",
+      "top1_v2": "10482758-f4c6-539a-9e61-9e08fd15f077"
+    },
+    {
+      "q_id": "1028891e-f841-533b-8507-04c356430539",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.4,
+      "overlap@10": 0.4,
+      "top1_legacy": "1028891e-f841-533b-8507-04c356430539",
+      "top1_v2": "1028891e-f841-533b-8507-04c356430539"
+    },
+    {
+      "q_id": "11cb3d45-35c7-5600-88e8-17429f6c1853",
+      "overlap@1": 0.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.4,
+      "overlap@10": 0.2,
+      "top1_legacy": "11cb3d45-35c7-5600-88e8-17429f6c1853",
+      "top1_v2": "63b09311-75d7-57e6-8a33-0b3c11313757"
+    },
+    {
+      "q_id": "0fbf5422-e979-50e4-9284-b5e01721569c",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.4,
+      "overlap@10": 0.3,
+      "top1_legacy": "0fbf5422-e979-50e4-9284-b5e01721569c",
+      "top1_v2": "0fbf5422-e979-50e4-9284-b5e01721569c"
+    },
+    {
+      "q_id": "0a15e42a-5399-5a70-9ec8-314cd0808543",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.3,
+      "top1_legacy": "0a15e42a-5399-5a70-9ec8-314cd0808543",
+      "top1_v2": "0a15e42a-5399-5a70-9ec8-314cd0808543"
+    },
+    {
+      "q_id": "21ccc44a-f49d-58a7-b6df-9a0c7defac5d",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.2,
+      "top1_legacy": "21ccc44a-f49d-58a7-b6df-9a0c7defac5d",
+      "top1_v2": "21ccc44a-f49d-58a7-b6df-9a0c7defac5d"
+    },
+    {
+      "q_id": "2a78499a-e8ec-5446-b6a3-1d2a485344c8",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.4,
+      "overlap@10": 0.5,
+      "top1_legacy": "2a78499a-e8ec-5446-b6a3-1d2a485344c8",
+      "top1_v2": "2a78499a-e8ec-5446-b6a3-1d2a485344c8"
+    },
+    {
+      "q_id": "2ac88fcd-e2cd-5423-8b2c-33c7684b5cff",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.2,
+      "top1_legacy": "2ac88fcd-e2cd-5423-8b2c-33c7684b5cff",
+      "top1_v2": "2ac88fcd-e2cd-5423-8b2c-33c7684b5cff"
+    },
+    {
+      "q_id": "1e764628-32d2-55ff-9e42-69837bcfe33d",
+      "overlap@1": 1.0,
+      "overlap@3": 1.0,
+      "overlap@5": 0.8,
+      "overlap@10": 0.7,
+      "top1_legacy": "1e764628-32d2-55ff-9e42-69837bcfe33d",
+      "top1_v2": "1e764628-32d2-55ff-9e42-69837bcfe33d"
+    },
+    {
+      "q_id": "09f87856-9aa2-52f7-afc0-53db3c319ca0",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.4,
+      "overlap@10": 0.5,
+      "top1_legacy": "09f87856-9aa2-52f7-afc0-53db3c319ca0",
+      "top1_v2": "09f87856-9aa2-52f7-afc0-53db3c319ca0"
+    },
+    {
+      "q_id": "07f7cf35-e12f-56c1-91ab-87e4873f4bd3",
+      "overlap@1": 1.0,
+      "overlap@3": 0.6666666666666666,
+      "overlap@5": 0.8,
+      "overlap@10": 0.7,
+      "top1_legacy": "07f7cf35-e12f-56c1-91ab-87e4873f4bd3",
+      "top1_v2": "07f7cf35-e12f-56c1-91ab-87e4873f4bd3"
+    },
+    {
+      "q_id": "2d0f1528-4c6d-5354-9d74-c065f580c10b",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.6,
+      "overlap@10": 0.3,
+      "top1_legacy": "2d0f1528-4c6d-5354-9d74-c065f580c10b",
+      "top1_v2": "2d0f1528-4c6d-5354-9d74-c065f580c10b"
+    },
+    {
+      "q_id": "24f4d550-0831-541e-a3ac-4c9e274d9ac2",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.4,
+      "overlap@10": 0.3,
+      "top1_legacy": "24f4d550-0831-541e-a3ac-4c9e274d9ac2",
+      "top1_v2": "24f4d550-0831-541e-a3ac-4c9e274d9ac2"
+    },
+    {
+      "q_id": "02d6a9c1-e156-5023-b584-86c4cce99691",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.2,
+      "top1_legacy": "02d6a9c1-e156-5023-b584-86c4cce99691",
+      "top1_v2": "02d6a9c1-e156-5023-b584-86c4cce99691"
+    },
+    {
+      "q_id": "28364251-7454-5cc7-b3c8-3cebccc6f9fd",
+      "overlap@1": 1.0,
+      "overlap@3": 0.6666666666666666,
+      "overlap@5": 0.6,
+      "overlap@10": 0.4,
+      "top1_legacy": "28364251-7454-5cc7-b3c8-3cebccc6f9fd",
+      "top1_v2": "28364251-7454-5cc7-b3c8-3cebccc6f9fd"
+    },
+    {
+      "q_id": "28f98357-8ef2-5055-85ce-ca53de71c320",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "28f98357-8ef2-5055-85ce-ca53de71c320",
+      "top1_v2": "28f98357-8ef2-5055-85ce-ca53de71c320"
+    },
+    {
+      "q_id": "0e75a74d-9fb6-5b05-bfe2-d9d40d600512",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.4,
+      "overlap@10": 0.3,
+      "top1_legacy": "0e75a74d-9fb6-5b05-bfe2-d9d40d600512",
+      "top1_v2": "0e75a74d-9fb6-5b05-bfe2-d9d40d600512"
+    },
+    {
+      "q_id": "247a1dbc-70e7-57e9-94a1-73c2862f0c3a",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "247a1dbc-70e7-57e9-94a1-73c2862f0c3a",
+      "top1_v2": "247a1dbc-70e7-57e9-94a1-73c2862f0c3a"
+    },
+    {
+      "q_id": "0172affc-8cf3-5640-acf8-54868cb3ac63",
+      "overlap@1": 0.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.4,
+      "overlap@10": 0.6,
+      "top1_legacy": "0172affc-8cf3-5640-acf8-54868cb3ac63",
+      "top1_v2": "181ac57e-cbb7-544b-a6b9-05d342e33498"
+    },
+    {
+      "q_id": "27a37405-f6cb-5058-a991-d6e109577f0f",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.4,
+      "overlap@10": 0.5,
+      "top1_legacy": "27a37405-f6cb-5058-a991-d6e109577f0f",
+      "top1_v2": "27a37405-f6cb-5058-a991-d6e109577f0f"
+    },
+    {
+      "q_id": "1b44cce4-3d21-59f3-a159-274886929fa7",
+      "overlap@1": 1.0,
+      "overlap@3": 0.6666666666666666,
+      "overlap@5": 0.6,
+      "overlap@10": 0.3,
+      "top1_legacy": "1b44cce4-3d21-59f3-a159-274886929fa7",
+      "top1_v2": "1b44cce4-3d21-59f3-a159-274886929fa7"
+    },
+    {
+      "q_id": "07ba78a3-af6a-5adc-a46b-4fd3579c04f3",
+      "overlap@1": 1.0,
+      "overlap@3": 0.6666666666666666,
+      "overlap@5": 0.4,
+      "overlap@10": 0.4,
+      "top1_legacy": "07ba78a3-af6a-5adc-a46b-4fd3579c04f3",
+      "top1_v2": "07ba78a3-af6a-5adc-a46b-4fd3579c04f3"
+    },
+    {
+      "q_id": "1c050a17-2969-5d82-94f0-84f7cbb3ef91",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.4,
+      "overlap@10": 0.4,
+      "top1_legacy": "1c050a17-2969-5d82-94f0-84f7cbb3ef91",
+      "top1_v2": "1c050a17-2969-5d82-94f0-84f7cbb3ef91"
+    },
+    {
+      "q_id": "15ab0491-e520-5fae-8828-b55c0aafc14c",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.4,
+      "overlap@10": 0.4,
+      "top1_legacy": "15ab0491-e520-5fae-8828-b55c0aafc14c",
+      "top1_v2": "15ab0491-e520-5fae-8828-b55c0aafc14c"
+    },
+    {
+      "q_id": "00b83472-9804-57f7-8818-ab9f78ed7372",
+      "overlap@1": 1.0,
+      "overlap@3": 0.6666666666666666,
+      "overlap@5": 0.6,
+      "overlap@10": 0.5,
+      "top1_legacy": "00b83472-9804-57f7-8818-ab9f78ed7372",
+      "top1_v2": "00b83472-9804-57f7-8818-ab9f78ed7372"
+    },
+    {
+      "q_id": "0fc6f541-321a-592e-bbe2-d532874569ea",
+      "overlap@1": 1.0,
+      "overlap@3": 1.0,
+      "overlap@5": 0.8,
+      "overlap@10": 0.5,
+      "top1_legacy": "0fc6f541-321a-592e-bbe2-d532874569ea",
+      "top1_v2": "0fc6f541-321a-592e-bbe2-d532874569ea"
+    },
+    {
+      "q_id": "13dfe4d2-6b06-51f7-b73d-fe7d4559eb37",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.3,
+      "top1_legacy": "13dfe4d2-6b06-51f7-b73d-fe7d4559eb37",
+      "top1_v2": "13dfe4d2-6b06-51f7-b73d-fe7d4559eb37"
+    },
+    {
+      "q_id": "2481da5c-7820-592d-90a4-4d41418c4711",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.2,
+      "top1_legacy": "2481da5c-7820-592d-90a4-4d41418c4711",
+      "top1_v2": "2481da5c-7820-592d-90a4-4d41418c4711"
+    },
+    {
+      "q_id": "19ef96a9-8108-5088-8dbf-55a3b560b59a",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.2,
+      "top1_legacy": "19ef96a9-8108-5088-8dbf-55a3b560b59a",
+      "top1_v2": "19ef96a9-8108-5088-8dbf-55a3b560b59a"
+    },
+    {
+      "q_id": "049f141d-29cd-5c19-9539-9daa6b044612",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.4,
+      "overlap@10": 0.2,
+      "top1_legacy": "049f141d-29cd-5c19-9539-9daa6b044612",
+      "top1_v2": "049f141d-29cd-5c19-9539-9daa6b044612"
+    },
+    {
+      "q_id": "1692ec17-2b03-5a8d-83bd-6cb950593913",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.4,
+      "overlap@10": 0.7,
+      "top1_legacy": "1692ec17-2b03-5a8d-83bd-6cb950593913",
+      "top1_v2": "1692ec17-2b03-5a8d-83bd-6cb950593913"
+    },
+    {
+      "q_id": "01369904-de5f-5f37-8aa5-980b94fa89b9",
+      "overlap@1": 1.0,
+      "overlap@3": 0.6666666666666666,
+      "overlap@5": 0.6,
+      "overlap@10": 0.3,
+      "top1_legacy": "01369904-de5f-5f37-8aa5-980b94fa89b9",
+      "top1_v2": "01369904-de5f-5f37-8aa5-980b94fa89b9"
+    },
+    {
+      "q_id": "26053ad6-9dbd-52d7-be8f-4c94db55c02d",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.6,
+      "overlap@10": 0.4,
+      "top1_legacy": "26053ad6-9dbd-52d7-be8f-4c94db55c02d",
+      "top1_v2": "26053ad6-9dbd-52d7-be8f-4c94db55c02d"
+    },
+    {
+      "q_id": "029c3c3d-2ccf-52b3-9885-95c9d07d1f1d",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.4,
+      "overlap@10": 0.3,
+      "top1_legacy": "029c3c3d-2ccf-52b3-9885-95c9d07d1f1d",
+      "top1_v2": "029c3c3d-2ccf-52b3-9885-95c9d07d1f1d"
+    },
+    {
+      "q_id": "23c1cfb8-e06c-536d-876c-31c18fe03e9d",
+      "overlap@1": 1.0,
+      "overlap@3": 0.6666666666666666,
+      "overlap@5": 0.6,
+      "overlap@10": 0.5,
+      "top1_legacy": "23c1cfb8-e06c-536d-876c-31c18fe03e9d",
+      "top1_v2": "23c1cfb8-e06c-536d-876c-31c18fe03e9d"
+    },
+    {
+      "q_id": "2a4494ed-2aaa-5790-a018-543471c32630",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.4,
+      "overlap@10": 0.4,
+      "top1_legacy": "2a4494ed-2aaa-5790-a018-543471c32630",
+      "top1_v2": "2a4494ed-2aaa-5790-a018-543471c32630"
+    },
+    {
+      "q_id": "205584b0-e9d5-5f24-9f44-5eead8643c45",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.4,
+      "overlap@10": 0.2,
+      "top1_legacy": "205584b0-e9d5-5f24-9f44-5eead8643c45",
+      "top1_v2": "205584b0-e9d5-5f24-9f44-5eead8643c45"
+    },
+    {
+      "q_id": "1dd4487a-ac1a-5786-9c28-b5ce9d7e5cf0",
+      "overlap@1": 0.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.4,
+      "overlap@10": 0.2,
+      "top1_legacy": "1dd4487a-ac1a-5786-9c28-b5ce9d7e5cf0",
+      "top1_v2": "502581c1-c3ec-5c15-b0fd-0e1d20681d62"
+    }
+  ]
+}

--- a/docs/operational/reindex-quality/legal_library.json
+++ b/docs/operational/reindex-quality/legal_library.json
@@ -1,0 +1,50 @@
+{
+  "summary": {
+    "collection": "legal_library",
+    "target": "legal_library_v2",
+    "n_queries": 3,
+    "top1_id_match_rate": 1.0,
+    "wall_seconds": 0.16079763788729906,
+    "mean_overlap@1": 1.0,
+    "median_overlap@1": 1.0,
+    "min_overlap@1": 1.0,
+    "mean_overlap@3": 1.0,
+    "median_overlap@3": 1.0,
+    "min_overlap@3": 1.0,
+    "mean_overlap@5": 0.6,
+    "median_overlap@5": 0.6,
+    "min_overlap@5": 0.6,
+    "mean_overlap@10": 0.3,
+    "median_overlap@10": 0.3,
+    "min_overlap@10": 0.3
+  },
+  "detail": [
+    {
+      "q_id": "d67d4b79-2dbf-5ae4-9314-58a05b584f36",
+      "overlap@1": 1.0,
+      "overlap@3": 1.0,
+      "overlap@5": 0.6,
+      "overlap@10": 0.3,
+      "top1_legacy": "d67d4b79-2dbf-5ae4-9314-58a05b584f36",
+      "top1_v2": "d67d4b79-2dbf-5ae4-9314-58a05b584f36"
+    },
+    {
+      "q_id": "23ba33df-4c0e-5f45-8f9d-1090469955d2",
+      "overlap@1": 1.0,
+      "overlap@3": 1.0,
+      "overlap@5": 0.6,
+      "overlap@10": 0.3,
+      "top1_legacy": "23ba33df-4c0e-5f45-8f9d-1090469955d2",
+      "top1_v2": "23ba33df-4c0e-5f45-8f9d-1090469955d2"
+    },
+    {
+      "q_id": "01a19f41-7c76-5d4a-927c-e91a0fc7a2a9",
+      "overlap@1": 1.0,
+      "overlap@3": 1.0,
+      "overlap@5": 0.6,
+      "overlap@10": 0.3,
+      "top1_legacy": "01a19f41-7c76-5d4a-927c-e91a0fc7a2a9",
+      "top1_v2": "01a19f41-7c76-5d4a-927c-e91a0fc7a2a9"
+    }
+  ]
+}

--- a/docs/operational/reindex-quality/legal_privileged_communications.json
+++ b/docs/operational/reindex-quality/legal_privileged_communications.json
@@ -1,0 +1,473 @@
+{
+  "summary": {
+    "collection": "legal_privileged_communications",
+    "target": "legal_privileged_communications_v2",
+    "n_queries": 50,
+    "top1_id_match_rate": 0.6,
+    "wall_seconds": 6.402663936140016,
+    "mean_overlap@1": 0.6,
+    "median_overlap@1": 1.0,
+    "min_overlap@1": 0.0,
+    "mean_overlap@3": 0.22,
+    "median_overlap@3": 0.3333333333333333,
+    "min_overlap@3": 0.0,
+    "mean_overlap@5": 0.136,
+    "median_overlap@5": 0.2,
+    "min_overlap@5": 0.0,
+    "mean_overlap@10": 0.08600000000000001,
+    "median_overlap@10": 0.1,
+    "min_overlap@10": 0.0
+  },
+  "detail": [
+    {
+      "q_id": "00530a6b-c20c-5f5f-b229-8e11adb82545",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "00530a6b-c20c-5f5f-b229-8e11adb82545",
+      "top1_v2": "00530a6b-c20c-5f5f-b229-8e11adb82545"
+    },
+    {
+      "q_id": "0070716f-6123-565f-9d6e-c66639d9912d",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "0070716f-6123-565f-9d6e-c66639d9912d",
+      "top1_v2": "0070716f-6123-565f-9d6e-c66639d9912d"
+    },
+    {
+      "q_id": "0054d60e-343f-5ec1-ae07-f8148c7937cc",
+      "overlap@1": 0.0,
+      "overlap@3": 0.0,
+      "overlap@5": 0.0,
+      "overlap@10": 0.0,
+      "top1_legacy": "7146c3d2-22cf-5425-8468-8d2b4fc4b6ff",
+      "top1_v2": "0054d60e-343f-5ec1-ae07-f8148c7937cc"
+    },
+    {
+      "q_id": "00342b19-a756-55a2-86d1-422b80166c0c",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "00342b19-a756-55a2-86d1-422b80166c0c",
+      "top1_v2": "00342b19-a756-55a2-86d1-422b80166c0c"
+    },
+    {
+      "q_id": "0018235e-5029-5fbf-bb4a-2b9b1b9c0b59",
+      "overlap@1": 0.0,
+      "overlap@3": 0.0,
+      "overlap@5": 0.0,
+      "overlap@10": 0.0,
+      "top1_legacy": "0018235e-5029-5fbf-bb4a-2b9b1b9c0b59",
+      "top1_v2": "6367fd29-6eac-576a-949b-a57c4e225fb7"
+    },
+    {
+      "q_id": "001826ef-9231-5d10-b541-fc917c7a07af",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "001826ef-9231-5d10-b541-fc917c7a07af",
+      "top1_v2": "001826ef-9231-5d10-b541-fc917c7a07af"
+    },
+    {
+      "q_id": "006d4e48-d734-5343-9741-540fa13169d6",
+      "overlap@1": 0.0,
+      "overlap@3": 0.0,
+      "overlap@5": 0.0,
+      "overlap@10": 0.0,
+      "top1_legacy": "006d4e48-d734-5343-9741-540fa13169d6",
+      "top1_v2": "9020d2bd-cf5e-5b46-b6a1-1246ca3f3eec"
+    },
+    {
+      "q_id": "0071cae5-2e80-57ac-a834-cd80be3746e1",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "0071cae5-2e80-57ac-a834-cd80be3746e1",
+      "top1_v2": "0071cae5-2e80-57ac-a834-cd80be3746e1"
+    },
+    {
+      "q_id": "00101ab4-7779-5123-954e-17a3c13f5531",
+      "overlap@1": 0.0,
+      "overlap@3": 0.0,
+      "overlap@5": 0.0,
+      "overlap@10": 0.0,
+      "top1_legacy": "00101ab4-7779-5123-954e-17a3c13f5531",
+      "top1_v2": "8bbfa7e3-9234-5aaa-9969-65e1724a0ea1"
+    },
+    {
+      "q_id": "007e3357-f136-5d18-92bd-19fa19328290",
+      "overlap@1": 0.0,
+      "overlap@3": 0.0,
+      "overlap@5": 0.0,
+      "overlap@10": 0.0,
+      "top1_legacy": "007e3357-f136-5d18-92bd-19fa19328290",
+      "top1_v2": "bf048a6d-5a7c-54f0-b69c-b8113cfbb49b"
+    },
+    {
+      "q_id": "00661f5e-fb51-58d6-b0de-9d5b9b5a3c69",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "00661f5e-fb51-58d6-b0de-9d5b9b5a3c69",
+      "top1_v2": "00661f5e-fb51-58d6-b0de-9d5b9b5a3c69"
+    },
+    {
+      "q_id": "007f6bd0-c6b4-57ab-a1c5-8ecc04d0b499",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "007f6bd0-c6b4-57ab-a1c5-8ecc04d0b499",
+      "top1_v2": "007f6bd0-c6b4-57ab-a1c5-8ecc04d0b499"
+    },
+    {
+      "q_id": "002ee5e4-246a-54e5-bb4f-dca1ee809d9b",
+      "overlap@1": 1.0,
+      "overlap@3": 0.6666666666666666,
+      "overlap@5": 0.4,
+      "overlap@10": 0.5,
+      "top1_legacy": "002ee5e4-246a-54e5-bb4f-dca1ee809d9b",
+      "top1_v2": "002ee5e4-246a-54e5-bb4f-dca1ee809d9b"
+    },
+    {
+      "q_id": "002df3fa-3f59-54c4-98fd-d6e0818dc83d",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "002df3fa-3f59-54c4-98fd-d6e0818dc83d",
+      "top1_v2": "002df3fa-3f59-54c4-98fd-d6e0818dc83d"
+    },
+    {
+      "q_id": "00335939-4b96-505d-84ef-e07d782d4976",
+      "overlap@1": 0.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "db6c13f1-c2db-5408-b535-766be38dd07d",
+      "top1_v2": "00335939-4b96-505d-84ef-e07d782d4976"
+    },
+    {
+      "q_id": "002cfc76-4445-5c9d-9d29-4bf0e37dc4ff",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "002cfc76-4445-5c9d-9d29-4bf0e37dc4ff",
+      "top1_v2": "002cfc76-4445-5c9d-9d29-4bf0e37dc4ff"
+    },
+    {
+      "q_id": "001b8e40-00bd-5897-b523-c3b1b1c02ee4",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "001b8e40-00bd-5897-b523-c3b1b1c02ee4",
+      "top1_v2": "001b8e40-00bd-5897-b523-c3b1b1c02ee4"
+    },
+    {
+      "q_id": "0061ec2d-3186-5091-9522-b8412748902f",
+      "overlap@1": 0.0,
+      "overlap@3": 0.0,
+      "overlap@5": 0.0,
+      "overlap@10": 0.0,
+      "top1_legacy": "46c617e8-3cf3-5a09-a11a-026b03a123b1",
+      "top1_v2": "319b9e66-9433-5190-a180-9da467c400d3"
+    },
+    {
+      "q_id": "0075ee54-8540-55bf-b5fa-4b469a13bcf2",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "0075ee54-8540-55bf-b5fa-4b469a13bcf2",
+      "top1_v2": "0075ee54-8540-55bf-b5fa-4b469a13bcf2"
+    },
+    {
+      "q_id": "0076877c-e8f3-5eb2-81f9-a307ecd6e6e3",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "0076877c-e8f3-5eb2-81f9-a307ecd6e6e3",
+      "top1_v2": "0076877c-e8f3-5eb2-81f9-a307ecd6e6e3"
+    },
+    {
+      "q_id": "005a06be-7ed1-527c-9ca4-989c01d1b578",
+      "overlap@1": 0.0,
+      "overlap@3": 0.0,
+      "overlap@5": 0.0,
+      "overlap@10": 0.0,
+      "top1_legacy": "005a06be-7ed1-527c-9ca4-989c01d1b578",
+      "top1_v2": "0c7c7e2f-9210-5f27-b48b-502842cf1dff"
+    },
+    {
+      "q_id": "001b3205-1aaf-5812-98d7-1f6209b2837d",
+      "overlap@1": 0.0,
+      "overlap@3": 0.0,
+      "overlap@5": 0.0,
+      "overlap@10": 0.0,
+      "top1_legacy": "b36483c7-9af6-5ecf-b3a6-23f21afabe0d",
+      "top1_v2": "001b3205-1aaf-5812-98d7-1f6209b2837d"
+    },
+    {
+      "q_id": "00151a21-b120-5706-830f-c4c17c847fb4",
+      "overlap@1": 0.0,
+      "overlap@3": 0.0,
+      "overlap@5": 0.0,
+      "overlap@10": 0.0,
+      "top1_legacy": "00151a21-b120-5706-830f-c4c17c847fb4",
+      "top1_v2": "8cc99385-2042-50d6-b60c-257d48b99796"
+    },
+    {
+      "q_id": "007d31c1-fd28-5ecb-8722-94bb5357956f",
+      "overlap@1": 0.0,
+      "overlap@3": 0.0,
+      "overlap@5": 0.0,
+      "overlap@10": 0.0,
+      "top1_legacy": "17a28da2-c908-59a6-b61b-2a4301fb6eae",
+      "top1_v2": "007d31c1-fd28-5ecb-8722-94bb5357956f"
+    },
+    {
+      "q_id": "006ad8fb-cd28-5ec7-b400-d0aef66e3ce0",
+      "overlap@1": 0.0,
+      "overlap@3": 0.0,
+      "overlap@5": 0.0,
+      "overlap@10": 0.0,
+      "top1_legacy": "006ad8fb-cd28-5ec7-b400-d0aef66e3ce0",
+      "top1_v2": "d3c8484d-d60c-522f-842c-29d202bebfcb"
+    },
+    {
+      "q_id": "0009d961-4280-51be-830f-52d8b83f93d6",
+      "overlap@1": 0.0,
+      "overlap@3": 0.0,
+      "overlap@5": 0.0,
+      "overlap@10": 0.0,
+      "top1_legacy": "0009d961-4280-51be-830f-52d8b83f93d6",
+      "top1_v2": "197da0d0-aa93-5f7b-88e0-894eb458a200"
+    },
+    {
+      "q_id": "0072c1c9-4561-509e-9c62-4c1fda330ee5",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "0072c1c9-4561-509e-9c62-4c1fda330ee5",
+      "top1_v2": "0072c1c9-4561-509e-9c62-4c1fda330ee5"
+    },
+    {
+      "q_id": "0073612f-5401-53e1-842b-0424746ed61e",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "0073612f-5401-53e1-842b-0424746ed61e",
+      "top1_v2": "0073612f-5401-53e1-842b-0424746ed61e"
+    },
+    {
+      "q_id": "002b4dfc-7158-53fc-a096-3e947edc8dda",
+      "overlap@1": 0.0,
+      "overlap@3": 0.0,
+      "overlap@5": 0.0,
+      "overlap@10": 0.0,
+      "top1_legacy": "002b4dfc-7158-53fc-a096-3e947edc8dda",
+      "top1_v2": "b111a177-6492-5421-b868-1a3a75751c08"
+    },
+    {
+      "q_id": "00688726-4a24-56b2-836a-49de1d77fcde",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "00688726-4a24-56b2-836a-49de1d77fcde",
+      "top1_v2": "00688726-4a24-56b2-836a-49de1d77fcde"
+    },
+    {
+      "q_id": "0004f4b4-6e35-5ef0-8f93-b3f8d8ce189b",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "0004f4b4-6e35-5ef0-8f93-b3f8d8ce189b",
+      "top1_v2": "0004f4b4-6e35-5ef0-8f93-b3f8d8ce189b"
+    },
+    {
+      "q_id": "00720072-0096-50aa-bfa1-336c04766cc8",
+      "overlap@1": 0.0,
+      "overlap@3": 0.0,
+      "overlap@5": 0.0,
+      "overlap@10": 0.0,
+      "top1_legacy": "00720072-0096-50aa-bfa1-336c04766cc8",
+      "top1_v2": "899f245b-6a17-564f-bba7-660ed84e1366"
+    },
+    {
+      "q_id": "0051778c-45ac-5ee1-8fc5-73a3ffab29fb",
+      "overlap@1": 1.0,
+      "overlap@3": 0.6666666666666666,
+      "overlap@5": 0.4,
+      "overlap@10": 0.3,
+      "top1_legacy": "0051778c-45ac-5ee1-8fc5-73a3ffab29fb",
+      "top1_v2": "0051778c-45ac-5ee1-8fc5-73a3ffab29fb"
+    },
+    {
+      "q_id": "0014b7b4-e599-578a-8ce1-2ea9487ffe3f",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "0014b7b4-e599-578a-8ce1-2ea9487ffe3f",
+      "top1_v2": "0014b7b4-e599-578a-8ce1-2ea9487ffe3f"
+    },
+    {
+      "q_id": "00530f80-60b4-5a50-9d6c-2e348700e236",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "00530f80-60b4-5a50-9d6c-2e348700e236",
+      "top1_v2": "00530f80-60b4-5a50-9d6c-2e348700e236"
+    },
+    {
+      "q_id": "003e6fe4-03f3-562f-9ff9-45f1ea834f92",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "003e6fe4-03f3-562f-9ff9-45f1ea834f92",
+      "top1_v2": "003e6fe4-03f3-562f-9ff9-45f1ea834f92"
+    },
+    {
+      "q_id": "0002e269-ad3c-58f4-b7b8-c9af0aab1265",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.4,
+      "overlap@10": 0.7,
+      "top1_legacy": "0002e269-ad3c-58f4-b7b8-c9af0aab1265",
+      "top1_v2": "0002e269-ad3c-58f4-b7b8-c9af0aab1265"
+    },
+    {
+      "q_id": "002da525-2cb2-5d23-9c53-70c388201fe2",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "002da525-2cb2-5d23-9c53-70c388201fe2",
+      "top1_v2": "002da525-2cb2-5d23-9c53-70c388201fe2"
+    },
+    {
+      "q_id": "0038c911-2054-5347-bc58-49a76db0188f",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "0038c911-2054-5347-bc58-49a76db0188f",
+      "top1_v2": "0038c911-2054-5347-bc58-49a76db0188f"
+    },
+    {
+      "q_id": "0068e3d1-11f0-519e-b84a-2154ddd51d64",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "0068e3d1-11f0-519e-b84a-2154ddd51d64",
+      "top1_v2": "0068e3d1-11f0-519e-b84a-2154ddd51d64"
+    },
+    {
+      "q_id": "004ce785-fdfb-5bb0-aa72-2f246e102167",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "004ce785-fdfb-5bb0-aa72-2f246e102167",
+      "top1_v2": "004ce785-fdfb-5bb0-aa72-2f246e102167"
+    },
+    {
+      "q_id": "000dd471-e9e5-5877-b5be-3ab0ff27eb84",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "000dd471-e9e5-5877-b5be-3ab0ff27eb84",
+      "top1_v2": "000dd471-e9e5-5877-b5be-3ab0ff27eb84"
+    },
+    {
+      "q_id": "00404bb9-ea8e-59b0-b28f-97cb65ca4be8",
+      "overlap@1": 0.0,
+      "overlap@3": 0.0,
+      "overlap@5": 0.0,
+      "overlap@10": 0.0,
+      "top1_legacy": "00404bb9-ea8e-59b0-b28f-97cb65ca4be8",
+      "top1_v2": "bf437b46-3e20-5ac2-86b0-4c9dee1f4ddc"
+    },
+    {
+      "q_id": "00030d66-c9db-5f6b-9875-c82086d99a9c",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "00030d66-c9db-5f6b-9875-c82086d99a9c",
+      "top1_v2": "00030d66-c9db-5f6b-9875-c82086d99a9c"
+    },
+    {
+      "q_id": "006d7236-a9b1-5ef2-9edb-a638c9302203",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "006d7236-a9b1-5ef2-9edb-a638c9302203",
+      "top1_v2": "006d7236-a9b1-5ef2-9edb-a638c9302203"
+    },
+    {
+      "q_id": "0008a319-3b78-5352-9a85-12ff79740c2a",
+      "overlap@1": 1.0,
+      "overlap@3": 0.3333333333333333,
+      "overlap@5": 0.2,
+      "overlap@10": 0.1,
+      "top1_legacy": "0008a319-3b78-5352-9a85-12ff79740c2a",
+      "top1_v2": "0008a319-3b78-5352-9a85-12ff79740c2a"
+    },
+    {
+      "q_id": "00678735-99e1-5cdc-95e4-52d6c6960943",
+      "overlap@1": 0.0,
+      "overlap@3": 0.0,
+      "overlap@5": 0.0,
+      "overlap@10": 0.0,
+      "top1_legacy": "00678735-99e1-5cdc-95e4-52d6c6960943",
+      "top1_v2": "24a6238a-35e7-52a1-bc80-a27f014d06c4"
+    },
+    {
+      "q_id": "0075776b-b61b-50c8-9502-3ae14a39aee1",
+      "overlap@1": 0.0,
+      "overlap@3": 0.0,
+      "overlap@5": 0.0,
+      "overlap@10": 0.0,
+      "top1_legacy": "0075776b-b61b-50c8-9502-3ae14a39aee1",
+      "top1_v2": "3e01f309-2131-5bf3-9c2a-69281829b972"
+    },
+    {
+      "q_id": "005ef7bd-a943-5edd-9eea-d2588c8a08d5",
+      "overlap@1": 0.0,
+      "overlap@3": 0.0,
+      "overlap@5": 0.0,
+      "overlap@10": 0.0,
+      "top1_legacy": "005ef7bd-a943-5edd-9eea-d2588c8a08d5",
+      "top1_v2": "0d762310-91f4-5902-beed-dce9c748c410"
+    },
+    {
+      "q_id": "0058d3c7-0a64-5c6a-afca-0135ee8db36f",
+      "overlap@1": 0.0,
+      "overlap@3": 0.0,
+      "overlap@5": 0.0,
+      "overlap@10": 0.0,
+      "top1_legacy": "0058d3c7-0a64-5c6a-afca-0135ee8db36f",
+      "top1_v2": "6d5e5c52-59d3-5679-9485-a850e531258a"
+    }
+  ]
+}

--- a/src/reindex_legal_qdrant_to_legal_embed.py
+++ b/src/reindex_legal_qdrant_to_legal_embed.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""
+Reindex a legacy 768-dim Qdrant legal collection to a 2048-dim _v2 collection
+embedded via the LiteLLM gateway alias `legal-embed`
+(llama-nemotron-embed-1b-v2 on spark-3:8102).
+
+Caller contract (verified via PR #300 §9.5):
+    model           = "legal-embed"
+    input_type      = "passage"      # asymmetric encoder; passage for indexing
+    encoding_format = "float"        # NIM rejects None default with HTTP 400
+
+Field branch (verified via PR #301 audit §2):
+    text_chunk : legal_caselaw, legal_library
+    text       : legal_privileged_communications
+
+Idempotent: source point IDs are preserved, so re-running over already-written
+points is a no-op upsert. Resume state (last successful offset) is persisted to
+/mnt/fortress_nas/fortress_data/reindex_state/<collection>.json.
+
+Hard constraint compliance: this script reindexes by COPY — it never touches
+the source collection. Source remains live throughout.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+from qdrant_client import QdrantClient
+from qdrant_client.http import models as qmodels
+
+
+# ---- Configuration ----------------------------------------------------------
+
+QDRANT_URL = os.environ.get("QDRANT_URL", "http://192.168.0.100:6333")
+GATEWAY_URL = os.environ.get("LITELLM_URL", "http://localhost:8002")
+TARGET_DIM = 2048
+TARGET_DISTANCE = qmodels.Distance.COSINE
+
+TEXT_FIELD = {
+    "legal_caselaw": "text_chunk",
+    "legal_library": "text_chunk",
+    "legal_privileged_communications": "text",
+}
+
+STATE_DIR = Path("/mnt/fortress_nas/fortress_data/reindex_state")
+LOG_DIR = Path("/var/log/fortress")
+
+
+# ---- Logging ----------------------------------------------------------------
+
+def setup_logging(collection: str) -> Path:
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    ts = time.strftime("%Y%m%d-%H%M%S")
+    log_path = LOG_DIR / f"reindex-{collection}-{ts}.log"
+    fmt = "%(asctime)s %(levelname)s %(message)s"
+    handlers = [logging.StreamHandler(sys.stdout), logging.FileHandler(log_path)]
+    logging.basicConfig(level=logging.INFO, format=fmt, handlers=handlers, force=True)
+    return log_path
+
+
+# ---- State file -------------------------------------------------------------
+
+@dataclass
+class State:
+    collection: str
+    next_offset: Any  # opaque Qdrant cursor (None at start)
+    processed: int
+    errors: int
+    started_at: str
+    last_update_at: str
+
+    @classmethod
+    def load(cls, collection: str) -> "State":
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        p = STATE_DIR / f"{collection}.json"
+        if p.exists():
+            d = json.loads(p.read_text())
+            return cls(**d)
+        return cls(
+            collection=collection,
+            next_offset=None,
+            processed=0,
+            errors=0,
+            started_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            last_update_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        )
+
+    def save(self) -> None:
+        p = STATE_DIR / f"{self.collection}.json"
+        self.last_update_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        p.write_text(json.dumps(self.__dict__, indent=2, default=str))
+
+
+# ---- Embedding via gateway --------------------------------------------------
+
+class Embedder:
+    def __init__(self, base_url: str, api_key: str, timeout: float = 60.0, concurrency: int = 4):
+        self.client = httpx.AsyncClient(
+            base_url=base_url,
+            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+            timeout=timeout,
+        )
+        self.sem = asyncio.Semaphore(concurrency)
+
+    async def aclose(self) -> None:
+        await self.client.aclose()
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        body = {
+            "input": texts,
+            "model": "legal-embed",
+            "input_type": "passage",
+            "encoding_format": "float",
+        }
+        async with self.sem:
+            for attempt in range(3):
+                try:
+                    r = await self.client.post("/embeddings", json=body)
+                    if r.status_code == 200:
+                        data = r.json()
+                        return [d["embedding"] for d in data["data"]]
+                    # HTTP 400: caller-contract bug, NEVER retry blindly (per stop conditions)
+                    if r.status_code == 400:
+                        raise RuntimeError(
+                            f"HTTP 400 from gateway — caller contract violated. "
+                            f"Body sent (truncated): model={body['model']} input_type={body['input_type']} "
+                            f"encoding_format={body['encoding_format']} n_texts={len(texts)}. "
+                            f"Response: {r.text[:500]}"
+                        )
+                    # Other transient: backoff + retry
+                    logging.warning("embed HTTP %s attempt %d: %s", r.status_code, attempt + 1, r.text[:200])
+                    await asyncio.sleep(1.0 * (2 ** attempt))
+                except httpx.RequestError as e:
+                    logging.warning("embed RequestError attempt %d: %s", attempt + 1, e)
+                    await asyncio.sleep(1.0 * (2 ** attempt))
+            raise RuntimeError(f"embed_batch failed after 3 attempts (n_texts={len(texts)})")
+
+
+# ---- Reindex worker ---------------------------------------------------------
+
+@dataclass
+class BatchResult:
+    n_in: int
+    n_out: int
+    embed_seconds: float
+    upsert_seconds: float
+    errors: int
+
+
+async def process_batch(
+    embedder: Embedder,
+    qclient: QdrantClient,
+    target: str,
+    points: list[qmodels.Record],
+    text_field: str,
+) -> BatchResult:
+    # Filter to points that have non-empty text_field
+    keep: list[qmodels.Record] = []
+    skipped = 0
+    for p in points:
+        text = (p.payload or {}).get(text_field)
+        if not isinstance(text, str) or not text.strip():
+            skipped += 1
+            continue
+        keep.append(p)
+    if not keep:
+        return BatchResult(n_in=len(points), n_out=0, embed_seconds=0, upsert_seconds=0, errors=skipped)
+
+    texts: list[str] = []
+    for p in keep:
+        assert p.payload is not None  # filtered above
+        texts.append(p.payload[text_field])
+    t0 = time.perf_counter()
+    vectors = await embedder.embed_batch(texts)
+    t1 = time.perf_counter()
+
+    upsert_points = [
+        qmodels.PointStruct(id=p.id, vector=v, payload=p.payload)
+        for p, v in zip(keep, vectors)
+    ]
+    # Qdrant client is sync; run upsert in thread pool to avoid blocking the loop
+    await asyncio.to_thread(qclient.upsert, collection_name=target, points=upsert_points, wait=True)
+    t2 = time.perf_counter()
+
+    return BatchResult(
+        n_in=len(points),
+        n_out=len(keep),
+        embed_seconds=t1 - t0,
+        upsert_seconds=t2 - t1,
+        errors=skipped,
+    )
+
+
+async def run_reindex(args: argparse.Namespace, master_key: str) -> int:
+    coll = args.collection
+    target = f"{coll}_v2"
+    text_field = TEXT_FIELD[coll]
+
+    state = State.load(coll)
+    qclient = QdrantClient(url=QDRANT_URL, timeout=60)
+
+    # Verify _v2 collection exists at expected dim/metric
+    info = qclient.get_collection(target)
+    vparams = info.config.params.vectors
+    if isinstance(vparams, dict):
+        # Named vectors — pick the default unnamed if present, else first key
+        v = vparams.get("") or next(iter(vparams.values()))
+        actual_dim, actual_dist = v.size, v.distance
+    elif vparams is None:
+        raise RuntimeError(f"{target} has no vector params")
+    else:
+        actual_dim, actual_dist = vparams.size, vparams.distance
+    if actual_dim != TARGET_DIM:
+        raise RuntimeError(f"{target} dim={actual_dim} expected {TARGET_DIM}")
+    if actual_dist != TARGET_DISTANCE:
+        raise RuntimeError(f"{target} distance={actual_dist} expected {TARGET_DISTANCE}")
+    logging.info("target collection %s verified: dim=%s distance=%s", target, actual_dim, actual_dist)
+
+    # Source point count (for progress)
+    src_info = qclient.get_collection(coll)
+    src_total = src_info.points_count
+    logging.info("source collection %s: %s points", coll, src_total)
+
+    embedder = Embedder(GATEWAY_URL, master_key, timeout=args.timeout, concurrency=args.workers)
+
+    started_wall = time.perf_counter()
+    batches_done = 0
+    total_embedded = state.processed
+    total_errors = state.errors
+
+    # Process a "window" of inflight_batches at a time. Within a window, batches
+    # run concurrently via asyncio.gather; state is saved after each window.
+    # Window-level checkpointing keeps resume logic simple while still giving
+    # real parallelism — anything in the current window is re-done on resume,
+    # but that is idempotent (point IDs preserved).
+    window_size = max(1, args.inflight_batches)
+
+    try:
+        cur_offset = state.next_offset
+        while True:
+            # Collect up to window_size batches by scrolling (sequential — Qdrant
+            # scroll returns its own next_offset cursor that must be threaded)
+            window: list[list[qmodels.Record]] = []
+            window_end_offset = cur_offset
+            for _ in range(window_size):
+                scroll_resp, next_offset = qclient.scroll(
+                    collection_name=coll,
+                    limit=args.batch_size,
+                    offset=cur_offset,
+                    with_payload=True,
+                    with_vectors=False,
+                )
+                if not scroll_resp:
+                    break
+                window.append(scroll_resp)
+                cur_offset = next_offset
+                window_end_offset = next_offset
+                if next_offset is None:
+                    break
+            if not window:
+                logging.info("scroll exhausted")
+                break
+
+            if args.dry_run:
+                logging.info("[dry-run] would process %d batches (skip embed/upsert)", len(window))
+                window_results: list[BatchResult] = []
+            else:
+                window_results = await asyncio.gather(
+                    *[process_batch(embedder, qclient, target, b, text_field) for b in window]
+                )
+                for i, br in enumerate(window_results, start=1):
+                    total_embedded += br.n_out
+                    total_errors += br.errors
+                    batches_done += 1
+                    elapsed = time.perf_counter() - started_wall
+                    rate = total_embedded / elapsed if elapsed > 0 else 0
+                    logging.info(
+                        "batch %d (window slot %d/%d): in=%d out=%d skipped=%d embed=%.2fs upsert=%.2fs total_done=%d/%s rate=%.1f docs/s",
+                        batches_done, i, len(window), br.n_in, br.n_out, br.errors,
+                        br.embed_seconds, br.upsert_seconds,
+                        total_embedded, src_total, rate,
+                    )
+
+            # Persist state at window boundary
+            state.next_offset = window_end_offset
+            state.processed = total_embedded
+            state.errors = total_errors
+            state.save()
+
+            if window_end_offset is None:
+                logging.info("reached end of source collection")
+                break
+
+            # Early termination check via env var (graceful shutdown signal)
+            if os.environ.get("REINDEX_HALT") == "1":
+                logging.warning("REINDEX_HALT=1 in env — graceful exit")
+                break
+    finally:
+        await embedder.aclose()
+        qclient.close()
+
+    wall = time.perf_counter() - started_wall
+    rate = total_embedded / wall if wall > 0 else 0
+    logging.info(
+        "DONE %s: processed=%d errors=%d wall=%.1fs rate=%.1f docs/s",
+        coll, total_embedded, total_errors, wall, rate,
+    )
+
+    # Final summary as JSON for downstream tooling
+    summary = {
+        "collection": coll,
+        "target": target,
+        "source_total": src_total,
+        "processed": total_embedded,
+        "errors": total_errors,
+        "wall_seconds": wall,
+        "docs_per_sec": rate,
+    }
+    print("\nSUMMARY: " + json.dumps(summary))
+    return 0
+
+
+# ---- CLI --------------------------------------------------------------------
+
+def parse_args() -> argparse.Namespace:
+    desc = (__doc__ or "").splitlines()[1] if __doc__ else ""
+    p = argparse.ArgumentParser(description=desc)
+    p.add_argument("--collection", required=True, choices=sorted(TEXT_FIELD.keys()))
+    p.add_argument("--batch-size", type=int, default=32)
+    p.add_argument("--workers", type=int, default=4,
+                   help="Max concurrent embed calls (semaphore on the embedder)")
+    p.add_argument("--inflight-batches", type=int, default=4,
+                   help="How many batches to process concurrently per window. State is "
+                        "checkpointed at window boundaries; on resume, the current "
+                        "window is re-processed (idempotent — point IDs preserved).")
+    p.add_argument("--timeout", type=float, default=60.0)
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--resume-from", type=str, default=None,
+                   help="Override saved state and resume from this point id (rare)")
+    p.add_argument("--reset-state", action="store_true",
+                   help="Delete saved state file before run")
+    return p.parse_args()
+
+
+def read_master_key() -> str:
+    """Read master_key from active config (gitignored, plaintext on host)."""
+    cfg_path = Path("/home/admin/Fortress-Prime/litellm_config.yaml")
+    for line in cfg_path.read_text().splitlines():
+        line = line.strip()
+        if line.startswith("master_key:"):
+            return line.split(":", 1)[1].strip()
+    raise RuntimeError("master_key not found in litellm_config.yaml")
+
+
+def main() -> int:
+    args = parse_args()
+    log_path = setup_logging(args.collection)
+    logging.info("log file: %s", log_path)
+    logging.info("args: %s", vars(args))
+
+    if args.reset_state:
+        sp = STATE_DIR / f"{args.collection}.json"
+        if sp.exists():
+            sp.unlink()
+            logging.info("removed state file %s", sp)
+
+    if args.resume_from:
+        # Force state to resume from given offset
+        state = State.load(args.collection)
+        state.next_offset = args.resume_from
+        state.save()
+        logging.info("forced resume from offset %s", args.resume_from)
+
+    master_key = read_master_key()
+    return asyncio.run(run_reindex(args, master_key))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/validate_reindex_quality.py
+++ b/src/validate_reindex_quality.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+Quality validation: pick 50 sample queries from a legacy 768-dim collection,
+get top-5 from legacy (nomic-embed-text via Ollama on spark-2:11434) and from
+the corresponding _v2 collection (legal-embed via gateway), and compare.
+
+Reports per-collection:
+- top-5 overlap@5: |legacy_top5 ∩ v2_top5| / 5, averaged across queries
+- rank correlation (Spearman ρ on the union of top-N IDs, where ranks are
+  taken from each list and missing IDs get a tail rank)
+- top-1 ID match rate (what fraction of queries return the same #1 hit)
+
+Usage:
+    validate_reindex_quality.py --collection legal_caselaw --n-queries 50
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+from qdrant_client import QdrantClient
+
+
+QDRANT_URL = "http://192.168.0.100:6333"
+GATEWAY_URL = "http://localhost:8002"
+OLLAMA_URL = "http://spark-2:11434"   # baseline encoder (nomic)
+
+TEXT_FIELD = {
+    "legal_caselaw": "text_chunk",
+    "legal_library": "text_chunk",
+    "legal_privileged_communications": "text",
+}
+
+
+def read_master_key() -> str:
+    for line in Path("/home/admin/Fortress-Prime/litellm_config.yaml").read_text().splitlines():
+        line = line.strip()
+        if line.startswith("master_key:"):
+            return line.split(":", 1)[1].strip()
+    raise RuntimeError("master_key not found")
+
+
+def embed_legal(client: httpx.Client, text: str, key: str) -> list[float]:
+    r = client.post(
+        f"{GATEWAY_URL}/embeddings",
+        json={"input": text, "model": "legal-embed", "input_type": "query", "encoding_format": "float"},
+        headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
+        timeout=60,
+    )
+    r.raise_for_status()
+    return r.json()["data"][0]["embedding"]
+
+
+def embed_nomic(client: httpx.Client, text: str) -> list[float]:
+    r = client.post(
+        f"{OLLAMA_URL}/api/embeddings",
+        json={"model": "nomic-embed-text", "prompt": text},
+        timeout=60,
+    )
+    r.raise_for_status()
+    return r.json()["embedding"]
+
+
+def overlap_at_k(a_ids: list[Any], b_ids: list[Any], k: int) -> float:
+    return len(set(a_ids[:k]) & set(b_ids[:k])) / k
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[1] if __doc__ else "")
+    ap.add_argument("--collection", required=True, choices=sorted(TEXT_FIELD.keys()))
+    ap.add_argument("--n-queries", type=int, default=50)
+    ap.add_argument("--seed", type=int, default=20260429)
+    ap.add_argument("--out", type=str, default=None)
+    args = ap.parse_args()
+
+    rng = random.Random(args.seed)
+    text_field = TEXT_FIELD[args.collection]
+    legacy = args.collection
+    target = f"{legacy}_v2"
+
+    qclient = QdrantClient(url=QDRANT_URL, timeout=60)
+    src = qclient.get_collection(legacy)
+    n_src = src.points_count
+    if n_src is None or n_src == 0:
+        print(f"WARN: source {legacy} has 0 points — nothing to validate")
+        return 0
+    n_v2 = qclient.get_collection(target).points_count
+    print(f"source {legacy}: {n_src} pts; target {target}: {n_v2} pts", file=sys.stderr)
+
+    # Sample n random queries by scrolling and reservoir-picking
+    sample_pts: list[Any] = []
+    seen = 0
+    next_offset = None
+    target_n = max(args.n_queries * 3, 200)  # over-sample then random-pick
+    while True:
+        pts, next_offset = qclient.scroll(
+            collection_name=legacy, limit=512, offset=next_offset,
+            with_payload=[text_field], with_vectors=False,
+        )
+        sample_pts.extend(p for p in pts if isinstance((p.payload or {}).get(text_field), str)
+                          and len((p.payload or {})[text_field].strip()) > 30)
+        seen += len(pts)
+        if next_offset is None or len(sample_pts) >= target_n:
+            break
+    print(f"scrolled {seen} pts; have {len(sample_pts)} candidates with text >30 chars", file=sys.stderr)
+    if len(sample_pts) < args.n_queries:
+        print(f"WARN: only {len(sample_pts)} candidate queries available (wanted {args.n_queries})")
+    rng.shuffle(sample_pts)
+    queries = sample_pts[: args.n_queries]
+    print(f"using {len(queries)} queries", file=sys.stderr)
+
+    key = read_master_key()
+    overlaps_at: dict[int, list[float]] = {1: [], 3: [], 5: [], 10: []}
+    top1_match = 0
+    detail = []
+    t0 = time.perf_counter()
+    with httpx.Client(timeout=60) as hc:
+        for i, p in enumerate(queries):
+            text = (p.payload or {})[text_field]
+            # Truncate very long chunks for the query — first 1200 chars is plenty
+            qtext = text[:1200]
+            try:
+                v_legal = embed_legal(hc, qtext, key)
+                v_nomic = embed_nomic(hc, qtext)
+            except Exception as e:
+                print(f"  q{i}: embed error {e}", file=sys.stderr)
+                continue
+            top_n = max(overlaps_at.keys())
+            legacy_hits = qclient.query_points(collection_name=legacy, query=v_nomic, limit=top_n, with_payload=False).points
+            v2_hits = qclient.query_points(collection_name=target, query=v_legal, limit=top_n, with_payload=False).points
+            legacy_ids = [h.id for h in legacy_hits]
+            v2_ids = [h.id for h in v2_hits]
+            row: dict[str, Any] = {"q_id": str(p.id)}
+            for k in overlaps_at:
+                ov = overlap_at_k(legacy_ids, v2_ids, k)
+                overlaps_at[k].append(ov)
+                row[f"overlap@{k}"] = ov
+            t1 = legacy_ids[0] if legacy_ids else None
+            t2 = v2_ids[0] if v2_ids else None
+            if t1 is not None and t1 == t2:
+                top1_match += 1
+            row["top1_legacy"] = str(t1)
+            row["top1_v2"] = str(t2)
+            detail.append(row)
+    wall = time.perf_counter() - t0
+
+    if not overlaps_at[5]:
+        print("ERROR: no successful queries", file=sys.stderr)
+        return 1
+
+    n_q = len(overlaps_at[5])
+    summary: dict[str, Any] = {
+        "collection": legacy,
+        "target": target,
+        "n_queries": n_q,
+        "top1_id_match_rate": top1_match / n_q,
+        "wall_seconds": wall,
+    }
+    for k, vals in overlaps_at.items():
+        summary[f"mean_overlap@{k}"] = statistics.mean(vals)
+        summary[f"median_overlap@{k}"] = statistics.median(vals)
+        summary[f"min_overlap@{k}"] = min(vals)
+    print("\nSUMMARY: " + json.dumps(summary, indent=2))
+
+    if args.out:
+        Path(args.out).write_text(json.dumps({"summary": summary, "detail": detail}, indent=2))
+        print(f"wrote {args.out}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
> ## ✅ Operator decision (2026-04-30): Option B
>
> | Collection | Decision |
> |---|---|
> | `legal_caselaw_v2`                  | ✅ **ACCEPT** for caller cutover (Phase A PR #2) |
> | `legal_library_v2`                  | ✅ **ACCEPT** for caller cutover (Phase A PR #2) |
> | `legal_privileged_communications_v2`| 🟡 **DEFER** — _v2 retained on Qdrant; callers stay on legacy 768-dim `nomic-embed-text` |
> | `legal_caselaw_federal_v2`          | N/A — schema-only, no content yet |
> | `legal_headhunter_memory_v2`        | N/A — schema-only, parity with empty legacy |
>
> **Rationale (full version in `docs/operational/qdrant-reindex-quality-batch1-2026-04-29.md` §Operator decision):** privileged overlap@5 = 0.136 vs the 0.300 threshold is plausibly a corpus property (high near-duplicate density in privileged email, ~800-char chunks, domain-specialized vs general encoder geometry) rather than encoder regression — but absent ground-truth labels the harness cannot confirm. Operator-side spot-check is deferred until Case II work specifically demands sovereign-embed privileged retrieval, OR retrieval-quality evidence emerges that legacy nomic is hurting privileged work. Privileged `_v2` is retained on Qdrant so a future spot-check can run without re-encoding 241k points.
>
> **Caller cutover (Phase A PR #2)** will be drafted as a separate brief and will cover ONLY `legal_caselaw_v2` + `legal_library_v2`. `legal_privileged_communications`, `legal_ediscovery`, `legal_hive_mind_memory` stay on their existing encoders.
>
> **PR ready for operator merge review** — decision committed at `3a06b31a3`.

---

> **🛑 MERGE BLOCKED.** Reindex completed mechanically for all three populated collections + 2 schema-only. Quality validation **passed** for `legal_caselaw_v2` and `legal_library_v2` but **breached the stop threshold** for `legal_privileged_communications_v2` (mean overlap@5 = 0.136 vs threshold 0.300). Per brief stop condition, surfacing for operator review before any caller cutover.

## Per-collection metrics

| Collection | Source pts | _v2 pts | Errors | Wall-clock | Throughput | mean overlap@5 | top-1 match | Stop pass? |
|---|---:|---:|---:|---:|---:|---:|---:|:---:|
| `legal_library`                 | 3       | 3       | 0 | 0.1 s   | 31.9 docs/s | 0.600 (capped — only 3 pts) | 1.000 | ✅ |
| `legal_caselaw`                 | 2,711   | 2,711   | 0 | 848.8 s | 3.2 docs/s  | **0.432** | 0.940 | ✅ |
| `legal_privileged_communications` | 241,167 | 241,167 | 0 | 9,664.8 s (2h41m) | 25.0 docs/s | **0.136** | 0.600 | **❌ STOP** |
| `legal_caselaw_federal_v2`      | (schema-only) | 0 | — | — | — | — | — | ✅ |
| `legal_headhunter_memory_v2`    | (schema-only) | 0 | — | — | — | — | — | ✅ |

All three reindexes completed with **zero embed errors**. The mechanics — point IDs preserved, payload preserved, vector dim 2048, distance cosine — are clean across all collections. The metric that breached is *ranking agreement* between encoders, not reindex correctness.

## What `mean overlap@5 = 0.136` actually means

For 50 random queries from `legal_privileged_communications`, the top-5 hits returned by `nomic-embed-text` (legacy) and `legal-embed` (_v2) overlap on average by **~0.68 documents out of 5** (13.6%). The full pattern is bimodal:
- median overlap@1 = 1.0 (most queries find the *same* #1 hit)
- mean overlap@1 = 0.6 (40% of queries find a *different* #1 hit)
- min overlap@1 = 0.0 (some queries diverge entirely)

Caselaw (which passed) showed mean overlap@5 = 0.432 on the identical harness — so the harness itself is calibrated. The privileged-collection result is a real divergence.

## Why this is plausibly a corpus property, not an encoder regression

- **High near-duplicate density**: privileged email = recurring signatures, threaded re-quoting, boilerplate disclosures. Many semantically near-identical chunks; different encoders pick different cluster members as #1 even when both are "right."
- **Short chunks (~800 chars)** vs caselaw's ~5.9k chars — less context to differentiate similar content.
- **Domain-specialized vs general encoder** — `legal-embed` is legal-corpus-trained, `nomic` is general; they may legitimately rank candidates differently with neither being wrong.

What the harness CANNOT tell, without ground-truth labels: whether the rankings have diverged into "different but equally good" or "one is wrong." That's the operator's call.

## Operator decision required

| Option | Action |
|---|---|
| **A — accept** | Treat 0.136 as a corpus property; proceed to Phase A PR #2 cutover for privileged_v2. |
| **B — spot-check** | Operator picks 5–10 known-relevant queries, eyeballs both rankings, decides. |
| **C — defer privileged** | PR #2 cuts over caselaw + sparse only; keep privileged on legacy 768-dim. |
| **D — re-encode with different settings** | Investigate whether different `input_type` mix or chunk strategy improves agreement. |

Full analysis + reasoning in `docs/operational/qdrant-reindex-quality-batch1-2026-04-29.md` §legal_privileged_communications.

## Confirmation: legacy collections untouched

Re-fetched after the privileged reindex completed (matching PR #301 audit numbers exactly):

| Collection | Dim | Distance | Points |
|---|---:|---|---:|
| `legal_caselaw`                  | 768 | Cosine | 2,711   |
| `legal_ediscovery`               | 768 | Cosine | 738,918 |
| `legal_privileged_communications`| 768 | Cosine | 241,167 |
| `legal_headhunter_memory`        | 768 | Cosine | 0       |
| `legal_hive_mind_memory`         | 768 | Cosine | 4       |
| `legal_library`                  | 768 | Cosine | 3       |

## Confirmation: no caller cutover

This PR does NOT modify any of:
- `legal_council.py`, `freeze_context`, `freeze_privileged_context`
- Phase B retrieval primitives
- ingestion scripts (`vault_ingest_legal_case.py` etc.)
- LiteLLM gateway config / systemd units / Vision NIM / spark-1 / spark-5 / BRAIN / `nomic-embed-text` Ollama
- `legal_ediscovery` (Phase A PR #2 follow-up — Phase B v0.1 dry-run still active)
- `legal_hive_mind_memory` (separate encoder decision — outcome labels not chunks)

Caller cutover is the scope of the future Phase A PR #2.

## Reindex tooling (lives at `src/`)

- `src/reindex_legal_qdrant_to_legal_embed.py` — async batched scroll → embed → upsert; idempotent on re-run (point IDs preserved); resumable via NAS-backed state file at `/mnt/fortress_nas/fortress_data/reindex_state/<collection>.json`; `--inflight-batches N` for window-pipelined parallelism (this is what got privileged from 3.2 → 25 docs/sec); `REINDEX_HALT=1` env for graceful shutdown.
- `src/validate_reindex_quality.py` — reproducible quality harness with fixed seed (`20260429`); reports overlap@1/3/5/10 + top-1 ID match.
- Reindex logs at `/var/log/fortress/reindex-<collection>-<timestamp>.log` on spark-2.

## Stop conditions checked

| Condition | Status |
|---|---|
| HTTP 400 from gateway | ✅ Not seen |
| Embed error rate >1% | ✅ 0 / 243,881 |
| _v2 / source point count divergence >0.1% | ✅ Exact match (3/3, 2711/2711, 241167/241167) |
| **Quality overlap@5 <0.3** | **❌ Breached on `legal_privileged_communications` (0.136)** |
| Disk <20% on Qdrant volume | ✅ 65% used (35% free), unchanged |
| Phase B retrieval errors during reindex | ✅ Not observed |

## Test plan

- [x] Branch + reindex tooling committed
- [x] All 5 _v2 collections schema-created at 2048-dim cosine (3 reindexed, 2 empty)
- [x] `legal_library` reindex + round-trip cosine sanity (cos~0.999998)
- [x] `legal_caselaw` reindex + quality validation (PASS)
- [x] `legal_privileged_communications` reindex (mechanically clean) + quality validation (**FAIL — overlap@5 0.136**)
- [x] Legacy collections verified untouched (point counts match PR #301 audit)
- [ ] **Operator review of privileged quality breach (A/B/C/D)** ← **MERGE BLOCKED HERE**
- [ ] (Follow-up PR after operator decision) caller cutover for whichever collections are accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
