### PR TITLE
chore: spark-5/6 fabric cutover prep — read-only audit + target netplans + runbook

### DIFF
--- a/docs/operational/cluster-network-canonical-baseline-2026-04-30.md
+++ b/docs/operational/cluster-network-canonical-baseline-2026-04-30.md
@@ -1,0 +1,104 @@
+# Cluster Network Canonical Baseline — 2026-04-30
+
+**Branch:** `chore/spark-5-6-fabric-cutover-prep-2026-04-30`
+**Source:** `docs/operational/spark-network-baseline-2026-04-30/spark-{104,100,105,106,109,115}.txt`
+**Driver:** Two new fs.com cables arriving today; spark-5 + spark-6 fabric cutover prep needs canonical reference derived from working sparks 1/2/3/4.
+
+---
+
+## 1. Canonical parity table (sparks 1/2/3/4)
+
+| Item | spark-1 (104) | spark-2 (100) | spark-3 (105) | spark-4 (106) | **CANONICAL** |
+|---|---|---|---|---|---|
+| Kernel | 6.17.0-1014-nvidia | 6.17.0-1014-nvidia | 6.17.0-1014-nvidia | 6.17.0-1014-nvidia | **6.17.0-1014-nvidia** |
+| mlx5_core srcversion | `89EEAF32656D79A2DACFFD3` | `89EEAF32656D79A2DACFFD3` | `89EEAF32656D79A2DACFFD3` | `89EEAF32656D79A2DACFFD3` | **`89EEAF32656D79A2DACFFD3`** |
+| ConnectX firmware | `28.45.4028` | `28.45.4028` | `28.45.4028` | `28.45.4028` | **`28.45.4028`** |
+| Mellanox PCI device | ConnectX-7 ×4 (00:00.0/.1, 02:00.0/.1) | ConnectX-7 ×4 | ConnectX-7 ×4 | ConnectX-7 ×4 | **ConnectX-7 ×4** |
+| Fabric A subnet | `10.10.10.0/24` (.1) | `10.10.10.0/24` (.2) | `10.10.10.0/24` (.3) | `10.10.10.0/24` (.4) | **`10.10.10.0/24`** |
+| Fabric A interface | `enp1s0f0np0` | `enp1s0f0np0` | `enp1s0f0np0` | `enp1s0f0np0` | **`enp1s0f0np0`** |
+| Fabric B subnet | `10.10.11.0/24` (.1) | `10.10.11.0/24` (.2) | `10.10.11.0/24` (.3) | `10.10.11.0/24` (.4) | **`10.10.11.0/24`** |
+| Fabric B interface | `enP2p1s0f1np1` | `enP2p1s0f1np1` | `enP2p1s0f1np1` | `enP2p1s0f1np1` | **`enP2p1s0f1np1`** |
+| Fabric MTU | 9000 (A+B) | 9000 (A+B) | 9000 (A+B) | 9000 (A+B) | **9000** |
+| Fabric netplan filename | `99-mellanox-roce.yaml` | `99-mellanox-roce.yaml` | `99-mellanox-roce.yaml` | `99-mellanox-roce.yaml` | **`99-mellanox-roce.yaml`** |
+| Mgmt LAN interface | `enP7s7` | `enP7s7` | `enP7s7` | `enP7s7` | **`enP7s7`** |
+| Mgmt LAN subnet | `192.168.0.0/24` | `192.168.0.0/24` | `192.168.0.0/24` | `192.168.0.0/24` | **`192.168.0.0/24`** (gw `192.168.0.1`, NS `8.8.8.8 1.1.1.1`) |
+| Bonding / LACP | none | none | none | none | **none — dual-subnet, not bonded** |
+| net.core.default_qdisc | fq_codel | fq_codel | fq_codel | fq_codel | **fq_codel** |
+| **net.core.rmem_max** | 536870912 | 536870912 | **212992** ⚠ | 536870912 | **DIVERGES** — sparks 1/2/4 = 536M; spark-3 = kernel default |
+| **net.core.wmem_max** | 536870912 | 536870912 | **212992** ⚠ | 536870912 | **DIVERGES** — same pattern |
+| **net.ipv4.tcp_rmem** | `4096 87380 268435456` | `4096 87380 268435456` | `4096 131072 33554432` ⚠ | `4096 87380 268435456` | **DIVERGES** |
+| **net.ipv4.tcp_wmem** | `4096 65536 268435456` | `4096 65536 268435456` | `4096 16384 4194304` ⚠ | `4096 65536 268435456` | **DIVERGES** |
+| net.core.netdev_max_backlog | 1000 | **250000** ⚠ | 1000 | 1000 | **DIVERGES** — only spark-2 tuned |
+| **net.ipv4.tcp_congestion_control** | bbr | bbr | **cubic** ⚠ | bbr | **DIVERGES** — spark-3 untuned |
+
+## 2. Canonical netplan template (verbatim from sparks 1/2/3/4)
+
+### 2.1 Mgmt LAN — `01-<role>-core.yaml` (filename varies by host)
+
+```yaml
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    enP7s7:
+      dhcp4: false
+      addresses:
+        - 192.168.0.<X>/24
+      routes:
+        - to: default
+          via: 192.168.0.1
+      nameservers:
+        addresses: [8.8.8.8, 1.1.1.1]
+```
+
+### 2.2 Fabric — `99-mellanox-roce.yaml`
+
+```yaml
+network:
+  version: 2
+  ethernets:
+    enp1s0f0np0:
+      addresses: [10.10.10.<X>/24]
+      mtu: 9000
+    enp1s0f1np1:
+      dhcp4: false
+      optional: true
+    enP2p1s0f1np1:
+      addresses: [10.10.11.<X>/24]
+      mtu: 9000
+      dhcp4: false
+```
+
+(Note: `enp1s0f1np1` declared `optional: true, dhcp4: false` so DHCP is suppressed but the port is allowed to remain idle. `enP2p1s0f0np0` is not configured by this file — it's used as a `/30` link in a separate `/etc/systemd/network/` file on spark-1, free elsewhere.)
+
+## 3. Divergence notes (canonical drift to surface)
+
+### 3.1 Sysctl drift — spark-3 untuned
+
+Spark-3 runs `cubic` congestion control + kernel-default TCP buffers (`rmem_max=212992`), while sparks 1/2/4 run `bbr` + 512 MiB buffers. This is a **production drift** — spark-3 hosts vision NIM (`:8101`) and embed NIM (`:8102`) that handle real traffic. Likely consequence: spark-3 inference latency and throughput are degraded vs the rest of the cluster.
+
+**Recommendation:** out of scope for this PR (no sysctl changes per hard constraints). Surface as separate issue once this PR lands. Either (a) align spark-3 to the bbr+536M canonical, or (b) document that spark-3 deliberately runs default-tuned. Operator decision.
+
+### 3.2 netdev_max_backlog drift — spark-2 has 250000
+
+Spark-2 has `net.core.netdev_max_backlog = 250000` while the other 3 canonical sparks have `1000`. This is consistent with spark-2 being the control-plane node handling more concurrent connections (LiteLLM gateway, FastAPI backend, qdrant, etc.). Not a drift bug — likely intentional.
+
+### 3.3 Spark-3 has both tcp_rmem and tcp_wmem at kernel defaults
+
+Same root cause as §3.1 — likely spark-3 was provisioned without the cluster's `99-network-tuning.conf` sysctl drop-in. Alignment is operator decision, separately tracked.
+
+## 4. Per-spark netplan filename inconsistency (cosmetic)
+
+| Spark | Mgmt netplan filename | Fabric netplan filename |
+|---|---|---|
+| spark-1 | `01-node1-core.yaml` | `99-mellanox-roce.yaml` |
+| spark-2 | `01-captain-core.yaml` | `99-mellanox-roce.yaml` |
+| spark-3 | `01-netcfg.yaml` | `99-mellanox-roce.yaml` |
+| spark-4 | `01-sovereign-core.yaml` | `99-mellanox-roce.yaml` |
+| spark-5 (current) | `01-mgmt.yaml` + `60-connectx-fabric.yaml` | (different layout, see §5 of parity check) |
+
+Mgmt filename varies by role; fabric filename is uniform on canonical. Spark-5 splits fabric into `60-connectx-fabric.yaml` rather than the canonical `99-mellanox-roce.yaml` filename. Functionally equivalent if content is right, but breaks naming convention.
+
+---
+
+End of canonical baseline.

--- a/docs/operational/spark-5-6-fabric-cutover-runbook-2026-04-30.md
+++ b/docs/operational/spark-5-6-fabric-cutover-runbook-2026-04-30.md
@@ -1,0 +1,191 @@
+# Spark-5 + Spark-6 Fabric Cutover Runbook — 2026-04-30
+
+**Branch:** `chore/spark-5-6-fabric-cutover-prep-2026-04-30`
+**Hardware arriving today:** 2× cables from fs.com.
+**Operator-execute.** This runbook is the step-by-step sequence; no agent-side execution.
+
+**Pre-reads (in order):**
+1. `docs/operational/cluster-network-canonical-baseline-2026-04-30.md` — what spark-5/6 should look like
+2. `docs/operational/spark-5-6-parity-check-2026-04-30.md` — current deltas
+3. `docs/operational/spark-6-driver-remediation-2026-04-30.md` — spark-6 hardware blocker
+4. `docs/operational/spark-5-target-netplan-2026-04-30.yaml` — target netplan for spark-5
+5. `docs/operational/spark-6-target-netplan-2026-04-30.yaml` — target netplan for spark-6
+6. `src/operational/validate-fabric-cutover.sh` — validation script
+
+---
+
+## 1. Pre-cutover health snapshot (run before touching anything)
+
+```bash
+# From any operator shell with cluster network access:
+bash src/operational/validate-fabric-cutover.sh > /tmp/fabric-pre-cutover.log 2>&1
+```
+
+Capture timestamp. Most rows expected to PASS for sparks 1/2/3/4. Spark-5 fabric B expected FAIL (currently mis-bound). Spark-6 fabric A + B expected FAIL.
+
+Key services that must stay green throughout:
+- BRAIN on spark-5:8100 (Llama-3.3-Nemotron-Super-49B)
+- vision-NIM on spark-3:8101
+- embed-NIM on spark-3:8102
+- LiteLLM gateway on spark-2:8002
+- Qdrant on spark-2:6333
+- Qdrant-VRS on spark-4:6333
+
+## 2. Spark-6 cutover (do FIRST — lower risk, no live service)
+
+### 2.1 Pre-flight — ConnectX hardware verification
+
+🛑 **GATING STEP. Do NOT plug cables into spark-6 until this passes.**
+
+```bash
+ssh admin@192.168.0.115 'lspci -nn | grep -i mellanox | wc -l'
+```
+
+- If output is `4` → hardware present, proceed to §2.2.
+- If output is `0` → hardware absent. Follow `docs/operational/spark-6-driver-remediation-2026-04-30.md` Steps 1–5.
+  - Plugging cables anyway will leave them physically connected to Mikrotik but with no NIC at the spark-6 end. Fabric will not activate.
+  - **Defer spark-6 cabling until hardware blocker resolved.** Continue with spark-5 cutover (§3) regardless.
+
+### 2.2 Plug cables
+
+- Cable A: spark-6 ConnectX port matching `enp1s0f0np0` ↔ Mikrotik 200G port (aggregated)
+- Cable B: spark-6 ConnectX port matching `enP2p1s0f1np1` ↔ Mikrotik 200G port (aggregated)
+
+Identify physical port-to-name mapping by following the same convention as on spark-1 (operator already has the wiring map).
+
+### 2.3 Verify mlx5_core enumerates new interfaces
+
+```bash
+ssh admin@192.168.0.115 'ip -d link show | grep -E "enp1s0f|enP2p1s0f"'
+```
+
+Expect 4 interfaces: `enp1s0f0np0`, `enp1s0f1np1`, `enP2p1s0f0np0`, `enP2p1s0f1np1`. The cabled ones should show `state=UP`. The uncabled ones may show `state=DOWN` — that's fine.
+
+### 2.4 Apply target netplan
+
+```bash
+# On spark-6:
+sudo cp /tmp/99-mellanox-roce.yaml /etc/netplan/99-mellanox-roce.yaml
+sudo chmod 600 /etc/netplan/99-mellanox-roce.yaml
+sudo chown root:root /etc/netplan/99-mellanox-roce.yaml
+sudo netplan generate
+sudo netplan apply
+```
+
+(Source: `docs/operational/spark-6-target-netplan-2026-04-30.yaml` second YAML block, scp'd to `/tmp/99-mellanox-roce.yaml` on spark-6.)
+
+### 2.5 Verify fabric reachability from spark-2
+
+```bash
+# From spark-2 (192.168.0.100):
+ping -c 3 -W 1 10.10.10.6  # fabric A to spark-6
+ping -c 3 -W 1 10.10.11.6  # fabric B to spark-6
+```
+
+Both expected to succeed. If either fails:
+- Re-check `ip -d link show` on spark-6 for `state=UP` and `mtu 9000`
+- Check Mikrotik aggregated port for spark-6's MAC addresses
+- Defer further investigation; spark-6 not on critical-path for today
+
+## 3. Spark-5 cutover (BRAIN serving — minimize downtime)
+
+### 3.1 Pre-flight — confirm BRAIN healthy
+
+```bash
+curl -sS --max-time 5 http://192.168.0.109:8100/v1/health/ready
+# expect: {"object":"health.response","message":"ready","status":"ready"}
+```
+
+If BRAIN is degraded BEFORE cutover, halt and surface — don't compound the issue.
+
+### 3.2 Confirm 192.168.0.111 dependency search returns clean
+
+```bash
+ssh admin@192.168.0.100 'sudo grep -rn "192\.168\.0\.111" /etc /home/admin/Fortress-Prime 2>/dev/null | head -5'
+```
+
+If result is empty (or only matches in `.bak`/comments), the mis-bound IP is safely dropped. If result has live config references, address those first.
+
+### 3.3 Plug cables
+
+- Cable A: spark-5 ConnectX port matching `enp1s0f0np0` ↔ Mikrotik 200G port (aggregated)
+- Cable B: spark-5 ConnectX port matching `enP2p1s0f1np1` ↔ Mikrotik 200G port (aggregated)
+
+(Spark-5 currently has 1 cable in `enp1s0f1np1`. Operator decision: leave that cable in place and add 2 new cables for canonical ports — temporarily 3 cables, then remove the legacy one — OR re-route the existing cable to canonical port `enp1s0f0np0` and add only 1 new cable to `enP2p1s0f1np1`. Whichever the cutover choreography supports without dropping BRAIN traffic.)
+
+### 3.4 Verify new ports come up
+
+```bash
+ssh admin@192.168.0.109 'ip -d link show | grep -E "enp1s0f|enP2p1s0f" | head -8'
+```
+
+Expect canonical ports (`enp1s0f0np0`, `enP2p1s0f1np1`) `state=UP`.
+
+### 3.5 Backup current spark-5 netplan + apply target
+
+```bash
+# On spark-5:
+sudo cp /etc/netplan/60-connectx-fabric.yaml /etc/netplan/60-connectx-fabric.yaml.bak.$(date +%Y%m%d_%H%M%S)
+sudo cp /tmp/99-mellanox-roce.yaml /etc/netplan/99-mellanox-roce.yaml
+sudo chmod 600 /etc/netplan/99-mellanox-roce.yaml
+sudo chown root:root /etc/netplan/99-mellanox-roce.yaml
+# Optionally remove the old fabric file (after confirming new one is functional):
+# sudo rm /etc/netplan/60-connectx-fabric.yaml
+sudo netplan generate
+sudo netplan apply
+```
+
+### 3.6 Verify BRAIN still serving
+
+```bash
+curl -sS --max-time 5 http://192.168.0.109:8100/v1/health/ready
+# expect: {"status":"ready"} — same as 3.1
+```
+
+If BRAIN unreachable after netplan apply: roll back via `sudo cp 60-connectx-fabric.yaml.bak.<timestamp> 60-connectx-fabric.yaml; sudo netplan apply`. Investigate cause before retrying.
+
+### 3.7 Verify fabric reachability from spark-2
+
+```bash
+# From spark-2:
+ping -c 3 -W 1 10.10.10.5  # fabric A to spark-5
+ping -c 3 -W 1 10.10.11.5  # fabric B to spark-5 (was mis-bound; should now work)
+```
+
+## 4. Post-cutover validation
+
+```bash
+# From any operator shell with cluster network access:
+bash src/operational/validate-fabric-cutover.sh > /tmp/fabric-post-cutover.log 2>&1
+diff /tmp/fabric-pre-cutover.log /tmp/fabric-post-cutover.log
+```
+
+Expected differences:
+- Spark-5 fabric B (10.10.11.5): FAIL → PASS
+- Spark-6 fabric A (10.10.10.6): FAIL → PASS (only if hardware present)
+- Spark-6 fabric B (10.10.11.6): FAIL → PASS (only if hardware present)
+
+Everything else (BRAIN/vision/embed/LiteLLM/Qdrant) should remain PASS.
+
+## 5. Rollback (per-spark)
+
+If post-cutover validation regresses a previously-working service:
+
+```bash
+# Spark-6 rollback (no service was running, so just remove the new file):
+ssh admin@192.168.0.115 'sudo rm /etc/netplan/99-mellanox-roce.yaml && sudo netplan apply'
+
+# Spark-5 rollback:
+ssh admin@192.168.0.109 'sudo mv /etc/netplan/60-connectx-fabric.yaml.bak.<timestamp> /etc/netplan/60-connectx-fabric.yaml && sudo rm /etc/netplan/99-mellanox-roce.yaml && sudo netplan apply'
+```
+
+Then re-run §1 pre-snapshot to confirm rollback restored expected state.
+
+## 6. After cutover lands
+
+- Re-run `ray status` from spark-2; spark-5 worker still won't appear (Ray enablement is separate work, gated on operator decision per cluster-network-audit-2026-04-30.md §5 Gap 2).
+- File issue if any sysctl drift surfaces in validation script (separate alignment work — out of cutover scope).
+
+---
+
+End of runbook.

--- a/docs/operational/spark-5-6-parity-check-2026-04-30.md
+++ b/docs/operational/spark-5-6-parity-check-2026-04-30.md
@@ -1,0 +1,85 @@
+# Spark-5 + Spark-6 Parity Check vs Canonical — 2026-04-30
+
+**Branch:** `chore/spark-5-6-fabric-cutover-prep-2026-04-30`
+**Canonical reference:** `docs/operational/cluster-network-canonical-baseline-2026-04-30.md`
+**Source data:** `docs/operational/spark-network-baseline-2026-04-30/spark-{109,115}.txt`
+
+---
+
+## 1. Spark-5 (`192.168.0.109`) — delta vs canonical
+
+| Item | Canonical | Spark-5 actual | Delta | Severity | Remediation |
+|---|---|---|---|---|---|
+| Kernel | 6.17.0-1014-nvidia | 6.17.0-1014-nvidia | match | — | none |
+| mlx5_core srcversion | `89EEAF...FFD3` | `89EEAF...FFD3` | match | — | none |
+| ConnectX firmware | `28.45.4028` | (not captured — admin lacks sudo NOPASSWD on spark-5) | **unverified** | LOW | re-run `sudo ethtool -i` after operator grants NOPASSWD or via direct console |
+| ConnectX hardware | ConnectX-7 ×4 PCI functions | ConnectX-7 ×4 PCI functions ✓ | match | — | none — hardware fully present |
+| Fabric A interface | `enp1s0f0np0` | **`enp1s0f1np1`** ⚠ | **DIFFERENT INTERFACE** | HIGH | netplan rewrite — see §1.1 |
+| Fabric A subnet | `10.10.10.0/24` | `10.10.10.5/24` | subnet match, host-specific .5 ✓ | — | keep |
+| Fabric B interface | `enP2p1s0f1np1` | (unconfigured for fabric; instead has `192.168.0.111/24` mis-bound) | **MIS-BOUND** | HIGH | remove `192.168.0.111/24`; assign `10.10.11.5/24 + mtu 9000` |
+| Fabric B subnet | `10.10.11.0/24` | **MISSING** ⚠ | DIFFERENT | HIGH | add fabric B in netplan |
+| Fabric MTU | 9000 (A+B) | 9000 on `enp1s0f1np1`; 1500 on `enP2p1s0f1np1` | partial | HIGH | set both fabric ports to MTU 9000 |
+| Fabric netplan filename | `99-mellanox-roce.yaml` | `60-connectx-fabric.yaml` (different name + layout) | naming drift | LOW | rename for cluster consistency, or leave |
+| ConnectX port `enp1s0f0np0` link state | UP @ 100 Gbps | DOWN ⚠ | DIFFERENT | HIGH | physical cable check — port not connected (or cable bad) |
+| ConnectX port `enP2p1s0f0np0` link state | UP (canonical: idle, but link UP) | DOWN | DIFFERENT | MED | one of the spark-5 cables today goes here for fabric A canonical; second cable goes to `enP2p1s0f1np1` for fabric B |
+| sysctl `tcp_congestion_control` | bbr | **cubic** ⚠ | DIFFERENT | MED | align with canonical (out of scope for this PR — separate sysctl drift issue) |
+| sysctl `rmem_max` | 536870912 | 212992 | DIFFERENT | MED | same as above |
+| sysctl `tcp_rmem` middle | 87380 | 131072 | DIFFERENT | LOW | same as above |
+| BRAIN service | n/a (spark-1 ran sovereign-8B) | `fortress-nim-brain.service` running, `:8100` HEALTHY | — | preserve through cutover |
+
+### 1.1 Spark-5 net effect of cable cutover today
+
+Operator plugs **2 new cables** into spark-5 ConnectX ports + Mikrotik 200 G port. Post-cutover state should match canonical:
+
+- `enp1s0f0np0` — fabric A — `10.10.10.5/24` MTU 9000 (was: down)
+- `enP2p1s0f1np1` — fabric B — `10.10.11.5/24` MTU 9000 (was: mis-bound to 192.168.0.111)
+- `enp1s0f1np1` — currently has 10.10.10.5/24; either (a) cable that's already plugged stays in same port and the IP migrates to the canonical port `enp1s0f0np0` after rewire, or (b) the existing cable stays and we accept the canonical-divergent port assignment. **Operator decision needed at cutover time.**
+- `enP2p1s0f0np0` — idle (canonical: not configured by `99-mellanox-roce.yaml`)
+
+**The brief says "1 cable to 1 Mikrotik 200G port → 2 cables post-cutover".** Interpretation: spark-5 currently has 1 cable into Mikrotik on `enp1s0f1np1`. Post-cutover, 2 cables into Mikrotik 200G — one for fabric A, one for fabric B. Both should land on the canonical ports (`enp1s0f0np0` for A, `enP2p1s0f1np1` for B) so the netplan can be uniform. If cabling lands differently for hardware reasons, netplan must adapt.
+
+## 2. Spark-6 (`192.168.0.115`) — delta vs canonical
+
+| Item | Canonical | Spark-6 actual | Delta | Severity | Remediation |
+|---|---|---|---|---|---|
+| Kernel | 6.17.0-1014-nvidia | 6.17.0-1014-nvidia | match | — | none |
+| mlx5_core srcversion | `89EEAF...FFD3` | `89EEAF...FFD3` | match | — | none — driver loaded but bound to nothing |
+| **ConnectX hardware** | **ConnectX-7 ×4 PCI functions** | **(none — `lspci -nn \| grep -i mellanox` returns empty)** ⚠ | **HARDWARE ABSENT** | **🛑 BLOCKER** | **operator must verify physical install in chassis** — see §2.1 |
+| ConnectX firmware | `28.45.4028` | n/a | n/a | n/a | unverifiable until hardware present |
+| Fabric A interface | `enp1s0f0np0` | n/a | n/a | n/a | no NIC to bind to |
+| Fabric B interface | `enP2p1s0f1np1` | n/a | n/a | n/a | no NIC to bind to |
+| Mgmt LAN | `enP7s7 192.168.0.X/24` | `enP7s7 192.168.0.115/24` ✓ | match | — | none |
+| Active fabric ports | n/a (all 4 ports UP on canonical) | none — only `enP7s7` (mgmt), `wlP9s9` (WiFi), `tailscale0`, `docker0` enumerated | DIFFERENT | 🛑 | per §2.1 |
+| sysctl tuning | bbr + 536M | cubic + 212k | DIFFERENT | MED (same as spark-3/5 drift) | out of scope; separate sysctl alignment issue |
+
+### 2.1 🛑 STOP CONDITION — Spark-6 ConnectX hardware not present
+
+`lspci -nn | grep -i mellanox` returns `(no mellanox PCI device found)` on spark-6. The kernel modules (`mlx5_core`, `mlx5_ib`, `mlx5_fwctl`, `mlxfw`) **are loaded** — but they have no PCI device to bind to.
+
+Possible causes (in priority order for operator to check):
+1. **ConnectX-7 adapter not physically installed** in spark-6's chassis. The other 5 sparks all have it; spark-6 was previously documented as the "spark-6 cable is the gating physical blocker for ADR-003 Phase 3" (per master plan §6.5). The blocker may actually be the **adapter**, not the cable.
+2. Adapter is installed but in an inactive PCIe slot (BIOS configuration).
+3. Adapter is installed and PCIe-enumerated but at a path the kernel can't see (`dmesg | grep -i mlx` would surface).
+4. Hardware fault — adapter installed but not recognized by BIOS.
+
+### 2.2 What this means for today's cutover
+
+**Plugging cables into spark-6 today will not activate fabric on spark-6** if the adapter is absent. The cables will physically connect to the Mikrotik switch, but spark-6 has no NIC for them to terminate at. Fabric A and Fabric B will remain empty for spark-6.
+
+**Operator must verify hardware before / during / after cabling:**
+- Before: power off spark-6, open chassis, confirm ConnectX-7 adapter is present in the expected PCIe slot.
+- If adapter is present but `lspci` doesn't see it: re-seat. Boot. Re-check `lspci`.
+- If adapter is absent: hardware procurement. Cable cutover for spark-6 deferred until hardware is installed.
+
+If the adapter is genuinely missing, today's cabling is partially wasted on spark-6 — the ports plug into Mikrotik, but spark-6 stays out of the fabric until hardware is added.
+
+## 3. Summary — what cutover today can and cannot accomplish
+
+| Spark | Hardware ready? | Cable cutover today: | Post-cutover fabric state |
+|---|---|---|---|
+| spark-5 | ✓ ConnectX-7 ×4 present | YES — 2 cables go in; netplan needs rewrite | Both fabric A + fabric B should activate **if** netplan applied |
+| spark-6 | ❌ no Mellanox in lspci | YES (cables plug in) but **NO ACTIVATION** | Fabric A + fabric B remain absent until adapter install resolved |
+
+---
+
+End of parity check.

--- a/docs/operational/spark-5-target-netplan-2026-04-30.yaml
+++ b/docs/operational/spark-5-target-netplan-2026-04-30.yaml
@@ -1,0 +1,60 @@
+# Target netplan for spark-5 — POST-CUTOVER 2026-04-30
+#
+# Intent: bring spark-5 to canonical fabric pattern matching sparks 1/2/3/4
+# Canonical reference: docs/operational/cluster-network-canonical-baseline-2026-04-30.md §2
+#
+# DO NOT APPLY UNTIL OPERATOR EXECUTES PHYSICAL CABLE CUTOVER AND CONFIRMS:
+#   - 2 cables plugged into spark-5 ConnectX ports + Mikrotik 200G aggregated port
+#   - Cable A → enp1s0f0np0  (fabric A canonical port)
+#   - Cable B → enP2p1s0f1np1 (fabric B canonical port)
+#
+# This file is a DRAFT, committed under docs/, NOT under /etc/netplan/.
+# Operator copies into /etc/netplan/ on spark-5 with appropriate mode (chmod 600,
+# chown root:root) when applying.
+#
+# Two-file split is recommended to match canonical:
+#   /etc/netplan/01-mgmt.yaml          — keep current spark-5 file (mgmt LAN)
+#   /etc/netplan/99-mellanox-roce.yaml — REPLACE current 60-connectx-fabric.yaml
+#                                         (rename for cluster filename consistency)
+
+# === 99-mellanox-roce.yaml content for spark-5 (target) ===
+network:
+  version: 2
+  ethernets:
+    enp1s0f0np0:
+      addresses: [10.10.10.5/24]
+      mtu: 9000
+    enp1s0f1np1:
+      dhcp4: false
+      optional: true
+    enP2p1s0f1np1:
+      addresses: [10.10.11.5/24]
+      mtu: 9000
+      dhcp4: false
+
+# === Notes ===
+#
+# 1. The current spark-5 state has a `192.168.0.111/24` mis-bound on
+#    enP2p1s0f1np1. The 99-mellanox-roce.yaml above will overwrite that
+#    binding with `10.10.11.5/24` — operator must verify no service depends
+#    on 192.168.0.111 before applying.
+#
+# 2. Search results for 192.168.0.111 across the cluster (operator should
+#    grep before apply):
+#      ssh admin@192.168.0.100 'sudo grep -rn "192\.168\.0\.111" /etc /home/admin/Fortress-Prime'
+#    If 0 hits, .111 is safely dropped. If hits exist, address them first.
+#
+# 3. Current spark-5 /etc/netplan/60-connectx-fabric.yaml content was not
+#    captured (admin lacks sudo NOPASSWD on spark-5). Operator should diff
+#    that file vs this target before replacing — there may be additional
+#    knobs (RoCE, DCB, PFC) in the existing file worth preserving.
+#
+# 4. Apply sequence:
+#      sudo cp 99-mellanox-roce.yaml /etc/netplan/99-mellanox-roce.yaml
+#      sudo chmod 600 /etc/netplan/99-mellanox-roce.yaml
+#      sudo chown root:root /etc/netplan/99-mellanox-roce.yaml
+#      sudo mv /etc/netplan/60-connectx-fabric.yaml /etc/netplan/60-connectx-fabric.yaml.bak.$(date +%Y%m%d_%H%M%S)
+#      sudo netplan generate
+#      sudo netplan apply
+#
+# 5. After apply, validate per docs/operational/spark-5-6-fabric-cutover-runbook-2026-04-30.md §4

--- a/docs/operational/spark-6-driver-remediation-2026-04-30.md
+++ b/docs/operational/spark-6-driver-remediation-2026-04-30.md
@@ -1,0 +1,90 @@
+# Spark-6 ConnectX Hardware Remediation — 2026-04-30
+
+**Status:** 🛑 BLOCKER for fabric activation on spark-6.
+**Source finding:** `docs/operational/spark-5-6-parity-check-2026-04-30.md` §2.1.
+**Driver issue?** No — `mlx5_core`, `mlx5_ib`, `mlx5_fwctl`, `mlxfw` modules are loaded on spark-6 (`lsmod | grep ^mlx` returns 4 entries). The kernel driver is fine.
+**Hardware issue?** Yes — `lspci -nn | grep -i mellanox` returns no PCI device. The adapter is either not installed, not seated correctly, or BIOS-disabled.
+
+---
+
+## 1. Diagnostic priority order (operator side, physical access required)
+
+### Step 1 — confirm `lspci` finding from a fresh boot
+Sometimes a transient PCIe enumeration failure clears on reboot. Power-cycle spark-6, then re-check:
+```
+ssh admin@192.168.0.115 'lspci -nn | grep -i mellanox | wc -l'
+```
+Expect **4** if hardware is OK. If still 0, proceed.
+
+### Step 2 — `dmesg` inspection
+Look for any PCIe enumeration error or mlx5_core load complaint at boot:
+```
+ssh admin@192.168.0.115 'sudo dmesg | grep -iE "mlx|connectx|pci.*15b3" | head -30'
+```
+Vendor ID `15b3` = Mellanox / NVIDIA. If kernel saw the device but failed to bind, dmesg will show why. If kernel never saw it, dmesg is silent.
+
+### Step 3 — physical chassis check
+Power off spark-6, open chassis. Verify:
+- Is a ConnectX-7 adapter physically installed? The other 5 sparks (1/2/3/4/5) all show ConnectX-7 ×4 PCI functions in `lspci`.
+- Is it in the same PCIe slot as on the working sparks?
+- Are PCIe pins clean? Re-seat to be safe.
+
+### Step 4 — BIOS check
+- PCIe slot enabled in BIOS?
+- Boot. Re-check `lspci`.
+
+### Step 5 — if hardware is genuinely absent
+Procurement: ConnectX-7 adapter (Mellanox MT2910 family, vendor:device `15b3:1021`, single 4-port adapter as installed on sparks 1/2/3/4/5). Brief mentions cables arriving from fs.com today; if adapter isn't in the same shipment, this is a separate procurement item.
+
+## 2. Module load (driver path) — for completeness
+
+If driver were missing (it isn't, on spark-6), the load command would be:
+```
+sudo modprobe mlx5_core
+```
+
+Spark-6 already has all 4 expected modules loaded (`mlx5_core`, `mlx5_ib`, `mlx5_fwctl`, `mlxfw`). No driver remediation needed.
+
+## 3. Firmware update path (only relevant once hardware present)
+
+The cluster-canonical firmware is `28.45.4028` (per `docs/operational/cluster-network-canonical-baseline-2026-04-30.md` §1). Once spark-6 has visible Mellanox PCI devices, verify firmware match:
+```
+sudo ethtool -i enp1s0f0np0 | grep firmware-version
+```
+
+If firmware diverges from `28.45.4028`:
+- NVIDIA-supplied firmware update tool: `mlxfwmanager` (part of MFT — Mellanox Firmware Tools)
+- Or operating-system supplied firmware blob loaded by `mlx5_core` at module init
+
+This is operator-side. Out of scope for today's cable cutover.
+
+## 4. When to run
+
+Sequence relative to today's cable cutover:
+
+1. **Before plugging cables into spark-6:** complete Step 1–4 above. If adapter is genuinely absent, skip cables for spark-6 — defer cutover until adapter installed.
+2. **If adapter present but `lspci` not seeing it:** re-seat, reboot, recheck. Don't plug cables until lspci shows 4 entries.
+3. **If lspci shows 4 entries:** plug cables, apply target netplan from `docs/operational/spark-6-target-netplan-2026-04-30.yaml`, validate.
+
+## 5. Validation post-remediation
+
+```
+ssh admin@192.168.0.115 'lspci -nn | grep -i mellanox | wc -l'
+# expect 4
+
+ssh admin@192.168.0.115 'ls /sys/class/net/ | grep -E "enp1s0f|enP2p1s0f"'
+# expect 4 interface names matching canonical
+
+ssh admin@192.168.0.115 'sudo ethtool -i enp1s0f0np0 | grep firmware-version'
+# expect: firmware-version: 28.45.4028 (or document divergence)
+
+ping -c 3 -W 1 10.10.10.6
+ping -c 3 -W 1 10.10.11.6
+# both should succeed from spark-2 after netplan apply
+```
+
+If all 5 pass → spark-6 fabric is live and aligned with canonical.
+
+---
+
+End of remediation plan.

--- a/docs/operational/spark-6-target-netplan-2026-04-30.yaml
+++ b/docs/operational/spark-6-target-netplan-2026-04-30.yaml
@@ -1,0 +1,80 @@
+# Target netplan for spark-6 — POST-CUTOVER 2026-04-30
+#
+# 🛑 PRECONDITION — DO NOT APPLY UNTIL ConnectX-7 HARDWARE IS PRESENT:
+#   `lspci -nn | grep -i mellanox` on spark-6 must return four lines like:
+#     0000:01:00.0 ...ConnectX-7...
+#     0000:01:00.1 ...ConnectX-7...
+#     0002:01:00.0 ...ConnectX-7...
+#     0002:01:00.1 ...ConnectX-7...
+#   per docs/operational/cluster-network-canonical-baseline-2026-04-30.md §1.
+#
+# As of audit 2026-04-30, spark-6 lspci returns NO Mellanox device. Cables
+# alone will not activate fabric — the adapter must be physically present
+# in the chassis and BIOS-recognized first.
+# See docs/operational/spark-5-6-parity-check-2026-04-30.md §2.1.
+#
+# Intent (after hardware blocker resolved): bring spark-6 to canonical
+# fabric pattern matching sparks 1/2/3/4.
+#
+# Canonical reference: docs/operational/cluster-network-canonical-baseline-2026-04-30.md §2
+#
+# This file is a DRAFT, committed under docs/, NOT under /etc/netplan/.
+# Operator copies into /etc/netplan/ on spark-6 with appropriate mode
+# (chmod 600, chown root:root) when applying.
+
+# === 01-mgmt.yaml content for spark-6 (target — mgmt-LAN, current spark-6 has equivalent) ===
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    enP7s7:
+      dhcp4: false
+      addresses:
+        - 192.168.0.115/24
+      routes:
+        - to: default
+          via: 192.168.0.1
+      nameservers:
+        addresses: [8.8.8.8, 1.1.1.1]
+
+---
+# === 99-mellanox-roce.yaml content for spark-6 (target — fabric, NEW — depends on hardware) ===
+network:
+  version: 2
+  ethernets:
+    enp1s0f0np0:
+      addresses: [10.10.10.6/24]
+      mtu: 9000
+    enp1s0f1np1:
+      dhcp4: false
+      optional: true
+    enP2p1s0f1np1:
+      addresses: [10.10.11.6/24]
+      mtu: 9000
+      dhcp4: false
+
+# === Notes ===
+#
+# 1. Spark-6 currently has only `00-installer-config.yaml` (49 bytes) and a
+#    NetworkManager file under /etc/netplan/. Mgmt LAN works (192.168.0.115
+#    binds, default route via 192.168.0.1). The `01-mgmt.yaml` above is a
+#    canonical-aligned restatement of the mgmt LAN — operator may keep
+#    existing 00-installer-config.yaml if it's functionally equivalent.
+#
+# 2. The 99-mellanox-roce.yaml fabric file DOES NOT EXIST on spark-6 today.
+#    Adding it before adapter is present is harmless (netplan won't bind to
+#    nonexistent interfaces) but creates a bootstrap inconsistency. Better
+#    sequence: install adapter → confirm lspci → drop in netplan → apply.
+#
+# 3. Apply sequence (after hardware blocker resolved):
+#      # confirm hardware first:
+#      ssh admin@192.168.0.115 'lspci -nn | grep -i mellanox | wc -l'
+#      # expect: 4
+#      # then:
+#      sudo cp 99-mellanox-roce.yaml /etc/netplan/99-mellanox-roce.yaml
+#      sudo chmod 600 /etc/netplan/99-mellanox-roce.yaml
+#      sudo chown root:root /etc/netplan/99-mellanox-roce.yaml
+#      sudo netplan generate
+#      sudo netplan apply
+#
+# 4. After apply, validate per docs/operational/spark-5-6-fabric-cutover-runbook-2026-04-30.md §5

--- a/docs/operational/spark-network-baseline-2026-04-30/spark-100.txt
+++ b/docs/operational/spark-network-baseline-2026-04-30/spark-100.txt
@@ -1,0 +1,251 @@
+=== HOSTNAME ===
+spark-node-2
+Linux spark-node-2 6.17.0-1014-nvidia #14-Ubuntu SMP PREEMPT_DYNAMIC Tue Mar 17 19:01:40 UTC 2026 aarch64 aarch64 aarch64 GNU/Linux
+
+=== KERNEL ===
+Linux version 6.17.0-1014-nvidia (buildd@bos03-arm64-009) (aarch64-linux-gnu-gcc-13 (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0, GNU ld (GNU Binutils for Ubuntu) 2.42) #14-Ubuntu SMP PREEMPT_DYNAMIC Tue Mar 17 19:01:40 UTC 2026
+
+=== NETPLAN ===
+total 60
+drwxr-xr-x   2 root root  4096 Apr 25 16:25 .
+drwxr-xr-x 193 root root 12288 Apr 25 15:31 ..
+-rw-------   1 root root   346 Apr 25 16:25 01-captain-core.yaml
+-rw-------   1 root root   251 Mar 27 13:21 01-captain-core.yaml.bak.20260327132145
+-rw-------   1 root root   431 Apr 25 12:50 01-captain-core.yaml.bak.20260425_125007
+-rw-------   1 root root   431 Apr 25 12:51 01-captain-core.yaml.bak.20260425_125141
+-rw-------   1 root root   330 Apr 25 14:42 01-captain-core.yaml.bak.20260425_144250
+-rw-------   1 root root   388 Apr 25 14:54 01-captain-core.yaml.bak.20260425_145418
+-rw-------   1 root root   425 Apr 25 14:57 01-captain-core.yaml.bak.20260425_145758
+-rw-------   1 root root   441 Apr 25 16:25 01-captain-core.yaml.bak.20260425_162536
+-rw-------   1 root root   328 Apr 25 12:51 01-captain-core.yaml.save
+-rw-------   1 root root   245 Apr 25 15:14 99-mellanox-roce.yaml
+-rw-r--r--   1 root root   101 Apr 25 14:42 99-mellanox-roce.yaml.bak.20260425_144250
+--- /etc/netplan/01-captain-core.yaml ---
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    enP7s7:
+      dhcp4: false
+      addresses:
+        - 192.168.0.100/24
+      routes:
+        - to: default
+          via: 192.168.0.1
+      nameservers:
+        addresses: [8.8.8.8, 1.1.1.1]
+    enP2p1s0f0np0:
+      dhcp4: false
+      addresses:
+        - 10.101.2.2/30
+      mtu: 9000
+--- /etc/netplan/99-mellanox-roce.yaml ---
+network:
+  version: 2
+  ethernets:
+    enp1s0f0np0:
+      addresses: [10.10.10.2/24]
+      mtu: 9000
+    enp1s0f1np1:
+      dhcp4: false
+      optional: true
+    enP2p1s0f1np1:
+      addresses: [10.10.11.2/24]
+      mtu: 9000
+      dhcp4: false
+
+=== ip addr ===
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+    inet 10.101.1.2/24 scope global lo
+       valid_lft forever preferred_lft forever
+2: enP7s7: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1420 qdisc mq state UP group default qlen 1000
+    altname enP7p1s0
+    inet 192.168.0.100/24 brd 192.168.0.255 scope global enP7s7
+       valid_lft forever preferred_lft forever
+3: enp1s0f0np0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP group default qlen 1000
+    inet 10.10.10.2/24 brd 10.10.10.255 scope global enp1s0f0np0
+       valid_lft forever preferred_lft forever
+5: enP2p1s0f0np0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP group default qlen 1000
+    inet 10.101.2.2/30 brd 10.101.2.3 scope global enP2p1s0f0np0
+       valid_lft forever preferred_lft forever
+6: enP2p1s0f1np1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP group default qlen 1000
+    inet 10.10.11.2/24 brd 10.10.11.255 scope global enP2p1s0f1np1
+       valid_lft forever preferred_lft forever
+8: tailscale0: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1280 qdisc fq_codel state UNKNOWN group default qlen 500
+    inet 100.80.122.100/32 scope global tailscale0
+       valid_lft forever preferred_lft forever
+9: br-04ea0c4e037b: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default 
+    inet 172.22.0.1/16 brd 172.22.255.255 scope global br-04ea0c4e037b
+       valid_lft forever preferred_lft forever
+10: br-4476048b3aa5: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default 
+    inet 172.28.0.1/16 brd 172.28.255.255 scope global br-4476048b3aa5
+       valid_lft forever preferred_lft forever
+11: docker0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1420 qdisc noqueue state UP group default 
+    inet 172.17.0.1/16 brd 172.17.255.255 scope global docker0
+       valid_lft forever preferred_lft forever
+12: docker_gwbridge: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default 
+    inet 172.19.0.1/16 brd 172.19.255.255 scope global docker_gwbridge
+       valid_lft forever preferred_lft forever
+13: br-fcdc5d0c0cf2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default 
+    inet 172.21.0.1/16 brd 172.21.255.255 scope global br-fcdc5d0c0cf2
+       valid_lft forever preferred_lft forever
+38: flannel.1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UNKNOWN group default 
+    inet 10.42.0.0/32 scope global flannel.1
+       valid_lft forever preferred_lft forever
+39: cni0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default qlen 1000
+    inet 10.42.0.1/24 brd 10.42.0.255 scope global cni0
+       valid_lft forever preferred_lft forever
+5134: fabric0: <BROADCAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN group default qlen 1000
+    inet 10.101.1.2/24 brd 10.101.1.255 scope global fabric0
+       valid_lft forever preferred_lft forever
+
+=== ip link (with mtu) ===
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00 promiscuity 0  allmulti 0 minmtu 0 maxmtu 0 addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+2: enP7s7: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1420 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 4c:bb:47:2f:80:70 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 9194 addrgenmode eui64 numtxqueues 16 numrxqueues 16 gso_max_size 64000 gso_max_segs 64 tso_max_size 64000 tso_max_segs 64 gro_max_size 65536 parentbus pci parentdev 0007:01:00.0 
+    altname enP7p1s0
+3: enp1s0f0np0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 4c:bb:47:2f:80:71 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 9978 addrgenmode eui64 numtxqueues 424 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 portname p0 switchid 71802f000347bb4c parentbus pci parentdev 0000:01:00.0 
+4: enp1s0f1np1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 4c:bb:47:2f:80:72 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 9978 addrgenmode eui64 numtxqueues 424 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 portname p1 switchid 71802f000347bb4c parentbus pci parentdev 0000:01:00.1 
+5: enP2p1s0f0np0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 4c:bb:47:2f:80:75 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 9978 addrgenmode eui64 numtxqueues 424 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 portname p0 switchid 71802f000347bb4c parentbus pci parentdev 0002:01:00.0 
+6: enP2p1s0f1np1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 4c:bb:47:2f:80:76 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 9978 addrgenmode eui64 numtxqueues 424 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 portname p1 switchid 71802f000347bb4c parentbus pci parentdev 0002:01:00.1 
+7: wlP9s9: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN mode DORMANT group default qlen 1000
+    link/ether 58:02:05:f6:24:18 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 256 maxmtu 2304 addrgenmode none numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 parentbus pci parentdev 0009:01:00.0 
+    altname wlP9p1s0
+8: tailscale0: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1280 qdisc fq_codel state UNKNOWN mode DEFAULT group default qlen 500
+    link/none  promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    tun type tun pi off vnet_hdr on persist off addrgenmode random numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 
+9: br-04ea0c4e037b: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default 
+    link/ether 0a:a1:ab:c4:1d:9e brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    bridge forward_delay 1500 hello_time 200 max_age 2000 ageing_time 30000 stp_state 0 priority 32768 vlan_filtering 0 vlan_protocol 802.1Q bridge_id 8000.a:a1:ab:c4:1d:9e designated_root 8000.a:a1:ab:c4:1d:9e root_port 0 root_path_cost 0 topology_change 0 topology_change_detected 0 hello_timer    0.00 tcn_timer    0.00 topology_change_timer    0.00 gc_timer  237.82 vlan_default_pvid 1 vlan_stats_enabled 0 vlan_stats_per_port 0 group_fwd_mask 0 group_address 01:80:c2:00:00:00 mcast_snooping 1 no_linklocal_learn 0 mcast_vlan_snooping 0 mcast_router 1 mcast_query_use_ifaddr 0 mcast_querier 0 mcast_hash_elasticity 16 mcast_hash_max 4096 mcast_last_member_count 2 mcast_startup_query_count 2 mcast_last_member_interval 100 mcast_membership_interval 26000 mcast_querier_interval 25500 mcast_query_interval 12500 mcast_query_response_interval 1000 mcast_startup_query_interval 3125 mcast_stats_enabled 0 mcast_igmp_version 2 mcast_mld_version 1 nf_call_iptables 0 nf_call_ip6tables 0 nf_call_arptables 0 addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+10: br-4476048b3aa5: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN mode DEFAULT group default 
+    link/ether c6:a3:9c:cd:53:f2 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    bridge forward_delay 1500 hello_time 200 max_age 2000 ageing_time 30000 stp_state 0 priority 32768 vlan_filtering 0 vlan_protocol 802.1Q bridge_id 8000.c6:a3:9c:cd:53:f2 designated_root 8000.c6:a3:9c:cd:53:f2 root_port 0 root_path_cost 0 topology_change 0 topology_change_detected 0 hello_timer    0.00 tcn_timer    0.00 topology_change_timer    0.00 gc_timer    0.00 vlan_default_pvid 1 vlan_stats_enabled 0 vlan_stats_per_port 0 group_fwd_mask 0 group_address 01:80:c2:00:00:00 mcast_snooping 1 no_linklocal_learn 0 mcast_vlan_snooping 0 mcast_router 1 mcast_query_use_ifaddr 0 mcast_querier 0 mcast_hash_elasticity 16 mcast_hash_max 4096 mcast_last_member_count 2 mcast_startup_query_count 2 mcast_last_member_interval 100 mcast_membership_interval 26000 mcast_querier_interval 25500 mcast_query_interval 12500 mcast_query_response_interval 1000 mcast_startup_query_interval 3125 mcast_stats_enabled 0 mcast_igmp_version 2 mcast_mld_version 1 nf_call_iptables 0 nf_call_ip6tables 0 nf_call_arptables 0 addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+11: docker0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1420 qdisc noqueue state UP mode DEFAULT group default 
+    link/ether 1e:88:f9:f3:ab:28 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    bridge forward_delay 1500 hello_time 200 max_age 2000 ageing_time 30000 stp_state 0 priority 32768 vlan_filtering 0 vlan_protocol 802.1Q bridge_id 8000.1e:88:f9:f3:ab:28 designated_root 8000.1e:88:f9:f3:ab:28 root_port 0 root_path_cost 0 topology_change 0 topology_change_detected 0 hello_timer    0.00 tcn_timer    0.00 topology_change_timer    0.00 gc_timer  168.70 vlan_default_pvid 1 vlan_stats_enabled 0 vlan_stats_per_port 0 group_fwd_mask 0 group_address 01:80:c2:00:00:00 mcast_snooping 1 no_linklocal_learn 0 mcast_vlan_snooping 0 mcast_router 1 mcast_query_use_ifaddr 0 mcast_querier 0 mcast_hash_elasticity 16 mcast_hash_max 4096 mcast_last_member_count 2 mcast_startup_query_count 2 mcast_last_member_interval 100 mcast_membership_interval 26000 mcast_querier_interval 25500 mcast_query_interval 12500 mcast_query_response_interval 1000 mcast_startup_query_interval 3125 mcast_stats_enabled 0 mcast_igmp_version 2 mcast_mld_version 1 nf_call_iptables 0 nf_call_ip6tables 0 nf_call_arptables 0 addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+12: docker_gwbridge: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default 
+    link/ether a6:23:38:af:fd:0e brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    bridge forward_delay 1500 hello_time 200 max_age 2000 ageing_time 30000 stp_state 0 priority 32768 vlan_filtering 0 vlan_protocol 802.1Q bridge_id 8000.a6:23:38:af:fd:e designated_root 8000.a6:23:38:af:fd:e root_port 0 root_path_cost 0 topology_change 0 topology_change_detected 0 hello_timer    0.00 tcn_timer    0.00 topology_change_timer    0.00 gc_timer  270.59 vlan_default_pvid 1 vlan_stats_enabled 0 vlan_stats_per_port 0 group_fwd_mask 0 group_address 01:80:c2:00:00:00 mcast_snooping 1 no_linklocal_learn 0 mcast_vlan_snooping 0 mcast_router 1 mcast_query_use_ifaddr 0 mcast_querier 0 mcast_hash_elasticity 16 mcast_hash_max 4096 mcast_last_member_count 2 mcast_startup_query_count 2 mcast_last_member_interval 100 mcast_membership_interval 26000 mcast_querier_interval 25500 mcast_query_interval 12500 mcast_query_response_interval 1000 mcast_startup_query_interval 3125 mcast_stats_enabled 0 mcast_igmp_version 2 mcast_mld_version 1 nf_call_iptables 0 nf_call_ip6tables 0 nf_call_arptables 0 addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+13: br-fcdc5d0c0cf2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default 
+    link/ether 3e:18:5b:a2:02:00 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    bridge forward_delay 1500 hello_time 200 max_age 2000 ageing_time 30000 stp_state 0 priority 32768 vlan_filtering 0 vlan_protocol 802.1Q bridge_id 8000.3e:18:5b:a2:2:0 designated_root 8000.3e:18:5b:a2:2:0 root_port 0 root_path_cost 0 topology_change 0 topology_change_detected 0 hello_timer    0.00 tcn_timer    0.00 topology_change_timer    0.00 gc_timer    0.00 vlan_default_pvid 1 vlan_stats_enabled 0 vlan_stats_per_port 0 group_fwd_mask 0 group_address 01:80:c2:00:00:00 mcast_snooping 1 no_linklocal_learn 0 mcast_vlan_snooping 0 mcast_router 1 mcast_query_use_ifaddr 0 mcast_querier 0 mcast_hash_elasticity 16 mcast_hash_max 4096 mcast_last_member_count 2 mcast_startup_query_count 2 mcast_last_member_interval 100 mcast_membership_interval 26000 mcast_querier_interval 25500 mcast_query_interval 12500 mcast_query_response_interval 1000 mcast_startup_query_interval 3125 mcast_stats_enabled 0 mcast_igmp_version 2 mcast_mld_version 1 nf_call_iptables 0 nf_call_ip6tables 0 nf_call_arptables 0 addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+38: flannel.1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UNKNOWN mode DEFAULT group default 
+    link/ether 6a:85:7d:ce:13:ec brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    vxlan id 1 fan-map 0.7.0.55/46335:32.100.64.57/63796 225.3.19.170/38911:248.3.0.170/64868 local 192.168.0.100 dev enP7s7 srcport 0 0 dstport 8472 nolearning ttl auto ageing 300 udpcsum noudp6zerocsumtx noudp6zerocsumrx addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 64000 gso_max_segs 64 tso_max_size 64000 tso_max_segs 64 gro_max_size 65536 
+39: cni0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP mode DEFAULT group default qlen 1000
+    link/ether 0e:27:77:b0:a1:8f brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    bridge forward_delay 1500 hello_time 200 max_age 2000 ageing_time 30000 stp_state 0 priority 32768 vlan_filtering 0 vlan_protocol 802.1Q bridge_id 8000.e:27:77:b0:a1:8f designated_root 8000.e:27:77:b0:a1:8f root_port 0 root_path_cost 0 topology_change 0 topology_change_detected 0 hello_timer    0.00 tcn_timer    0.00 topology_change_timer    0.00 gc_timer  237.74 vlan_default_pvid 1 vlan_stats_enabled 0 vlan_stats_per_port 0 group_fwd_mask 0 group_address 01:80:c2:00:00:00 mcast_snooping 1 no_linklocal_learn 0 mcast_vlan_snooping 0 mcast_router 1 mcast_query_use_ifaddr 0 mcast_querier 0 mcast_hash_elasticity 16 mcast_hash_max 4096 mcast_last_member_count 2 mcast_startup_query_count 2 mcast_last_member_interval 100 mcast_membership_interval 26000 mcast_querier_interval 25500 mcast_query_interval 12500 mcast_query_response_interval 1000 mcast_startup_query_interval 3125 mcast_stats_enabled 0 mcast_igmp_version 2 mcast_mld_version 1 nf_call_iptables 0 nf_call_ip6tables 0 nf_call_arptables 0 addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+47: vetha11efdc5@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether c6:20:8c:68:f7:12 brd ff:ff:ff:ff:ff:ff link-netns cni-d08724aa-2e42-5c1a-a4c7-357968c16e56 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8002 port_no 0x2 designated_port 32770 designated_cost 0 designated_bridge 8000.e:27:77:b0:a1:8f designated_root 8000.e:27:77:b0:a1:8f hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+48: veth25a933c9@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether 8e:04:8f:cc:f1:f3 brd ff:ff:ff:ff:ff:ff link-netns cni-11f3ded4-2798-6e69-f315-c32c903d6918 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8001 port_no 0x1 designated_port 32769 designated_cost 0 designated_bridge 8000.e:27:77:b0:a1:8f designated_root 8000.e:27:77:b0:a1:8f hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+51: veth5d3b4e08@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether 82:32:3c:c2:f6:ba brd ff:ff:ff:ff:ff:ff link-netns cni-ba679977-12d7-6351-48ef-78855dcd3c63 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8005 port_no 0x5 designated_port 32773 designated_cost 0 designated_bridge 8000.e:27:77:b0:a1:8f designated_root 8000.e:27:77:b0:a1:8f hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+52: veth237a5e8f@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether 52:c7:61:e9:3d:6d brd ff:ff:ff:ff:ff:ff link-netns cni-ce7f4b46-7996-ee47-b9ea-d769c40436ca promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8006 port_no 0x6 designated_port 32774 designated_cost 0 designated_bridge 8000.e:27:77:b0:a1:8f designated_root 8000.e:27:77:b0:a1:8f hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+53: veth7e0888e8@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether 1e:6e:97:af:9b:f4 brd ff:ff:ff:ff:ff:ff link-netns cni-a1850c6a-f4cb-3652-46c1-6cef53d92253 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8003 port_no 0x3 designated_port 32771 designated_cost 0 designated_bridge 8000.e:27:77:b0:a1:8f designated_root 8000.e:27:77:b0:a1:8f hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+54: vethdac8662e@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether 8e:03:c4:4f:5c:c2 brd ff:ff:ff:ff:ff:ff link-netns cni-d9e40602-156c-1358-782d-68c8ee59fc06 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8004 port_no 0x4 designated_port 32772 designated_cost 0 designated_bridge 8000.e:27:77:b0:a1:8f designated_root 8000.e:27:77:b0:a1:8f hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+5134: fabric0: <BROADCAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
+    link/ether 2e:5a:72:00:5c:f5 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 0 maxmtu 0 
+    dummy addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 
+25324: veth68632ee@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1420 qdisc noqueue master docker0 state UP mode DEFAULT group default 
+    link/ether fa:f5:c6:43:b3:5c brd ff:ff:ff:ff:ff:ff link-netnsid 0 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin off guard off root_block off fastleave off learning on flood on port_id 0x8001 port_no 0x1 designated_port 32769 designated_cost 0 designated_bridge 8000.1e:88:f9:f3:ab:28 designated_root 8000.1e:88:f9:f3:ab:28 hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+25325: veth900f75c@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master br-04ea0c4e037b state UP mode DEFAULT group default 
+    link/ether 5e:92:14:b2:80:fb brd ff:ff:ff:ff:ff:ff link-netnsid 1 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin off guard off root_block off fastleave off learning on flood on port_id 0x8001 port_no 0x1 designated_port 32769 designated_cost 0 designated_bridge 8000.a:a1:ab:c4:1d:9e designated_root 8000.a:a1:ab:c4:1d:9e hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+25326: vethc80292a@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master br-fcdc5d0c0cf2 state UP mode DEFAULT group default 
+    link/ether 2a:83:2e:9f:b8:73 brd ff:ff:ff:ff:ff:ff link-netnsid 2 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin off guard off root_block off fastleave off learning on flood on port_id 0x8001 port_no 0x1 designated_port 32769 designated_cost 0 designated_bridge 8000.3e:18:5b:a2:2:0 designated_root 8000.3e:18:5b:a2:2:0 hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+25327: veth275a0ba@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master br-04ea0c4e037b state UP mode DEFAULT group default 
+
+=== ConnectX hardware (lspci) ===
+0000:01:00.0 Ethernet controller [0200]: Mellanox Technologies MT2910 Family [ConnectX-7] [15b3:1021]
+0000:01:00.1 Ethernet controller [0200]: Mellanox Technologies MT2910 Family [ConnectX-7] [15b3:1021]
+0002:01:00.0 Ethernet controller [0200]: Mellanox Technologies MT2910 Family [ConnectX-7] [15b3:1021]
+0002:01:00.1 Ethernet controller [0200]: Mellanox Technologies MT2910 Family [ConnectX-7] [15b3:1021]
+
+=== mlx kernel modules ===
+mlx5_fwctl             16384  0
+mlx5_ib               520192  0
+mlx5_core            2756608  2 mlx5_fwctl,mlx5_ib
+mlxfw                  32768  1 mlx5_core
+
+=== mlx5_core modinfo ===
+filename:       /lib/modules/6.17.0-1014-nvidia/kernel/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.ko.zst
+srcversion:     89EEAF32656D79A2DACFFD3
+
+=== Firmware per ConnectX device ===
+--- enp1s0f0np0 ---
+driver: mlx5_core
+version: 6.17.0-1014-nvidia
+firmware-version: 28.45.4028 (NVD0000000087)
+expansion-rom-version: 
+--- enp1s0f1np1 ---
+driver: mlx5_core
+version: 6.17.0-1014-nvidia
+firmware-version: 28.45.4028 (NVD0000000087)
+expansion-rom-version: 
+--- enP2p1s0f0np0 ---
+driver: mlx5_core
+version: 6.17.0-1014-nvidia
+firmware-version: 28.45.4028 (NVD0000000087)
+expansion-rom-version: 
+--- enP2p1s0f1np1 ---
+driver: mlx5_core
+version: 6.17.0-1014-nvidia
+firmware-version: 28.45.4028 (NVD0000000087)
+expansion-rom-version: 
+
+=== ip route ===
+default via 192.168.0.1 dev enP7s7 proto static 
+10.10.10.0/24 dev enp1s0f0np0 proto kernel scope link src 10.10.10.2 
+10.10.11.0/24 dev enP2p1s0f1np1 proto kernel scope link src 10.10.11.2 
+10.42.0.0/24 dev cni0 proto kernel scope link src 10.42.0.1 
+10.42.1.0/24 via 10.42.1.0 dev flannel.1 onlink 
+10.42.2.0/24 via 10.42.2.0 dev flannel.1 onlink 
+10.42.3.0/24 via 10.42.3.0 dev flannel.1 onlink 
+10.101.1.0/24 dev fabric0 proto kernel scope link src 10.101.1.2 
+10.101.2.0/30 dev enP2p1s0f0np0 proto kernel scope link src 10.101.2.2 
+172.17.0.0/16 dev docker0 proto kernel scope link src 172.17.0.1 
+172.19.0.0/16 dev docker_gwbridge proto kernel scope link src 172.19.0.1 
+172.21.0.0/16 dev br-fcdc5d0c0cf2 proto kernel scope link src 172.21.0.1 
+172.22.0.0/16 dev br-04ea0c4e037b proto kernel scope link src 172.22.0.1 
+172.28.0.0/16 dev br-4476048b3aa5 proto kernel scope link src 172.28.0.1 linkdown 
+192.168.0.0/24 dev enP7s7 proto kernel scope link src 192.168.0.100 
+
+=== sysctl network tuning ===
+net.core.rmem_max = 536870912
+net.core.wmem_max = 536870912
+net.ipv4.tcp_rmem = 4096	87380	268435456
+net.ipv4.tcp_wmem = 4096	65536	268435456
+net.core.netdev_max_backlog = 250000
+net.core.default_qdisc = fq_codel
+net.ipv4.tcp_congestion_control = bbr
+
+=== bonding (if any) ===
+(no bonding interfaces)

--- a/docs/operational/spark-network-baseline-2026-04-30/spark-104.txt
+++ b/docs/operational/spark-network-baseline-2026-04-30/spark-104.txt
@@ -1,0 +1,261 @@
+=== HOSTNAME ===
+spark-node-1
+Linux spark-node-1 6.17.0-1014-nvidia #14-Ubuntu SMP PREEMPT_DYNAMIC Tue Mar 17 19:01:40 UTC 2026 aarch64 aarch64 aarch64 GNU/Linux
+
+=== KERNEL ===
+Linux version 6.17.0-1014-nvidia (buildd@bos03-arm64-009) (aarch64-linux-gnu-gcc-13 (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0, GNU ld (GNU Binutils for Ubuntu) 2.42) #14-Ubuntu SMP PREEMPT_DYNAMIC Tue Mar 17 19:01:40 UTC 2026
+
+=== NETPLAN ===
+total 52
+drwxr-xr-x   2 root root  4096 Apr 25 13:16 .
+drwxr-xr-x 190 root root 12288 Apr 28 10:52 ..
+-rw-------   1 root root   330 Apr 25 13:16 01-node1-core.yaml
+-rw-------   1 root root   251 Mar 27 13:22 01-node1-core.yaml.bak.20260327132204
+-rw-------   1 root root   431 Apr 25 12:45 01-node1-core.yaml.bak.20260425_124510
+-rw-------   1 root root   431 Apr 23 19:06 01-node1-core.yaml.phase1-bak-20260423_190639
+-rw-------   1 root root   431 Apr 23 19:13 01-node1-core.yaml.phase1-bak-20260423_191346
+-rw-------   1 root root   431 Apr 23 19:14 01-node1-core.yaml.phase1-bak-20260423_191423
+-rw-------   1 root root   718 Apr 16 10:06 90-NM-52982d62-d6d7-42f6-b065-303c587caa97.yaml
+-rw-------   1 root root   735 Feb  4 19:10 90-NM-backup.yaml.disabled
+-rw-------   1 root root   245 Apr 25 15:13 99-mellanox-roce.yaml
+--- /etc/netplan/01-node1-core.yaml ---
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    enP7s7:
+      dhcp4: false
+      addresses:
+        - 192.168.0.104/24
+      routes:
+        - to: default
+          via: 192.168.0.1
+      nameservers:
+        addresses: [8.8.8.8, 1.1.1.1]
+    enP2p1s0f0np0:
+      dhcp4: false
+      addresses:
+        - 10.101.2.1/30
+--- /etc/netplan/90-NM-52982d62-d6d7-42f6-b065-303c587caa97.yaml ---
+network:
+  version: 2
+  wifis:
+    NM-52982d62-d6d7-42f6-b065-303c587caa97:
+      renderer: NetworkManager
+      match:
+        name: "wlP9s9"
+      dhcp4: true
+      dhcp6: true
+      access-points:
+        "200 Amber Ridge":
+          auth:
+            key-management: "psk"
+            password: "200amberridge"
+          networkmanager:
+            uuid: "52982d62-d6d7-42f6-b065-303c587caa97"
+            name: "200 Amber Ridge"
+            passthrough:
+              wifi-security.auth-alg: "open"
+              ipv6.addr-gen-mode: "default"
+              ipv6.ip6-privacy: "-1"
+              proxy._: ""
+      networkmanager:
+        uuid: "52982d62-d6d7-42f6-b065-303c587caa97"
+        name: "200 Amber Ridge"
+--- /etc/netplan/99-mellanox-roce.yaml ---
+network:
+  version: 2
+  ethernets:
+    enp1s0f0np0:
+      addresses: [10.10.10.1/24]
+      mtu: 9000
+    enp1s0f1np1:
+      dhcp4: false
+      optional: true
+    enP2p1s0f1np1:
+      addresses: [10.10.11.1/24]
+      mtu: 9000
+      dhcp4: false
+
+=== ip addr ===
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+2: enP7s7: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
+    altname enP7p1s0
+    inet 192.168.0.104/24 brd 192.168.0.255 scope global enP7s7
+       valid_lft forever preferred_lft forever
+3: enp1s0f0np0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP group default qlen 1000
+    inet 10.10.10.1/24 brd 10.10.10.255 scope global enp1s0f0np0
+       valid_lft forever preferred_lft forever
+5: enP2p1s0f0np0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
+    inet 10.101.2.1/30 brd 10.101.2.3 scope global enP2p1s0f0np0
+       valid_lft forever preferred_lft forever
+6: enP2p1s0f1np1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP group default qlen 1000
+    inet 10.10.11.1/24 brd 10.10.11.255 scope global enP2p1s0f1np1
+       valid_lft forever preferred_lft forever
+7: wlP9s9: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
+    altname wlP9p1s0
+    inet 10.0.0.31/24 brd 10.0.0.255 scope global dynamic noprefixroute wlP9s9
+       valid_lft 72384sec preferred_lft 72384sec
+9: docker0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default 
+    inet 172.17.0.1/16 brd 172.17.255.255 scope global docker0
+       valid_lft forever preferred_lft forever
+10: docker_gwbridge: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default 
+    inet 172.18.0.1/16 brd 172.18.255.255 scope global docker_gwbridge
+       valid_lft forever preferred_lft forever
+23: flannel.1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UNKNOWN group default 
+    inet 10.42.1.0/32 scope global flannel.1
+       valid_lft forever preferred_lft forever
+24: cni0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default qlen 1000
+    inet 10.42.1.1/24 brd 10.42.1.255 scope global cni0
+       valid_lft forever preferred_lft forever
+35: tailscale0: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1280 qdisc fq_codel state UNKNOWN group default qlen 500
+    inet 100.127.241.36/32 scope global tailscale0
+       valid_lft forever preferred_lft forever
+
+=== ip link (with mtu) ===
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00 promiscuity 0  allmulti 0 minmtu 0 maxmtu 0 addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+2: enP7s7: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 4c:bb:47:2b:3d:4b brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 9194 addrgenmode eui64 numtxqueues 16 numrxqueues 16 gso_max_size 64000 gso_max_segs 64 tso_max_size 64000 tso_max_segs 64 gro_max_size 65536 parentbus pci parentdev 0007:01:00.0 
+    altname enP7p1s0
+3: enp1s0f0np0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 4c:bb:47:2b:3d:4c brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 9978 addrgenmode eui64 numtxqueues 424 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 portname p0 switchid 4c3d2b000347bb4c parentbus pci parentdev 0000:01:00.0 
+4: enp1s0f1np1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 4c:bb:47:2b:3d:4d brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 9978 addrgenmode eui64 numtxqueues 424 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 portname p1 switchid 4c3d2b000347bb4c parentbus pci parentdev 0000:01:00.1 
+5: enP2p1s0f0np0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 4c:bb:47:2b:3d:50 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 9978 addrgenmode eui64 numtxqueues 424 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 portname p0 switchid 4c3d2b000347bb4c parentbus pci parentdev 0002:01:00.0 
+6: enP2p1s0f1np1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 4c:bb:47:2b:3d:51 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 9978 addrgenmode eui64 numtxqueues 424 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 portname p1 switchid 4c3d2b000347bb4c parentbus pci parentdev 0002:01:00.1 
+7: wlP9s9: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DORMANT group default qlen 1000
+    link/ether f8:3d:c6:af:c6:52 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 256 maxmtu 2304 addrgenmode none numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 parentbus pci parentdev 0009:01:00.0 
+    altname wlP9p1s0
+9: docker0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP mode DEFAULT group default 
+    link/ether c2:6d:61:a7:65:e0 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    bridge forward_delay 1500 hello_time 200 max_age 2000 ageing_time 30000 stp_state 0 priority 32768 vlan_filtering 0 vlan_protocol 802.1Q bridge_id 8000.c2:6d:61:a7:65:e0 designated_root 8000.c2:6d:61:a7:65:e0 root_port 0 root_path_cost 0 topology_change 0 topology_change_detected 0 hello_timer    0.00 tcn_timer    0.00 topology_change_timer    0.00 gc_timer  209.63 vlan_default_pvid 1 vlan_stats_enabled 0 vlan_stats_per_port 0 group_fwd_mask 0 group_address 01:80:c2:00:00:00 mcast_snooping 1 no_linklocal_learn 0 mcast_vlan_snooping 0 mcast_router 1 mcast_query_use_ifaddr 0 mcast_querier 0 mcast_hash_elasticity 16 mcast_hash_max 4096 mcast_last_member_count 2 mcast_startup_query_count 2 mcast_last_member_interval 100 mcast_membership_interval 26000 mcast_querier_interval 25500 mcast_query_interval 12500 mcast_query_response_interval 1000 mcast_startup_query_interval 3125 mcast_stats_enabled 0 mcast_igmp_version 2 mcast_mld_version 1 nf_call_iptables 0 nf_call_ip6tables 0 nf_call_arptables 0 addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+10: docker_gwbridge: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default 
+    link/ether fa:e3:45:52:e2:ac brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    bridge forward_delay 1500 hello_time 200 max_age 2000 ageing_time 30000 stp_state 0 priority 32768 vlan_filtering 0 vlan_protocol 802.1Q bridge_id 8000.fa:e3:45:52:e2:ac designated_root 8000.fa:e3:45:52:e2:ac root_port 0 root_path_cost 0 topology_change 0 topology_change_detected 0 hello_timer    0.00 tcn_timer    0.00 topology_change_timer    0.00 gc_timer  187.10 vlan_default_pvid 1 vlan_stats_enabled 0 vlan_stats_per_port 0 group_fwd_mask 0 group_address 01:80:c2:00:00:00 mcast_snooping 1 no_linklocal_learn 0 mcast_vlan_snooping 0 mcast_router 1 mcast_query_use_ifaddr 0 mcast_querier 0 mcast_hash_elasticity 16 mcast_hash_max 4096 mcast_last_member_count 2 mcast_startup_query_count 2 mcast_last_member_interval 100 mcast_membership_interval 26000 mcast_querier_interval 25500 mcast_query_interval 12500 mcast_query_response_interval 1000 mcast_startup_query_interval 3125 mcast_stats_enabled 0 mcast_igmp_version 2 mcast_mld_version 1 nf_call_iptables 0 nf_call_ip6tables 0 nf_call_arptables 0 addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+22: vethd378411@if21: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master docker_gwbridge state UP mode DEFAULT group default 
+    link/ether 5e:97:f4:01:3f:1a brd ff:ff:ff:ff:ff:ff link-netnsid 4 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin off guard off root_block off fastleave off learning on flood on port_id 0x8002 port_no 0x2 designated_port 32770 designated_cost 0 designated_bridge 8000.fa:e3:45:52:e2:ac designated_root 8000.fa:e3:45:52:e2:ac hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+23: flannel.1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UNKNOWN mode DEFAULT group default 
+    link/ether 42:21:13:53:0e:6a brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    vxlan id 1 fan-map 0.7.0.55/46335:32.100.64.57/63796 225.3.19.170/38911:248.3.0.170/64868 local 192.168.0.104 dev enP7s7 srcport 0 0 dstport 8472 nolearning ttl auto ageing 300 udpcsum noudp6zerocsumtx noudp6zerocsumrx addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 64000 gso_max_segs 64 tso_max_size 64000 tso_max_segs 64 gro_max_size 65536 
+24: cni0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP mode DEFAULT group default qlen 1000
+    link/ether 96:14:41:6e:4e:6e brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    bridge forward_delay 1500 hello_time 200 max_age 2000 ageing_time 30000 stp_state 0 priority 32768 vlan_filtering 0 vlan_protocol 802.1Q bridge_id 8000.96:14:41:6e:4e:6e designated_root 8000.96:14:41:6e:4e:6e root_port 0 root_path_cost 0 topology_change 0 topology_change_detected 0 hello_timer    0.00 tcn_timer    0.00 topology_change_timer    0.00 gc_timer  219.87 vlan_default_pvid 1 vlan_stats_enabled 0 vlan_stats_per_port 0 group_fwd_mask 0 group_address 01:80:c2:00:00:00 mcast_snooping 1 no_linklocal_learn 0 mcast_vlan_snooping 0 mcast_router 1 mcast_query_use_ifaddr 0 mcast_querier 0 mcast_hash_elasticity 16 mcast_hash_max 4096 mcast_last_member_count 2 mcast_startup_query_count 2 mcast_last_member_interval 100 mcast_membership_interval 26000 mcast_querier_interval 25500 mcast_query_interval 12500 mcast_query_response_interval 1000 mcast_startup_query_interval 3125 mcast_stats_enabled 0 mcast_igmp_version 2 mcast_mld_version 1 nf_call_iptables 0 nf_call_ip6tables 0 nf_call_arptables 0 addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+25: veth0166e6d1@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether 3e:b9:8b:0d:e1:fd brd ff:ff:ff:ff:ff:ff link-netns cni-286bab1d-518f-a70c-7208-511ad318d56c promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8001 port_no 0x1 designated_port 32769 designated_cost 0 designated_bridge 8000.96:14:41:6e:4e:6e designated_root 8000.96:14:41:6e:4e:6e hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+26: veth7af8e1e7@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether 66:80:6c:22:0c:08 brd ff:ff:ff:ff:ff:ff link-netns cni-ede14901-bf44-d3f6-3b35-49063cc532ba promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8002 port_no 0x2 designated_port 32770 designated_cost 0 designated_bridge 8000.96:14:41:6e:4e:6e designated_root 8000.96:14:41:6e:4e:6e hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+27: veth56d37146@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether 9e:7f:56:b9:34:fc brd ff:ff:ff:ff:ff:ff link-netns cni-9cc5e2e5-bbe6-3010-3a83-4325f2c6dd1a promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8003 port_no 0x3 designated_port 32771 designated_cost 0 designated_bridge 8000.96:14:41:6e:4e:6e designated_root 8000.96:14:41:6e:4e:6e hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+28: veth7e962268@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether 42:92:ea:09:e3:f3 brd ff:ff:ff:ff:ff:ff link-netns cni-28f32d53-cf43-c27f-32f8-883f8257fd41 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8004 port_no 0x4 designated_port 32772 designated_cost 0 designated_bridge 8000.96:14:41:6e:4e:6e designated_root 8000.96:14:41:6e:4e:6e hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+29: veth016fa1e2@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether ee:50:8d:7c:57:09 brd ff:ff:ff:ff:ff:ff link-netns cni-251f8d17-cefa-6155-e6b4-650fcf87e16b promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8005 port_no 0x5 designated_port 32773 designated_cost 0 designated_bridge 8000.96:14:41:6e:4e:6e designated_root 8000.96:14:41:6e:4e:6e hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+30: vethd62cc732@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether 2a:76:c3:5e:35:33 brd ff:ff:ff:ff:ff:ff link-netns cni-0533a796-b1fc-c8a6-a7e2-b15b94d6a49f promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8006 port_no 0x6 designated_port 32774 designated_cost 0 designated_bridge 8000.96:14:41:6e:4e:6e designated_root 8000.96:14:41:6e:4e:6e hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+31: veth66983000@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether 46:2e:02:6f:7a:b1 brd ff:ff:ff:ff:ff:ff link-netns cni-5265d6ed-6962-6beb-b5bf-07466e8f89b5 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8007 port_no 0x7 designated_port 32775 designated_cost 0 designated_bridge 8000.96:14:41:6e:4e:6e designated_root 8000.96:14:41:6e:4e:6e hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+32: veth1650ca93@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether 9e:9d:ab:44:2f:18 brd ff:ff:ff:ff:ff:ff link-netns cni-8187fd15-a14c-5237-a55e-5e004f844162 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8008 port_no 0x8 designated_port 32776 designated_cost 0 designated_bridge 8000.96:14:41:6e:4e:6e designated_root 8000.96:14:41:6e:4e:6e hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+33: veth3d8c7469@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether 8e:eb:18:a5:55:a7 brd ff:ff:ff:ff:ff:ff link-netns cni-5bc4d782-20b6-63ad-c62c-0644d2d300f4 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8009 port_no 0x9 designated_port 32777 designated_cost 0 designated_bridge 8000.96:14:41:6e:4e:6e designated_root 8000.96:14:41:6e:4e:6e hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+35: tailscale0: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1280 qdisc fq_codel state UNKNOWN mode DEFAULT group default qlen 500
+    link/none  promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    tun type tun pi off vnet_hdr on persist off addrgenmode random numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 
+36: veth2beb9ff@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master docker0 state UP mode DEFAULT group default 
+    link/ether be:88:5e:ad:2a:37 brd ff:ff:ff:ff:ff:ff link-netnsid 14 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin off guard off root_block off fastleave off learning on flood on port_id 0x8001 port_no 0x1 designated_port 32769 designated_cost 0 designated_bridge 8000.c2:6d:61:a7:65:e0 designated_root 8000.c2:6d:61:a7:65:e0 hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+52: veth03ba4a0@if51: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master docker_gwbridge state UP mode DEFAULT group default 
+    link/ether b2:93:70:eb:46:59 brd ff:ff:ff:ff:ff:ff link-netnsid 2 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin off guard off root_block off fastleave off learning on flood on port_id 0x8001 port_no 0x1 designated_port 32769 designated_cost 0 designated_bridge 8000.fa:e3:45:52:e2:ac designated_root 8000.fa:e3:45:52:e2:ac hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+
+=== ConnectX hardware (lspci) ===
+0000:01:00.0 Ethernet controller [0200]: Mellanox Technologies MT2910 Family [ConnectX-7] [15b3:1021]
+0000:01:00.1 Ethernet controller [0200]: Mellanox Technologies MT2910 Family [ConnectX-7] [15b3:1021]
+0002:01:00.0 Ethernet controller [0200]: Mellanox Technologies MT2910 Family [ConnectX-7] [15b3:1021]
+0002:01:00.1 Ethernet controller [0200]: Mellanox Technologies MT2910 Family [ConnectX-7] [15b3:1021]
+
+=== mlx kernel modules ===
+mlx5_fwctl             16384  0
+mlx5_ib               520192  0
+mlx5_core            2756608  2 mlx5_fwctl,mlx5_ib
+mlxfw                  32768  1 mlx5_core
+
+=== mlx5_core modinfo ===
+filename:       /lib/modules/6.17.0-1014-nvidia/kernel/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.ko.zst
+srcversion:     89EEAF32656D79A2DACFFD3
+
+=== Firmware per ConnectX device ===
+--- enp1s0f0np0 ---
+driver: mlx5_core
+version: 6.17.0-1014-nvidia
+firmware-version: 28.45.4028 (NVD0000000087)
+expansion-rom-version: 
+--- enp1s0f1np1 ---
+driver: mlx5_core
+version: 6.17.0-1014-nvidia
+firmware-version: 28.45.4028 (NVD0000000087)
+expansion-rom-version: 
+--- enP2p1s0f0np0 ---
+driver: mlx5_core
+version: 6.17.0-1014-nvidia
+firmware-version: 28.45.4028 (NVD0000000087)
+expansion-rom-version: 
+--- enP2p1s0f1np1 ---
+driver: mlx5_core
+version: 6.17.0-1014-nvidia
+firmware-version: 28.45.4028 (NVD0000000087)
+expansion-rom-version: 
+
+=== ip route ===
+default via 192.168.0.1 dev enP7s7 proto static 
+default via 10.0.0.1 dev wlP9s9 proto dhcp src 10.0.0.31 metric 600 
+10.0.0.0/24 dev wlP9s9 proto kernel scope link src 10.0.0.31 metric 600 
+10.10.10.0/24 dev enp1s0f0np0 proto kernel scope link src 10.10.10.1 
+10.10.11.0/24 dev enP2p1s0f1np1 proto kernel scope link src 10.10.11.1 
+10.42.0.0/24 via 10.42.0.0 dev flannel.1 onlink 
+10.42.1.0/24 dev cni0 proto kernel scope link src 10.42.1.1 
+10.42.2.0/24 via 10.42.2.0 dev flannel.1 onlink 
+10.42.3.0/24 via 10.42.3.0 dev flannel.1 onlink 
+10.101.2.0/30 dev enP2p1s0f0np0 proto kernel scope link src 10.101.2.1 
+172.17.0.0/16 dev docker0 proto kernel scope link src 172.17.0.1 
+172.18.0.0/16 dev docker_gwbridge proto kernel scope link src 172.18.0.1 
+192.168.0.0/24 dev enP7s7 proto kernel scope link src 192.168.0.104 
+
+=== sysctl network tuning ===
+net.core.rmem_max = 536870912
+net.core.wmem_max = 536870912
+net.ipv4.tcp_rmem = 4096	87380	268435456
+net.ipv4.tcp_wmem = 4096	65536	268435456
+net.core.netdev_max_backlog = 1000
+net.core.default_qdisc = fq_codel
+net.ipv4.tcp_congestion_control = bbr
+
+=== bonding (if any) ===
+(no bonding interfaces)

--- a/docs/operational/spark-network-baseline-2026-04-30/spark-105.txt
+++ b/docs/operational/spark-network-baseline-2026-04-30/spark-105.txt
@@ -1,0 +1,228 @@
+=== HOSTNAME ===
+spark-3
+Linux spark-3 6.17.0-1014-nvidia #14-Ubuntu SMP PREEMPT_DYNAMIC Tue Mar 17 19:01:40 UTC 2026 aarch64 aarch64 aarch64 GNU/Linux
+
+=== KERNEL ===
+Linux version 6.17.0-1014-nvidia (buildd@bos03-arm64-009) (aarch64-linux-gnu-gcc-13 (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0, GNU ld (GNU Binutils for Ubuntu) 2.42) #14-Ubuntu SMP PREEMPT_DYNAMIC Tue Mar 17 19:01:40 UTC 2026
+
+=== NETPLAN ===
+total 44
+drwxr-xr-x   2 root root  4096 Apr 25 16:26 .
+drwxr-xr-x 183 root root 12288 Apr 25 15:38 ..
+-rw-------   1 root root   251 Apr 25 16:26 01-netcfg.yaml
+-rw-------   1 root root   248 Apr 25 13:03 01-netcfg.yaml.bak.20260425_130333
+-rw-------   1 root root   251 Apr 25 14:46 01-netcfg.yaml.bak.20260425_144637
+-rw-------   1 root root   367 Apr 25 14:54 01-netcfg.yaml.bak.20260425_145426
+-rw-------   1 root root   441 Apr 25 16:26 01-netcfg.yaml.bak.20260425_162631
+-rw-------   1 root root   245 Apr 25 15:14 99-mellanox-roce.yaml
+-rw-r--r--   1 root root   101 Apr 25 14:46 99-mellanox-roce.yaml.bak.20260425_144637
+--- /etc/netplan/01-netcfg.yaml ---
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    enP7s7:
+      dhcp4: false
+      addresses:
+        - 192.168.0.105/24
+      routes:
+        - to: default
+          via: 192.168.0.1
+      nameservers:
+        addresses: [8.8.8.8, 1.1.1.1]
+--- /etc/netplan/99-mellanox-roce.yaml ---
+network:
+  version: 2
+  ethernets:
+    enp1s0f0np0:
+      addresses: [10.10.10.3/24]
+      mtu: 9000
+    enp1s0f1np1:
+      dhcp4: false
+      optional: true
+    enP2p1s0f1np1:
+      addresses: [10.10.11.3/24]
+      mtu: 9000
+      dhcp4: false
+
+=== ip addr ===
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+2: enP7s7: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
+    altname enP7p1s0
+    inet 192.168.0.105/24 brd 192.168.0.255 scope global enP7s7
+       valid_lft forever preferred_lft forever
+3: enp1s0f0np0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP group default qlen 1000
+    inet 10.10.10.3/24 brd 10.10.10.255 scope global enp1s0f0np0
+       valid_lft forever preferred_lft forever
+6: enP2p1s0f1np1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP group default qlen 1000
+    inet 10.10.11.3/24 brd 10.10.11.255 scope global enP2p1s0f1np1
+       valid_lft forever preferred_lft forever
+8: tailscale0: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1200 qdisc fq_codel state UNKNOWN group default qlen 500
+    inet 100.96.44.85/32 scope global tailscale0
+       valid_lft forever preferred_lft forever
+9: docker_gwbridge: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default 
+    inet 172.18.0.1/16 brd 172.18.255.255 scope global docker_gwbridge
+       valid_lft forever preferred_lft forever
+10: br-3b2b2d221c7e: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default 
+    inet 172.20.0.1/16 brd 172.20.255.255 scope global br-3b2b2d221c7e
+       valid_lft forever preferred_lft forever
+11: docker0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default 
+    inet 172.17.0.1/16 brd 172.17.255.255 scope global docker0
+       valid_lft forever preferred_lft forever
+12: br-84b5d6064b6c: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default 
+    inet 172.19.0.1/16 brd 172.19.255.255 scope global br-84b5d6064b6c
+       valid_lft forever preferred_lft forever
+15: flannel.1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UNKNOWN group default 
+    inet 10.42.2.0/32 scope global flannel.1
+       valid_lft forever preferred_lft forever
+28: cni0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default qlen 1000
+    inet 10.42.2.1/24 brd 10.42.2.255 scope global cni0
+       valid_lft forever preferred_lft forever
+
+=== ip link (with mtu) ===
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00 promiscuity 0  allmulti 0 minmtu 0 maxmtu 0 addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+2: enP7s7: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 4c:bb:47:80:2d:15 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 9194 addrgenmode eui64 numtxqueues 16 numrxqueues 16 gso_max_size 64000 gso_max_segs 64 tso_max_size 64000 tso_max_segs 64 gro_max_size 65536 parentbus pci parentdev 0007:01:00.0 
+    altname enP7p1s0
+3: enp1s0f0np0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 4c:bb:47:80:2d:16 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 9978 addrgenmode eui64 numtxqueues 424 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 portname p0 switchid 162d80000347bb4c parentbus pci parentdev 0000:01:00.0 
+4: enp1s0f1np1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 4c:bb:47:80:2d:17 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 9978 addrgenmode eui64 numtxqueues 424 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 portname p1 switchid 162d80000347bb4c parentbus pci parentdev 0000:01:00.1 
+5: enP2p1s0f0np0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 4c:bb:47:80:2d:1a brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 9978 addrgenmode eui64 numtxqueues 424 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 portname p0 switchid 162d80000347bb4c parentbus pci parentdev 0002:01:00.0 
+6: enP2p1s0f1np1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 4c:bb:47:80:2d:1b brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 9978 addrgenmode eui64 numtxqueues 424 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 portname p1 switchid 162d80000347bb4c parentbus pci parentdev 0002:01:00.1 
+7: wlP9s9: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN mode DORMANT group default qlen 1000
+    link/ether 50:2e:91:5b:49:ea brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 256 maxmtu 2304 addrgenmode none numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 parentbus pci parentdev 0009:01:00.0 
+    altname wlP9p1s0
+8: tailscale0: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1200 qdisc fq_codel state UNKNOWN mode DEFAULT group default qlen 500
+    link/none  promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    tun type tun pi off vnet_hdr on persist off numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 
+9: docker_gwbridge: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default 
+    link/ether ee:89:2e:4e:26:c1 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    bridge forward_delay 1500 hello_time 200 max_age 2000 ageing_time 30000 stp_state 0 priority 32768 vlan_filtering 0 vlan_protocol 802.1Q bridge_id 8000.ee:89:2e:4e:26:c1 designated_root 8000.ee:89:2e:4e:26:c1 root_port 0 root_path_cost 0 topology_change 0 topology_change_detected 0 hello_timer    0.00 tcn_timer    0.00 topology_change_timer    0.00 gc_timer   21.19 vlan_default_pvid 1 vlan_stats_enabled 0 vlan_stats_per_port 0 group_fwd_mask 0 group_address 01:80:c2:00:00:00 mcast_snooping 1 no_linklocal_learn 0 mcast_vlan_snooping 0 mcast_router 1 mcast_query_use_ifaddr 0 mcast_querier 0 mcast_hash_elasticity 16 mcast_hash_max 4096 mcast_last_member_count 2 mcast_startup_query_count 2 mcast_last_member_interval 100 mcast_membership_interval 26000 mcast_querier_interval 25500 mcast_query_interval 12500 mcast_query_response_interval 1000 mcast_startup_query_interval 3125 mcast_stats_enabled 0 mcast_igmp_version 2 mcast_mld_version 1 nf_call_iptables 0 nf_call_ip6tables 0 nf_call_arptables 0 addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+10: br-3b2b2d221c7e: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN mode DEFAULT group default 
+    link/ether 9a:b1:ad:b8:34:34 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    bridge forward_delay 1500 hello_time 200 max_age 2000 ageing_time 30000 stp_state 0 priority 32768 vlan_filtering 0 vlan_protocol 802.1Q bridge_id 8000.9a:b1:ad:b8:34:34 designated_root 8000.9a:b1:ad:b8:34:34 root_port 0 root_path_cost 0 topology_change 0 topology_change_detected 0 hello_timer    0.00 tcn_timer    0.00 topology_change_timer    0.00 gc_timer  152.26 vlan_default_pvid 1 vlan_stats_enabled 0 vlan_stats_per_port 0 group_fwd_mask 0 group_address 01:80:c2:00:00:00 mcast_snooping 1 no_linklocal_learn 0 mcast_vlan_snooping 0 mcast_router 1 mcast_query_use_ifaddr 0 mcast_querier 0 mcast_hash_elasticity 16 mcast_hash_max 4096 mcast_last_member_count 2 mcast_startup_query_count 2 mcast_last_member_interval 100 mcast_membership_interval 26000 mcast_querier_interval 25500 mcast_query_interval 12500 mcast_query_response_interval 1000 mcast_startup_query_interval 3125 mcast_stats_enabled 0 mcast_igmp_version 2 mcast_mld_version 1 nf_call_iptables 0 nf_call_ip6tables 0 nf_call_arptables 0 addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 
+11: docker0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default 
+    link/ether 36:a1:d1:d6:d4:52 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    bridge forward_delay 1500 hello_time 200 max_age 2000 ageing_time 30000 stp_state 0 priority 32768 vlan_filtering 0 vlan_protocol 802.1Q bridge_id 8000.36:a1:d1:d6:d4:52 designated_root 8000.36:a1:d1:d6:d4:52 root_port 0 root_path_cost 0 topology_change 0 topology_change_detected 0 hello_timer    0.00 tcn_timer    0.00 topology_change_timer    0.00 gc_timer  192.71 vlan_default_pvid 1 vlan_stats_enabled 0 vlan_stats_per_port 0 group_fwd_mask 0 group_address 01:80:c2:00:00:00 mcast_snooping 1 no_linklocal_learn 0 mcast_vlan_snooping 0 mcast_router 1 mcast_query_use_ifaddr 0 mcast_querier 0 mcast_hash_elasticity 16 mcast_hash_max 4096 mcast_last_member_count 2 mcast_startup_query_count 2 mcast_last_member_interval 100 mcast_membership_interval 26000 mcast_querier_interval 25500 mcast_query_interval 12500 mcast_query_response_interval 1000 mcast_startup_query_interval 3125 mcast_stats_enabled 0 mcast_igmp_version 2 mcast_mld_version 1 nf_call_iptables 0 nf_call_ip6tables 0 nf_call_arptables 0 addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+12: br-84b5d6064b6c: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN mode DEFAULT group default 
+    link/ether 9a:3c:16:18:0e:1b brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    bridge forward_delay 1500 hello_time 200 max_age 2000 ageing_time 30000 stp_state 0 priority 32768 vlan_filtering 0 vlan_protocol 802.1Q bridge_id 8000.9a:3c:16:18:e:1b designated_root 8000.9a:3c:16:18:e:1b root_port 0 root_path_cost 0 topology_change 0 topology_change_detected 0 hello_timer    0.00 tcn_timer    0.00 topology_change_timer    0.00 gc_timer  152.26 vlan_default_pvid 1 vlan_stats_enabled 0 vlan_stats_per_port 0 group_fwd_mask 0 group_address 01:80:c2:00:00:00 mcast_snooping 1 no_linklocal_learn 0 mcast_vlan_snooping 0 mcast_router 1 mcast_query_use_ifaddr 0 mcast_querier 0 mcast_hash_elasticity 16 mcast_hash_max 4096 mcast_last_member_count 2 mcast_startup_query_count 2 mcast_last_member_interval 100 mcast_membership_interval 26000 mcast_querier_interval 25500 mcast_query_interval 12500 mcast_query_response_interval 1000 mcast_startup_query_interval 3125 mcast_stats_enabled 0 mcast_igmp_version 2 mcast_mld_version 1 nf_call_iptables 0 nf_call_ip6tables 0 nf_call_arptables 0 addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 
+14: vethbdfaa76@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master docker0 state UP mode DEFAULT group default 
+    link/ether b2:7d:d2:d5:bd:1a brd ff:ff:ff:ff:ff:ff link-netnsid 1 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin off guard off root_block off fastleave off learning on flood on port_id 0x8002 port_no 0x2 designated_port 32770 designated_cost 0 designated_bridge 8000.36:a1:d1:d6:d4:52 designated_root 8000.36:a1:d1:d6:d4:52 hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+15: flannel.1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UNKNOWN mode DEFAULT group default 
+    link/ether 8a:96:fd:bd:78:d1 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    vxlan id 1 fan-map 0.7.0.55/46335:32.100.64.57/63796 225.3.19.170/38911:248.3.0.170/64868 local 192.168.0.105 dev enP7s7 srcport 0 0 dstport 8472 nolearning ttl auto ageing 300 udpcsum noudp6zerocsumtx noudp6zerocsumrx addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 64000 gso_max_segs 64 tso_max_size 64000 tso_max_segs 64 gro_max_size 65536 
+27: veth7e3a0a0@if26: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master docker_gwbridge state UP mode DEFAULT group default 
+    link/ether 6a:60:d3:91:44:4b brd ff:ff:ff:ff:ff:ff link-netnsid 6 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin off guard off root_block off fastleave off learning on flood on port_id 0x8002 port_no 0x2 designated_port 32770 designated_cost 0 designated_bridge 8000.ee:89:2e:4e:26:c1 designated_root 8000.ee:89:2e:4e:26:c1 hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+28: cni0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP mode DEFAULT group default qlen 1000
+    link/ether e2:e0:73:0e:26:cb brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    bridge forward_delay 1500 hello_time 200 max_age 2000 ageing_time 30000 stp_state 0 priority 32768 vlan_filtering 0 vlan_protocol 802.1Q bridge_id 8000.e2:e0:73:e:26:cb designated_root 8000.e2:e0:73:e:26:cb root_port 0 root_path_cost 0 topology_change 0 topology_change_detected 0 hello_timer    0.00 tcn_timer    0.00 topology_change_timer    0.00 gc_timer  248.81 vlan_default_pvid 1 vlan_stats_enabled 0 vlan_stats_per_port 0 group_fwd_mask 0 group_address 01:80:c2:00:00:00 mcast_snooping 1 no_linklocal_learn 0 mcast_vlan_snooping 0 mcast_router 1 mcast_query_use_ifaddr 0 mcast_querier 0 mcast_hash_elasticity 16 mcast_hash_max 4096 mcast_last_member_count 2 mcast_startup_query_count 2 mcast_last_member_interval 100 mcast_membership_interval 26000 mcast_querier_interval 25500 mcast_query_interval 12500 mcast_query_response_interval 1000 mcast_startup_query_interval 3125 mcast_stats_enabled 0 mcast_igmp_version 2 mcast_mld_version 1 nf_call_iptables 0 nf_call_ip6tables 0 nf_call_arptables 0 addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+29: veth09a515f3@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether 6a:7b:b8:dd:05:b8 brd ff:ff:ff:ff:ff:ff link-netns cni-ab8c3e5d-aeef-5067-51fa-22c2149d53ea promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8001 port_no 0x1 designated_port 32769 designated_cost 0 designated_bridge 8000.e2:e0:73:e:26:cb designated_root 8000.e2:e0:73:e:26:cb hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+30: veth308f115b@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether 32:e5:0e:ce:a4:c2 brd ff:ff:ff:ff:ff:ff link-netns cni-8c0417c2-5395-fe68-7590-2c959488ff99 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8002 port_no 0x2 designated_port 32770 designated_cost 0 designated_bridge 8000.e2:e0:73:e:26:cb designated_root 8000.e2:e0:73:e:26:cb hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+31: veth793e196b@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether a2:ef:05:53:0f:e2 brd ff:ff:ff:ff:ff:ff link-netns cni-efa5a668-623b-cf43-dd11-f8cdcfd4f0cc promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8003 port_no 0x3 designated_port 32771 designated_cost 0 designated_bridge 8000.e2:e0:73:e:26:cb designated_root 8000.e2:e0:73:e:26:cb hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+32: veth80ad0a05@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether 3a:a7:ee:ed:72:7e brd ff:ff:ff:ff:ff:ff link-netns cni-5d3c51bd-de7d-2e75-d553-50487ba38d67 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8004 port_no 0x4 designated_port 32772 designated_cost 0 designated_bridge 8000.e2:e0:73:e:26:cb designated_root 8000.e2:e0:73:e:26:cb hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+33: vethfed8f079@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether f6:73:5a:be:4c:dd brd ff:ff:ff:ff:ff:ff link-netns cni-121b467b-cec0-133d-eaf5-24850e3b26ee promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8005 port_no 0x5 designated_port 32773 designated_cost 0 designated_bridge 8000.e2:e0:73:e:26:cb designated_root 8000.e2:e0:73:e:26:cb hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+34: vetha7a82202@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether 22:0b:e4:be:50:35 brd ff:ff:ff:ff:ff:ff link-netns cni-2b416bd4-924c-e58d-ef17-badf13121250 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8006 port_no 0x6 designated_port 32774 designated_cost 0 designated_bridge 8000.e2:e0:73:e:26:cb designated_root 8000.e2:e0:73:e:26:cb hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+205: vethe41b0c2@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master docker0 state UP mode DEFAULT group default 
+    link/ether c2:98:3e:c2:53:05 brd ff:ff:ff:ff:ff:ff link-netnsid 13 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin off guard off root_block off fastleave off learning on flood on port_id 0x8003 port_no 0x3 designated_port 32771 designated_cost 0 designated_bridge 8000.36:a1:d1:d6:d4:52 designated_root 8000.36:a1:d1:d6:d4:52 hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+350: veth2c7fa0b7@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether c2:9b:ad:bd:06:ac brd ff:ff:ff:ff:ff:ff link-netns cni-9bed2cdf-d890-f836-36f7-a72b9d0a0c39 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8007 port_no 0x7 designated_port 32775 designated_cost 0 designated_bridge 8000.e2:e0:73:e:26:cb designated_root 8000.e2:e0:73:e:26:cb hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+351: veth17fe4dab@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether 3e:4b:6a:ca:b3:49 brd ff:ff:ff:ff:ff:ff link-netns cni-992ce7eb-4b88-b664-0f25-39ec54225c90 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+
+=== ConnectX hardware (lspci) ===
+0000:01:00.0 Ethernet controller [0200]: Mellanox Technologies MT2910 Family [ConnectX-7] [15b3:1021]
+0000:01:00.1 Ethernet controller [0200]: Mellanox Technologies MT2910 Family [ConnectX-7] [15b3:1021]
+0002:01:00.0 Ethernet controller [0200]: Mellanox Technologies MT2910 Family [ConnectX-7] [15b3:1021]
+0002:01:00.1 Ethernet controller [0200]: Mellanox Technologies MT2910 Family [ConnectX-7] [15b3:1021]
+
+=== mlx kernel modules ===
+mlx5_fwctl             16384  0
+mlx5_ib               520192  0
+mlx5_core            2756608  2 mlx5_fwctl,mlx5_ib
+mlxfw                  32768  1 mlx5_core
+
+=== mlx5_core modinfo ===
+filename:       /lib/modules/6.17.0-1014-nvidia/kernel/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.ko.zst
+srcversion:     89EEAF32656D79A2DACFFD3
+
+=== Firmware per ConnectX device ===
+--- enp1s0f0np0 ---
+driver: mlx5_core
+version: 6.17.0-1014-nvidia
+firmware-version: 28.45.4028 (NVD0000000087)
+expansion-rom-version: 
+--- enp1s0f1np1 ---
+driver: mlx5_core
+version: 6.17.0-1014-nvidia
+firmware-version: 28.45.4028 (NVD0000000087)
+expansion-rom-version: 
+--- enP2p1s0f0np0 ---
+driver: mlx5_core
+version: 6.17.0-1014-nvidia
+firmware-version: 28.45.4028 (NVD0000000087)
+expansion-rom-version: 
+--- enP2p1s0f1np1 ---
+driver: mlx5_core
+version: 6.17.0-1014-nvidia
+firmware-version: 28.45.4028 (NVD0000000087)
+expansion-rom-version: 
+
+=== ip route ===
+default via 192.168.0.1 dev enP7s7 proto static 
+10.10.10.0/24 dev enp1s0f0np0 proto kernel scope link src 10.10.10.3 
+10.10.11.0/24 dev enP2p1s0f1np1 proto kernel scope link src 10.10.11.3 
+10.42.0.0/24 via 10.42.0.0 dev flannel.1 onlink 
+10.42.1.0/24 via 10.42.1.0 dev flannel.1 onlink 
+10.42.2.0/24 dev cni0 proto kernel scope link src 10.42.2.1 
+10.42.3.0/24 via 10.42.3.0 dev flannel.1 onlink 
+172.17.0.0/16 dev docker0 proto kernel scope link src 172.17.0.1 
+172.18.0.0/16 dev docker_gwbridge proto kernel scope link src 172.18.0.1 
+172.19.0.0/16 dev br-84b5d6064b6c proto kernel scope link src 172.19.0.1 linkdown 
+172.20.0.0/16 dev br-3b2b2d221c7e proto kernel scope link src 172.20.0.1 linkdown 
+192.168.0.0/24 dev enP7s7 proto kernel scope link src 192.168.0.105 
+
+=== sysctl network tuning ===
+net.core.rmem_max = 212992
+net.core.wmem_max = 212992
+net.ipv4.tcp_rmem = 4096	131072	33554432
+net.ipv4.tcp_wmem = 4096	16384	4194304
+net.core.netdev_max_backlog = 1000
+net.core.default_qdisc = fq_codel
+net.ipv4.tcp_congestion_control = cubic
+
+=== bonding (if any) ===
+(no bonding interfaces)

--- a/docs/operational/spark-network-baseline-2026-04-30/spark-106.txt
+++ b/docs/operational/spark-network-baseline-2026-04-30/spark-106.txt
@@ -1,0 +1,217 @@
+=== HOSTNAME ===
+Spark-4
+Linux Spark-4 6.17.0-1014-nvidia #14-Ubuntu SMP PREEMPT_DYNAMIC Tue Mar 17 19:01:40 UTC 2026 aarch64 aarch64 aarch64 GNU/Linux
+
+=== KERNEL ===
+Linux version 6.17.0-1014-nvidia (buildd@bos03-arm64-009) (aarch64-linux-gnu-gcc-13 (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0, GNU ld (GNU Binutils for Ubuntu) 2.42) #14-Ubuntu SMP PREEMPT_DYNAMIC Tue Mar 17 19:01:40 UTC 2026
+
+=== NETPLAN ===
+total 48
+drwxr-xr-x   2 root root  4096 Apr 25 16:27 .
+drwxr-xr-x 181 root root 12288 Apr 25 16:08 ..
+-rw-------   1 root root   251 Apr 25 16:27 01-sovereign-core.yaml
+-rw-------   1 root root   251 Apr 25 14:51 01-sovereign-core.yaml.bak.20260425_145129
+-rw-------   1 root root   367 Apr 25 14:54 01-sovereign-core.yaml.bak.20260425_145431
+-rw-------   1 root root   441 Apr 25 16:27 01-sovereign-core.yaml.bak.20260425_162717
+-rw-------   1 root root   245 Apr 25 15:15 99-mellanox-roce.yaml
+-rw-------   1 root root   167 Apr 25 13:10 99-mellanox-roce.yaml.bak.20260425_131046
+-rw-------   1 root root   233 Apr 25 14:51 99-mellanox-roce.yaml.bak.20260425_145129
+-rw-------   1 root root   167 Apr 23 19:23 99-mellanox-roce.yaml.phase1-bak-20260423_192350
+--- /etc/netplan/01-sovereign-core.yaml ---
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    enP7s7:
+      dhcp4: false
+      addresses:
+        - 192.168.0.106/24
+      routes:
+        - to: default
+          via: 192.168.0.1
+      nameservers:
+        addresses: [8.8.8.8, 1.1.1.1]
+--- /etc/netplan/99-mellanox-roce.yaml ---
+network:
+  version: 2
+  ethernets:
+    enp1s0f0np0:
+      addresses: [10.10.10.4/24]
+      mtu: 9000
+    enp1s0f1np1:
+      dhcp4: false
+      optional: true
+    enP2p1s0f1np1:
+      addresses: [10.10.11.4/24]
+      mtu: 9000
+      dhcp4: false
+
+=== ip addr ===
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+2: enP7s7: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
+    altname enP7p1s0
+    inet 192.168.0.106/24 brd 192.168.0.255 scope global enP7s7
+       valid_lft forever preferred_lft forever
+3: enp1s0f0np0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP group default qlen 1000
+    inet 10.10.10.4/24 brd 10.10.10.255 scope global enp1s0f0np0
+       valid_lft forever preferred_lft forever
+6: enP2p1s0f1np1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP group default qlen 1000
+    inet 10.10.11.4/24 brd 10.10.11.255 scope global enP2p1s0f1np1
+       valid_lft forever preferred_lft forever
+8: tailscale0: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1280 qdisc fq_codel state UNKNOWN group default qlen 500
+    inet 100.125.35.42/32 scope global tailscale0
+       valid_lft forever preferred_lft forever
+9: docker0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default 
+    inet 172.17.0.1/16 brd 172.17.255.255 scope global docker0
+       valid_lft forever preferred_lft forever
+11: flannel.1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UNKNOWN group default 
+    inet 10.42.3.0/32 scope global flannel.1
+       valid_lft forever preferred_lft forever
+13: cni0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default qlen 1000
+    inet 10.42.3.1/24 brd 10.42.3.255 scope global cni0
+       valid_lft forever preferred_lft forever
+
+=== ip link (with mtu) ===
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00 promiscuity 0  allmulti 0 minmtu 0 maxmtu 0 addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+2: enP7s7: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 4c:bb:47:2b:e3:20 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 9194 addrgenmode eui64 numtxqueues 16 numrxqueues 16 gso_max_size 64000 gso_max_segs 64 tso_max_size 64000 tso_max_segs 64 gro_max_size 65536 parentbus pci parentdev 0007:01:00.0 
+    altname enP7p1s0
+3: enp1s0f0np0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 4c:bb:47:2b:e3:21 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 9978 addrgenmode eui64 numtxqueues 424 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 portname p0 switchid 21e32b000347bb4c parentbus pci parentdev 0000:01:00.0 
+4: enp1s0f1np1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 4c:bb:47:2b:e3:22 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 9978 addrgenmode eui64 numtxqueues 424 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 portname p1 switchid 21e32b000347bb4c parentbus pci parentdev 0000:01:00.1 
+5: enP2p1s0f0np0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 4c:bb:47:2b:e3:25 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 9978 addrgenmode eui64 numtxqueues 424 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 portname p0 switchid 21e32b000347bb4c parentbus pci parentdev 0002:01:00.0 
+6: enP2p1s0f1np1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 4c:bb:47:2b:e3:26 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 9978 addrgenmode eui64 numtxqueues 424 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 portname p1 switchid 21e32b000347bb4c parentbus pci parentdev 0002:01:00.1 
+7: wlP9s9: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN mode DORMANT group default qlen 1000
+    link/ether f8:3d:c6:f1:25:78 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 256 maxmtu 2304 addrgenmode none numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 parentbus pci parentdev 0009:01:00.0 
+    altname wlP9p1s0
+8: tailscale0: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1280 qdisc fq_codel state UNKNOWN mode DEFAULT group default qlen 500
+    link/none  promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    tun type tun pi off vnet_hdr on persist off addrgenmode random numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 
+9: docker0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default 
+    link/ether 26:f9:27:a2:9c:d5 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    bridge forward_delay 1500 hello_time 200 max_age 2000 ageing_time 30000 stp_state 0 priority 32768 vlan_filtering 0 vlan_protocol 802.1Q bridge_id 8000.26:f9:27:a2:9c:d5 designated_root 8000.26:f9:27:a2:9c:d5 root_port 0 root_path_cost 0 topology_change 0 topology_change_detected 0 hello_timer    0.00 tcn_timer    0.00 topology_change_timer    0.00 gc_timer  240.35 vlan_default_pvid 1 vlan_stats_enabled 0 vlan_stats_per_port 0 group_fwd_mask 0 group_address 01:80:c2:00:00:00 mcast_snooping 1 no_linklocal_learn 0 mcast_vlan_snooping 0 mcast_router 1 mcast_query_use_ifaddr 0 mcast_querier 0 mcast_hash_elasticity 16 mcast_hash_max 4096 mcast_last_member_count 2 mcast_startup_query_count 2 mcast_last_member_interval 100 mcast_membership_interval 26000 mcast_querier_interval 25500 mcast_query_interval 12500 mcast_query_response_interval 1000 mcast_startup_query_interval 3125 mcast_stats_enabled 0 mcast_igmp_version 2 mcast_mld_version 1 nf_call_iptables 0 nf_call_ip6tables 0 nf_call_arptables 0 addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+10: vethb30bb9d@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master docker0 state UP mode DEFAULT group default 
+    link/ether 76:28:e4:27:96:86 brd ff:ff:ff:ff:ff:ff link-netnsid 0 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin off guard off root_block off fastleave off learning on flood on port_id 0x8001 port_no 0x1 designated_port 32769 designated_cost 0 designated_bridge 8000.26:f9:27:a2:9c:d5 designated_root 8000.26:f9:27:a2:9c:d5 hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+11: flannel.1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UNKNOWN mode DEFAULT group default 
+    link/ether 16:4a:80:7d:a7:32 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    vxlan id 1 fan-map 0.7.0.55/46335:32.100.64.57/63796 225.3.19.170/38911:248.3.0.170/64868 local 192.168.0.106 dev enP7s7 srcport 0 0 dstport 8472 nolearning ttl auto ageing 300 udpcsum noudp6zerocsumtx noudp6zerocsumrx addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 64000 gso_max_segs 64 tso_max_size 64000 tso_max_segs 64 gro_max_size 65536 
+12: veth968efd0@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master docker0 state UP mode DEFAULT group default 
+    link/ether 36:c8:7d:33:5a:45 brd ff:ff:ff:ff:ff:ff link-netnsid 1 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin off guard off root_block off fastleave off learning on flood on port_id 0x8002 port_no 0x2 designated_port 32770 designated_cost 0 designated_bridge 8000.26:f9:27:a2:9c:d5 designated_root 8000.26:f9:27:a2:9c:d5 hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+13: cni0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP mode DEFAULT group default qlen 1000
+    link/ether 72:e2:f5:04:9f:3e brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    bridge forward_delay 1500 hello_time 200 max_age 2000 ageing_time 30000 stp_state 0 priority 32768 vlan_filtering 0 vlan_protocol 802.1Q bridge_id 8000.72:e2:f5:4:9f:3e designated_root 8000.72:e2:f5:4:9f:3e root_port 0 root_path_cost 0 topology_change 0 topology_change_detected 0 hello_timer    0.00 tcn_timer    0.00 topology_change_timer    0.00 gc_timer  172.04 vlan_default_pvid 1 vlan_stats_enabled 0 vlan_stats_per_port 0 group_fwd_mask 0 group_address 01:80:c2:00:00:00 mcast_snooping 1 no_linklocal_learn 0 mcast_vlan_snooping 0 mcast_router 1 mcast_query_use_ifaddr 0 mcast_querier 0 mcast_hash_elasticity 16 mcast_hash_max 4096 mcast_last_member_count 2 mcast_startup_query_count 2 mcast_last_member_interval 100 mcast_membership_interval 26000 mcast_querier_interval 25500 mcast_query_interval 12500 mcast_query_response_interval 1000 mcast_startup_query_interval 3125 mcast_stats_enabled 0 mcast_igmp_version 2 mcast_mld_version 1 nf_call_iptables 0 nf_call_ip6tables 0 nf_call_arptables 0 addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+14: vethce53b3ea@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether 52:20:64:7c:83:21 brd ff:ff:ff:ff:ff:ff link-netns cni-6c7496a8-9ab2-228c-b3bd-c1b4b1112d7b promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8001 port_no 0x1 designated_port 32769 designated_cost 0 designated_bridge 8000.72:e2:f5:4:9f:3e designated_root 8000.72:e2:f5:4:9f:3e hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+15: veth1918cb43@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether d2:09:3d:4f:f2:93 brd ff:ff:ff:ff:ff:ff link-netns cni-13283099-cbcd-d58b-0e9d-2670d7304b34 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8002 port_no 0x2 designated_port 32770 designated_cost 0 designated_bridge 8000.72:e2:f5:4:9f:3e designated_root 8000.72:e2:f5:4:9f:3e hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+16: vethb0f4b5ee@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether 1e:94:07:9b:8b:ba brd ff:ff:ff:ff:ff:ff link-netns cni-f20822fe-1fbf-b232-256e-c7576712a74e promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8003 port_no 0x3 designated_port 32771 designated_cost 0 designated_bridge 8000.72:e2:f5:4:9f:3e designated_root 8000.72:e2:f5:4:9f:3e hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+17: veth21a76d47@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether f6:55:42:46:77:64 brd ff:ff:ff:ff:ff:ff link-netns cni-435d75d9-6092-5ded-84e2-9c242bfc88d7 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8004 port_no 0x4 designated_port 32772 designated_cost 0 designated_bridge 8000.72:e2:f5:4:9f:3e designated_root 8000.72:e2:f5:4:9f:3e hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+18: veth7d631150@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether 56:31:66:e9:3a:c0 brd ff:ff:ff:ff:ff:ff link-netns cni-78f28ba9-c84c-1795-a918-206d9b3b3413 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8005 port_no 0x5 designated_port 32773 designated_cost 0 designated_bridge 8000.72:e2:f5:4:9f:3e designated_root 8000.72:e2:f5:4:9f:3e hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+19: veth53f2f87d@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether 0a:52:c3:44:d6:76 brd ff:ff:ff:ff:ff:ff link-netns cni-e08ffdac-b205-a41b-c6a7-8fa55d1ce5a9 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8006 port_no 0x6 designated_port 32774 designated_cost 0 designated_bridge 8000.72:e2:f5:4:9f:3e designated_root 8000.72:e2:f5:4:9f:3e hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+20: veth7fe40737@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether 2e:f2:a7:18:1c:9c brd ff:ff:ff:ff:ff:ff link-netns cni-c29733c4-f29c-270e-5b91-52c71eee0f77 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8007 port_no 0x7 designated_port 32775 designated_cost 0 designated_bridge 8000.72:e2:f5:4:9f:3e designated_root 8000.72:e2:f5:4:9f:3e hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+21: veth8d71bf0d@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether a2:81:b7:ec:62:a6 brd ff:ff:ff:ff:ff:ff link-netns cni-bcc74290-3373-dc33-9c75-8672e83cc8fc promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8008 port_no 0x8 designated_port 32776 designated_cost 0 designated_bridge 8000.72:e2:f5:4:9f:3e designated_root 8000.72:e2:f5:4:9f:3e hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+22: vethf72edb12@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether 86:b3:24:d2:01:d3 brd ff:ff:ff:ff:ff:ff link-netns cni-3318497e-2871-e16f-4463-4fe2acf3f747 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8009 port_no 0x9 designated_port 32777 designated_cost 0 designated_bridge 8000.72:e2:f5:4:9f:3e designated_root 8000.72:e2:f5:4:9f:3e hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+23: veth6b092f9c@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether 1a:21:f6:dd:eb:f9 brd ff:ff:ff:ff:ff:ff link-netns cni-5283781f-f58d-6ea6-7ca4-5cb16f85138f promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x800a port_no 0xa designated_port 32778 designated_cost 0 designated_bridge 8000.72:e2:f5:4:9f:3e designated_root 8000.72:e2:f5:4:9f:3e hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+25: veth202e9937@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master cni0 state UP mode DEFAULT group default 
+    link/ether c2:c7:ac:ce:68:f9 brd ff:ff:ff:ff:ff:ff link-netns cni-632a7f57-cfe4-be8e-88e5-26b7ed0eeca9 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x800b port_no 0xb designated_port 32779 designated_cost 0 designated_bridge 8000.72:e2:f5:4:9f:3e designated_root 8000.72:e2:f5:4:9f:3e hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+
+=== ConnectX hardware (lspci) ===
+0000:01:00.0 Ethernet controller [0200]: Mellanox Technologies MT2910 Family [ConnectX-7] [15b3:1021]
+0000:01:00.1 Ethernet controller [0200]: Mellanox Technologies MT2910 Family [ConnectX-7] [15b3:1021]
+0002:01:00.0 Ethernet controller [0200]: Mellanox Technologies MT2910 Family [ConnectX-7] [15b3:1021]
+0002:01:00.1 Ethernet controller [0200]: Mellanox Technologies MT2910 Family [ConnectX-7] [15b3:1021]
+
+=== mlx kernel modules ===
+mlx5_fwctl             16384  0
+mlx5_ib               520192  0
+mlx5_core            2756608  2 mlx5_fwctl,mlx5_ib
+mlxfw                  32768  1 mlx5_core
+
+=== mlx5_core modinfo ===
+filename:       /lib/modules/6.17.0-1014-nvidia/kernel/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.ko.zst
+srcversion:     89EEAF32656D79A2DACFFD3
+
+=== Firmware per ConnectX device ===
+--- enp1s0f0np0 ---
+driver: mlx5_core
+version: 6.17.0-1014-nvidia
+firmware-version: 28.45.4028 (NVD0000000087)
+expansion-rom-version: 
+--- enp1s0f1np1 ---
+driver: mlx5_core
+version: 6.17.0-1014-nvidia
+firmware-version: 28.45.4028 (NVD0000000087)
+expansion-rom-version: 
+--- enP2p1s0f0np0 ---
+driver: mlx5_core
+version: 6.17.0-1014-nvidia
+firmware-version: 28.45.4028 (NVD0000000087)
+expansion-rom-version: 
+--- enP2p1s0f1np1 ---
+driver: mlx5_core
+version: 6.17.0-1014-nvidia
+firmware-version: 28.45.4028 (NVD0000000087)
+expansion-rom-version: 
+
+=== ip route ===
+default via 192.168.0.1 dev enP7s7 proto static 
+10.10.10.0/24 dev enp1s0f0np0 proto kernel scope link src 10.10.10.4 
+10.10.11.0/24 dev enP2p1s0f1np1 proto kernel scope link src 10.10.11.4 
+10.42.0.0/24 via 10.42.0.0 dev flannel.1 onlink 
+10.42.1.0/24 via 10.42.1.0 dev flannel.1 onlink 
+10.42.2.0/24 via 10.42.2.0 dev flannel.1 onlink 
+10.42.3.0/24 dev cni0 proto kernel scope link src 10.42.3.1 
+172.17.0.0/16 dev docker0 proto kernel scope link src 172.17.0.1 
+192.168.0.0/24 dev enP7s7 proto kernel scope link src 192.168.0.106 
+
+=== sysctl network tuning ===
+net.core.rmem_max = 536870912
+net.core.wmem_max = 536870912
+net.ipv4.tcp_rmem = 4096	87380	268435456
+net.ipv4.tcp_wmem = 4096	65536	268435456
+net.core.netdev_max_backlog = 1000
+net.core.default_qdisc = fq_codel
+net.ipv4.tcp_congestion_control = bbr
+
+=== bonding (if any) ===
+(no bonding interfaces)

--- a/docs/operational/spark-network-baseline-2026-04-30/spark-109.txt
+++ b/docs/operational/spark-network-baseline-2026-04-30/spark-109.txt
@@ -1,0 +1,105 @@
+=== HOSTNAME ===
+spark-5
+Linux spark-5 6.17.0-1014-nvidia #14-Ubuntu SMP PREEMPT_DYNAMIC Tue Mar 17 19:01:40 UTC 2026 aarch64 aarch64 aarch64 GNU/Linux
+
+=== KERNEL ===
+Linux version 6.17.0-1014-nvidia (buildd@bos03-arm64-009) (aarch64-linux-gnu-gcc-13 (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0, GNU ld (GNU Binutils for Ubuntu) 2.42) #14-Ubuntu SMP PREEMPT_DYNAMIC Tue Mar 17 19:01:40 UTC 2026
+
+=== NETPLAN ===
+sudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper
+sudo: a password is required
+--- /etc/netplan/00-installer-config.yaml ---
+--- /etc/netplan/01-mgmt.yaml ---
+--- /etc/netplan/60-connectx-fabric.yaml ---
+--- /etc/netplan/90-NM-bb4136bd-af53-413c-a3a5-8a7c5c0ddff3.yaml ---
+
+=== ip addr ===
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+2: enP7s7: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
+    altname enP7p1s0
+    inet 192.168.0.109/24 brd 192.168.0.255 scope global enP7s7
+       valid_lft forever preferred_lft forever
+8: tailscale0: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1280 qdisc fq_codel state UNKNOWN group default qlen 500
+    inet 100.96.13.99/32 scope global tailscale0
+       valid_lft forever preferred_lft forever
+9: docker0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default 
+    inet 172.17.0.1/16 brd 172.17.255.255 scope global docker0
+       valid_lft forever preferred_lft forever
+15: enp1s0f1np1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP group default qlen 1000
+    inet 10.10.10.5/24 brd 10.10.10.255 scope global enp1s0f1np1
+       valid_lft forever preferred_lft forever
+17: enP2p1s0f1np1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
+    inet 192.168.0.111/24 brd 192.168.0.255 scope global dynamic noprefixroute enP2p1s0f1np1
+       valid_lft 6560sec preferred_lft 6560sec
+
+=== ip link (with mtu) ===
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00 promiscuity 0  allmulti 0 minmtu 0 maxmtu 0 addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+2: enP7s7: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 4c:bb:47:2c:06:90 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 9194 addrgenmode eui64 numtxqueues 16 numrxqueues 16 gso_max_size 64000 gso_max_segs 64 tso_max_size 64000 tso_max_segs 64 gro_max_size 65536 parentbus pci parentdev 0007:01:00.0 
+    altname enP7p1s0
+7: wlP9s9: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN mode DORMANT group default qlen 1000
+    link/ether f8:3d:c6:b7:1e:4e brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 256 maxmtu 2304 addrgenmode none numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 parentbus pci parentdev 0009:01:00.0 
+    altname wlP9p1s0
+8: tailscale0: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1280 qdisc fq_codel state UNKNOWN mode DEFAULT group default qlen 500
+    link/none  promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    tun type tun pi off vnet_hdr on persist off addrgenmode random numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 
+9: docker0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default 
+    link/ether 1e:6d:3d:ed:ea:dd brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    bridge forward_delay 1500 hello_time 200 max_age 2000 ageing_time 30000 stp_state 0 priority 32768 vlan_filtering 0 vlan_protocol 802.1Q bridge_id 8000.1e:6d:3d:ed:ea:dd designated_root 8000.1e:6d:3d:ed:ea:dd root_port 0 root_path_cost 0 topology_change 0 topology_change_detected 0 hello_timer    0.00 tcn_timer    0.00 topology_change_timer    0.00 gc_timer  100.28 vlan_default_pvid 1 vlan_stats_enabled 0 vlan_stats_per_port 0 group_fwd_mask 0 group_address 01:80:c2:00:00:00 mcast_snooping 1 no_linklocal_learn 0 mcast_vlan_snooping 0 mcast_router 1 mcast_query_use_ifaddr 0 mcast_querier 0 mcast_hash_elasticity 16 mcast_hash_max 4096 mcast_last_member_count 2 mcast_startup_query_count 2 mcast_last_member_interval 100 mcast_membership_interval 26000 mcast_querier_interval 25500 mcast_query_interval 12500 mcast_query_response_interval 1000 mcast_startup_query_interval 3125 mcast_stats_enabled 0 mcast_igmp_version 2 mcast_mld_version 1 nf_call_iptables 0 nf_call_ip6tables 0 nf_call_arptables 0 addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+14: enp1s0f0np0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc mq state DOWN mode DEFAULT group default qlen 1000
+    link/ether 4c:bb:47:2c:06:91 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 9978 addrgenmode none numtxqueues 424 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 portname p0 switchid 91062c000347bb4c parentbus pci parentdev 0000:01:00.0 
+15: enp1s0f1np1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 4c:bb:47:2c:06:92 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 9978 addrgenmode eui64 numtxqueues 424 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 portname p1 switchid 91062c000347bb4c parentbus pci parentdev 0000:01:00.1 
+16: enP2p1s0f0np0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc mq state DOWN mode DEFAULT group default qlen 1000
+    link/ether 4c:bb:47:2c:06:95 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 9978 addrgenmode none numtxqueues 424 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 portname p0 switchid 91062c000347bb4c parentbus pci parentdev 0002:01:00.0 
+17: enP2p1s0f1np1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 4c:bb:47:2c:06:96 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 9978 addrgenmode none numtxqueues 424 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 portname p1 switchid 91062c000347bb4c parentbus pci parentdev 0002:01:00.1 
+82: vethfedc716@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master docker0 state UP mode DEFAULT group default 
+    link/ether aa:3a:2a:9e:ac:a2 brd ff:ff:ff:ff:ff:ff link-netnsid 0 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535 
+    veth 
+    bridge_slave state forwarding priority 32 cost 2 hairpin off guard off root_block off fastleave off learning on flood on port_id 0x8001 port_no 0x1 designated_port 32769 designated_cost 0 designated_bridge 8000.1e:6d:3d:ed:ea:dd designated_root 8000.1e:6d:3d:ed:ea:dd hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off addrgenmode eui64 numtxqueues 20 numrxqueues 20 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+
+=== ConnectX hardware (lspci) ===
+0000:01:00.0 Ethernet controller [0200]: Mellanox Technologies MT2910 Family [ConnectX-7] [15b3:1021]
+0000:01:00.1 Ethernet controller [0200]: Mellanox Technologies MT2910 Family [ConnectX-7] [15b3:1021]
+0002:01:00.0 Ethernet controller [0200]: Mellanox Technologies MT2910 Family [ConnectX-7] [15b3:1021]
+0002:01:00.1 Ethernet controller [0200]: Mellanox Technologies MT2910 Family [ConnectX-7] [15b3:1021]
+
+=== mlx kernel modules ===
+mlx5_fwctl             16384  0
+mlx5_ib               520192  0
+mlx5_core            2756608  2 mlx5_fwctl,mlx5_ib
+mlxfw                  32768  1 mlx5_core
+
+=== mlx5_core modinfo ===
+filename:       /lib/modules/6.17.0-1014-nvidia/kernel/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.ko.zst
+srcversion:     89EEAF32656D79A2DACFFD3
+
+=== Firmware per ConnectX device ===
+--- enp1s0f0np0 ---
+--- enp1s0f1np1 ---
+--- enP2p1s0f0np0 ---
+--- enP2p1s0f1np1 ---
+
+=== ip route ===
+default via 192.168.0.1 dev enP7s7 proto static 
+default via 192.168.0.1 dev enP2p1s0f1np1 proto dhcp src 192.168.0.111 metric 100 
+10.10.10.0/24 dev enp1s0f1np1 proto kernel scope link src 10.10.10.5 
+172.17.0.0/16 dev docker0 proto kernel scope link src 172.17.0.1 
+192.168.0.0/24 dev enP7s7 proto kernel scope link src 192.168.0.109 
+192.168.0.0/24 dev enP2p1s0f1np1 proto kernel scope link src 192.168.0.111 metric 100 
+
+=== sysctl network tuning ===
+net.core.rmem_max = 212992
+net.core.wmem_max = 212992
+net.ipv4.tcp_rmem = 4096	131072	33554432
+net.ipv4.tcp_wmem = 4096	16384	4194304
+net.core.netdev_max_backlog = 1000
+net.core.default_qdisc = fq_codel
+net.ipv4.tcp_congestion_control = cubic
+
+=== bonding (if any) ===
+(no bonding interfaces)

--- a/docs/operational/spark-network-baseline-2026-04-30/spark-115.txt
+++ b/docs/operational/spark-network-baseline-2026-04-30/spark-115.txt
@@ -1,0 +1,74 @@
+=== HOSTNAME ===
+spark-6
+Linux spark-6 6.17.0-1014-nvidia #14-Ubuntu SMP PREEMPT_DYNAMIC Tue Mar 17 19:01:40 UTC 2026 aarch64 aarch64 aarch64 GNU/Linux
+
+=== KERNEL ===
+Linux version 6.17.0-1014-nvidia (buildd@bos03-arm64-009) (aarch64-linux-gnu-gcc-13 (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0, GNU ld (GNU Binutils for Ubuntu) 2.42) #14-Ubuntu SMP PREEMPT_DYNAMIC Tue Mar 17 19:01:40 UTC 2026
+
+=== NETPLAN ===
+sudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper
+sudo: a password is required
+--- /etc/netplan/00-installer-config.yaml ---
+
+=== ip addr ===
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+2: enP7s7: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
+    altname enP7p1s0
+    inet 192.168.0.115/24 brd 192.168.0.255 scope global noprefixroute enP7s7
+       valid_lft forever preferred_lft forever
+8: tailscale0: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1280 qdisc fq_codel state UNKNOWN group default qlen 500
+    inet 100.71.225.76/32 scope global tailscale0
+       valid_lft forever preferred_lft forever
+9: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default 
+    inet 172.17.0.1/16 brd 172.17.255.255 scope global docker0
+       valid_lft forever preferred_lft forever
+
+=== ip link (with mtu) ===
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00 promiscuity 0  allmulti 0 minmtu 0 maxmtu 0 addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+2: enP7s7: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 4c:bb:47:2b:e8:1e brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 9194 addrgenmode none numtxqueues 16 numrxqueues 16 gso_max_size 64000 gso_max_segs 64 tso_max_size 64000 tso_max_segs 64 gro_max_size 65536 parentbus pci parentdev 0007:01:00.0 
+    altname enP7p1s0
+7: wlP9s9: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN mode DORMANT group default qlen 1000
+    link/ether f8:3d:c6:af:d7:96 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 256 maxmtu 2304 addrgenmode none numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 parentbus pci parentdev 0009:01:00.0 
+    altname wlP9p1s0
+8: tailscale0: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1280 qdisc fq_codel state UNKNOWN mode DEFAULT group default qlen 500
+    link/none  promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    tun type tun pi off vnet_hdr on persist off addrgenmode random numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 
+9: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN mode DEFAULT group default 
+    link/ether 06:32:cd:e9:fd:b7 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
+    bridge forward_delay 1500 hello_time 200 max_age 2000 ageing_time 30000 stp_state 0 priority 32768 vlan_filtering 0 vlan_protocol 802.1Q bridge_id 8000.6:32:cd:e9:fd:b7 designated_root 8000.6:32:cd:e9:fd:b7 root_port 0 root_path_cost 0 topology_change 0 topology_change_detected 0 hello_timer    0.00 tcn_timer    0.00 topology_change_timer    0.00 gc_timer  210.43 vlan_default_pvid 1 vlan_stats_enabled 0 vlan_stats_per_port 0 group_fwd_mask 0 group_address 01:80:c2:00:00:00 mcast_snooping 1 no_linklocal_learn 0 mcast_vlan_snooping 0 mcast_router 1 mcast_query_use_ifaddr 0 mcast_querier 0 mcast_hash_elasticity 16 mcast_hash_max 4096 mcast_last_member_count 2 mcast_startup_query_count 2 mcast_last_member_interval 100 mcast_membership_interval 26000 mcast_querier_interval 25500 mcast_query_interval 12500 mcast_query_response_interval 1000 mcast_startup_query_interval 3125 mcast_stats_enabled 0 mcast_igmp_version 2 mcast_mld_version 1 nf_call_iptables 0 nf_call_ip6tables 0 nf_call_arptables 0 addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
+
+=== ConnectX hardware (lspci) ===
+(no mellanox PCI device found)
+
+=== mlx kernel modules ===
+mlx5_fwctl             16384  0
+mlx5_ib               520192  0
+mlx5_core            2756608  2 mlx5_fwctl,mlx5_ib
+mlxfw                  32768  1 mlx5_core
+
+=== mlx5_core modinfo ===
+filename:       /lib/modules/6.17.0-1014-nvidia/kernel/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.ko.zst
+srcversion:     89EEAF32656D79A2DACFFD3
+
+=== Firmware per ConnectX device ===
+
+=== ip route ===
+default via 192.168.0.1 dev enP7s7 proto dhcp src 192.168.0.115 metric 100 
+172.17.0.0/16 dev docker0 proto kernel scope link src 172.17.0.1 linkdown 
+192.168.0.0/24 dev enP7s7 proto kernel scope link src 192.168.0.115 metric 100 
+
+=== sysctl network tuning ===
+net.core.rmem_max = 212992
+net.core.wmem_max = 212992
+net.ipv4.tcp_rmem = 4096	131072	33554432
+net.ipv4.tcp_wmem = 4096	16384	4194304
+net.core.netdev_max_backlog = 1000
+net.core.default_qdisc = fq_codel
+net.ipv4.tcp_congestion_control = cubic
+
+=== bonding (if any) ===
+(no bonding interfaces)

--- a/src/operational/validate-fabric-cutover.sh
+++ b/src/operational/validate-fabric-cutover.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# validate-fabric-cutover.sh — read-only post-cutover validation for spark-5/6 fabric.
+#
+# Cluster-network-audit drove this script. Run from any host with cluster
+# network access (e.g. spark-2). Outputs pass/fail table to stdout.
+#
+# Usage:
+#   bash src/operational/validate-fabric-cutover.sh
+#
+# Exit code:
+#   0 if all checks pass
+#   1 if any check fails (so the script can drive CI/cron)
+#
+# This script is READ-ONLY. It does not modify any host config.
+
+set -u
+
+CANONICAL_KERNEL="6.17.0-1014-nvidia"
+CANONICAL_FW="28.45.4028"
+CANONICAL_MTU=9000
+RC=0
+
+pass() { printf "  ✓ %-60s PASS\n" "$1"; }
+fail() { printf "  ✗ %-60s FAIL — %s\n" "$1" "$2"; RC=1; }
+
+ssh_run() {
+  local ip=$1; shift
+  timeout 10 ssh -o BatchMode=yes -o ConnectTimeout=5 admin@"$ip" "$@" 2>/dev/null
+}
+
+echo "=========================================================="
+echo "  Fortress Cluster Fabric Validation — $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "=========================================================="
+
+echo
+echo "[1/8] SSH reachability on mgmt LAN"
+for ip in 192.168.0.104 192.168.0.100 192.168.0.105 192.168.0.106 192.168.0.109 192.168.0.115; do
+  out=$(ssh_run "$ip" 'hostname' 2>&1)
+  if [ -n "$out" ] && ! echo "$out" | grep -qi "denied\|refused\|timeout"; then
+    pass "ssh admin@$ip ($out)"
+  else
+    fail "ssh admin@$ip" "$out"
+  fi
+done
+
+echo
+echo "[2/8] Fabric A pings (10.10.10.X) from $(hostname)"
+for x in 1 2 3 4 5 6; do
+  ip="10.10.10.$x"
+  if timeout 3 ping -c 2 -W 1 "$ip" >/dev/null 2>&1; then
+    pass "ping $ip (spark-$x fabric A)"
+  else
+    fail "ping $ip (spark-$x fabric A)" "no response"
+  fi
+done
+
+echo
+echo "[3/8] Fabric B pings (10.10.11.X) from $(hostname)"
+for x in 1 2 3 4 5 6; do
+  ip="10.10.11.$x"
+  if timeout 3 ping -c 2 -W 1 "$ip" >/dev/null 2>&1; then
+    pass "ping $ip (spark-$x fabric B)"
+  else
+    fail "ping $ip (spark-$x fabric B)" "no response"
+  fi
+done
+
+echo
+echo "[4/8] Kernel version match (canonical: $CANONICAL_KERNEL)"
+for ip in 192.168.0.104 192.168.0.100 192.168.0.105 192.168.0.106 192.168.0.109 192.168.0.115; do
+  k=$(ssh_run "$ip" 'uname -r' 2>&1)
+  if [ "$k" = "$CANONICAL_KERNEL" ]; then
+    pass "spark-${ip##*.} kernel ($k)"
+  else
+    fail "spark-${ip##*.} kernel" "got '$k' want '$CANONICAL_KERNEL'"
+  fi
+done
+
+echo
+echo "[5/8] mlx5_core driver loaded"
+for ip in 192.168.0.104 192.168.0.100 192.168.0.105 192.168.0.106 192.168.0.109 192.168.0.115; do
+  if ssh_run "$ip" 'lsmod | grep -q "^mlx5_core"' >/dev/null 2>&1; then
+    pass "spark-${ip##*.} mlx5_core loaded"
+  else
+    fail "spark-${ip##*.} mlx5_core loaded" "module not in lsmod"
+  fi
+done
+
+echo
+echo "[6/8] ConnectX firmware match (canonical: $CANONICAL_FW)"
+for ip in 192.168.0.104 192.168.0.100 192.168.0.105 192.168.0.106 192.168.0.109 192.168.0.115; do
+  fw=$(ssh_run "$ip" 'sudo -n ethtool -i enp1s0f0np0 2>/dev/null | grep firmware-version | awk "{print \$2}"' 2>&1)
+  if [ -z "$fw" ]; then
+    fail "spark-${ip##*.} firmware" "could not read (no NIC, no sudo NOPASSWD, or port absent)"
+  elif [ "$fw" = "$CANONICAL_FW" ]; then
+    pass "spark-${ip##*.} firmware ($fw)"
+  else
+    fail "spark-${ip##*.} firmware" "got '$fw' want '$CANONICAL_FW'"
+  fi
+done
+
+echo
+echo "[7/8] Fabric port MTU = $CANONICAL_MTU"
+for ip in 192.168.0.104 192.168.0.100 192.168.0.105 192.168.0.106 192.168.0.109 192.168.0.115; do
+  for iface in enp1s0f0np0 enP2p1s0f1np1; do
+    mtu=$(ssh_run "$ip" "cat /sys/class/net/$iface/mtu 2>/dev/null" 2>&1)
+    if [ -z "$mtu" ]; then
+      fail "spark-${ip##*.} $iface mtu" "interface absent"
+    elif [ "$mtu" = "$CANONICAL_MTU" ]; then
+      pass "spark-${ip##*.} $iface mtu ($mtu)"
+    else
+      fail "spark-${ip##*.} $iface mtu" "got $mtu want $CANONICAL_MTU"
+    fi
+  done
+done
+
+echo
+echo "[8/8] Critical service health"
+brain=$(curl -sS --max-time 5 http://192.168.0.109:8100/v1/health/ready 2>/dev/null)
+echo "$brain" | grep -q "ready" && pass "BRAIN spark-5:8100" || fail "BRAIN spark-5:8100" "$brain"
+
+vision=$(curl -sS --max-time 5 http://192.168.0.105:8101/v1/health/ready 2>/dev/null)
+echo "$vision" | grep -q "ready" && pass "vision-NIM spark-3:8101" || fail "vision-NIM spark-3:8101" "$vision"
+
+embed=$(curl -sS --max-time 5 http://192.168.0.105:8102/v1/health/ready 2>/dev/null)
+echo "$embed" | grep -q "ready" && pass "embed-NIM spark-3:8102" || fail "embed-NIM spark-3:8102" "$embed"
+
+litellm=$(curl -sS --max-time 5 http://192.168.0.100:8002/health 2>/dev/null)
+echo "$litellm" | grep -qE "(error|message|status|model_info)" && pass "LiteLLM spark-2:8002 (responding)" || fail "LiteLLM spark-2:8002" "$litellm"
+
+qdrant=$(curl -sS --max-time 5 http://192.168.0.100:6333 2>/dev/null)
+echo "$qdrant" | grep -q "qdrant" && pass "Qdrant spark-2:6333" || fail "Qdrant spark-2:6333" "$qdrant"
+
+qvrs=$(curl -sS --max-time 5 http://192.168.0.106:6333 2>/dev/null)
+echo "$qvrs" | grep -q "qdrant" && pass "Qdrant-VRS spark-4:6333" || fail "Qdrant-VRS spark-4:6333" "$qvrs"
+
+echo
+echo "=========================================================="
+[ $RC -eq 0 ] && echo "  RESULT: ALL CHECKS PASSED" || echo "  RESULT: $RC OR MORE FAILURES — review above"
+echo "=========================================================="
+
+exit $RC


### PR DESCRIPTION
Read-only audit + cutover prep for today's 2× fs.com cable arrival. No /etc/netplan/, service, kernel module, or firmware changes in this PR.

## 🛑 Critical finding — Spark-6 ConnectX adapter not present

\`lspci -nn | grep -i mellanox\` on spark-6 (192.168.0.115) returns **no Mellanox device**. The mlx5_core driver is loaded but has nothing to bind to. \`/sys/class/net/\` enumerates only mgmt LAN, WiFi, tailscale0, docker0 — no fabric interfaces.

**Plugging cables into spark-6 today will not activate fabric on spark-6.** Operator must verify physical adapter install before / during cabling. If adapter is absent, spark-6 cutover defers until procurement. See \`docs/operational/spark-6-driver-remediation-2026-04-30.md\`.

## Canonical baseline (sparks 1/2/3/4 — all uniform)

| Item | Canonical |
|---|---|
| Kernel | \`6.17.0-1014-nvidia\` (uniform across all 6 sparks) |
| mlx5_core srcversion | \`89EEAF32656D79A2DACFFD3\` (uniform across all 6) |
| ConnectX firmware | \`28.45.4028\` (sparks 1/2/3/4 verified; spark-5 unverified due to no-NOPASSWD; spark-6 N/A) |
| Mellanox PCI | ConnectX-7 ×4 functions per spark (sparks 1/2/3/4/5); **none on spark-6** |
| Fabric A | \`10.10.10.X/24\` on \`enp1s0f0np0\` MTU 9000 |
| Fabric B | \`10.10.11.X/24\` on \`enP2p1s0f1np1\` MTU 9000 |
| Mgmt LAN | \`192.168.0.X/24\` on \`enP7s7\`, gw \`192.168.0.1\` |
| Bonding / LACP | none — dual-subnet pattern |
| Fabric netplan | \`/etc/netplan/99-mellanox-roce.yaml\` |

## Spark-5 deltas (HIGH severity, fixable in cutover)

- Hardware: ✓ ConnectX-7 ×4 fully present
- Fabric A: on wrong port (\`enp1s0f1np1\` instead of canonical \`enp1s0f0np0\`)
- Fabric B: **MISSING** — \`enP2p1s0f1np1\` has \`192.168.0.111/24\` mis-bound (should be \`10.10.11.5/24\`)
- 2 of 4 ConnectX ports \`state=down\` (cables not yet in canonical positions)
- BRAIN (\`fortress-nim-brain.service\`, Llama-3.3-Nemotron-Super-49B-v1.5) on \`:8100\` HEALTHY — must stay green through cutover
- Sysctl drift: cubic + 212k buffers (canonical = bbr + 536M) — flagged separately, out of cutover scope

## Sysctl drift surfaced (separate issue)

| Spark | tcp_congestion_control | rmem_max | tcp_rmem |
|---|---|---|---|
| 1 | bbr | 536M | 4096 87380 268M |
| 2 | bbr | 536M | 4096 87380 268M |
| **3** | **cubic** ⚠ | **212k** ⚠ | **4096 131072 33M** ⚠ |
| 4 | bbr | 536M | 4096 87380 268M |
| **5** | **cubic** ⚠ | **212k** ⚠ | **4096 131072 33M** ⚠ |
| **6** | **cubic** ⚠ | **212k** ⚠ | **4096 131072 33M** ⚠ |

Spark-3 hosts vision NIM + embed NIM (production traffic). Likely degraded throughput vs canonical. **Not addressed in this PR** (no sysctl changes per hard constraint); separate alignment issue recommended.

## Files committed (10)

- \`docs/operational/spark-network-baseline-2026-04-30/spark-{100,104,105,106,109,115}.txt\` — raw per-spark baselines (6 files)
- \`docs/operational/cluster-network-canonical-baseline-2026-04-30.md\` — canonical baseline derivation
- \`docs/operational/spark-5-6-parity-check-2026-04-30.md\` — deltas vs canonical
- \`docs/operational/spark-5-target-netplan-2026-04-30.yaml\` — DRAFT, not in /etc
- \`docs/operational/spark-6-target-netplan-2026-04-30.yaml\` — DRAFT, not in /etc
- \`docs/operational/spark-6-driver-remediation-2026-04-30.md\` — hardware blocker diagnostic + install path
- \`docs/operational/spark-5-6-fabric-cutover-runbook-2026-04-30.md\` — operator-execute sequence
- \`src/operational/validate-fabric-cutover.sh\` — executable, NOT run in this PR

## What this PR does NOT do

- No netplan changes applied (/etc/netplan/ untouched on all 6 sparks)
- No kernel module load/unload
- No firmware updates
- No BRAIN service modification
- No spark-1/2/3/4 changes (read-only canonical reference)
- No sysctl alignment (separate issue)
- No physical cable changes (operator-execute, runbook documents)
- No validation script run (committed as executable, not invoked)

## Operator next steps (after this PR lands)

1. Read \`docs/operational/spark-5-6-fabric-cutover-runbook-2026-04-30.md\` end-to-end
2. \`bash src/operational/validate-fabric-cutover.sh > /tmp/fabric-pre-cutover.log\` — pre-cutover snapshot
3. Spark-6 first (lower risk):
   a. Verify ConnectX-7 hardware present (gating step)
   b. If present: plug 2 cables, apply target netplan, verify
   c. If absent: defer spark-6, proceed to spark-5
4. Spark-5 second (BRAIN serving — minimize downtime):
   a. Confirm BRAIN health
   b. Confirm \`192.168.0.111\` dependency clean (no live config refs)
   c. Plug 2 cables, apply target netplan, verify BRAIN still serving + both fabric IPs reachable
5. Post-cutover: re-run validation script, diff vs pre-snapshot

**Merge BLOCKED on operator review.**