### PR TITLE
Phase A PR #2: caller cutover for caselaw + library to legal-embed _v2

### DIFF
--- a/fortress-guest-platform/backend/api/intelligence.py
+++ b/fortress-guest-platform/backend/api/intelligence.py
@@ -587,18 +587,29 @@ async def _exec_get_case_deadlines(case_slug: str) -> Dict:
         ))
 
 
+# Phase A PR #2 (2026-04-30): legal_library cut over to legal_library_v2 on the
+# 2048-dim sovereign legal-embed encoder. The other two collections in this
+# federated search ride nomic-embed-text at 768-dim. Each collection's row
+# below carries its own encoder marker so the federated search embeds the
+# query once per encoder rather than once globally.
+_ENCODER_NOMIC = "nomic"
+_ENCODER_LEGAL = "legal-embed"
+
 _QDRANT_COLLECTIONS = {
     "fortress_knowledge": {
         "content_field": "text",
         "source_field": "source_file",
+        "encoder": _ENCODER_NOMIC,
     },
     "email_embeddings": {
         "content_field": "preview",
         "source_field": "subject",
+        "encoder": _ENCODER_NOMIC,
     },
-    "legal_library": {
-        "content_field": "text",
-        "source_field": "source_file",
+    "legal_library_v2": {
+        "content_field": "text_chunk",
+        "source_field": "file_name",
+        "encoder": _ENCODER_LEGAL,
     },
 }
 
@@ -645,31 +656,53 @@ async def _search_single_collection(
 
 
 async def _exec_search_knowledge_base(query: str) -> Dict:
-    """Federated search across fortress_knowledge, email_embeddings, and legal_library."""
+    """Federated search across fortress_knowledge, email_embeddings, and legal_library_v2.
+
+    Embeds the query separately per encoder family — nomic-embed-text for
+    fortress_knowledge + email_embeddings, sovereign legal-embed (2048-dim,
+    PR #300 §9.5 caller contract) for legal_library_v2 — then dispatches one
+    search per collection with the matching vector.
+    """
     try:
+        from backend.core.vector_db import embed_legal_query as _embed_legal
         from backend.core.vector_db import embed_text as _embed_text
 
-        embedding = await _embed_text(query[:8000])
-        if not embedding:
+        truncated = query[:8000]
+        nomic_vec = await _embed_text(truncated)
+        if not nomic_vec:
             return _model_dump(ToolError(
                 tool_error="Embedding generation failed",
-                details="Embedding endpoint returned no vector",
+                details="nomic-embed-text returned no vector",
             ))
+        try:
+            legal_vec = await _embed_legal(truncated)
+        except Exception as e:
+            logger.warning("federated_legal_embed_failed", error=str(e)[:200])
+            legal_vec = None
+
+        encoder_vec = {_ENCODER_NOMIC: nomic_vec, _ENCODER_LEGAL: legal_vec}
 
         async with httpx.AsyncClient(timeout=20.0) as client:
             per_collection = 5
-            search_tasks = [
-                _search_single_collection(client, coll, embedding, per_collection)
-                for coll in _QDRANT_COLLECTIONS
-            ]
+            search_tasks = []
+            scheduled_collections: List[str] = []
+            for coll, schema in _QDRANT_COLLECTIONS.items():
+                vec = encoder_vec.get(schema["encoder"])
+                if vec is None:
+                    logger.warning(
+                        "federated_search_skip_collection_no_encoder_vec",
+                        collection=coll, encoder=schema["encoder"],
+                    )
+                    continue
+                search_tasks.append(_search_single_collection(client, coll, vec, per_collection))
+                scheduled_collections.append(coll)
             collection_results = await asyncio.gather(
                 *search_tasks, return_exceptions=True,
             )
 
             merged: List[KnowledgeResult] = []
-            searched: List[str] = []
-            for coll_name, result in zip(_QDRANT_COLLECTIONS, collection_results):
-                searched.append(coll_name)
+            searched: List[str] = list(scheduled_collections)
+            for coll_name, result in zip(scheduled_collections, collection_results):
                 if isinstance(result, Exception):
                     logger.warning(
                         "federated_search_collection_error",

--- a/fortress-guest-platform/backend/core/vector_db.py
+++ b/fortress-guest-platform/backend/core/vector_db.py
@@ -106,3 +106,43 @@ def embed_text_sync(text: str) -> List[float]:
         resp.raise_for_status()
         data = resp.json()
         return data["data"][0]["embedding"]
+
+
+LEGAL_EMBED_MODEL = "legal-embed"
+LEGAL_EMBED_DIM = 2048
+
+
+async def embed_legal_query(text: str) -> List[float]:
+    """
+    Embed a query for retrieval against the sovereign legal-embed _v2 collections.
+
+    Uses the LiteLLM gateway alias `legal-embed` (llama-nemotron-embed-1b-v2 on
+    spark-3:8102 — see PR #300 §9). Returns a 2048-dim vector for cosine search
+    against `legal_caselaw_v2` / `legal_library_v2`.
+
+    Caller contract (verified PR #300 §9.5, enforced here):
+      - input_type="query" — asymmetric encoder; passages are indexed with
+        "passage", queries must use "query"
+      - encoding_format="float" — NIM strictly validates; the OpenAI client's
+        implicit None default is rejected with HTTP 400
+
+    Authenticates with `settings.litellm_master_key` (Bearer). Raises on
+    transport / auth / validation errors so callers can decide how to degrade.
+    """
+    base = settings.litellm_base_url.rstrip("/")
+    url = f"{base}/embeddings"
+    payload = {
+        "input": text,
+        "model": LEGAL_EMBED_MODEL,
+        "input_type": "query",
+        "encoding_format": "float",
+    }
+    headers = {
+        "Authorization": f"Bearer {settings.litellm_master_key}",
+        "Content-Type": "application/json",
+    }
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(url, json=payload, headers=headers)
+        resp.raise_for_status()
+        data = resp.json()
+        return data["data"][0]["embedding"]

--- a/fortress-guest-platform/backend/services/knowledge_retriever.py
+++ b/fortress-guest-platform/backend/services/knowledge_retriever.py
@@ -279,7 +279,30 @@ async def _upsert_batch(
     await dual_upsert_points(points)
 
 
-LEGAL_COLLECTION = "legal_library"
+# Phase A PR #2 (2026-04-30): legal_library cut over to legal_library_v2 on the
+# 2048-dim sovereign legal-embed encoder. Other collections in this module
+# (fortress_knowledge / KB / etc) stay on nomic-embed-text.
+LEGAL_COLLECTION = "legal_library_v2"
+LEGAL_VECTOR_DIM = 2048
+
+
+async def _embed_legal_query(text: str) -> Optional[List[float]]:
+    """Embed a query for the sovereign legal-embed _v2 collections.
+
+    Routes via the LiteLLM gateway alias `legal-embed` with the mandatory
+    caller contract (input_type=query, encoding_format=float — see PR #300
+    §9.5). Returns None on any failure so callers can gracefully degrade.
+    """
+    from backend.core.vector_db import embed_legal_query as _embed_legal_vec
+
+    try:
+        vec = await _embed_legal_vec(text[:8000])
+        if len(vec) == LEGAL_VECTOR_DIM:
+            return vec
+        logger.warning("legal_query_embedding_dim_mismatch", expected=LEGAL_VECTOR_DIM, got=len(vec))
+    except Exception as e:
+        logger.warning("legal_query_embedding_failed", error=str(e)[:200])
+    return None
 
 
 async def _qdrant_legal_search(
@@ -353,7 +376,7 @@ async def legal_library_search(
     contract context rather than crashing).
     """
     try:
-        query_vector = await _embed_query(question)
+        query_vector = await _embed_legal_query(question)
         if query_vector is None:
             logger.warning("legal_library_embed_failed", query=question[:80])
             return []

--- a/fortress-guest-platform/backend/services/legal_auditor.py
+++ b/fortress-guest-platform/backend/services/legal_auditor.py
@@ -11,7 +11,7 @@ Performs two layers of analysis on every damage report:
                        never exposed to the guest.
 
 NIM endpoint: Sparks 1&2 clustered (DGX_REASONER_URL, FP8 model)
-Statutory vectors: Qdrant legal_library (2,455+ vectors, 768-dim)
+Statutory vectors: Qdrant legal_library_v2 (2048-dim sovereign legal-embed; cut over 2026-04-30 in Phase A PR #2)
 Fallback: Anthropic Opus 4.6 -> Council cascade
 """
 
@@ -28,9 +28,12 @@ from backend.services.ai_engine import query_horseman, query_council
 
 logger = structlog.get_logger()
 
-EMBED_URL = "http://192.168.0.100/api/embeddings"
-EMBED_MODEL = "nomic-embed-text"
-STATUTORY_COLLECTION = "legal_library"
+# Phase A PR #2 (2026-04-30): legal_library cut over to legal_library_v2 on the
+# 2048-dim sovereign legal-embed encoder. Statutory queries now go through the
+# LiteLLM gateway (see _embed_statutory_query below) with the mandatory caller
+# contract from PR #300 §9.5 (input_type=query + encoding_format=float).
+STATUTORY_COLLECTION = "legal_library_v2"
+STATUTORY_EMBED_DIM = 2048
 
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -103,14 +106,14 @@ async def query_statutory_law(query: str, top_k: int = 5) -> str:
                 logger.debug("statutory_collection_not_found", collection=STATUTORY_COLLECTION)
                 return ""
 
-            embed_resp = await client.post(
-                EMBED_URL,
-                json={"model": EMBED_MODEL, "prompt": query[:4000]},
-                timeout=30,
-            )
-            embed_resp.raise_for_status()
-            vec = embed_resp.json().get("embedding", [])
-            if len(vec) != 768:
+            from backend.core.vector_db import embed_legal_query
+            try:
+                vec = await embed_legal_query(query[:4000])
+            except Exception as e:
+                logger.warning("statutory_embed_failed", error=str(e)[:200])
+                return ""
+            if len(vec) != STATUTORY_EMBED_DIM:
+                logger.warning("statutory_embed_dim_unexpected", got=len(vec))
                 return ""
 
             search_resp = await client.post(

--- a/fortress-guest-platform/backend/services/legal_council.py
+++ b/fortress-guest-platform/backend/services/legal_council.py
@@ -71,12 +71,18 @@ PERSONAS_DIR = os.getenv(
     "LEGAL_PERSONAS_DIR",
     "/home/admin/Fortress-Prime/personas/legal",
 )
-LEGAL_ALLOWED_VECTOR_COLLECTIONS = frozenset({"legal_library", "legal_ediscovery", "legal_caselaw"})
+# Phase A PR #2 (2026-04-30): caselaw + library cut over to 2048-dim legal-embed
+# _v2 collections; ediscovery stays on legacy 768-dim nomic-embed-text per Option B.
+# Legacy `legal_library` and `legal_caselaw` removed from the allowlist so the
+# council strictly uses the cut-over targets.
+LEGAL_ALLOWED_VECTOR_COLLECTIONS = frozenset(
+    {"legal_library_v2", "legal_ediscovery", "legal_caselaw_v2"}
+)
 
-# Precedent retrieval knobs — legal_caselaw holds the controlling-authority corpus
+# Precedent retrieval knobs — legal_caselaw_v2 holds the controlling-authority corpus
 # (CourtListener opinions). Defaults picked to fit comfortably inside frontier-model
 # context budgets after case brief + evidence chunks.
-CASELAW_COLLECTION = "legal_caselaw"
+CASELAW_COLLECTION = "legal_caselaw_v2"
 CASELAW_TOP_K = int(os.getenv("LEGAL_COUNCIL_CASELAW_TOP_K", "10"))
 CONTEXT_BUDGET_TOKENS = int(os.getenv("LEGAL_COUNCIL_CONTEXT_BUDGET_TOKENS", "12000"))
 # Approximate char-per-token ratio used for budget enforcement on pre-prompt
@@ -464,7 +470,7 @@ class LegalPersona:
     def load(cls, filepath: str) -> "LegalPersona":
         with open(filepath, "r") as f:
             data = json.load(f)
-        vector_collection = data.get("vector_collection", "legal_library")
+        vector_collection = data.get("vector_collection", "legal_library_v2")
         _validate_legal_persona_boundary(
             slug=data.get("slug", os.path.basename(filepath)),
             vector_collection=vector_collection,
@@ -1209,7 +1215,12 @@ def _council_retrieval_flags() -> tuple[bool, bool]:
 
 
 async def _embed_text(text: str) -> Optional[List[float]]:
-    """Embed via Ollama OpenAI-compatible /v1/embeddings (backend.core.vector_db)."""
+    """Embed via Ollama OpenAI-compatible /v1/embeddings (backend.core.vector_db).
+
+    Used for legacy 768-dim collections that still ride nomic-embed-text:
+    `legal_ediscovery`, `legal_privileged_communications`. Caselaw + library
+    queries go through `_embed_legal_query` instead (see Phase A PR #2).
+    """
     from backend.core.vector_db import embed_text as _embed_vec
 
     try:
@@ -1219,6 +1230,29 @@ async def _embed_text(text: str) -> Optional[List[float]]:
         logger.warning("embed_dim_unexpected  got=%d", len(vec))
     except Exception as e:
         logger.warning("embed_failed  error=%s", str(e)[:200])
+    return None
+
+
+async def _embed_legal_query(text: str) -> Optional[List[float]]:
+    """Embed a query for the sovereign legal-embed _v2 collections (caselaw + library).
+
+    Sends `input_type=query` and `encoding_format=float` per the NIM caller
+    contract verified in PR #300 §9.5; both are mandatory and the gateway
+    will reject HTTP 400 if either is missing/None.
+
+    Returns None on transport / dim-mismatch / auth failure so callers can
+    degrade to "no RAG context" rather than crash — matching the failure
+    semantics of `_embed_text` above.
+    """
+    from backend.core.vector_db import LEGAL_EMBED_DIM, embed_legal_query
+
+    try:
+        vec = await embed_legal_query(text[:8000])
+        if len(vec) == LEGAL_EMBED_DIM:
+            return vec
+        logger.warning("legal_embed_dim_unexpected  got=%d", len(vec))
+    except Exception as e:
+        logger.warning("legal_embed_failed  error=%s", str(e)[:200])
     return None
 
 
@@ -1425,7 +1459,7 @@ async def freeze_caselaw_context(
     """
     logger.info("freeze_caselaw_context_start  collection=%s  top_k=%d", CASELAW_COLLECTION, top_k)
 
-    query_vec = await _embed_text(case_brief)
+    query_vec = await _embed_legal_query(case_brief)
     if query_vec is None:
         logger.warning("freeze_caselaw_context_no_embedding — proceeding without precedent")
         return [], []

--- a/fortress-guest-platform/backend/tests/test_legal_council_caselaw_retrieval.py
+++ b/fortress-guest-platform/backend/tests/test_legal_council_caselaw_retrieval.py
@@ -1,6 +1,6 @@
 """
 Tests for Legal Council precedent retrieval — ensures the council now pulls
-controlling-authority chunks from the legal_caselaw Qdrant collection in
+controlling-authority chunks from the legal_caselaw_v2 Qdrant collection in
 addition to the existing legal_ediscovery evidence retrieval, keeps the
 merged context within the configured token budget, stamps seat prompts with
 citation discipline, and threads caselaw opinion ids into the vault payload.
@@ -97,12 +97,22 @@ def mock_qdrant(monkeypatch: pytest.MonkeyPatch):
 
 @pytest.fixture
 def mock_embed(monkeypatch: pytest.MonkeyPatch):
-    """Return a non-None deterministic embedding so freeze paths don't early-exit."""
+    """Return a non-None deterministic embedding so freeze paths don't early-exit.
 
-    async def fake_embed(text: str):
+    Phase A PR #2: caselaw + library queries route through `_embed_legal_query`
+    (2048-dim sovereign legal-embed); ediscovery + privileged still ride
+    `_embed_text` (768-dim nomic). Mock both so either path is intercepted.
+    """
+    from backend.core.vector_db import LEGAL_EMBED_DIM
+
+    async def fake_embed_nomic(text: str):
         return [0.1] * lc._cfg.embed_dim
 
-    monkeypatch.setattr(lc, "_embed_text", fake_embed)
+    async def fake_embed_legal(text: str):
+        return [0.1] * LEGAL_EMBED_DIM
+
+    monkeypatch.setattr(lc, "_embed_text", fake_embed_nomic)
+    monkeypatch.setattr(lc, "_embed_legal_query", fake_embed_legal)
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -114,7 +124,7 @@ async def test_council_context_includes_caselaw_block(
     mock_qdrant: Dict[str, List[Dict[str, Any]]],
     mock_embed,
 ) -> None:
-    mock_qdrant["legal_caselaw"] = [
+    mock_qdrant["legal_caselaw_v2"] = [
         _caselaw_point(
             111, 0,
             "The insurer owes a duty of good faith in settlement negotiations.",
@@ -150,7 +160,7 @@ async def test_council_caselaw_retrieval_respects_top_k(
     mock_embed,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    mock_qdrant["legal_caselaw"] = [
+    mock_qdrant["legal_caselaw_v2"] = [
         _caselaw_point(i, 0, f"Authority chunk {i}.") for i in range(20)
     ]
 
@@ -158,12 +168,12 @@ async def test_council_caselaw_retrieval_respects_top_k(
     original_post = _FakeAsyncClient.post
 
     async def capture_post(self, url, json=None, headers=None):  # type: ignore[no-untyped-def]
-        if "legal_caselaw" in url and json:
+        if "legal_caselaw_v2" in url and json:
             captured_limits.append(int(json.get("limit", -1)))
         # Respect the limit so the returned payload size matches the request.
-        if "legal_caselaw" in url and json:
+        if "legal_caselaw_v2" in url and json:
             limit = int(json.get("limit", 0))
-            payload = {"result": mock_qdrant["legal_caselaw"][:limit]}
+            payload = {"result": mock_qdrant["legal_caselaw_v2"][:limit]}
             return _FakeResponse(payload)
         return await original_post(self, url, json=json, headers=headers)
 
@@ -225,7 +235,7 @@ async def test_council_seat_prompt_contains_citation_instruction(
         focus_areas=["Citations"],
         trigger_events=["test event"],
         godhead_prompt="You are The Test Seat.",
-        vector_collection="legal_library",
+        vector_collection="legal_library_v2",
     )
 
     captured: Dict[str, str] = {}
@@ -266,7 +276,7 @@ async def test_vaulted_deliberation_records_caselaw_opinion_ids(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
 ) -> None:
-    mock_qdrant["legal_caselaw"] = [
+    mock_qdrant["legal_caselaw_v2"] = [
         _caselaw_point(42, 0, "Authority chunk 42."),
         _caselaw_point(77, 1, "Authority chunk 77."),
     ]
@@ -310,7 +320,7 @@ async def test_vaulted_deliberation_records_caselaw_opinion_ids(
         focus_areas=["f"],
         trigger_events=["e"],
         godhead_prompt="prompt",
-        vector_collection="legal_library",
+        vector_collection="legal_library_v2",
     )
     monkeypatch.setattr(lc.LegalPersona, "load_all", staticmethod(lambda: [persona]))
 
@@ -370,7 +380,7 @@ async def test_ediscovery_retrieval_unchanged(
         _evidence_point("ev-A", "Alpha chunk", case_slug="matter-001"),
         _evidence_point("ev-B", "Beta chunk", case_slug="matter-001"),
     ]
-    mock_qdrant["legal_caselaw"] = [_caselaw_point(9, 0, "should not appear in this result")]
+    mock_qdrant["legal_caselaw_v2"] = [_caselaw_point(9, 0, "should not appear in this result")]
 
     captured_bodies: List[Dict[str, Any]] = []
     original_post = _FakeAsyncClient.post
@@ -388,7 +398,7 @@ async def test_ediscovery_retrieval_unchanged(
     # Only ediscovery was queried by freeze_context.
     hit_urls = [b["url"] for b in captured_bodies]
     assert any("legal_ediscovery" in u for u in hit_urls)
-    assert not any("legal_caselaw" in u for u in hit_urls)
+    assert not any("legal_caselaw_v2" in u for u in hit_urls)
 
     # case_slug filter applied.
     ediscovery_body = next(b for b in captured_bodies if "legal_ediscovery" in b["url"])
@@ -398,3 +408,81 @@ async def test_ediscovery_retrieval_unchanged(
     # Shape is still (ids, "[file] text" strings).
     assert vector_ids == ["ev-A", "ev-B"]
     assert chunks == ["[Exhibit-A.pdf] Alpha chunk", "[Exhibit-A.pdf] Beta chunk"]
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Phase A PR #2 — encoder-routing assertion
+# Caselaw retrieval must use `_embed_legal_query` (2048-dim legal-embed),
+# ediscovery retrieval must use `_embed_text` (768-dim nomic).
+# ═══════════════════════════════════════════════════════════════════════
+
+@pytest.mark.asyncio
+async def test_freeze_caselaw_uses_legal_embed_router(
+    mock_qdrant: Dict[str, List[Dict[str, Any]]],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Cutover guard: freeze_caselaw_context() must dispatch through
+    _embed_legal_query (2048-dim legal-embed via gateway), not the legacy
+    _embed_text path (768-dim nomic). Regressing this would silently
+    re-route caselaw search to the wrong encoder + collection dim."""
+    from backend.core.vector_db import LEGAL_EMBED_DIM
+
+    legal_calls: List[str] = []
+    nomic_calls: List[str] = []
+
+    async def spy_legal(text: str):
+        legal_calls.append(text[:32])
+        return [0.1] * LEGAL_EMBED_DIM
+
+    async def spy_nomic(text: str):
+        nomic_calls.append(text[:32])
+        return [0.1] * lc._cfg.embed_dim
+
+    monkeypatch.setattr(lc, "_embed_legal_query", spy_legal)
+    monkeypatch.setattr(lc, "_embed_text", spy_nomic)
+
+    mock_qdrant["legal_caselaw_v2"] = [_caselaw_point(7, 0, "Sovereign caselaw chunk")]
+
+    refs, chunks = await lc.freeze_caselaw_context("complaint alleges breach", top_k=5)
+
+    assert legal_calls == ["complaint alleges breach"], legal_calls
+    assert nomic_calls == [], nomic_calls
+    assert refs and chunks
+    assert refs[0].startswith("caselaw:")
+
+
+@pytest.mark.asyncio
+async def test_freeze_ediscovery_still_uses_legacy_nomic(
+    mock_qdrant: Dict[str, List[Dict[str, Any]]],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Cutover guard: freeze_context() (ediscovery) MUST stay on the legacy
+    _embed_text / 768-dim nomic encoder. Phase A PR #2 only cuts over
+    caselaw + library; ediscovery deferred to PR #4."""
+    legal_calls: List[str] = []
+    nomic_calls: List[str] = []
+
+    from backend.core.vector_db import LEGAL_EMBED_DIM
+
+    async def spy_legal(text: str):
+        legal_calls.append(text[:32])
+        return [0.1] * LEGAL_EMBED_DIM
+
+    async def spy_nomic(text: str):
+        nomic_calls.append(text[:32])
+        return [0.1] * lc._cfg.embed_dim
+
+    monkeypatch.setattr(lc, "_embed_legal_query", spy_legal)
+    monkeypatch.setattr(lc, "_embed_text", spy_nomic)
+
+    mock_qdrant["legal_ediscovery"] = [
+        _evidence_point("ev-1", "Email exhibit 1", case_slug="matter-007"),
+    ]
+
+    vector_ids, chunks = await lc.freeze_context(
+        "discovery query", top_k=5, case_slug="matter-007",
+    )
+
+    assert nomic_calls == ["discovery query"], nomic_calls
+    assert legal_calls == [], legal_calls
+    assert vector_ids and chunks

--- a/fortress-guest-platform/backend/tests/test_legal_council_provider_gating.py
+++ b/fortress-guest-platform/backend/tests/test_legal_council_provider_gating.py
@@ -33,7 +33,7 @@ def _build_persona(seat: int, name: str = "Test Persona") -> legal_council.Legal
         focus_areas=["Test focus."],
         trigger_events=["test trigger"],
         godhead_prompt=f"You are persona at seat {seat}.",
-        vector_collection="legal_library",
+        vector_collection="legal_library_v2",
     )
 
 

--- a/fortress-guest-platform/backend/tests/test_legal_council_retry.py
+++ b/fortress-guest-platform/backend/tests/test_legal_council_retry.py
@@ -22,7 +22,7 @@ def build_persona() -> LegalPersona:
         focus_areas=["Pleading tone", "Forum realism"],
         trigger_events=["pleading draft requested"],
         godhead_prompt="You are The Local Counsel.",
-        vector_collection="legal_library",
+        vector_collection="legal_library_v2",
     )
 
 

--- a/fortress-guest-platform/backend/tests/test_persona_domain_guards.py
+++ b/fortress-guest-platform/backend/tests/test_persona_domain_guards.py
@@ -34,7 +34,7 @@ def test_concierge_persona_guard_rejects_legal_collection(tmp_path, monkeypatch:
     _write_persona(
         tmp_path / "01-invalid.json",
         slug="guest-experience-lead",
-        vector_collection="legal_library",
+        vector_collection="legal_library_v2",
         domain="hospitality",
     )
     monkeypatch.setattr(crog_concierge_engine, "CONCIERGE_PERSONAS_DIR", str(tmp_path))

--- a/fortress_atlas.yaml
+++ b/fortress_atlas.yaml
@@ -280,7 +280,7 @@ fortress_prime:
         - "public.legal_matter_notes"
 
       qdrant_collections:
-        - "legal_library"           # 2,455 vectors of legal documents
+        - "legal_library_v2"        # 2,455 vectors of legal documents (cut over to 2048-dim legal-embed in Phase A PR #2, 2026-04-30)
         - "email_embeddings"        # Filtered by division = 'LEGAL_ADMIN'
 
       email_divisions:

--- a/personas/legal/01-senior-litigator.json
+++ b/personas/legal/01-senior-litigator.json
@@ -22,6 +22,6 @@
     "timeline contradiction identified"
   ],
   "godhead_prompt": "You are The Senior Litigator for Fortress Prime's Legal Council. Produce a disciplined defense assessment suitable for briefing operators and drafting counsel. Never hallucinate facts or authorities. Return only the requested JSON object.",
-  "vector_collection": "legal_library",
+  "vector_collection": "legal_library_v2",
   "created_at": "2026-03-29T00:00:00Z"
 }

--- a/personas/legal/02-contract-auditor.json
+++ b/personas/legal/02-contract-auditor.json
@@ -22,6 +22,6 @@
     "representation inconsistency surfaced"
   ],
   "godhead_prompt": "You are The Contract Auditor for Fortress Prime's Legal Council. Audit the dispute as if every defense must be anchored to operative language in the record. Never invent clauses or facts. Return only the requested JSON object.",
-  "vector_collection": "legal_library",
+  "vector_collection": "legal_library_v2",
   "created_at": "2026-03-29T00:00:00Z"
 }

--- a/personas/legal/03-statutory-scholar.json
+++ b/personas/legal/03-statutory-scholar.json
@@ -22,6 +22,6 @@
     "limitations issue raised"
   ],
   "godhead_prompt": "You are The Statutory Scholar for Fortress Prime's Legal Council. Analyze the case under the governing statutes and procedural rules, especially Georgia law where applicable. Do not invent authority citations. Return only the requested JSON object.",
-  "vector_collection": "legal_library",
+  "vector_collection": "legal_library_v2",
   "created_at": "2026-03-29T00:00:00Z"
 }

--- a/personas/legal/04-e-discovery-forensic.json
+++ b/personas/legal/04-e-discovery-forensic.json
@@ -22,6 +22,6 @@
     "preservation question raised"
   ],
   "godhead_prompt": "You are The E-Discovery Forensic for Fortress Prime's Legal Council. Reconstruct the case from records and metadata, not assumptions. Highlight objective evidence and contradiction vectors. Return only the requested JSON object.",
-  "vector_collection": "legal_library",
+  "vector_collection": "legal_library_v2",
   "created_at": "2026-03-29T00:00:00Z"
 }

--- a/personas/legal/05-devils-advocate.json
+++ b/personas/legal/05-devils-advocate.json
@@ -22,6 +22,6 @@
     "operator asks for risk check"
   ],
   "godhead_prompt": "You are The Devil's Advocate for Fortress Prime's Legal Council. Deliberately attack the defense case and identify the strongest arguments against it. Stay grounded in the supplied record. Return only the requested JSON object.",
-  "vector_collection": "legal_library",
+  "vector_collection": "legal_library_v2",
   "created_at": "2026-03-29T00:00:00Z"
 }

--- a/personas/legal/06-compliance-officer.json
+++ b/personas/legal/06-compliance-officer.json
@@ -22,6 +22,6 @@
     "regulatory or policy exposure flagged"
   ],
   "godhead_prompt": "You are The Compliance Officer for Fortress Prime's Legal Council. Assess the record for policy, process, and compliance implications that change litigation posture or required remediation. Return only the requested JSON object.",
-  "vector_collection": "legal_library",
+  "vector_collection": "legal_library_v2",
   "created_at": "2026-03-29T00:00:00Z"
 }

--- a/personas/legal/07-local-counsel.json
+++ b/personas/legal/07-local-counsel.json
@@ -22,6 +22,6 @@
     "judge-specific caution needed"
   ],
   "godhead_prompt": "You are The Local Counsel for Fortress Prime's Legal Council. Give the practical forum-facing assessment a local litigator would want before filing. Stay concrete, restrained, and record-bound. Return only the requested JSON object.",
-  "vector_collection": "legal_library",
+  "vector_collection": "legal_library_v2",
   "created_at": "2026-03-29T00:00:00Z"
 }

--- a/personas/legal/08-risk-assessor.json
+++ b/personas/legal/08-risk-assessor.json
@@ -22,6 +22,6 @@
     "risk factors need prioritization"
   ],
   "godhead_prompt": "You are The Risk Assessor for Fortress Prime's Legal Council. Quantify the posture qualitatively: where the defense is strong, where risk concentrates, and what action best preserves leverage. Return only the requested JSON object.",
-  "vector_collection": "legal_library",
+  "vector_collection": "legal_library_v2",
   "created_at": "2026-03-29T00:00:00Z"
 }

--- a/personas/legal/09-chief-justice.json
+++ b/personas/legal/09-chief-justice.json
@@ -22,6 +22,6 @@
     "final answer posture selected"
   ],
   "godhead_prompt": "You are The Chief Justice for Fortress Prime's Legal Council. Synthesize the strongest defensible final posture from the record and the competing analytical lenses. Be balanced, disciplined, and exact. Return only the requested JSON object.",
-  "vector_collection": "legal_library",
+  "vector_collection": "legal_library_v2",
   "created_at": "2026-03-29T00:00:00Z"
 }


### PR DESCRIPTION
> **🛑 MERGE BLOCKED on operator review.** Read-side cutover only — no privileged or ediscovery changes (per Option B in PR #308). Smoke run on Case I (7il-v-knight-ndga-i) passes all stop-condition gates with citations *above* baseline.

## Summary

Switch retrieval consumers of `legal_caselaw` and `legal_library` from the legacy 768-dim `nomic-embed-text` collections to the 2048-dim sovereign `legal-embed` `_v2` collections that PR #308 reindexed and PR #308 §Operator-decision accepted. Privileged + ediscovery + hive_mind_memory **stay on legacy** per Option B.

`legal-embed` was dormant from the consumer's perspective until this PR — the gateway alias has existed since PR #300 but nothing was reading from `_v2`. After this PR merges, caselaw + library retrieval rides the new encoder + collections; everything else is unchanged.

## Files changed

### Embedder (1)
- `fortress-guest-platform/backend/core/vector_db.py` — new `embed_legal_query()` helper. Routes via the LiteLLM gateway alias `legal-embed`, sends the **mandatory caller contract** (`input_type=\"query\"` + `encoding_format=\"float\"` per PR #300 §9.5; the NIM rejects the OpenAI-client implicit `None` default with HTTP 400). Auth via `settings.litellm_master_key`.

### Retrieval consumers cut over (5)
- `fortress-guest-platform/backend/services/legal_council.py` — `CASELAW_COLLECTION` → `legal_caselaw_v2`; default `vector_collection` → `legal_library_v2`; `LEGAL_ALLOWED_VECTOR_COLLECTIONS` allowlist updated; new `_embed_legal_query` helper used by `freeze_caselaw_context`. Legacy `_embed_text` retained for `freeze_context` (ediscovery) + `freeze_privileged_context` (privileged) — those paths stay on nomic.
- `fortress-guest-platform/backend/services/knowledge_retriever.py` — `LEGAL_COLLECTION` → `legal_library_v2`; `legal_library_search()` uses `_embed_legal_query`. Other (non-legal) consumers in this module (`fortress_knowledge`, KB sync) stay on nomic.
- `fortress-guest-platform/backend/services/legal_auditor.py` — `STATUTORY_COLLECTION` → `legal_library_v2`; `query_statutory_law()` uses `embed_legal_query` via the gateway, replacing the direct Ollama call.
- `fortress-guest-platform/backend/api/intelligence.py` — federated knowledge search now embeds the query separately per encoder family: nomic for `fortress_knowledge` + `email_embeddings`, legal-embed for `legal_library_v2`. Per-collection encoder dispatch added.

### Persona configs (9)
- `personas/legal/0[1-9]-*.json` — `vector_collection`: `legal_library` → `legal_library_v2` across all 9 council personas.

### Atlas + tests (5)
- `fortress_atlas.yaml` — `legal_library` → `legal_library_v2` in `division_legal.qdrant_collections`.
- `fortress-guest-platform/backend/tests/test_legal_council_caselaw_retrieval.py` — fixtures + 2 new routing-guard tests (`test_freeze_caselaw_uses_legal_embed_router`, `test_freeze_ediscovery_still_uses_legacy_nomic`).
- `fortress-guest-platform/backend/tests/test_legal_council_provider_gating.py` — fixture rename.
- `fortress-guest-platform/backend/tests/test_legal_council_retry.py` — fixture rename.
- `fortress-guest-platform/backend/tests/test_persona_domain_guards.py` — fixture rename.

## Caller-contract enforcement

Every embed call site that targets `legal-embed` sends both required fields. The contract is concentrated in `embed_legal_query()` so consumers can't accidentally drop them:

```python
payload = {
    \"input\": text,
    \"model\": \"legal-embed\",
    \"input_type\": \"query\",        # asymmetric encoder
    \"encoding_format\": \"float\",   # NIM rejects None default → HTTP 400
}
```

Call sites verified end-to-end through the smoke run (zero HTTP 400s in the gateway log during the 39-min run window).

## Pytest

```
28 passed in 0.86s
```

Targeted run:
```bash
.uv-venv/bin/pytest backend/tests/test_legal_council_caselaw_retrieval.py \\
                    backend/tests/test_legal_council_provider_gating.py \\
                    backend/tests/test_legal_council_retry.py \\
                    backend/tests/test_persona_domain_guards.py -x -q
```

The two new tests assert the routing invariant after this PR:
- `test_freeze_caselaw_uses_legal_embed_router` — `freeze_caselaw_context` MUST dispatch through `_embed_legal_query` (2048-dim legal-embed via gateway), NOT `_embed_text` (768-dim nomic). Regressing this would silently re-route caselaw search to the wrong encoder + collection dim.
- `test_freeze_ediscovery_still_uses_legacy_nomic` — `freeze_context` (ediscovery path) MUST stay on `_embed_text` / 768-dim nomic. Phase A PR #2 only cuts over caselaw + library; ediscovery is queued for Phase A PR #4.

## Smoke run — Case I (7il-v-knight-ndga-i)

```
$ python -m backend.scripts.case_briefing_cli compose \\
    --case-slug 7il-v-knight-ndga-i \\
    --output-dir /tmp/phase-a-pr2-smoke-out

real    39m17s
sections_count        = 10
contains_privileged   = False
vault_documents       = 820
work_product_chunks   = 30
privileged_chunks     = 0
```

Output: `Attorney_Briefing_Package_7IL_Properties_LLC_v_Knight_Case_I_v1_20260430.md` — 563 lines, 44.8 KB.

### Stop-condition gates

| Gate | Threshold | Result | PASS? |
|---|---|---:|:---:|
| Sections produced | 10/10 | **10/10** | ✅ |
| Section 7 defense-counsel exclusion (`privileged_chunks`) | 0 | **0** | ✅ |
| Cloud outbound during run | 0 | **0** (URL-anchored grep on litellm-gateway journal, 06:34–07:15 EDT) | ✅ |
| Retrieval errors / HTTP 400 from `legal-embed` | 0 | **0** in stdout + gateway log | ✅ |
| Word count delta vs PR #302 v3 baseline | ±25% | +1.1% (563 / 557 lines) | ✅ |
| Average drop in synthesis-section citations | <20% drop | **+41.8% average increase** | ✅ |

### Per-synthesis-section citation comparison vs PR #302 baseline

PR #302 §Section 7-table established the baseline as **18 / 21 / 18 / 22 / 28 = 107** citations across the 5 synthesis sections (2 / 4 / 5 / 7 / 8). Re-running the same orchestrator with `legal_caselaw_v2` + `legal_library_v2` cut over:

| Section | Mode | Baseline cites | This PR cites | Delta |
|---|---|---:|---:|---:|
| 2 Critical Timeline       | synthesis | 18 | **38** | **+111%** |
| 4 Claims Analysis         | synthesis | 21 | **22** | **+5%**   |
| 5 Key Defenses Identified | synthesis | 18 | **22** | **+22%**  |
| 7 Email Intelligence Report | synthesis | 22 | **40** | **+82%**  |
| 8 Financial Exposure Analysis | synthesis | 28 | **25** | **-11%**  |
| **Total synthesis cites** | | **107** | **147** | **+37%** |

Citation density increased on 4 of 5 synthesis sections; only Section 8 dropped (-11%), well within the 20% per-section tolerance the brief implies. No section degraded materially. The bigger picture: average +41.8%, total +37%.

This is consistent with operator-decision Option B's hypothesis from PR #308 — `legal-embed` (legal-corpus-trained, 2048-dim) appears to surface MORE relevant retrieval hits per query on the case-law-and-library queries that drive these sections, vs. general-purpose `nomic-embed-text` (768-dim).

### Section 6 Evidence Inventory — apples-to-apples 0 → 0

Section 6 is **mechanical** mode in both baseline and this PR (it lists curated vault clusters from `legal_ediscovery`, which this PR does NOT touch). Both runs produce 0 `[*.pdf]`-style citations because the section uses tabular evidence-cluster listings, not citation-style references. Same content shape; encoder swap had no effect (as expected — ediscovery stays on nomic per scope).

## What this PR does NOT modify

| Surface | Status |
|---|---|
| `legal_privileged_communications` retrieval | unchanged (Option B defer) |
| `legal_ediscovery` retrieval | unchanged (Phase A PR #4) |
| `legal_hive_mind_memory` retrieval | unchanged (separate encoder decision) |
| `case_briefing_synthesizers.py` | untouched (Phase B v0.2 owns) |
| Ingestion writers (`legal_vector_sync.py`, `ingest_courtlistener*.py`, contract ingest) | untouched (write-side cutover is post-soak) |
| LiteLLM gateway config / NIM service / Vision NIM / BRAIN / spark-1 / spark-5 | untouched |
| `nomic-embed-text` Ollama service | untouched |
| Legacy 768-dim `legal_*` collections | untouched (retained until post-soak retirement PR) |
| All `_v2` collections (point counts, schemas) | untouched (read-only consumers) |

## Operator review checklist

- [ ] Caller-contract enforcement looks right (`input_type=query` + `encoding_format=float` everywhere `legal-embed` is hit)
- [ ] Encoder-routing tests cover the invariant (caselaw → legal-embed; ediscovery → nomic)
- [ ] Smoke citation numbers look healthy (avg +41.8% on 5 synthesis sections; no section dropped >20%)
- [ ] Section 7 privileged exclusion still holds (privileged_chunks = 0)
- [ ] Zero cloud outbound during the 39-min run window
- [ ] Word count within ±25% (actual +1.1%)
- [ ] No write-side surprise (ingestion paths consciously left on legacy until post-soak)
- [ ] Branch-rewind incident note: branch was force-rewound mid-session by another agent twice; commits recovered via `git update-ref` and fast-forward push (no force-push, no destructive operation). Final ref state matches the commits in this PR exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)