### PR TITLE
Phase B v0.2: synthesizer <think>-block stripping (Pass 1, Case I Outcome A target)

### DIFF
--- a/fortress-guest-platform/backend/services/case_briefing_synthesizers.py
+++ b/fortress-guest-platform/backend/services/case_briefing_synthesizers.py
@@ -44,6 +44,59 @@ _SYSTEM_PROMPT = (
 )
 
 
+# ── Reasoning-trace stripping (Phase B v0.2 Pass 1) ──────────────────────────
+#
+# BRAIN (Nemotron-Super-49B-v1.5-fp8) emits visible <think>...</think> blocks
+# by design — the system prompt's "detailed thinking on" turns this on, and
+# the model uses the trace as a working memory before producing its actual
+# answer. The trace is unsuitable for white-shoe-grade attorney briefs:
+# it contains first-person planning prose ("Let me address...", "I should
+# focus on..."), self-corrections, and meta-commentary that breaks the
+# voice of a legal product.
+#
+# Pass 1 (this PR): strip the <think>...</think> tags + their contents.
+# Pass 2 (deferred): handle first-person planning prose that survives
+#   *outside* the tags. Tracked as a follow-up if the surviving count is
+#   non-trivial.
+
+_THINK_BLOCK_RE = re.compile(r"<think>.*?</think>", flags=re.DOTALL)
+# Truncated trace: <think> with no matching close tag. Strip from <think>
+# to the next blank line (double-newline) or end of text — the model is
+# either still trace-thinking when it ran out of tokens or the stream cut
+# mid-thought; either way the partial trace is unusable downstream.
+_UNCLOSED_THINK_RE = re.compile(r"<think>(?:(?!\n\n).)*(?:\n\n|\Z)", flags=re.DOTALL)
+_EXCESS_NEWLINES_RE = re.compile(r"\n{3,}")
+
+
+def strip_reasoning_trace(text: str) -> str:
+    """Remove BRAIN's <think>...</think> reasoning traces from synthesizer output.
+
+    Pass 1 scope: tag-only stripping. First-person prose that survives
+    outside <think> tags is intentionally preserved — Pass 2 (if needed) is
+    a separate brief.
+
+    Behavior:
+    - Strip every closed `<think>...</think>` block (multiline-aware, greedy
+      to the nearest `</think>`).
+    - For an unclosed `<think>` (truncated mid-trace): strip from `<think>`
+      to the next double-newline OR end of text, whichever comes first.
+    - Collapse runs of 3+ consecutive newlines down to 2 (artifact cleanup).
+    - Strip leading/trailing whitespace.
+
+    Idempotent: running twice on the same text equals running once.
+    """
+    if not text:
+        return text
+    # 1. Strip closed blocks first (the common case).
+    cleaned = _THINK_BLOCK_RE.sub("", text)
+    # 2. Strip any remaining unclosed <think> (truncated stream).
+    cleaned = _UNCLOSED_THINK_RE.sub("", cleaned)
+    # 3. Collapse newline runs.
+    cleaned = _EXCESS_NEWLINES_RE.sub("\n\n", cleaned)
+    # 4. Trim outer whitespace.
+    return cleaned.strip()
+
+
 _DEFENSE_COUNSEL_DOMAINS = (
     "mhtlegal.com",
     "fgplaw.com",
@@ -246,6 +299,14 @@ async def synthesize_synthesis_section(
     )
     async for chunk in iterator:
         response += chunk
+
+    # Phase B v0.2 Pass 1: strip BRAIN's <think>...</think> reasoning traces
+    # before any downstream processing (citation detection, SectionResult).
+    # Done before _detect_grounding_citations so the citation match runs
+    # against the cleaned body — citations don't appear inside <think>
+    # blocks (BRAIN doesn't cite mid-trace), but stripping first keeps
+    # semantics clean and avoids any future trace-mining ambiguity.
+    response = strip_reasoning_trace(response)
 
     grounded_citations, matched_sources = _detect_grounding_citations(
         response,

--- a/fortress-guest-platform/backend/tests/test_case_briefing_synthesizers.py
+++ b/fortress-guest-platform/backend/tests/test_case_briefing_synthesizers.py
@@ -1,0 +1,165 @@
+"""Tests for case_briefing_synthesizers — focused on Phase B v0.2 Pass 1
+reasoning-trace stripping. The synthesis-call path itself (BRAIN streaming,
+citation detection, defense-counsel exclusion) is exercised end-to-end by
+the dry-run smoke documented in `docs/operational/phase-b-v0.1-dry-run-2026-04-29.md`
+and the Phase A PR #2 cutover smoke; this file isolates the deterministic
+text-cleanup primitive.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.services.case_briefing_synthesizers import strip_reasoning_trace
+
+
+class TestStripReasoningTrace:
+    """Pass 1 — strip <think>...</think> blocks. First-person prose handling
+    outside the tags is intentionally out of scope; Pass 2 (if needed) is a
+    separate brief."""
+
+    def test_strips_simple_think_block(self):
+        # Smallest synthetic case.
+        body = "<think>I should write this section.</think>\n\nThe result body."
+        out = strip_reasoning_trace(body)
+        assert "<think>" not in out
+        assert "</think>" not in out
+        assert "I should write this section." not in out
+        assert out == "The result body."
+
+    def test_strips_multiline_think_block(self):
+        # Real fixture from PR #311 Phase A cutover smoke (Section 2 Critical
+        # Timeline). The trace spans many lines and contains the model's
+        # working memory before it produced the actual table.
+        body = (
+            "<think>\n"
+            "Okay, let's tackle this. The user wants a chronological timeline of dated events from the case evidence provided. I need to go through each evidence block and extract any dates mentioned, then organize them in order.\n"
+            "\n"
+            "Starting with the first evidence block, [2022.01.04 Pl's Initial Disclosures.pdf], there's a mention of March 14, 2021, when 7 IL Properties and Gary Knight entered into a contract for 253 River Heights Road. Then April 5, 2021, for the 92 Fish Trap Road agreement.\n"
+            "</think>\n"
+            "\n"
+            "| Date | Event | Source |\n"
+            "|------|-------|--------|\n"
+            "| 2021-03-14 | Contract executed for 253 River Heights Road | [2022.01.04 Pl's Initial Disclosures.pdf] |\n"
+        )
+        out = strip_reasoning_trace(body)
+        assert "<think>" not in out
+        assert "</think>" not in out
+        assert "Okay, let's tackle this" not in out
+        assert "I need to go through" not in out
+        # Substantive content preserved.
+        assert "| Date | Event | Source |" in out
+        assert "2021-03-14" in out
+        assert "[2022.01.04 Pl's Initial Disclosures.pdf]" in out
+
+    def test_strips_multiple_think_blocks(self):
+        # BRAIN occasionally emits multiple traces per response (mid-section
+        # self-correction). Each must be stripped independently — greedy on
+        # the *nearest* close tag, not on document end.
+        body = (
+            "<think>First trace — planning the table.</think>\n"
+            "\n"
+            "Section header.\n"
+            "\n"
+            "<think>Second trace — checking the citation format.</think>\n"
+            "\n"
+            "Final body line.\n"
+        )
+        out = strip_reasoning_trace(body)
+        assert out.count("<think>") == 0
+        assert out.count("</think>") == 0
+        assert "First trace" not in out
+        assert "Second trace" not in out
+        assert "Section header." in out
+        assert "Final body line." in out
+
+    def test_handles_unclosed_think_tag(self):
+        # Truncated stream — BRAIN ran out of tokens mid-trace OR the stream
+        # cut before </think>. Strip from <think> to the next blank line
+        # (double-newline) or end of text. The substantive body that follows
+        # the blank line must be preserved.
+        body = (
+            "Existing prose above the trace.\n"
+            "\n"
+            "<think>\n"
+            "Now I need to think about how to phrase this carefully — the user wants a clean response so I should\n"
+            "\n"
+            "Actual final body that survived after the truncated trace.\n"
+        )
+        out = strip_reasoning_trace(body)
+        assert "<think>" not in out
+        assert "Now I need to think" not in out
+        assert "Existing prose above the trace." in out
+        assert "Actual final body that survived" in out
+
+    def test_preserves_substantive_body_prose(self):
+        # No-op on clean input — must not corrupt or rewrite anything.
+        clean = (
+            "## 4. Claims Analysis\n"
+            "\n"
+            "### Specific Performance\n"
+            "Plaintiff alleges breach of the 253 River Heights Road purchase agreement. "
+            "[#13 Joint Preliminary Statement.pdf, p. 5]\n"
+            "\n"
+            "### Breach of Contract\n"
+            "The closing was set for 2021-06-01 but the contract expired without closing. "
+            "[2022.01.04 Pl's Initial Disclosures.pdf]\n"
+        )
+        out = strip_reasoning_trace(clean)
+        assert out == clean.strip()
+
+    def test_collapses_excess_newlines(self):
+        # Stripping a <think> block can leave a long run of blank lines in
+        # the surrounding text. Collapse 3+ to exactly 2 so the markdown
+        # rendering stays tidy.
+        body = "Header\n\n\n\n\n<think>trace</think>\n\n\n\n\nBody"
+        out = strip_reasoning_trace(body)
+        # Must not contain a run of 3+ newlines.
+        assert "\n\n\n" not in out
+        assert "Header" in out
+        assert "Body" in out
+        # Exactly one paragraph break between Header and Body.
+        assert out == "Header\n\nBody"
+
+    def test_idempotent(self):
+        # Running strip twice equals running once — useful when callers
+        # double-wrap the helper or the synthesizer is retried.
+        body = (
+            "<think>plan</think>\n\n# Title\n\n<think>recheck</think>\n\nBody."
+        )
+        once = strip_reasoning_trace(body)
+        twice = strip_reasoning_trace(once)
+        assert once == twice
+
+    def test_preserves_first_person_outside_think(self):
+        # Pass 1 ONLY strips tags. First-person planning prose that survives
+        # *outside* <think> tags is intentionally preserved here — Pass 2
+        # (system-prompt fix or post-strip prose filter) is a separate brief.
+        # This test pins that contract so a future change can't silently
+        # promote Pass 2 into Pass 1.
+        body = (
+            "<think>Okay, let me plan this.</think>\n"
+            "\n"
+            "Let me address the four counts in plaintiff's complaint.\n"
+            "\n"
+            "Now, looking at the evidence record, I should focus on...\n"
+        )
+        out = strip_reasoning_trace(body)
+        assert "<think>" not in out
+        # First-person prose OUTSIDE the tags survives:
+        assert "Let me address the four counts" in out
+        assert "Now, looking at the evidence record" in out
+        assert "I should focus on" in out
+
+
+@pytest.mark.parametrize(
+    "input_text,expected",
+    [
+        ("", ""),
+        (None, None),
+        ("no tags here", "no tags here"),
+        ("<think></think>", ""),  # empty trace
+    ],
+)
+def test_strip_edge_cases(input_text, expected):
+    """Edge cases that aren't worth a named test method."""
+    assert strip_reasoning_trace(input_text) == expected


### PR DESCRIPTION
> **🛑 MERGE BLOCKED on operator review.** Pass 1 stripper is correct + 12/12 unit-tested. Re-run on Case I reveals BRAIN puts substantive answer content INSIDE `<think>` for sections 4/5/8 — stripping per spec eats most of those sections. Two HARD PASS gates breached. Recommendation: **v0.3 prompt-fix required** before Case II.

## TL;DR

| | |
|---|---|
| Pass 1 stripper | ✅ 12/12 unit tests; integrated at single call site |
| Re-run on Case I | ✅ 39 min, 0 cloud outbound, 0 errors |
| `<think>` tags in v0.2 output | **0** ✅ |
| First-person planning prose | **6** (was 22 in PR #302) — −73% |
| Section 4 grounding cites | **2** (≥3 floor) — **❌ HALT** |
| Word count vs PR #311 baseline | **−44.3%** (>25% threshold) — **❌ HALT** |
| Root cause | BRAIN treats `<think>` as primary output container for sections 4/5/8 |
| Recommendation | **v0.3 brief: synthesizer prompt fix** (remove "detailed thinking on" or two-pass) |

## What this PR adds

`backend/services/case_briefing_synthesizers.py`:
- `strip_reasoning_trace(text)` — Pass 1 tag-only strip per brief spec (multiline `<think>...</think>`; truncated unclosed `<think>` to next blank line; collapse 3+ newlines → 2; idempotent).
- Integrated in `synthesize_synthesis_section()` after streamed `response` accumulates, before `_detect_grounding_citations`.

`backend/tests/test_case_briefing_synthesizers.py` (NEW):
- 8 named cases per brief + 4 parameterized edge cases.
- Real Nemotron `<think>` excerpts from PR #311 smoke output as fixtures.
- `test_preserves_first_person_outside_think` pins Pass 1 contract — prevents silent Pass 2 promotion.

```
12 passed in 0.75s
```

## Re-run on Case I

39m17s, 384 lines, 24,950 bytes. Output at `/mnt/fortress_nas/legal-briefs/7il-v-knight-ndga-i-v3-2026-04-30.md`. Outcome-b PR #302 v3 preserved at `7il-v-knight-ndga-i-v3-outcome-b-2026-04-29.md`.

## HARD PASS criteria

| Criterion | Threshold | Actual | PASS? |
|---|---|---:|:---:|
| `<think>` / `</think>` count | 0 | **0 / 0** | ✅ |
| Sections produced | 10/10 | **10/10** | ✅ |
| Section 7 defense-counsel exclusion | 0 hits | **privileged_chunks=0** | ✅ |
| FYEO absent for Case I | yes | **0 hits** | ✅ |
| Cloud outbound | 0 | **0** | ✅ |
| Retrieval errors | 0 | **0** | ✅ |
| **Cites ≥3 per synth section** | ≥3 | **Section 4 = 2** | **❌** |

## Per-section citation comparison

| Section | PR #302 | PR #311 | v0.2 | v0.2 vs #311 |
|---|---:|---:|---:|---:|
| 2 Critical Timeline       | 18 | 38 | **38** | 0% |
| 4 Claims Analysis         | 21 | 22 | **2**  | **−91%** |
| 5 Key Defenses Identified | 18 | 22 | **8**  | −64% |
| 7 Email Intelligence      | 22 | 40 | **40** | 0% |
| 8 Financial Exposure      | 28 | 25 | **12** | −52% |
| **Total synth cites**     | 107 | 147 | 100 | −32% |

Sections 2 + 7 unaffected — content lived OUTSIDE `<think>`. Sections 4/5/8 collapsed because most content was inside `<think>` blocks.

## Word count

| vs baseline | PR #302 (557 lines, 46 KB) | PR #311 (563 lines, 44.8 KB) |
|---|---:|---:|
| v0.2 (384 lines, 24,950 B) | −31% lines, −45.9% bytes | −32% lines, **−44.3% bytes** |

>25% drop fires the brief's stop condition. The drop is **expected behavior** of the stripper given how BRAIN structured the input — the threshold was set assuming small scratchpad traces; in practice the trace was the bulk.

## Root cause

Sample from v0.2 Section 4 tail (post-strip):
```
- **Plaintiff's Claim:** The 92 Fish Trap Road Agreement had a closing deadline of June 1, 2021
  ([#13 Joint Preliminary Statement.pdf], p. 3; ...).
- **
```

Section ends mid-bullet — BRAIN exhausted `max_tokens=2000` inside `<think>` and the visible answer got cut. PR #311 Section 4 (pre-strip) showed the same shape: 50+ lines of `<think>` with 22 citations, followed by ~10 lines of visible body. Stripping the trace per spec leaves only the abbreviated body.

Consistent with the `_SYSTEM_PROMPT`'s `"detailed thinking on\n\n"` directive — Nemotron-Super-49B-v1.5-fp8 treats the trace as its working answer surface for some sections, not as a separate scratchpad. **Stripper is correct; the input has the wrong shape.**

## Recommendation

Per brief decision rule: first-person count (**6**) ≥ 5 threshold + Section 4 cite breach → **v0.3 prompt-fix required**.

Proposed v0.3 scope (NOT this PR):
- **Option A:** Remove `"detailed thinking on\n\n"` from `_SYSTEM_PROMPT`. Simplest. BRAIN won't emit `<think>`; streams the answer directly.
- **Option B:** Keep "detailed thinking on" but add: *"After your reasoning, output a complete final answer with full citations OUTSIDE the `<think>` block."* (Nemotron may or may not respect.)
- **Option C:** Two-pass synthesis (first call: reasoning; second call: clean answer with first call as context). Most robust; ~2× token spend.
- Re-baseline Case I; expect Section 4/5/8 cites to recover toward PR #311 numbers (22/22/25).
- **Keep this PR's Pass 1 stripper** as defense-in-depth.

**Outcome A on Case I is NOT achieved.** Counsel-hire critical path (master plan §2, ~46 days remaining) requires v0.3 before Case II.

## What this PR does NOT touch

BRAIN, Vision NIM, embed NIM, LiteLLM gateway, `legal_council.py`, Phase B retrieval primitives, Qdrant collections (legacy + `_v2`), `case_briefing_compose.py`, synthesizer system prompts, Pass 2 / first-person prose handling, Case II.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
