### PR TITLE
Phase B v0.3.5: drop 'detailed thinking on' from synthesizer prompt (Case I Outcome A target)

### DIFF
--- a/fortress-guest-platform/backend/services/case_briefing_synthesizers.py
+++ b/fortress-guest-platform/backend/services/case_briefing_synthesizers.py
@@ -34,8 +34,18 @@ from backend.services.case_briefing_compose import (
 logger = logging.getLogger("case_briefing_synthesizers")
 
 
+# Phase B v0.3.5 (2026-04-30): the previous prompt began with `"detailed
+# thinking on\n\n"`, which activates Nemotron-Super-49B-v1.5-fp8's visible
+# chain-of-thought mode and emits <think>...</think> blocks. PR #313 v0.2
+# stripped the blocks but lost answer content because the model used <think>
+# as a primary output container; PR #316 v0.3 added an OUTPUT CONTRACT
+# instruction to relocate the answer outside the tags but Nemotron read that
+# as a "be brief" directive and dropped citations. Removing the directive
+# entirely is option (a) per the v0.3 close-out — the model streams the
+# answer directly without a reasoning trace, which was being discarded
+# anyway. The Pass 1 stripper below stays in place as a defensive no-op:
+# if the model still occasionally emits a stray <think> block it gets caught.
 _SYSTEM_PROMPT = (
-    "detailed thinking on\n\n"
     "You are a meticulous legal analyst supporting Fortress Prime's defense team. "
     "Answer ONLY from the CASE EVIDENCE blocks provided. Cite the bracketed source "
     "filename in each chunk header for every factual claim. Privileged chunks are "

--- a/fortress-guest-platform/backend/services/case_briefing_synthesizers.py
+++ b/fortress-guest-platform/backend/services/case_briefing_synthesizers.py
@@ -44,6 +44,59 @@ _SYSTEM_PROMPT = (
 )
 
 
+# ── Reasoning-trace stripping (Phase B v0.2 Pass 1) ──────────────────────────
+#
+# BRAIN (Nemotron-Super-49B-v1.5-fp8) emits visible <think>...</think> blocks
+# by design — the system prompt's "detailed thinking on" turns this on, and
+# the model uses the trace as a working memory before producing its actual
+# answer. The trace is unsuitable for white-shoe-grade attorney briefs:
+# it contains first-person planning prose ("Let me address...", "I should
+# focus on..."), self-corrections, and meta-commentary that breaks the
+# voice of a legal product.
+#
+# Pass 1 (this PR): strip the <think>...</think> tags + their contents.
+# Pass 2 (deferred): handle first-person planning prose that survives
+#   *outside* the tags. Tracked as a follow-up if the surviving count is
+#   non-trivial.
+
+_THINK_BLOCK_RE = re.compile(r"<think>.*?</think>", flags=re.DOTALL)
+# Truncated trace: <think> with no matching close tag. Strip from <think>
+# to the next blank line (double-newline) or end of text — the model is
+# either still trace-thinking when it ran out of tokens or the stream cut
+# mid-thought; either way the partial trace is unusable downstream.
+_UNCLOSED_THINK_RE = re.compile(r"<think>(?:(?!\n\n).)*(?:\n\n|\Z)", flags=re.DOTALL)
+_EXCESS_NEWLINES_RE = re.compile(r"\n{3,}")
+
+
+def strip_reasoning_trace(text: str) -> str:
+    """Remove BRAIN's <think>...</think> reasoning traces from synthesizer output.
+
+    Pass 1 scope: tag-only stripping. First-person prose that survives
+    outside <think> tags is intentionally preserved — Pass 2 (if needed) is
+    a separate brief.
+
+    Behavior:
+    - Strip every closed `<think>...</think>` block (multiline-aware, greedy
+      to the nearest `</think>`).
+    - For an unclosed `<think>` (truncated mid-trace): strip from `<think>`
+      to the next double-newline OR end of text, whichever comes first.
+    - Collapse runs of 3+ consecutive newlines down to 2 (artifact cleanup).
+    - Strip leading/trailing whitespace.
+
+    Idempotent: running twice on the same text equals running once.
+    """
+    if not text:
+        return text
+    # 1. Strip closed blocks first (the common case).
+    cleaned = _THINK_BLOCK_RE.sub("", text)
+    # 2. Strip any remaining unclosed <think> (truncated stream).
+    cleaned = _UNCLOSED_THINK_RE.sub("", cleaned)
+    # 3. Collapse newline runs.
+    cleaned = _EXCESS_NEWLINES_RE.sub("\n\n", cleaned)
+    # 4. Trim outer whitespace.
+    return cleaned.strip()
+
+
 _DEFENSE_COUNSEL_DOMAINS = (
     "mhtlegal.com",
     "fgplaw.com",
@@ -246,6 +299,14 @@ async def synthesize_synthesis_section(
     )
     async for chunk in iterator:
         response += chunk
+
+    # Phase B v0.2 Pass 1: strip BRAIN's <think>...</think> reasoning traces
+    # before any downstream processing (citation detection, SectionResult).
+    # Done before _detect_grounding_citations so the citation match runs
+    # against the cleaned body — citations don't appear inside <think>
+    # blocks (BRAIN doesn't cite mid-trace), but stripping first keeps
+    # semantics clean and avoids any future trace-mining ambiguity.
+    response = strip_reasoning_trace(response)
 
     grounded_citations, matched_sources = _detect_grounding_citations(
         response,

--- a/fortress-guest-platform/backend/tests/test_case_briefing_synthesizers.py
+++ b/fortress-guest-platform/backend/tests/test_case_briefing_synthesizers.py
@@ -1,0 +1,165 @@
+"""Tests for case_briefing_synthesizers — focused on Phase B v0.2 Pass 1
+reasoning-trace stripping. The synthesis-call path itself (BRAIN streaming,
+citation detection, defense-counsel exclusion) is exercised end-to-end by
+the dry-run smoke documented in `docs/operational/phase-b-v0.1-dry-run-2026-04-29.md`
+and the Phase A PR #2 cutover smoke; this file isolates the deterministic
+text-cleanup primitive.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.services.case_briefing_synthesizers import strip_reasoning_trace
+
+
+class TestStripReasoningTrace:
+    """Pass 1 — strip <think>...</think> blocks. First-person prose handling
+    outside the tags is intentionally out of scope; Pass 2 (if needed) is a
+    separate brief."""
+
+    def test_strips_simple_think_block(self):
+        # Smallest synthetic case.
+        body = "<think>I should write this section.</think>\n\nThe result body."
+        out = strip_reasoning_trace(body)
+        assert "<think>" not in out
+        assert "</think>" not in out
+        assert "I should write this section." not in out
+        assert out == "The result body."
+
+    def test_strips_multiline_think_block(self):
+        # Real fixture from PR #311 Phase A cutover smoke (Section 2 Critical
+        # Timeline). The trace spans many lines and contains the model's
+        # working memory before it produced the actual table.
+        body = (
+            "<think>\n"
+            "Okay, let's tackle this. The user wants a chronological timeline of dated events from the case evidence provided. I need to go through each evidence block and extract any dates mentioned, then organize them in order.\n"
+            "\n"
+            "Starting with the first evidence block, [2022.01.04 Pl's Initial Disclosures.pdf], there's a mention of March 14, 2021, when 7 IL Properties and Gary Knight entered into a contract for 253 River Heights Road. Then April 5, 2021, for the 92 Fish Trap Road agreement.\n"
+            "</think>\n"
+            "\n"
+            "| Date | Event | Source |\n"
+            "|------|-------|--------|\n"
+            "| 2021-03-14 | Contract executed for 253 River Heights Road | [2022.01.04 Pl's Initial Disclosures.pdf] |\n"
+        )
+        out = strip_reasoning_trace(body)
+        assert "<think>" not in out
+        assert "</think>" not in out
+        assert "Okay, let's tackle this" not in out
+        assert "I need to go through" not in out
+        # Substantive content preserved.
+        assert "| Date | Event | Source |" in out
+        assert "2021-03-14" in out
+        assert "[2022.01.04 Pl's Initial Disclosures.pdf]" in out
+
+    def test_strips_multiple_think_blocks(self):
+        # BRAIN occasionally emits multiple traces per response (mid-section
+        # self-correction). Each must be stripped independently — greedy on
+        # the *nearest* close tag, not on document end.
+        body = (
+            "<think>First trace — planning the table.</think>\n"
+            "\n"
+            "Section header.\n"
+            "\n"
+            "<think>Second trace — checking the citation format.</think>\n"
+            "\n"
+            "Final body line.\n"
+        )
+        out = strip_reasoning_trace(body)
+        assert out.count("<think>") == 0
+        assert out.count("</think>") == 0
+        assert "First trace" not in out
+        assert "Second trace" not in out
+        assert "Section header." in out
+        assert "Final body line." in out
+
+    def test_handles_unclosed_think_tag(self):
+        # Truncated stream — BRAIN ran out of tokens mid-trace OR the stream
+        # cut before </think>. Strip from <think> to the next blank line
+        # (double-newline) or end of text. The substantive body that follows
+        # the blank line must be preserved.
+        body = (
+            "Existing prose above the trace.\n"
+            "\n"
+            "<think>\n"
+            "Now I need to think about how to phrase this carefully — the user wants a clean response so I should\n"
+            "\n"
+            "Actual final body that survived after the truncated trace.\n"
+        )
+        out = strip_reasoning_trace(body)
+        assert "<think>" not in out
+        assert "Now I need to think" not in out
+        assert "Existing prose above the trace." in out
+        assert "Actual final body that survived" in out
+
+    def test_preserves_substantive_body_prose(self):
+        # No-op on clean input — must not corrupt or rewrite anything.
+        clean = (
+            "## 4. Claims Analysis\n"
+            "\n"
+            "### Specific Performance\n"
+            "Plaintiff alleges breach of the 253 River Heights Road purchase agreement. "
+            "[#13 Joint Preliminary Statement.pdf, p. 5]\n"
+            "\n"
+            "### Breach of Contract\n"
+            "The closing was set for 2021-06-01 but the contract expired without closing. "
+            "[2022.01.04 Pl's Initial Disclosures.pdf]\n"
+        )
+        out = strip_reasoning_trace(clean)
+        assert out == clean.strip()
+
+    def test_collapses_excess_newlines(self):
+        # Stripping a <think> block can leave a long run of blank lines in
+        # the surrounding text. Collapse 3+ to exactly 2 so the markdown
+        # rendering stays tidy.
+        body = "Header\n\n\n\n\n<think>trace</think>\n\n\n\n\nBody"
+        out = strip_reasoning_trace(body)
+        # Must not contain a run of 3+ newlines.
+        assert "\n\n\n" not in out
+        assert "Header" in out
+        assert "Body" in out
+        # Exactly one paragraph break between Header and Body.
+        assert out == "Header\n\nBody"
+
+    def test_idempotent(self):
+        # Running strip twice equals running once — useful when callers
+        # double-wrap the helper or the synthesizer is retried.
+        body = (
+            "<think>plan</think>\n\n# Title\n\n<think>recheck</think>\n\nBody."
+        )
+        once = strip_reasoning_trace(body)
+        twice = strip_reasoning_trace(once)
+        assert once == twice
+
+    def test_preserves_first_person_outside_think(self):
+        # Pass 1 ONLY strips tags. First-person planning prose that survives
+        # *outside* <think> tags is intentionally preserved here — Pass 2
+        # (system-prompt fix or post-strip prose filter) is a separate brief.
+        # This test pins that contract so a future change can't silently
+        # promote Pass 2 into Pass 1.
+        body = (
+            "<think>Okay, let me plan this.</think>\n"
+            "\n"
+            "Let me address the four counts in plaintiff's complaint.\n"
+            "\n"
+            "Now, looking at the evidence record, I should focus on...\n"
+        )
+        out = strip_reasoning_trace(body)
+        assert "<think>" not in out
+        # First-person prose OUTSIDE the tags survives:
+        assert "Let me address the four counts" in out
+        assert "Now, looking at the evidence record" in out
+        assert "I should focus on" in out
+
+
+@pytest.mark.parametrize(
+    "input_text,expected",
+    [
+        ("", ""),
+        (None, None),
+        ("no tags here", "no tags here"),
+        ("<think></think>", ""),  # empty trace
+    ],
+)
+def test_strip_edge_cases(input_text, expected):
+    """Edge cases that aren't worth a named test method."""
+    assert strip_reasoning_trace(input_text) == expected


### PR DESCRIPTION
> **🛑 MERGE BLOCKED. Option (a) ALSO FAILED HARD PASS.** Removing `"detailed thinking on"` from the prompt eliminated `<think>` blocks at source (0 tags emitted) but citation density did not recover — synth-section totals are essentially tied with v0.3 (56 vs 57). Section 5 cleared its floor; sections 2 / 4 / 7 / 8 did not. Word count still −42.8% vs PR #311. **All three single-prompt-edit attempts (v0.2 strip, v0.3 OUTPUT CONTRACT, v0.3.5 directive removal) have failed.** Recommendation: **escalate to option (c) two-pass synthesis** — separate v0.4 PR.

## TL;DR

| | |
|---|---|
| Branch + PR | `feat/phase-b-v035-drop-detailed-thinking-2026-04-30` (stacked on PR #313) |
| Prompt change | Single line removed: `"detailed thinking on\n\n"` |
| Pytest | ✅ 12/12 (no test pinned prompt content) |
| Re-run on Case I | ✅ ~37 min, 0 cloud, 0 errors |
| `<think>` tags in v3 | **0** ✅ (model stopped emitting them at source — directive removal worked as designed) |
| First-person planning prose | **6** (same as v0.2; was 22 in PR #302, 4 in PR #316) |
| Section 5 cites | **20** ≥ 18 floor | ✅ |
| Section 2 / 4 / 7 / 8 cites | **22 / 0 / 10 / 4** vs floors **30 / 18 / 36 / 20** | ❌ |
| Word count vs PR #311 | **−42.8%** (>15% threshold) | ❌ |
| Recommendation | **Escalate to v0.4 option (c) — two-pass synthesis** |

## Diff (single-line removal + explanatory comment)

```diff
+# Phase B v0.3.5 (2026-04-30): the previous prompt began with `"detailed
+# thinking on\n\n"`, which activates Nemotron-Super-49B-v1.5-fp8's visible
+# chain-of-thought mode and emits <think>...</think> blocks. PR #313 v0.2
+# stripped the blocks but lost answer content because the model used <think>
+# as a primary output container; PR #316 v0.3 added an OUTPUT CONTRACT
+# instruction to relocate the answer outside the tags but Nemotron read that
+# as a "be brief" directive and dropped citations. Removing the directive
+# entirely is option (a) per the v0.3 close-out — the model streams the
+# answer directly without a reasoning trace, which was being discarded
+# anyway. The Pass 1 stripper below stays in place as a defensive no-op:
+# if the model still occasionally emits a stray <think> block it gets caught.
 _SYSTEM_PROMPT = (
-    "detailed thinking on\n\n"
     "You are a meticulous legal analyst supporting Fortress Prime's defense team. "
     "Answer ONLY from the CASE EVIDENCE blocks provided. Cite the bracketed source "
     "filename in each chunk header for every factual claim. Privileged chunks are "
     "marked [PRIVILEGED · ...]; do not paraphrase them outside this engagement. "
     "If the evidence does not answer a question, say so plainly — never invent."
 )
```

Pass 1 stripper from PR #313 is preserved as a defensive no-op: it now does nothing on the steady-state output (no `<think>` blocks emitted) but catches any stray block if the model regresses.

## HARD PASS criteria

| Gate | Threshold | Actual | PASS? |
|---|---|---:|:---:|
| `<think>` / `</think>` count | 0 | **0 / 0** | ✅ |
| Sections produced | 10/10 | **10/10** | ✅ |
| Section 7 defense-counsel exclusion | 0 hits | **privileged_chunks=0** | ✅ |
| FYEO absent for Case I | yes | **0 hits** | ✅ |
| Cloud outbound | 0 | **0** | ✅ |
| Retrieval errors | 0 | **0** | ✅ |
| **Section 2 cites** | ≥ 30 | **22** | **❌** |
| **Section 4 cites** | ≥ 18 | **0** | **❌** |
| **Section 5 cites** | ≥ 18 | **20** | **✅** |
| **Section 7 cites** | ≥ 36 | **10** | **❌** |
| **Section 8 cites** | ≥ 20 | **4** | **❌** |
| **Word count vs PR #311 (±15%)** | within ±15% | **−42.8%** | **❌** |
| **Word count vs PR #302 (±15%)** | within ±15% | **−44.4%** | **❌** |

## Citation lineage across all four versions

| Section | v0.1 (#302) | v0.2 (#313) | v0.3 (#316) | **v0.3.5 (this)** | gate floor |
|---|---:|---:|---:|---:|---:|
| 2 Critical Timeline       | 18  | 38  | 24  | **22** | ≥30 ❌ |
| 4 Claims Analysis         | 21  | 2   | 0   | **0**  | ≥18 ❌ |
| 5 Key Defenses Identified | 18  | 8   | 12  | **20** | ≥18 ✅ |
| 7 Email Intelligence      | 22  | 40  | 17  | **10** | ≥36 ❌ |
| 8 Financial Exposure      | 28  | 12  | 4   | **4**  | ≥20 ❌ |
| **Total synth cites**     | **107** | **100** | **57** | **56** | |

v0.3.5 cite-total (56) is nearly tied with v0.3 (57). Both are roughly half of v0.1 (107) and v0.2 (100). Section 5 is the only synth section that improved this round.

## Word count

| vs baseline | PR #302 (557 lines, 46 KB) | PR #311 (563 lines, 44.8 KB) | v0.2 (388 lines, 24,950 B) | v0.3 (319 lines, 25,830 B) |
|---|---:|---:|---:|---:|
| v0.3.5 (317 lines, 25,618 B) | **−43% lines, −44.4% bytes** ❌ | **−43% lines, −42.8% bytes** ❌ | −18% lines, +2.7% bytes | −1% lines, −0.8% bytes |

v0.3.5 is essentially the same size as v0.3 (within ±1%). Removing the directive didn't restore the volume v0.1 produced when the directive was present — confirming Nemotron's elaboration with `"detailed thinking on"` was producing a lot of the v0.1 substance (much of it inside `<think>` that wasn't stripped because v0.1 had no Pass 1 stripper).

## Hypothesis recap (now disproven)

Pre-run hypothesis: *"Without 'detailed thinking on', Nemotron produces direct answers without `<think>` blocks; v0.3.5 should cite at least the v0.1 baseline of 18-28 per synthesis section or higher."*

Outcome: the model did stop emitting `<think>` (✅ first prediction) but the citation density did NOT recover (❌ second prediction). Section 5 was the only one that cleared its floor; the others ranged from 0 to 22 cites against floors of 18 to 36.

Two reasons this hypothesis seems to have been wrong:
1. **v0.1's high citation count came from inside `<think>` blocks.** v0.1 had no Pass 1 stripper, so `<think>` content was effectively part of the brief output and counted toward citations. Removing the directive removed that whole channel of content.
2. **`"detailed thinking on"` was implicitly a "be thorough" directive.** Without it, Nemotron defaults to terser, less-elaborated output — fewer factual claims per section, therefore fewer citations.

In hindsight, the v0.1 / PR #311 baseline numbers were inflated by counting trace content as substantive output. None of the three single-prompt-edit attempts can recover that without re-introducing the trace.

## Recommendation: v0.4 — option (c) two-pass synthesis

Single-prompt-edit attempts have been exhausted. The remaining structural option:

1. **First call**: Nemotron with `"detailed thinking on"` (full trace + answer, like v0.1 baseline) — produces the high-quality elaboration. Output stored as draft.
2. **Second call**: Nemotron with a "rewrite this draft as a clean attorney-grade brief, preserving all citations, no first-person prose, no `<think>` blocks" prompt. Output is the final SectionResult content.

Cost: ~2× per-section token spend. But it's the only path that preserves v0.1's content density AND produces clean output.

**Counsel-hire critical path**: 46 days. Case II is gated on Case I Outcome A. Option (c) v0.4 is now the only remaining single-PR path before counsel-hire deadline.

## What this PR does NOT touch

BRAIN service, LiteLLM gateway, `legal_council.py`, Phase B retrieval primitives, Qdrant collections, `case_briefing_compose.py` orchestrator, Pass 1 stripper code (inherited from PR #313 — preserved as defensive no-op), Case II.

## Test plan

- [x] Branch + PR opened
- [x] `_SYSTEM_PROMPT` directive removed (single line + explanatory comment)
- [x] Pytest 12/12 passes
- [x] Phase B re-run on Case I completes in ~37 min (within 60-min cap)
- [x] 0 `<think>` tags in v3 (confirms directive removal worked at source)
- [x] FYEO + defense-counsel exclusion correct
- [x] 0 cloud outbound, 0 retrieval errors
- [x] Section 5 cites ≥ floor
- [ ] **Sections 2 / 4 / 7 / 8 cites ≥ floor** ← **STOP — all 4 below floor**
- [ ] **Word count within ±15% of #311 baseline** ← **STOP — −42.8%**
- [ ] **Word count within ±15% of #302 baseline** ← **STOP — −44.4%**
- [ ] (gated on v0.4 PASS) Case II dry-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
