### PR TITLE
fix(brain-client): TP=2 frontier compatibility (3 defects, Path X)

### DIFF
--- a/docs/operational/brain-client-fix-validation-2026-04-30.md
+++ b/docs/operational/brain-client-fix-validation-2026-04-30.md
@@ -1,0 +1,158 @@
+# BrainClient TP=2 Fix — Validation Report
+
+**Date:** 2026-04-30
+**Branch:** `fix/brain-client-tp2-frontier-compatibility-2026-04-30`
+**Driver:** Path X fix for Track A (PR #323) BrainClient defects
+**Brief:** `docs/operational/brain-client-tp2-frontier-fix-brief.md`
+
+## Pre-fix BrainClient state
+
+| Field | Value |
+|---|---|
+| File | `fortress-guest-platform/backend/services/brain_client.py` (162 lines) |
+| Constructor | `BrainClient(base_url, timeout=600.0, model=…)` — no reasoning controls |
+| `chat()` default | `max_tokens: int = 4000` (chat default; synthesizer overrides to 2000) |
+| Module constant | none for max_tokens |
+| `_stream()` parser | parses `delta.content` only; `delta.reasoning` silently discarded |
+| Caller surface | 8 callers across orchestrator + scripts + tests (no behavior change in callers required) |
+| Existing tests | 7 passing |
+
+## Pre-fix repro (synthesis-style prompt against TP=2 frontier, default BrainClient)
+
+Confirmed via Track A run 2026-04-30 (PR #323):
+
+```
+CONTENT_LEN: 0
+REASONING_LEN: (not exposed by old BrainClient)
+FINISH: length
+```
+
+5 of 5 synthesis sections empty; reasoning trace consumed full max_tokens=2000 budget; content emission never started.
+
+## Edits applied
+
+| File | Change |
+|---|---|
+| `fortress-guest-platform/backend/services/brain_client.py` | Surgical refactor (170 lines, +50 LOC): module constant `_DEFAULT_MAX_TOKENS = 8000`; constructor adds `default_max_tokens`, `reasoning_effort`, `thinking` kwargs; `chat()` resolves max_tokens via constructor default when None, accepts per-call `reasoning_effort`/`thinking` overrides, builds `extra_body` + `chat_template_kwargs`; `_stream()` parses both `delta.content` (yielded) AND `delta.reasoning` (accumulated to `client.last_reasoning`); `_oneshot()` extracts `message.reasoning` + `finish_reason` to `client.last_reasoning` / `client.last_finish_reason` |
+| `fortress-guest-platform/backend/tests/test_brain_client.py` | +10 new tests covering all 3 defects (reasoning chunk parsing, max_tokens default, kwargs injection, per-call override, oneshot reasoning capture) |
+
+Diff stats: 2 files changed, ~250 insertions, ~30 deletions (constructor + chat signature reshape).
+
+## Post-fix unit test results
+
+| | Pre-fix | Post-fix |
+|---|---|---|
+| Existing tests | 7 passing / 0 failing | 7 passing / 0 failing |
+| New Path-X tests | n/a | **10 new** |
+| Total | 7/7 | **17/17 PASS** |
+
+No regression. All 7 prior tests continue to pass with the refactored signatures (`max_tokens=None` default + `chat()` resolves; per-call args still wire through correctly).
+
+## Post-fix repro (BrainClient direct, synthesis-style prompt)
+
+`/tmp/brain-client-repro.py` against live `http://10.10.10.3:8000` with `nemotron-3-super`:
+
+| Run | content_chars | reasoning_chars | finish_reason |
+|---|---|---|---|
+| Default (no reasoning kwargs, default_max_tokens=8000) | **3,203** | **4,495** | **stop** ✅ |
+| reasoning_effort=high, thinking=True | 3,203 | 4,495 | stop |
+| reasoning_effort=low, thinking=False | 3,203 | 4,495 | stop |
+
+**Defect 1 + 2 fix validated.** Pre-fix: 0 chars. Post-fix: 3,203 chars of clean affirmative-defenses table grounded in the bracketed-filename evidence. `finish_reason=stop` (not length).
+
+## reasoning_effort behavior validation
+
+| | reasoning_chars |
+|---|---|
+| reasoning_effort=high | 4,495 |
+| reasoning_effort=low | 4,495 |
+| **Δ** | **0** |
+
+**Defect 3 wiring validated; vLLM activation deferred.** Per brief §7.4: "If they're equal: vLLM build may not honor `reasoning_effort` extra_body kwarg. Document the finding; the constructor wiring is still correct (frontier may need newer vLLM build to act on it). Don't halt — the kwarg infrastructure is in place; activation depends on vLLM features."
+
+The kwargs are present in the request body (verified by unit test `test_extra_body_injection_when_reasoning_kwargs_set`); the live vLLM build (`0.20.1rc1.dev96+gefdc95674.d20260430`) does not differentiate the reasoning trace based on the flag. When upstream vLLM honors `reasoning_effort` for nemotron_v3, BrainClient is already wired to pass it through.
+
+## §8 Track A re-run via real orchestrator
+
+Re-ran `track_a_case_i_runner.py` end-to-end against case `7il-v-knight-ndga-i`. Wall: 421.5 s.
+
+| § | Mode | Wall (s) | Content chars | finish_reason | Cites |
+|---|---|---|---|---|---|
+| 1 | mechanical (deterministic) | <1 | 511 | n/a | 0 |
+| 2 | synthesis via BrainClient | 84.05 | **0** | (length per BrainClient `last_finish_reason`) | 0 |
+| 3 | mechanical (deterministic) | <1 | 509 | n/a | 0 |
+| 4 | synthesis via BrainClient | 84.33 | **0** | length | 0 |
+| 5 | synthesis via BrainClient | 84.25 | **0** | length | 0 |
+| 6 | mechanical (deterministic) | <1 | 1,376 | n/a | 0 |
+| 7 | synthesis via BrainClient | 84.09 | **0** | length | 0 |
+| 8 | synthesis via BrainClient | 84.16 | **0** | length | 0 |
+| 9 (placeholder) | operator_written | <1 | 383 | n/a | 0 |
+| **9 (augmented)** | **LiteLLM legal-reasoning, post-run** | 174.73 | **6,375** | **stop** | **14 (1 unique)** |
+| 10 | mechanical (deterministic) | <1 | 611 | n/a | 0 |
+
+**Result: 5 synthesis sections via the orchestrator pipeline still empty.** Section 9 augmentation (which uses LiteLLM directly, NOT BrainClient + synthesizer) produced 6,375 chars cleanly — up from 4,578 chars in the original Track A run.
+
+### Why the synthesizer pipeline still fails (per brief §8 documented finding)
+
+The BrainClient fix raised the **client-level** default `max_tokens` from 4,000 to 8,000 — but the synthesizer at `case_briefing_synthesizers.py:205` **hardcodes its own `max_tokens=2000`** parameter and passes it explicitly to `brain_client.chat(max_tokens=2000)`. The new BrainClient resolves `max_tokens=None` → 8,000, but `max_tokens=2000` (explicit) → 2,000.
+
+Per brief §11 ("DO NOT touch: Synthesizer prompt logic / case_briefing_compose.py orchestrator"), the synthesizer was **not modified** in this PR.
+
+This is a separate, narrowly-scoped follow-up: change one default at `case_briefing_synthesizers.py:205` from 2000 → 8000.
+
+Per brief §8: "If any of the 5 still fail: Defect set wasn't complete. Surface, halt, do NOT modify further. File new issue."
+
+**Halt honored.** Synthesizer not modified. Follow-up issue queued.
+
+## Defect status
+
+| Defect | Status | Validation |
+|---|---|---|
+| 1 — `_stream()` discards `delta.reasoning` | ✅ **FIXED** | Unit test `test_stream_parses_delta_reasoning_separately` PASS; live repro shows `reasoning_chars=4,495` in `client.last_reasoning` |
+| 2 — default `max_tokens=2000` (synthesizer) / 4000 (chat) too low | ✅ **FIXED at BrainClient layer** | Unit test `test_default_max_tokens_is_8000` PASS; live repro with default produces 3,203 content chars + finish=stop. **Caveat:** synthesizer's own hardcoded `max_tokens=2000` overrides the BrainClient default; cascade requires synthesizer-side follow-up (out of Path X scope) |
+| 3 — no `reasoning_effort` / `thinking` kwarg mechanism | ✅ **FIXED at BrainClient layer; vLLM activation deferred** | Unit tests `test_extra_body_injection_when_reasoning_kwargs_set` + `test_per_call_reasoning_kwargs_override_constructor` PASS; live behavior identical between high/low (vLLM build doesn't honor extra_body kwarg yet — wiring complete, awaiting vLLM upgrade) |
+
+## Soak impact
+
+- Frontier endpoint `/health` 200 throughout
+- No soak halt triggers fired
+- ~14 min total TP=2 endpoint load consumed by this PR's repro + Track A re-run (productive load; Section 9 augmentation produced 6,375 chars of usable content)
+- Memory peak captured indirectly via next hourly soak collector tick
+
+## Follow-up issue to file post-merge
+
+| Title | Priority |
+|---|---|
+| **Phase B synthesizer `max_tokens` cap — raise from 2000 to 8000 (cascade BrainClient fix to orchestrator pipeline)** | **P1** |
+
+Body draft:
+> Track A re-run 2026-04-30 (BrainClient TP=2 fix PR) confirmed BrainClient defects closed at the client layer. However, `fortress-guest-platform/backend/services/case_briefing_synthesizers.py:205` hardcodes `max_tokens: int = 2000` in `synthesize_synthesis_section()`, which it passes explicitly to `brain_client.chat(max_tokens=2000)`. The new BrainClient resolves `max_tokens=None` → 8000, but explicit 2000 → 2000.
+>
+> All 5 LLM synthesis sections (2/4/5/7/8) still hit `finish_reason=length` on the orchestrator pipeline post-BrainClient-fix. Reasoning trace fills the 2000 budget; content emission never starts.
+>
+> **Fix scope:** change one default in `case_briefing_synthesizers.py:205` from `max_tokens: int = 2000` to `max_tokens: int = 8000`. Tiny PR. Test: re-run Track A; expect non-empty content with `finish_reason=stop` on all 5 sections.
+>
+> **Why not in the BrainClient fix PR:** brief §11 explicitly excluded synthesizer modifications. Path X = surgical BrainClient fix only.
+>
+> **Empirical evidence:** Track A re-run 2026-04-30 (this PR's `RUN_DIR=/tmp/track-a-case-i-v3-20260430T183436Z/`); section files for 2/4/5/7/8 are 0 bytes; per-section wall ~84 s with content_chars=0 and finish_reason=length. Section 9 augmentation (which uses LiteLLM directly with max_tokens=5000) produced 6,375 chars cleanly — proving the endpoint works when given enough budget.
+
+## What this PR unblocks
+
+- ✅ **Direct BrainClient consumers** (e.g., `brain_rag_probe.py`, future direct callers) can now produce content against the TP=2 frontier with default settings — Defect 1+2+3 closed at the BrainClient layer
+- ✅ **The wiring for per-section reasoning depth control** is in place; activation lands when vLLM upgrade honors `reasoning_effort` extra_body
+- ✅ **Track A's empirical evidence is closed at one layer** — the BrainClient defects identified are no longer the active bottleneck for direct callers
+
+## What remains blocked (until follow-up issue lands)
+
+- ❌ **Phase B v0.1 orchestrator synthesis sections** — still hit synthesizer's hardcoded 2000 cap. Track A full pipeline re-run still produces empty synthesis sections.
+- ❌ **Case II briefing on the orchestrator pipeline** — same root cause as above; cannot complete until synthesizer-cap follow-up merges.
+
+The Section 9 augmentation pattern (post-run LiteLLM call with `legal-reasoning` alias) **continues to work as a viable interim path** for any single-section synthesis use case until the synthesizer-cap fix lands.
+
+## Path Y (Wave 6 NAT migration) status
+
+Unchanged. Path Y (retire BrainClient, route synthesizers via LiteLLM aliases) remains the strategic endgame; not blocked, not urgent. Tracked under issue #325.
+
+---
+
+End of validation report.

--- a/docs/operational/brain-client-tp2-frontier-fix-brief.md
+++ b/docs/operational/brain-client-tp2-frontier-fix-brief.md
@@ -1,0 +1,698 @@
+# Phase B BrainClient — TP=2 Frontier Compatibility Fix (Path X)
+
+**Target:** Claude Code on spark-2
+**Branch:** `fix/brain-client-tp2-frontier-compatibility-2026-04-30`
+**Date:** 2026-04-30
+**Operator:** Gary Knight
+**Mode:** END-TO-END AUTONOMOUS. Hard stops only on real break conditions.
+**Driver:** Track A run (PR #323) surfaced three structural defects in `fortress-guest-platform/backend/services/brain_client.py` against the new TP=2 frontier with nemotron_v3 reasoning parser. Path X chosen over Path Y: fix BrainClient surgically; preserve v0.1 architecture; unblock Case II briefing. Path Y (retire BrainClient, route via LiteLLM) is Wave 6 NAT migration work, not this PR.
+**Stacks on:**
+- PR #322 (Phase 9 alias surgery + BRAIN retirement, merged)
+- PR #323 (Track A empirical evidence, draft, awaiting operator promotion)
+- PR #321 (TP=2 deployment evidence, soak in progress to 2026-05-14)
+- vLLM stream sample at `docs/operational/track-a-evidence-2026-04-30/vllm-stream-sample-delta-reasoning.txt`
+**Resolves:** P1 follow-up issue from Track A — Phase B BrainClient TP=2 compatibility
+
+---
+
+## 1. Mission
+
+Fix three structural defects in `BrainClient` so it produces non-empty content against the TP=2 frontier endpoint with nemotron_v3 reasoning parser. Validate by reproducing Track A's failed sections and confirming `finish_reason=stop` with non-empty content. Do not migrate to LiteLLM (that's Wave 6). Do not change synthesizer logic. Targeted file edits only.
+
+---
+
+## 2. Hard stops (the ONLY conditions that halt execution)
+
+1. **`brain_client.py` not found** at the path Track A identified (`fortress-guest-platform/backend/services/brain_client.py`).
+2. **vLLM stream sample evidence file missing** at `docs/operational/track-a-evidence-2026-04-30/vllm-stream-sample-delta-reasoning.txt`. Need it to confirm wire format before changing parser.
+3. **Frontier endpoint dead.** `curl /v1/health/ready` non-200 sustained >60s. Cannot validate fix without it.
+4. **Tests fail with no clear path forward.** Existing tests catastrophically broken by the change with non-trivial fix scope.
+5. **Fix introduces new defect detected during validation.** New regression in non-Track-A code paths.
+6. **Soak halt event fires.** Cluster telling you to stop.
+7. **Disk full.** <5GB free anywhere.
+
+Everything else proceeds. Defaults documented; deviations land in final report.
+
+---
+
+## 3. Three defects (precise scope)
+
+### Defect 1: Stream parser discards `delta.reasoning` chunks
+
+**Evidence:** `docs/operational/track-a-evidence-2026-04-30/vllm-stream-sample-delta-reasoning.txt` (415 lines).
+
+**Wire format confirmed:** vLLM nemotron_v3 parser emits two distinct delta channels per stream:
+
+```
+data: {..."choices":[{"delta":{"reasoning":"We"}}]}
+data: {..."choices":[{"delta":{"reasoning":" need"}}]}
+...
+data: {..."choices":[{"delta":{"content":"## Section"}}]}
+data: {..."choices":[{"delta":{"content":" 4"}}]}
+```
+
+Reasoning emits first (until reasoning trace completes), then content emits.
+
+**Current `_stream()` behavior:** parses `delta.content` only. Reasoning chunks silently discarded. When max_tokens too low (Defect 2), reasoning fills the budget; content never starts; stream returns empty string.
+
+**Fix:** parse both `delta.reasoning` and `delta.content`. Accumulate separately. Return both via the response object.
+
+### Defect 2: Default `max_tokens=2000` below reasoning floor
+
+**Evidence:** Phase 7 Section 5 smoke captured ~2,000-token reasoning traces on synthesis prompts. Track A's 5 failed sections all hit `finish_reason=length` at 2000.
+
+**Fix:** raise default `max_tokens` for synthesis calls. Production-safe default 8000. Per-call override preserved.
+
+**Why 8000 not 6000:** Nemotron-Super-120B reasoning + content on Section 4/5/9 (the deepest reasoning sections) can total 6,000-7,000 tokens. 8000 leaves headroom without being wasteful — Section 9 augmentation via LiteLLM used 5000 max_tokens and produced 4,578 bytes content with `finish_reason=stop`, so 8000 is conservative-safe across all section types.
+
+### Defect 3: No reasoning_effort / thinking flag injection
+
+**Evidence:** Phase 9 alias surgery defined per-alias profiles (`legal-reasoning` = `reasoning_effort: high`, `thinking: true`; `legal-summarization` = `reasoning_effort: low`, `thinking: false`). BrainClient has no constructor or per-call kwarg for these.
+
+**Fix:** add constructor params + per-call override for:
+- `reasoning_effort` (string: `low` / `medium` / `high`)
+- `thinking` (bool, maps to `chat_template_kwargs.thinking`)
+
+Both pass through to the request body's `extra_body` / appropriate keys per vLLM API.
+
+---
+
+## 4. Pre-flight (autonomous)
+
+### 4.1 Branch + state
+
+```bash
+git fetch origin
+git checkout origin/main
+git checkout -b fix/brain-client-tp2-frontier-compatibility-2026-04-30
+git status
+git log origin/main..HEAD --oneline
+```
+
+### 4.2 Locate files
+
+```bash
+ssh admin@192.168.0.100 '
+  cd /home/admin/Fortress-Prime
+  ls -la fortress-guest-platform/backend/services/brain_client.py
+  ls -la docs/operational/track-a-evidence-2026-04-30/vllm-stream-sample-delta-reasoning.txt
+  
+  # Existing tests
+  find . -path "*test*brain*" -name "*.py" 2>/dev/null | grep -v __pycache__ | head -10
+  
+  # Callers (we are NOT modifying these — just inventorying impact surface)
+  grep -rn "from.*brain_client\|import.*BrainClient\|BrainClient(" \
+    --include="*.py" 2>/dev/null | grep -v __pycache__ | grep -v ".git/" | grep -v test_
+'
+```
+
+If `brain_client.py` missing: hard stop §2.1.
+If evidence file missing: hard stop §2.2.
+
+### 4.3 Read current BrainClient
+
+```bash
+ssh admin@192.168.0.100 'cat /home/admin/Fortress-Prime/fortress-guest-platform/backend/services/brain_client.py'
+```
+
+Surface inline:
+- Constructor signature
+- `_stream()` method
+- Public method signatures (likely `complete()` or similar)
+- Module-level defaults (`_DEFAULT_MODEL`, `_DEFAULT_MAX_TOKENS`, etc.)
+
+### 4.4 Frontier health
+
+```bash
+ssh admin@192.168.0.100 '
+  curl -fsS --max-time 10 http://10.10.10.3:8000/v1/health/ready
+  curl -fsS --max-time 30 http://localhost:4000/v1/chat/completions \
+    -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
+    -H "Content-Type: application/json" \
+    -d "{\"model\": \"legal-reasoning\", \"messages\": [{\"role\":\"user\",\"content\":\"PONG\"}], \"max_tokens\": 10}" \
+    | jq -r ".choices[0].message.content"
+'
+```
+
+200 + PONG → proceed. Otherwise hard stop §2.3.
+
+---
+
+## 5. The fix — surgical edits to `brain_client.py`
+
+### 5.1 Edit 1: Constructor — add kwargs
+
+Add to `__init__`:
+
+```python
+def __init__(
+    self,
+    base_url: str = _DEFAULT_BASE_URL,
+    model: str = _DEFAULT_MODEL,
+    api_key: str | None = None,
+    timeout: float = 180.0,
+    # NEW — Defect 3
+    reasoning_effort: str | None = None,    # "low" | "medium" | "high"
+    thinking: bool | None = None,            # maps to chat_template_kwargs.thinking
+    default_max_tokens: int = 8000,          # NEW — Defect 2 (was 2000)
+):
+    # existing init body
+    # ...
+    self._reasoning_effort = reasoning_effort
+    self._thinking = thinking
+    self._default_max_tokens = default_max_tokens
+```
+
+Preserve all existing constructor params verbatim. Additions only.
+
+### 5.2 Edit 2: Public completion method — wire kwargs through
+
+Whichever method exposes the public API (likely `complete()`, `synthesize()`, or similar — surface in §4.3 read), add kwargs:
+
+```python
+def complete(
+    self,
+    prompt: str,
+    *,
+    max_tokens: int | None = None,
+    temperature: float = 0.5,
+    # NEW — Defect 3 per-call override
+    reasoning_effort: str | None = None,
+    thinking: bool | None = None,
+    stream: bool = True,
+):
+    # Resolve effective values: per-call > constructor > None
+    effective_max_tokens = max_tokens or self._default_max_tokens
+    effective_reasoning_effort = reasoning_effort or self._reasoning_effort
+    effective_thinking = thinking if thinking is not None else self._thinking
+    
+    # Build request body
+    body = {
+        "model": self._model,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": effective_max_tokens,
+        "temperature": temperature,
+        "stream": stream,
+    }
+    
+    # Inject reasoning controls if specified
+    extra_body = {}
+    if effective_reasoning_effort is not None:
+        extra_body["reasoning_effort"] = effective_reasoning_effort
+    chat_template_kwargs = {}
+    if effective_thinking is not None:
+        chat_template_kwargs["thinking"] = effective_thinking
+    if chat_template_kwargs:
+        extra_body["chat_template_kwargs"] = chat_template_kwargs
+    if extra_body:
+        body.update(extra_body)
+    
+    # ... rest of method
+```
+
+Preserve existing return shape. Add reasoning content as new attribute on return object (not as content; content stays content).
+
+### 5.3 Edit 3: `_stream()` — handle delta.reasoning
+
+Current behavior (per Track A evidence): only `delta.content` parsed. `delta.reasoning` discarded.
+
+New behavior: parse both. Yield content as before (consumer compatibility preserved). Accumulate reasoning into a side channel exposed via the response object.
+
+```python
+async def _stream(self, response):
+    """
+    Yield content chunks. Accumulate reasoning chunks into self._last_reasoning.
+    nemotron_v3 emits delta.reasoning before delta.content; both must be parsed.
+    """
+    self._last_reasoning = ""
+    self._last_finish_reason = None
+    
+    async for line in response.aiter_lines():
+        if not line or not line.startswith("data: "):
+            continue
+        payload = line[len("data: "):].strip()
+        if payload == "[DONE]":
+            break
+        try:
+            obj = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+        
+        choices = obj.get("choices") or []
+        if not choices:
+            continue
+        choice = choices[0]
+        delta = choice.get("delta") or {}
+        finish = choice.get("finish_reason")
+        if finish is not None:
+            self._last_finish_reason = finish
+        
+        # Accumulate reasoning (do NOT yield — consumers expect content only)
+        reasoning_chunk = delta.get("reasoning")
+        if reasoning_chunk is not None:
+            self._last_reasoning += reasoning_chunk
+        
+        # Yield content as before
+        content_chunk = delta.get("content")
+        if content_chunk is not None:
+            yield content_chunk
+```
+
+Key behavior:
+- Existing consumers (`async for chunk in client._stream(): response += chunk`) continue to receive content-only chunks. No consumer code change required.
+- Reasoning accessible via `client._last_reasoning` after stream consumed.
+- `finish_reason` accessible via `client._last_finish_reason` (likely already exposed; preserve).
+
+### 5.4 Edit 4: Module-level default constant
+
+```python
+_DEFAULT_MAX_TOKENS = 8000   # was 2000 — Defect 2 fix
+```
+
+Or wherever the current `2000` literal lives — replace with `8000`. Surface what existed before in the §11 final report.
+
+### 5.5 Edit 5: Surface reasoning + finish_reason on synchronous (non-stream) path
+
+If BrainClient has a `stream=False` code path (likely yes — Section 9 augmentation used a non-streaming pattern), parse `choices[0].message.reasoning` and `choices[0].message.content` separately. Same accumulator pattern.
+
+```python
+if not stream:
+    obj = response.json()
+    msg = obj["choices"][0].get("message", {})
+    self._last_reasoning = msg.get("reasoning", "")
+    self._last_finish_reason = obj["choices"][0].get("finish_reason")
+    return msg.get("content", "")
+```
+
+---
+
+## 6. Tests
+
+### 6.1 Existing tests
+
+```bash
+ssh admin@192.168.0.100 '
+  cd /home/admin/Fortress-Prime/fortress-guest-platform
+  
+  # Run only brain_client-related tests pre-fix to establish baseline
+  source .venv/bin/activate 2>/dev/null || true
+  python -m pytest backend/tests/ -k "brain" -v 2>&1 | tee /tmp/brain-tests-pre-fix.log
+'
+```
+
+Surface count: pre-fix passing/failing.
+
+### 6.2 New test cases
+
+Add to `backend/tests/test_brain_client.py` (create if not exists):
+
+```python
+import pytest
+from unittest.mock import AsyncMock, patch
+import json
+
+from backend.services.brain_client import BrainClient
+
+
+def test_brain_client_default_max_tokens_is_8000():
+    """Defect 2 regression guard."""
+    client = BrainClient()
+    assert client._default_max_tokens == 8000
+
+
+def test_brain_client_constructor_accepts_reasoning_kwargs():
+    """Defect 3 — kwargs accepted at construction."""
+    client = BrainClient(
+        reasoning_effort="high",
+        thinking=True,
+    )
+    assert client._reasoning_effort == "high"
+    assert client._thinking is True
+
+
+def test_brain_client_complete_passes_reasoning_effort():
+    """Defect 3 — kwargs reach request body."""
+    client = BrainClient(reasoning_effort="high", thinking=True)
+    
+    captured_body = {}
+    
+    async def fake_post(url, json=None, **kw):
+        captured_body.update(json)
+        # Return a non-streaming mock
+        ...
+    
+    # Invoke complete() with mocked transport; assert extra_body in captured
+    # Implementation depends on how BrainClient calls httpx
+    ...
+
+
+def test_stream_parses_delta_reasoning_separately():
+    """Defect 1 — reasoning chunks accumulated, not discarded."""
+    client = BrainClient()
+    
+    # Construct a fake stream response with the nemotron_v3 wire format
+    fake_lines = [
+        'data: {"choices":[{"delta":{"reasoning":"We"}}]}',
+        'data: {"choices":[{"delta":{"reasoning":" need"}}]}',
+        'data: {"choices":[{"delta":{"content":"## Section"}}]}',
+        'data: {"choices":[{"delta":{"content":" 4"},"finish_reason":"stop"}]}',
+        'data: [DONE]',
+    ]
+    
+    # Mock response.aiter_lines to yield these
+    # Consume the stream; assert content yielded = "## Section 4"
+    # Assert client._last_reasoning == "We need"
+    # Assert client._last_finish_reason == "stop"
+    ...
+
+
+def test_stream_backward_compatible_yield_shape():
+    """Defect 1 — existing consumers unchanged."""
+    client = BrainClient()
+    
+    # Same fake stream
+    # Use the existing consumer pattern: response = ""; async for chunk in client._stream(...): response += chunk
+    # Assert response == "## Section 4"  (content only, not "We need## Section 4")
+    ...
+```
+
+Run new + existing tests post-fix:
+
+```bash
+python -m pytest backend/tests/ -k "brain" -v 2>&1 | tee /tmp/brain-tests-post-fix.log
+```
+
+If existing tests fail post-fix that didn't fail pre-fix: investigate. If unfixable in a clean way: hard stop §2.4.
+
+---
+
+## 7. Reproduce Track A failure → confirm fix
+
+This is the empirical proof.
+
+### 7.1 Pre-fix repro (sanity — should fail same as Track A)
+
+If the runner script from Track A is committed (`fortress-guest-platform/backend/scripts/track_a_case_i_runner.py`), use it. Otherwise build a minimal repro:
+
+```bash
+ssh admin@192.168.0.100 '
+  cd /home/admin/Fortress-Prime
+  source fortress-guest-platform/.venv/bin/activate 2>/dev/null || true
+  
+  cat > /tmp/brain-client-repro.py <<EOF
+import asyncio
+from backend.services.brain_client import BrainClient
+
+async def main():
+    # Use the new TP=2 frontier
+    client = BrainClient(
+        base_url="http://10.10.10.3:8000",
+        model="nemotron-3-super",
+    )
+    
+    # The kind of synthesis prompt that failed in Track A — long context, deep reasoning ask
+    prompt = "Analyze the following claims under Georgia law. " * 200 + " What defenses are strongest?"
+    
+    # Existing complete() pattern
+    result = await client.complete(prompt)
+    print(f"CONTENT_LEN={len(result)}")
+    print(f"REASONING_LEN={len(getattr(client, \"_last_reasoning\", \"\"))}")
+    print(f"FINISH={getattr(client, \"_last_finish_reason\", None)}")
+
+asyncio.run(main())
+EOF
+  
+  cd fortress-guest-platform
+  python /tmp/brain-client-repro.py
+'
+```
+
+**Pre-fix expected:** `CONTENT_LEN=0`, `FINISH=length`. (Reasoning length may not print pre-fix — attribute does not exist.)
+
+If pre-fix run shows `CONTENT_LEN > 0` somehow (e.g., short prompt that finishes within 2000 tokens): use Track A's actual Section 5 prompt, which is the real-world failing case.
+
+### 7.2 Apply the fix
+
+Edits per §5.
+
+### 7.3 Post-fix repro
+
+Same script. Now expect:
+- `CONTENT_LEN > 1000` (Section 9 augmentation produced 4,578 — synthesis sections similar order of magnitude)
+- `REASONING_LEN > 1000`
+- `FINISH=stop`
+
+Surface inline. This is the fix proven empirically.
+
+### 7.4 With explicit reasoning controls
+
+```bash
+# Add to repro:
+client_high = BrainClient(
+    base_url="http://10.10.10.3:8000",
+    model="nemotron-3-super",
+    reasoning_effort="high",
+    thinking=True,
+)
+result_high = await client_high.complete(prompt)
+
+client_low = BrainClient(
+    base_url="http://10.10.10.3:8000",
+    model="nemotron-3-super",
+    reasoning_effort="low",
+    thinking=False,
+)
+result_low = await client_low.complete(prompt)
+
+# Compare reasoning lengths — high should produce longer reasoning trace
+```
+
+If `len(reasoning_high) > len(reasoning_low)` significantly: Defect 3 fix verified — reasoning_effort actually changes behavior at the model.
+
+If they're equal: vLLM build may not honor `reasoning_effort` extra_body kwarg. Document the finding; the constructor wiring is still correct (frontier may need newer vLLM build to act on it). Don't halt — the kwarg infrastructure is in place; activation depends on vLLM features.
+
+---
+
+## 8. Track A re-run (the real proof)
+
+After repro confirms fix at the unit level, run Track A's failed sections through the real orchestrator path. Don't run all 10 sections — run just the 5 that failed (2, 4, 5, 7, 8) to validate orchestrator integration.
+
+```bash
+ssh admin@192.168.0.100 '
+  cd /home/admin/Fortress-Prime
+  
+  # Re-invoke the Track A runner against Case I, but only synthesis sections
+  python -m backend.scripts.track_a_case_i_runner \
+    --case-slug 7il-v-knight-ndga-i \
+    --sections 2,4,5,7,8 \
+    --output-dir /tmp/brain-fix-validation-$(date +%Y%m%dT%H%M%SZ) \
+    2>&1 | tee /tmp/brain-fix-track-a-rerun.log
+'
+```
+
+If runner doesn't accept `--sections` filter, run full 10-section pipeline; just inspect the previously-failed sections in output.
+
+**Expected:** all 5 synthesis sections produce non-empty content with `finish_reason=stop`. Citation density should now be measurable; format compliance per Phase 7 smoke (no first-person bleed, no `<think>` leakage in content).
+
+If any of the 5 still fail: Defect set wasn't complete. Surface, halt, do NOT modify further. File new issue.
+
+---
+
+## 9. PR
+
+### 9.1 Files
+
+```bash
+ssh admin@192.168.0.100 '
+  cd /home/admin/Fortress-Prime
+  git status
+  
+  # Expected modifications:
+  #   fortress-guest-platform/backend/services/brain_client.py
+  #   fortress-guest-platform/backend/tests/test_brain_client.py (new or modified)
+  #   docs/operational/brain-client-tp2-fix-2026-04-30.md (this brief, copy)
+  #   docs/operational/brain-client-fix-validation-2026-04-30.md (run report)
+'
+```
+
+Validation report content:
+
+```markdown
+# BrainClient TP=2 Fix — Validation Report
+
+**Date:** 2026-04-30
+**Driver:** Path X fix for Track A (PR #323) BrainClient defects
+
+## Pre-fix repro
+- CONTENT_LEN: 0
+- FINISH: length
+- (Track A reproduced)
+
+## Post-fix repro
+- CONTENT_LEN: <actual>
+- REASONING_LEN: <actual>
+- FINISH: stop
+
+## reasoning_effort verification
+- high: <reasoning_len>
+- low: <reasoning_len>
+- Delta: <observation>
+
+## Track A re-run (sections 2/4/5/7/8 only)
+- Section 2: <tokens>, <cites>, finish=<finish>
+- Section 4: <tokens>, <cites>, finish=<finish>
+- Section 5: <tokens>, <cites>, finish=<finish>
+- Section 7: <tokens>, <cites>, finish=<finish>
+- Section 8: <tokens>, <cites>, finish=<finish>
+
+## Test results
+- Pre-fix: <passing>/<total>
+- Post-fix: <passing>/<total>
+- New tests: <count>
+
+## Defect status
+- Defect 1 (delta.reasoning parsing): FIXED + validated
+- Defect 2 (max_tokens default): FIXED + validated
+- Defect 3 (reasoning_effort/thinking kwargs): FIXED + wiring validated; activation depends on vLLM build features
+```
+
+### 9.2 Commit + push + PR
+
+```bash
+ssh admin@192.168.0.100 '
+  cd /home/admin/Fortress-Prime
+  git add fortress-guest-platform/backend/services/brain_client.py
+  git add fortress-guest-platform/backend/tests/test_brain_client.py
+  git add docs/operational/brain-client-tp2-fix-2026-04-30.md
+  git add docs/operational/brain-client-fix-validation-2026-04-30.md
+  
+  git commit -m "fix(brain-client): TP=2 frontier compatibility (3 defects)
+
+Defect 1: _stream() now parses delta.reasoning chunks alongside
+delta.content. Reasoning accumulated to client._last_reasoning;
+content yielded as before (backward-compatible).
+
+Defect 2: Default max_tokens raised from 2000 to 8000. Track A
+synthesis sections hit length=2000 with reasoning-only output
+(content never started emitting). 8000 leaves headroom for
+deepest reasoning + content on Sections 4/5/9.
+
+Defect 3: Constructor + per-call kwargs reasoning_effort and
+thinking added. Pass through to request body extra_body /
+chat_template_kwargs per vLLM nemotron_v3 API.
+
+Validation: Track A failed-sections re-run on real orchestrator
+path produces non-empty content with finish_reason=stop on all
+5 previously-failing synthesis sections.
+
+Resolves: P1 follow-up from PR #323 Track A evidence.
+Path X (surgical fix) chosen over Path Y (LiteLLM migration).
+Path Y deferred to Wave 6 NAT migration.
+"
+  
+  git push -u origin fix/brain-client-tp2-frontier-compatibility-2026-04-30
+  
+  gh pr create \
+    --title "fix(brain-client): TP=2 frontier compatibility (3 defects, Path X)" \
+    --body-file docs/operational/brain-client-fix-validation-2026-04-30.md \
+    --draft
+'
+```
+
+PR opens as draft. Operator promotes to ready after reviewing diff + validation report.
+
+---
+
+## 10. Final report (auto-surface)
+
+1. **Pre-flight summary**
+   - Branch cut, files located, frontier health 200, evidence file present
+
+2. **Pre-fix BrainClient state**
+   - Constructor signature
+   - `_stream()` behavior summary
+   - Default max_tokens value
+   - Caller surface count
+
+3. **Pre-fix repro**
+   - CONTENT_LEN, FINISH, full repro script output
+
+4. **Edits applied**
+   - File diff stats
+   - Line-level changes per defect
+
+5. **Post-fix unit test results**
+   - Pre-fix: X passing / Y failing
+   - Post-fix: X passing / Y failing
+   - New tests added: Z
+
+6. **Post-fix repro**
+   - CONTENT_LEN, REASONING_LEN, FINISH
+
+7. **reasoning_effort behavior validation**
+   - high reasoning length, low reasoning length, delta
+
+8. **Track A re-run on real orchestrator**
+   - Per-section: tokens, cites, finish_reason
+   - All 5 previously-failing sections now content-producing? Y/N
+
+9. **Soak impact**
+   - Endpoint health throughout
+   - No halt triggers fired
+
+10. **PR**
+    - Branch
+    - PR number + URL
+    - Files modified (3 expected)
+
+11. **Defect closure**
+    - Defect 1: closed/open
+    - Defect 2: closed/open
+    - Defect 3: closed/open (note vLLM activation dependency)
+
+12. **What this unblocks**
+    - Phase B v0.1 synthesis works end-to-end against TP=2 frontier
+    - Track A full re-run can produce a real v3 brief
+    - Case II briefing path is unblocked on existing orchestrator architecture
+    - Path Y (Wave 6 NAT migration) remains the strategic endgame; not blocked, not urgent
+
+---
+
+## 11. Constraints
+
+- Branches from `origin/main` only.
+- Single Claude Code session at a time on the cluster.
+- Never `--admin`, never self-merge, never force-push main.
+- Modify ONLY:
+  - `fortress-guest-platform/backend/services/brain_client.py` (the fix)
+  - `fortress-guest-platform/backend/tests/test_brain_client.py` (new/extended tests)
+  - `docs/operational/brain-client-*.md` (this brief + validation report)
+- DO NOT touch:
+  - Synthesizer prompt logic
+  - case_briefing_compose.py orchestrator
+  - Phase B runner script
+  - LiteLLM config
+  - Frontier endpoint
+  - Any other service
+- DO NOT migrate to LiteLLM in this PR — that's Path Y / Wave 6.
+- DO NOT halt for soft conditions. Hard stops in §2 only.
+- Backward compatibility on `_stream()` is non-negotiable: existing content-only consumers continue to work.
+
+---
+
+## 12. Wall time budget
+
+- Pre-flight + read code: 5-10 min
+- Apply edits per §5: 10-15 min
+- Add + run unit tests: 15-20 min
+- Pre-fix + post-fix repro: 10-15 min
+- Track A re-run on 5 sections: ~15-20 min (reasoning section call ~1-3 min each on Super-120B)
+- Validation report + PR commit: 10 min
+
+**Total: 1-1.5 hours wall time** for fix + validation + PR.
+
+If Track A re-run reveals additional defects: STOP, surface, do not auto-iterate. File new issue.
+
+---
+
+End of brief.

--- a/fortress-guest-platform/backend/services/brain_client.py
+++ b/fortress-guest-platform/backend/services/brain_client.py
@@ -7,6 +7,20 @@ mid-response on the underlying NIM/vLLM stack.
 
 This module is read-only: it does not retry, mutate any sovereign store, or
 call Council deliberation paths. Caller decides retry policy.
+
+# Phase B BrainClient TP=2 frontier compatibility (Path X, 2026-04-30)
+Following Track A (PR #323) the client now handles vLLM's nemotron_v3
+reasoning parser wire format:
+- Stream parses `delta.reasoning` chunks alongside `delta.content`.
+  Reasoning is accumulated to `self.last_reasoning` (and exposed via
+  `last_finish_reason`); content is yielded as before, so existing
+  consumers continue to work unchanged.
+- `default_max_tokens` constructor kwarg (default 8000) raises the
+  per-call max_tokens floor when callers don't specify, leaving room for
+  the reasoning trace to complete before content emission begins.
+- `reasoning_effort` and `thinking` kwargs (constructor + per-call) inject
+  into the request body's `extra_body` / `chat_template_kwargs`, mirroring
+  the per-alias profile config established by Phase 9 LiteLLM alias surgery.
 """
 
 from __future__ import annotations
@@ -25,6 +39,7 @@ logger = logging.getLogger(__name__)
 
 _NONSTREAM_MAX_TOKENS_LIMIT = 1000
 _DEFAULT_MODEL = "nvidia/llama-3.3-nemotron-super-49b-v1.5-fp8"
+_DEFAULT_MAX_TOKENS = 8000  # was 4000 (chat default) / 2000 (synthesizer cap) — see Track A finding
 
 
 class BrainClientError(RuntimeError):
@@ -35,6 +50,11 @@ class BrainClient:
     """Async OpenAI-compatible client for the BRAIN inference service.
 
     Defaults to streaming; non-streaming is allowed only for short outputs.
+
+    Reasoning-aware: handles vLLM nemotron_v3 reasoning parser wire format.
+    After a chat() call completes, `client.last_reasoning` exposes the
+    reasoning trace and `client.last_finish_reason` exposes the terminating
+    cause (`stop`, `length`, etc.) for both streaming and non-streaming paths.
     """
 
     def __init__(
@@ -42,38 +62,73 @@ class BrainClient:
         base_url: Optional[str] = None,
         timeout: float = 600.0,
         model: str = _DEFAULT_MODEL,
+        *,
+        # Defect 2 — per-instance default for callers that don't specify max_tokens
+        default_max_tokens: int = _DEFAULT_MAX_TOKENS,
+        # Defect 3 — reasoning controls for vLLM nemotron_v3 parser
+        reasoning_effort: Optional[str] = None,  # "low" | "medium" | "high"
+        thinking: Optional[bool] = None,          # → chat_template_kwargs.thinking
     ) -> None:
         self.base_url = (base_url or _cfg.brain_base_url).rstrip("/")
         self.timeout = timeout
         self.model = model
+        self.default_max_tokens = default_max_tokens
+        self.reasoning_effort = reasoning_effort
+        self.thinking = thinking
+        # Reasoning accumulator + terminating cause exposed after each chat() call
+        self.last_reasoning: str = ""
+        self.last_finish_reason: Optional[str] = None
 
     async def chat(
         self,
         messages: list[dict],
-        max_tokens: int = 4000,
+        max_tokens: Optional[int] = None,
         temperature: float = 0.0,
         stream: bool = True,
         transport: Optional[httpx.AsyncBaseTransport] = None,
+        *,
+        # Per-call overrides for Defect 3 reasoning controls
+        reasoning_effort: Optional[str] = None,
+        thinking: Optional[bool] = None,
     ) -> Union[AsyncIterator[str], dict]:
         """Call BRAIN /v1/chat/completions.
 
         - stream=True (default): returns an async iterator yielding content chunks.
         - stream=False: returns the parsed response dict; rejects max_tokens > 1000.
 
+        ``max_tokens=None`` resolves to ``self.default_max_tokens`` (Defect 2).
+        ``reasoning_effort`` / ``thinking`` per-call args fall back to the
+        instance defaults set in ``__init__`` (Defect 3); both are injected into
+        the request body's ``extra_body`` / ``chat_template_kwargs`` if set.
+
         ``transport`` is for tests only (httpx.MockTransport injection).
         """
-        if not stream and max_tokens > _NONSTREAM_MAX_TOKENS_LIMIT:
+        effective_max_tokens = max_tokens if max_tokens is not None else self.default_max_tokens
+        if not stream and effective_max_tokens > _NONSTREAM_MAX_TOKENS_LIMIT:
             raise BrainClientError(
                 "non-streaming long-output forbidden; use stream=True"
             )
 
-        payload = {
+        effective_reasoning_effort = (
+            reasoning_effort if reasoning_effort is not None else self.reasoning_effort
+        )
+        effective_thinking = thinking if thinking is not None else self.thinking
+
+        payload: dict[str, Any] = {
             "model": self.model,
             "messages": messages,
-            "max_tokens": max_tokens,
+            "max_tokens": effective_max_tokens,
             "temperature": temperature,
             "stream": stream,
         }
+        if effective_reasoning_effort is not None:
+            payload["reasoning_effort"] = effective_reasoning_effort
+        if effective_thinking is not None:
+            payload["chat_template_kwargs"] = {"thinking": effective_thinking}
+
+        # Reset per-call accumulators
+        self.last_reasoning = ""
+        self.last_finish_reason = None
 
         if stream:
             return self._stream(payload, transport=transport)
@@ -93,7 +148,16 @@ class BrainClient:
             async with httpx.AsyncClient(**client_kwargs) as client:
                 resp = await client.post(url, json=payload)
                 resp.raise_for_status()
-                return resp.json()
+                data = resp.json()
+                # Capture reasoning + finish_reason for caller introspection (Defect 1, oneshot path)
+                try:
+                    choice0 = data["choices"][0]
+                    msg = choice0.get("message", {}) or {}
+                    self.last_reasoning = msg.get("reasoning") or ""
+                    self.last_finish_reason = choice0.get("finish_reason")
+                except (KeyError, IndexError, TypeError):
+                    pass
+                return data
         except httpx.TimeoutException as exc:
             elapsed = time.monotonic() - started
             logger.warning(
@@ -112,6 +176,12 @@ class BrainClient:
         payload: dict,
         transport: Optional[httpx.AsyncBaseTransport],
     ) -> AsyncIterator[str]:
+        """Yield ``delta.content`` chunks. Accumulate ``delta.reasoning`` chunks
+        to ``self.last_reasoning`` (Defect 1). vLLM nemotron_v3 parser emits
+        reasoning chunks first (until the trace completes), then content;
+        without parsing both, the content stream may appear empty when the
+        reasoning fills the budget — see Track A (PR #323) for the failure mode.
+        """
         url = f"{self.base_url}/v1/chat/completions"
         started = time.monotonic()
         ttft: Optional[float] = None
@@ -138,7 +208,16 @@ class BrainClient:
                         choices = event.get("choices") or []
                         if not choices:
                             continue
-                        delta = choices[0].get("delta") or {}
+                        choice = choices[0]
+                        finish = choice.get("finish_reason")
+                        if finish is not None:
+                            self.last_finish_reason = finish
+                        delta = choice.get("delta") or {}
+                        # Defect 1: accumulate reasoning; do NOT yield (consumers expect content only)
+                        reasoning_chunk = delta.get("reasoning")
+                        if reasoning_chunk:
+                            self.last_reasoning += reasoning_chunk
+                        # Yield content as before (backward-compatible)
                         chunk = delta.get("content")
                         if chunk:
                             if ttft is None:

--- a/fortress-guest-platform/backend/tests/test_brain_client.py
+++ b/fortress-guest-platform/backend/tests/test_brain_client.py
@@ -184,3 +184,276 @@ async def test_streaming_unreachable_raises_brain_client_error():
     with pytest.raises(BrainClientError):
         async for _ in iterator:
             pass
+
+
+# ── Path X TP=2 frontier compatibility (Track A defects 1/2/3) ─────────────
+
+
+def _sse_response_with_reasoning(
+    reasoning_chunks: list[str],
+    content_chunks: list[str],
+    finish_reason: str = "stop",
+) -> httpx.Response:
+    """vLLM nemotron_v3 wire format: reasoning chunks first, then content."""
+    lines: list[str] = []
+    role_event = {
+        "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}]
+    }
+    lines.append(f"data: {json.dumps(role_event)}")
+    lines.append("")
+    for r in reasoning_chunks:
+        ev = {"choices": [{"index": 0, "delta": {"reasoning": r}, "finish_reason": None}]}
+        lines.append(f"data: {json.dumps(ev)}")
+        lines.append("")
+    for c in content_chunks:
+        ev = {"choices": [{"index": 0, "delta": {"content": c}, "finish_reason": None}]}
+        lines.append(f"data: {json.dumps(ev)}")
+        lines.append("")
+    finish_event = {"choices": [{"index": 0, "delta": {}, "finish_reason": finish_reason}]}
+    lines.append(f"data: {json.dumps(finish_event)}")
+    lines.append("")
+    lines.append("data: [DONE]")
+    lines.append("")
+    body = ("\n".join(lines) + "\n").encode("utf-8")
+    return httpx.Response(
+        200,
+        content=body,
+        headers={"content-type": "text/event-stream"},
+    )
+
+
+def test_default_max_tokens_is_8000():
+    """Defect 2 regression guard — module + instance defaults bumped from 4000 to 8000."""
+    from backend.services import brain_client as _bc
+    assert _bc._DEFAULT_MAX_TOKENS == 8000
+    client = BrainClient(base_url="http://mock-brain")
+    assert client.default_max_tokens == 8000
+
+
+def test_constructor_accepts_reasoning_kwargs():
+    """Defect 3 — constructor stores reasoning_effort + thinking kwargs."""
+    client = BrainClient(
+        base_url="http://mock-brain",
+        reasoning_effort="high",
+        thinking=True,
+    )
+    assert client.reasoning_effort == "high"
+    assert client.thinking is True
+
+
+@pytest.mark.asyncio
+async def test_extra_body_injection_when_reasoning_kwargs_set():
+    """Defect 3 — reasoning_effort + thinking land in payload."""
+    captured_payloads: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_payloads.append(json.loads(request.content))
+        return _ok_nonstream_response("x")
+
+    transport = httpx.MockTransport(handler)
+    client = BrainClient(
+        base_url="http://mock-brain",
+        reasoning_effort="high",
+        thinking=True,
+    )
+    await client.chat(
+        messages=[{"role": "user", "content": "x"}],
+        max_tokens=500,
+        stream=False,
+        transport=transport,
+    )
+    assert len(captured_payloads) == 1
+    body = captured_payloads[0]
+    assert body.get("reasoning_effort") == "high"
+    assert body.get("chat_template_kwargs") == {"thinking": True}
+
+
+@pytest.mark.asyncio
+async def test_extra_body_omitted_when_reasoning_kwargs_unset():
+    """Defect 3 — when neither constructor nor per-call sets the flags, they are NOT in payload."""
+    captured_payloads: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_payloads.append(json.loads(request.content))
+        return _ok_nonstream_response("x")
+
+    transport = httpx.MockTransport(handler)
+    client = BrainClient(base_url="http://mock-brain")  # no reasoning kwargs
+    await client.chat(
+        messages=[{"role": "user", "content": "x"}],
+        max_tokens=500,
+        stream=False,
+        transport=transport,
+    )
+    body = captured_payloads[0]
+    assert "reasoning_effort" not in body
+    assert "chat_template_kwargs" not in body
+
+
+@pytest.mark.asyncio
+async def test_per_call_reasoning_kwargs_override_constructor():
+    """Defect 3 — per-call kwargs win over constructor defaults."""
+    captured_payloads: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_payloads.append(json.loads(request.content))
+        return _ok_nonstream_response("x")
+
+    transport = httpx.MockTransport(handler)
+    client = BrainClient(
+        base_url="http://mock-brain",
+        reasoning_effort="high",
+        thinking=True,
+    )
+    await client.chat(
+        messages=[{"role": "user", "content": "x"}],
+        max_tokens=500,
+        stream=False,
+        transport=transport,
+        reasoning_effort="low",
+        thinking=False,
+    )
+    body = captured_payloads[0]
+    assert body["reasoning_effort"] == "low"
+    assert body["chat_template_kwargs"]["thinking"] is False
+
+
+@pytest.mark.asyncio
+async def test_stream_parses_delta_reasoning_separately():
+    """Defect 1 — reasoning chunks accumulate to client.last_reasoning, not yielded as content."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return _sse_response_with_reasoning(
+            reasoning_chunks=["We", " need", " to"],
+            content_chunks=["## Section", " 4"],
+            finish_reason="stop",
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = BrainClient(base_url="http://mock-brain")
+    iterator: AsyncIterator[str] = await client.chat(  # type: ignore[assignment]
+        messages=[{"role": "user", "content": "x"}],
+        stream=True,
+        transport=transport,
+    )
+
+    received: list[str] = []
+    async for chunk in iterator:
+        received.append(chunk)
+
+    # Backward-compat: only content chunks yielded
+    assert received == ["## Section", " 4"]
+    assert "".join(received) == "## Section 4"
+    # Defect 1 fix: reasoning accumulated in side channel
+    assert client.last_reasoning == "We need to"
+    assert client.last_finish_reason == "stop"
+
+
+@pytest.mark.asyncio
+async def test_stream_pre_existing_consumer_pattern_unchanged():
+    """Defect 1 — backward-compat sanity: existing `response += chunk` accumulator
+    still produces content-only string with no reasoning bleed-through."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return _sse_response_with_reasoning(
+            reasoning_chunks=["First, I'll", " analyze"],  # first-person prose
+            content_chunks=["Defense theory: ", "encroachment ", "voids ", "performance."],
+            finish_reason="stop",
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = BrainClient(base_url="http://mock-brain")
+    iterator: AsyncIterator[str] = await client.chat(  # type: ignore[assignment]
+        messages=[{"role": "user", "content": "x"}],
+        stream=True,
+        transport=transport,
+    )
+    response = ""
+    async for chunk in iterator:
+        response += chunk
+    assert response == "Defense theory: encroachment voids performance."
+    # Critically: no first-person reasoning in the content stream
+    assert "I'll" not in response
+    assert "First" not in response
+
+
+@pytest.mark.asyncio
+async def test_oneshot_captures_reasoning_and_finish_reason():
+    """Defect 1 — non-streaming path also exposes reasoning + finish_reason via instance attrs."""
+    body = {
+        "id": "cmpl-test",
+        "object": "chat.completion",
+        "model": "nemotron-3-super",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "## Defenses",
+                    "reasoning": "Think through each defense theory under Georgia law.",
+                },
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 3, "total_tokens": 13},
+    }
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=body)
+
+    transport = httpx.MockTransport(handler)
+    client = BrainClient(base_url="http://mock-brain")
+    result = await client.chat(
+        messages=[{"role": "user", "content": "x"}],
+        max_tokens=500,
+        stream=False,
+        transport=transport,
+    )
+    assert isinstance(result, dict)
+    assert result["choices"][0]["message"]["content"] == "## Defenses"
+    assert client.last_reasoning == "Think through each defense theory under Georgia law."
+    assert client.last_finish_reason == "stop"
+
+
+@pytest.mark.asyncio
+async def test_chat_resolves_default_max_tokens_when_caller_passes_none():
+    """Defect 2 — max_tokens=None resolves to client.default_max_tokens (8000)."""
+    captured_payloads: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_payloads.append(json.loads(request.content))
+        return _sse_response_with_reasoning(
+            reasoning_chunks=[],
+            content_chunks=["ok"],
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = BrainClient(base_url="http://mock-brain")
+    iterator: AsyncIterator[str] = await client.chat(  # type: ignore[assignment]
+        messages=[{"role": "user", "content": "x"}],
+        # max_tokens omitted → falls back to default_max_tokens
+        transport=transport,
+    )
+    async for _ in iterator:
+        pass
+    assert captured_payloads[0]["max_tokens"] == 8000
+
+
+@pytest.mark.asyncio
+async def test_constructor_default_max_tokens_override():
+    """Defect 2 — constructor can override the per-instance default."""
+    captured_payloads: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_payloads.append(json.loads(request.content))
+        return _sse_response_with_reasoning(reasoning_chunks=[], content_chunks=["ok"])
+
+    transport = httpx.MockTransport(handler)
+    client = BrainClient(base_url="http://mock-brain", default_max_tokens=12000)
+    iterator: AsyncIterator[str] = await client.chat(  # type: ignore[assignment]
+        messages=[{"role": "user", "content": "x"}],
+        transport=transport,
+    )
+    async for _ in iterator:
+        pass
+    assert captured_payloads[0]["max_tokens"] == 12000


### PR DESCRIPTION
## Summary

Path X surgical fix for Track A's three BrainClient defects (issue #324). `BrainClient` now produces non-empty content against the spark-3+spark-4 TP=2 frontier with `nemotron_v3` reasoning parser. Path Y (retire BrainClient, route via LiteLLM — Wave 6 NAT migration, issue #325) NOT in scope.

**Do NOT merge** — surface for operator review.

## Defect status

| Defect | Status | Validation |
|---|---|---|
| 1 — `_stream()` discards `delta.reasoning` | ✅ **FIXED** | Live repro: `client.last_reasoning` = 4,495 chars; new test `test_stream_parses_delta_reasoning_separately` passes |
| 2 — default `max_tokens` too low | ✅ **FIXED at BrainClient layer** | `_DEFAULT_MAX_TOKENS=8000`; live repro produces 3,203 content chars + `finish=stop`. **Caveat:** synthesizer hardcodes its own 2000 cap — separate follow-up |
| 3 — no `reasoning_effort` / `thinking` kwarg mechanism | ✅ **FIXED at BrainClient layer; vLLM activation deferred** | Wiring validated by 4 new unit tests (request body assertions); live vLLM build does not differentiate reasoning length based on flag yet |

## Live repro on TP=2 endpoint (`http://10.10.10.3:8000` / `nemotron-3-super`)

| | Pre-fix (Track A) | Post-fix (this PR) |
|---|---|---|
| `content_chars` | **0** | **3,203** |
| `reasoning_chars` | (not exposed) | **4,495** |
| `finish_reason` | length | **stop** |

Same synthesis-style prompt, same model, same endpoint. The only change is BrainClient.

## Tests

| | Pre-fix | Post-fix |
|---|---|---|
| Existing tests | 7 passing | **7 passing** (all backward-compat preserved) |
| New Path-X tests | n/a | **10 new** (3 defects × stream/oneshot/kwargs/override coverage) |
| **Total** | **7/7** | **17/17 PASS** |

## Track A re-run via orchestrator pipeline (§8)

Wall: 421.5 s. Result: **5 synthesis sections still empty.** The synthesizer at `case_briefing_synthesizers.py:205` hardcodes `max_tokens: int = 2000` and passes it explicitly to `brain_client.chat(max_tokens=2000)`. The new BrainClient resolves `max_tokens=None` → 8000, but explicit 2000 stays 2000. **Reasoning fills 2000-token budget; content emission never starts.**

Per brief §11 (no synthesizer modifications) and §8 (file new issue if any of the 5 still fail), the synthesizer-cap is **out of Path X scope**. Section 9 augmentation (uses LiteLLM directly with max_tokens=5000) produced **6,375 chars / 14 citations** — confirms endpoint works when given budget.

## Follow-up issue to file post-merge

| Title | Priority |
|---|---|
| **Phase B synthesizer `max_tokens` cap — raise from 2000 to 8000 (cascade BrainClient fix to orchestrator pipeline)** | **P1** |

One-line synthesizer change at `case_briefing_synthesizers.py:205`. With this follow-up + Path X merged, Track A's 5 synthesis sections will produce content end-to-end.

## Files in PR (4)

- `fortress-guest-platform/backend/services/brain_client.py` (+91, -6)
- `fortress-guest-platform/backend/tests/test_brain_client.py` (+273)
- `docs/operational/brain-client-tp2-frontier-fix-brief.md` (added: copy of brief)
- `docs/operational/brain-client-fix-validation-2026-04-30.md` (added: full validation report)

## NOT modified (per brief §11)

- Synthesizer prompt logic (`case_briefing_synthesizers.py`)
- Orchestrator (`case_briefing_compose.py`)
- Phase B runner script
- LiteLLM config
- Frontier endpoint
- Any other service

## Soak impact

- Frontier endpoint `/health` 200 throughout
- No soak halt triggers fired
- ~14 min total TP=2 endpoint load (BrainClient repro + Track A re-run; productive load — Section 9 augmentation produced 6,375 chars)

## What this PR unblocks

- ✅ Direct BrainClient consumers (`brain_rag_probe.py`, future direct callers) produce content with default settings
- ✅ Per-section reasoning depth wiring is in place; activation lands when vLLM upgrade honors `reasoning_effort` extra_body
- ✅ Track A's BrainClient-layer empirical evidence is closed

## What remains blocked

- ❌ Phase B v0.1 orchestrator synthesis sections — until synthesizer-cap follow-up merges (one-line change)
- ❌ Case II briefing on the orchestrator pipeline — same root cause as above

Section 9 augmentation pattern remains a viable interim path for any single-section synthesis use case.

## Test plan (operator review)

- [ ] Read `brain_client.py` diff — confirm 3 defects addressed surgically; backward-compat preserved
- [ ] Read `test_brain_client.py` new tests — confirm coverage matches the 3 defects
- [ ] Read `brain-client-fix-validation-2026-04-30.md` — confirm pre/post-fix repro evidence + Track A re-run finding
- [ ] Confirm synthesizer-cap follow-up issue gets filed post-merge (P1)
- [ ] Decide whether to file the synthesizer-cap fix as a separate small PR or fold into a Wave 4 batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)