### PR TITLE
feat(brain-client): wire Nemotron reasoning controls (top-level chat_template_kwargs, dual response field parsing)

### DIFF
--- a/docs/operational/brain-client-reasoning-control-validation-2026-04-30.md
+++ b/docs/operational/brain-client-reasoning-control-validation-2026-04-30.md
@@ -1,0 +1,184 @@
+# BrainClient Reasoning-Control Validation — Phase 2
+
+**Branch:** `feat/brain-client-reasoning-control-2026-04-30` (from `origin/main` 8d8c41b65)
+**Date:** 2026-04-30
+**Stacks on:** PR #326 (BrainClient TP=2 Path X), PR #327 (synthesizer cap 8000), PR #329 (Track A v3 analysis), PR #330 (Phase 1 reasoning-control probes), Issue #328 reframing.
+**Frontier load consumed:** §4 stress probes + 3 isolated single-section runs = ~12 minutes wall on the spark-3 vLLM frontier. Frontier health 200 throughout. No soak halts.
+
+This report covers Phase 2 of the [4-phase plan](../../nemotron-3-super-tp2-stabilization-4-phase-plan-v2-2026-04-30.md) — wiring the reasoning controls PR #330 proved work on the build, with empirical per-knob attribution to settle the Phase 3 per-section policy table.
+
+---
+
+## 1. Step 3 §4 stress-test gate — PASS
+
+PR #330's probes settled the schema (top-level `chat_template_kwargs`, top-level `thinking_token_budget`, no `extra_body` wrapper) but the probe prompt was 3 KB and reasoning naturally landed at ~1,195 tokens — under the 2,048-token budget. Whether the budget actually enforced was inconclusive on a small prompt. Phase 2 Step 3 re-runs the probe against the actual §4 production prompt (25,291 chars, 5,414 unbounded reasoning tokens at PR #329 baseline).
+
+### §4 prompt reconstruction
+
+The 19:45Z run did not preserve raw request bodies — the runner never wrote `raw/section_4_request.json`. Reconstructed via `compose()`'s `stage_0_curate` + `stage_1_grounding_packet` (top_k=15, privileged_top_k=10) + `_build_synthesis_user_prompt`. Total: **25,291 chars (drift 0.00% vs PR #329 baseline)**, 30 work-product chunks, 0 privileged chunks. Byte-identical to the 19:45Z prompt.
+
+### §4 stress probe results
+
+| Path | wall_s | content_chars | reasoning_chars | reasoning tok | finish | reasoning field |
+|---|---:|---:|---:|---:|---|---|
+| 19:45Z baseline (no controls) | 306.1 | 7,818 | 21,656 | ~5,414 | stop | — |
+| Direct vLLM (low_effort + budget=2048) | 137.5 | 10,253 | **1,337** | ~334 | stop | `reasoning` |
+| LiteLLM passthrough (same body) | 87.1 | 7,920 | **210** | ~52 | stop | `reasoning_content` |
+
+**Hard-stop §4 (reasoning_chars >12,300):** not triggered — direct 1,337 chars, LiteLLM 210 chars, both well under threshold.
+
+**Decision-gate read:** Reasoning is *way under* the 2,048-token budget on both paths. Either the budget is enforced (tight) or `low_effort=True` already drives reasoning under any cap. Steps 6+7 isolate this empirically.
+
+---
+
+## 2. BrainClient surgery (Step 4) — what changed
+
+`fortress-guest-platform/backend/services/brain_client.py`:
+
+### Added (constructor + per-call kwargs)
+- `enable_thinking: bool | None` — top-level `chat_template_kwargs.enable_thinking`
+- `low_effort: bool | None` — top-level `chat_template_kwargs.low_effort`
+- `thinking_token_budget: int | None` — top-level `thinking_token_budget` field
+
+All three placed at **top level** of the request body. The OpenAI-style `extra_body` wrapper is silently dropped by vLLM's OpenAI-compat server (PR #330 Probe E: same body wrapped in `extra_body` ran 2,554 reasoning tokens against a 2,048 budget vs 1,195 unwrapped).
+
+### Response parsing — both shapes
+- Direct vLLM: `message.reasoning` (and `delta.reasoning` in streaming)
+- Via LiteLLM: `message.reasoning_content` (and `delta.reasoning_content` in streaming)
+
+`last_reasoning` accumulates whichever field is present, preferring `reasoning_content` first (production callers route through LiteLLM).
+
+### Deprecated (kept for backward compat, NOT injected into payload)
+- `reasoning_effort` (PR #326 Defect 3) — OpenAI-class schema, not honored by Nemotron's chat template; LiteLLM `drop_params: true` silently drops it.
+- `thinking` (PR #326 Defect 3) — wrong key (chat template uses `enable_thinking`, not `thinking`).
+
+Both log a one-shot `brain_client_deprecated` warning when set. Backward-compatible: existing callers that pass these kwargs continue to work, just with a warning and a no-op on the wire.
+
+### Default behavior unchanged
+When no Phase 2 kwargs are set (constructor or per-call), `chat_template_kwargs` and `thinking_token_budget` are absent from the payload. Existing callers see byte-identical behavior to PR #327's wire format.
+
+---
+
+## 3. Unit tests (Step 5)
+
+22 tests pass (`backend/tests/test_brain_client.py`). Coverage additions:
+
+- `test_chat_template_kwargs_at_top_level` — regression guard against `extra_body` nesting.
+- `test_thinking_token_budget_at_top_level` — same.
+- `test_per_call_phase2_kwargs_override_constructor` — kwarg precedence.
+- `test_reasoning_kwargs_omitted_when_unset` — default behavior preserved.
+- `test_reasoning_effort_deprecated_not_injected` — caplog-asserted warning + payload absence.
+- `test_thinking_kwarg_deprecated_not_injected` — same.
+- `test_oneshot_captures_reasoning_content_field` — LiteLLM shape.
+- `test_stream_parses_delta_reasoning_content_field` — LiteLLM streaming shape.
+
+The two old PR #326 Defect-3 tests (`test_extra_body_injection_when_reasoning_kwargs_set`, `test_per_call_reasoning_kwargs_override_constructor`) were replaced — they asserted the now-deprecated wiring.
+
+---
+
+## 4. §4 single-section validation — three isolated runs (Steps 6–7)
+
+The Step 3 stress probe used `temperature=1.0` (Nemotron's published recommended sampling). Production synthesizer uses `temperature=0.0`. Three runs at production temperature, each isolating a knob, against the same §4 prompt:
+
+| Run | enable_thinking | low_effort | budget | content_chars | reasoning_chars | wall_s | finish | grounding | first-person | `<think>` | ASCII cits | CJK cits |
+|---|---|---|---|---:|---:|---:|---|---:|---:|---:|---:|---:|
+| Baseline (PR #329) | _(default)_ | — | — | 7,818 | 21,656 | 306.09 | stop | 4 | 0 | 0 | 0 | many |
+| **Run 1** | True | — | — | **7,818** | **21,656** | 308.12 | stop | 4 | 0 | 0 | 0 | many |
+| **Run 2** | True | True | — | **10,074** | **527** | 126.37 | stop | 4 | 0 | 0 | 45 | 0 |
+| **Run 3** | True | True | 2048 | 10,074 | 527 | 125.51 | stop | 4 | 0 | 0 | 45 | 0 |
+
+### Per-knob empirical attribution
+
+- **`enable_thinking=True` alone (Run 1)**: byte-identical to baseline. Chat template default is already True. **No-op when toggled to True.** (Whether toggled to False suppresses thinking is covered by PR #330 Probe B — confirmed yes there.)
+- **`low_effort=True` (Run 2 vs Run 1)**: drives 100% of the observed behavior delta.
+  - reasoning_chars: 21,656 → 527 (−97.57%)
+  - wall_seconds: 308.12 → 126.37 (−59.0%)
+  - content_chars: 7,818 → 10,074 (+28.9%)
+  - citation format: CJK `【...】` → ASCII `[...]` (45 ASCII citations vs baseline's 0)
+  - More thorough enumeration: 5 explicit causes of action vs baseline's narrative coverage.
+- **`thinking_token_budget=2048` (Run 3 vs Run 2)**: byte-identical. **No-op on this prompt class** — `low_effort=True` already drives reasoning to 527 chars (~132 tokens), well under the 2,048-token ceiling. The defensive cap never engages.
+
+### Hard-stop disposition
+
+| Plan hard stop | Status | Note |
+|---|---|---|
+| §1 — `brain_client.py` not at expected path | PASS | path verified |
+| §2 — frontier `/health` non-200 sustained >60s | PASS | 200 throughout |
+| §3 — soak halt event | PASS | not observed |
+| §4 — Step 3 reasoning_chars >12,300 (budget not enforced) | PASS | direct 1,337 / LiteLLM 210, both far under |
+| **§5 — content_chars >5% off baseline (quality regression)** | **TRIGGERED LETTER, NOT SPIRIT** | +28.9%; attributed to `low_effort` chat-template engagement, not regression. Same grounding citations (4), same finish_reason (stop), more idiomatic ASCII brackets, more thorough enumeration. Operator-confirmed proceed. |
+| §6 — reasoning_chars not meaningfully lower with controls | PASS | −97.57% |
+| §7 — disk full | PASS | 1.3T avail |
+
+The §5 letter trigger is unavoidable given the chat-template-engagement effect, and the plan's ±5% tolerance assumed byte-deterministic output at `temperature=0.0` — but engaging `low_effort=True` itself is a non-byte-equivalent input change. The Run 1/Run 2/Run 3 isolation cleanly attributes the delta to a non-regressive mechanism.
+
+---
+
+## 5. Implications for Phase 3
+
+The plan's per-section policy table can be simplified given the empirical attribution:
+
+| Section | Mode | Phase 3 plan (original) | Phase 3 plan (post-Phase 2 attribution) |
+|---|---|---|---|
+| §1 Case Summary | mechanical | enable_thinking=False, max_tokens=4000 | enable_thinking=False, max_tokens=4000 |
+| §2 Critical Timeline | synthesis (broken) | enable_thinking=False, max_tokens=4000 | enable_thinking=False, max_tokens=4000 |
+| §3 Parties & Counsel | mechanical | enable_thinking=False, max_tokens=4000 | enable_thinking=False, max_tokens=4000 |
+| §4 Claims | synthesis | enable_thinking=True, low_effort=True, **budget=2048**, max_tokens=8000 | enable_thinking=True, low_effort=True, max_tokens=8000 |
+| §5 Defenses | synthesis | same | same |
+| §6 Evidence Inventory | mechanical | enable_thinking=False, max_tokens=5000 | enable_thinking=False, max_tokens=5000 |
+| §7 Email Intelligence | synthesis (broken) | enable_thinking=False, max_tokens=4000 | enable_thinking=False, max_tokens=4000 |
+| §8 Financial | synthesis | enable_thinking=True, low_effort=True, **budget=2048**, max_tokens=4000 | enable_thinking=True, low_effort=True, max_tokens=4000 |
+| §9 Strategy | synthesis | same | same |
+| §10 Filing Checklist | mechanical | enable_thinking=False, max_tokens=4000 | enable_thinking=False, max_tokens=4000 |
+
+**Drop `thinking_token_budget` from Phase 3 routing.** Empirically inert on §4's 25 KB prompt class — `low_effort=True` clamps reasoning to ~132 tokens, far under any 2,048 budget. The kwarg stays in BrainClient as a defensive ceiling for hypothetical prompt classes where reasoning might naturally exceed 2,048 tokens, but Phase 3 should not include it in the per-section policy. If §5 / §8 / §9 unexpectedly produce >2,048 reasoning tokens with `low_effort=True` during the Phase 3 full Track A re-run, surface and reconsider.
+
+`enable_thinking=True` for reasoning sections is a no-op (default already True) but worth keeping in the policy table for **explicitness** — future readers can see the per-section intent without spelunking chat-template defaults.
+
+---
+
+## 6. Frontier health log
+
+```
+Stress probe pre:    200  (2026-04-30T21:55:51Z)
+Stress probe post:   200  (2026-04-30T21:58:08Z direct)
+Stress probe post:   200  (2026-04-30T21:59:53Z LiteLLM)
+Run 1 pre:           200  (2026-04-30T22:09:28Z)
+Run 1 post:          200
+Run 2 pre:           200  (2026-04-30T22:15:14Z)
+Run 2 post:          200
+Run 3 (Step 6) post: 200
+```
+
+No soak halt events observed. KV cache pressure not tripped (frontier `--max-num-seqs 10` not saturated).
+
+---
+
+## 7. Artifacts (`/tmp`, NOT in repo)
+
+```
+/tmp/budget-stress-20260430T215520Z/             # Step 3 stress probes
+├── reconstruction-metadata.json                 # 25,291 chars, 0.00% drift
+├── stress-direct-{body,response,metrics}.json   # vLLM direct
+├── stress-litellm-{body,response,metrics}.json  # LiteLLM passthrough
+└── raw/health.log
+
+/tmp/phase2-section4-validation-20260430T220419Z/   # Run 3 (all three knobs)
+/tmp/phase2-section4-run1-20260430T220928Z/         # Run 1 (enable_thinking only)
+/tmp/phase2-section4-run2-20260430T221515Z/         # Run 2 (+ low_effort)
+```
+
+Each per-run dir holds `metrics/validation-summary.json`, `sections/section_04_claims_analysis.md`, `compose-output/`, and `raw/health.log`.
+
+The reconstruction harness (`reconstruct_section4_prompt.py`) and validation harness (`validate_brain_client_phase2_section4.py`) are removed before commit — single-use, not needed long-term.
+
+---
+
+## 8. References
+
+- PR #326 — BrainClient TP=2 frontier compatibility (introduced now-deprecated `reasoning_effort`, `thinking`)
+- PR #327 — synthesizer cap 8000 (unchanged by Phase 2)
+- PR #329 — Track A v3 analysis (cap=20000 measurement halted; baseline metrics for §4/§5/§8 used here)
+- PR #330 — Phase 1 reasoning-control probes (decision matrix this PR builds on)
+- vLLM bugs [#39103](https://github.com/vllm-project/vllm/issues/39103), [#39573](https://github.com/vllm-project/vllm/issues/39573), [#25714](https://github.com/vllm-project/vllm/issues/25714) — confirmed not exposed on this build
+- Issue #328 — §2/§7 gap; Phase 3 (next PR) closes it via `enable_thinking=False`

--- a/fortress-guest-platform/backend/services/brain_client.py
+++ b/fortress-guest-platform/backend/services/brain_client.py
@@ -8,19 +8,39 @@ mid-response on the underlying NIM/vLLM stack.
 This module is read-only: it does not retry, mutate any sovereign store, or
 call Council deliberation paths. Caller decides retry policy.
 
-# Phase B BrainClient TP=2 frontier compatibility (Path X, 2026-04-30)
-Following Track A (PR #323) the client now handles vLLM's nemotron_v3
-reasoning parser wire format:
-- Stream parses `delta.reasoning` chunks alongside `delta.content`.
-  Reasoning is accumulated to `self.last_reasoning` (and exposed via
-  `last_finish_reason`); content is yielded as before, so existing
-  consumers continue to work unchanged.
-- `default_max_tokens` constructor kwarg (default 8000) raises the
-  per-call max_tokens floor when callers don't specify, leaving room for
-  the reasoning trace to complete before content emission begins.
-- `reasoning_effort` and `thinking` kwargs (constructor + per-call) inject
-  into the request body's `extra_body` / `chat_template_kwargs`, mirroring
-  the per-alias profile config established by Phase 9 LiteLLM alias surgery.
+# Reasoning controls (post-PR #330 probe matrix, 2026-04-30)
+The vLLM nemotron_v3 reasoning parser exposes thinking depth via three knobs.
+PR #330's empirical probes settled the schema: all three must be placed at
+the TOP LEVEL of the request body. The OpenAI-style `extra_body` wrapper is
+silently dropped by vLLM's OpenAI-compat server (Probe E ran 2,554 reasoning
+tokens against a 2,048 budget when wrapped, vs 1,195 unwrapped — same body
+otherwise).
+
+Wired knobs (constructor + per-call):
+- ``enable_thinking: bool | None`` — when False, model emits content directly
+  with no reasoning trace (mechanical sections, §2/§7 fix).
+- ``low_effort: bool | None`` — meaningful only when enable_thinking=True;
+  cuts reasoning depth dramatically (§4 stress test: 21,656 → 1,337 chars
+  direct, 21,656 → 210 chars via LiteLLM).
+- ``thinking_token_budget: int | None`` — top-level field; defensive ceiling.
+  PR #330 + Phase 2 stress could not conclusively prove logits-processor
+  enforcement on this build (low_effort kept reasoning well under budget),
+  so the budget is wired as a defensive ceiling rather than load-bearing.
+
+Response-shape divergence between paths:
+- Direct vLLM: ``message.reasoning`` (and ``delta.reasoning`` in streaming).
+- Via LiteLLM: ``message.reasoning_content`` (and ``delta.reasoning_content``
+  in streaming).
+``last_reasoning`` accumulates whichever field is present.
+
+# Deprecated kwargs
+- ``reasoning_effort`` (added in PR #326 Defect 3) — OpenAI-class schema,
+  not honored by Nemotron's chat template. LiteLLM's ``drop_params: true``
+  silently drops it. Kept for backward compat; logs a one-shot deprecation
+  warning when set; NOT injected into the request body.
+- ``thinking`` (added in PR #326 Defect 3) — wrong key (chat template uses
+  ``enable_thinking``). Kept for backward compat; logs a one-shot deprecation
+  warning when set; NOT injected. Callers should switch to ``enable_thinking``.
 """
 
 from __future__ import annotations
@@ -51,10 +71,11 @@ class BrainClient:
 
     Defaults to streaming; non-streaming is allowed only for short outputs.
 
-    Reasoning-aware: handles vLLM nemotron_v3 reasoning parser wire format.
-    After a chat() call completes, `client.last_reasoning` exposes the
-    reasoning trace and `client.last_finish_reason` exposes the terminating
-    cause (`stop`, `length`, etc.) for both streaming and non-streaming paths.
+    Reasoning-aware: parses both ``message.reasoning`` (direct vLLM) and
+    ``message.reasoning_content`` (via LiteLLM). After a chat() call completes,
+    ``client.last_reasoning`` exposes the reasoning trace and
+    ``client.last_finish_reason`` exposes the terminating cause (``stop``,
+    ``length``, etc.).
     """
 
     def __init__(
@@ -65,16 +86,35 @@ class BrainClient:
         *,
         # Defect 2 — per-instance default for callers that don't specify max_tokens
         default_max_tokens: int = _DEFAULT_MAX_TOKENS,
-        # Defect 3 — reasoning controls for vLLM nemotron_v3 parser
-        reasoning_effort: Optional[str] = None,  # "low" | "medium" | "high"
-        thinking: Optional[bool] = None,          # → chat_template_kwargs.thinking
+        # Phase 2 reasoning controls (PR #330 probe matrix)
+        enable_thinking: Optional[bool] = None,
+        low_effort: Optional[bool] = None,
+        thinking_token_budget: Optional[int] = None,
+        # Deprecated — kept for backward compat (PR #326)
+        reasoning_effort: Optional[str] = None,
+        thinking: Optional[bool] = None,
     ) -> None:
         self.base_url = (base_url or _cfg.brain_base_url).rstrip("/")
         self.timeout = timeout
         self.model = model
         self.default_max_tokens = default_max_tokens
+        self.enable_thinking = enable_thinking
+        self.low_effort = low_effort
+        self.thinking_token_budget = thinking_token_budget
+        # Deprecated — stored for introspection but never injected into the request
         self.reasoning_effort = reasoning_effort
         self.thinking = thinking
+        if reasoning_effort is not None:
+            _warn_deprecated_once(
+                "BrainClient(reasoning_effort=...) — OpenAI-class schema not honored "
+                "by Nemotron; param will not be injected. Use low_effort=True or "
+                "thinking_token_budget=N instead."
+            )
+        if thinking is not None:
+            _warn_deprecated_once(
+                "BrainClient(thinking=...) — wrong chat-template key; not injected. "
+                "Use enable_thinking=... instead."
+            )
         # Reasoning accumulator + terminating cause exposed after each chat() call
         self.last_reasoning: str = ""
         self.last_finish_reason: Optional[str] = None
@@ -87,7 +127,11 @@ class BrainClient:
         stream: bool = True,
         transport: Optional[httpx.AsyncBaseTransport] = None,
         *,
-        # Per-call overrides for Defect 3 reasoning controls
+        # Phase 2 per-call overrides
+        enable_thinking: Optional[bool] = None,
+        low_effort: Optional[bool] = None,
+        thinking_token_budget: Optional[int] = None,
+        # Deprecated — kept for backward compat (PR #326)
         reasoning_effort: Optional[str] = None,
         thinking: Optional[bool] = None,
     ) -> Union[AsyncIterator[str], dict]:
@@ -96,10 +140,17 @@ class BrainClient:
         - stream=True (default): returns an async iterator yielding content chunks.
         - stream=False: returns the parsed response dict; rejects max_tokens > 1000.
 
-        ``max_tokens=None`` resolves to ``self.default_max_tokens`` (Defect 2).
-        ``reasoning_effort`` / ``thinking`` per-call args fall back to the
-        instance defaults set in ``__init__`` (Defect 3); both are injected into
-        the request body's ``extra_body`` / ``chat_template_kwargs`` if set.
+        ``max_tokens=None`` resolves to ``self.default_max_tokens``.
+
+        Reasoning-control kwargs (per-call value wins over instance default):
+        - ``enable_thinking`` → top-level ``chat_template_kwargs.enable_thinking``
+        - ``low_effort``      → top-level ``chat_template_kwargs.low_effort``
+        - ``thinking_token_budget`` → top-level ``thinking_token_budget`` field
+        All three are placed at the top level of the request body (NOT inside
+        ``extra_body`` — vLLM silently drops nested fields per PR #330 Probe E).
+
+        Deprecated kwargs (``reasoning_effort``, ``thinking``) emit a one-shot
+        warning and are NOT injected into the request body.
 
         ``transport`` is for tests only (httpx.MockTransport injection).
         """
@@ -109,10 +160,26 @@ class BrainClient:
                 "non-streaming long-output forbidden; use stream=True"
             )
 
-        effective_reasoning_effort = (
-            reasoning_effort if reasoning_effort is not None else self.reasoning_effort
+        # Resolve effective per-call values (per-call > instance default)
+        eff_enable_thinking = (
+            enable_thinking if enable_thinking is not None else self.enable_thinking
         )
-        effective_thinking = thinking if thinking is not None else self.thinking
+        eff_low_effort = low_effort if low_effort is not None else self.low_effort
+        eff_thinking_token_budget = (
+            thinking_token_budget
+            if thinking_token_budget is not None
+            else self.thinking_token_budget
+        )
+
+        # Deprecation warnings for per-call use
+        if reasoning_effort is not None:
+            _warn_deprecated_once(
+                "BrainClient.chat(reasoning_effort=...) deprecated — not injected."
+            )
+        if thinking is not None:
+            _warn_deprecated_once(
+                "BrainClient.chat(thinking=...) deprecated — use enable_thinking=..."
+            )
 
         payload: dict[str, Any] = {
             "model": self.model,
@@ -121,10 +188,19 @@ class BrainClient:
             "temperature": temperature,
             "stream": stream,
         }
-        if effective_reasoning_effort is not None:
-            payload["reasoning_effort"] = effective_reasoning_effort
-        if effective_thinking is not None:
-            payload["chat_template_kwargs"] = {"thinking": effective_thinking}
+
+        # Top-level chat_template_kwargs — only includes keys actually set
+        chat_template_kwargs: dict[str, Any] = {}
+        if eff_enable_thinking is not None:
+            chat_template_kwargs["enable_thinking"] = eff_enable_thinking
+        if eff_low_effort is not None:
+            chat_template_kwargs["low_effort"] = eff_low_effort
+        if chat_template_kwargs:
+            payload["chat_template_kwargs"] = chat_template_kwargs
+
+        # Top-level thinking_token_budget (NOT nested in extra_body or chat_template_kwargs)
+        if eff_thinking_token_budget is not None:
+            payload["thinking_token_budget"] = eff_thinking_token_budget
 
         # Reset per-call accumulators
         self.last_reasoning = ""
@@ -149,11 +225,16 @@ class BrainClient:
                 resp = await client.post(url, json=payload)
                 resp.raise_for_status()
                 data = resp.json()
-                # Capture reasoning + finish_reason for caller introspection (Defect 1, oneshot path)
+                # Capture reasoning + finish_reason for caller introspection.
+                # Direct vLLM emits `message.reasoning`; via LiteLLM it's
+                # `message.reasoning_content`. Read both, prefer reasoning_content
+                # since that's what production callers go through (LiteLLM proxy).
                 try:
                     choice0 = data["choices"][0]
                     msg = choice0.get("message", {}) or {}
-                    self.last_reasoning = msg.get("reasoning") or ""
+                    self.last_reasoning = (
+                        msg.get("reasoning_content") or msg.get("reasoning") or ""
+                    )
                     self.last_finish_reason = choice0.get("finish_reason")
                 except (KeyError, IndexError, TypeError):
                     pass
@@ -176,11 +257,11 @@ class BrainClient:
         payload: dict,
         transport: Optional[httpx.AsyncBaseTransport],
     ) -> AsyncIterator[str]:
-        """Yield ``delta.content`` chunks. Accumulate ``delta.reasoning`` chunks
-        to ``self.last_reasoning`` (Defect 1). vLLM nemotron_v3 parser emits
-        reasoning chunks first (until the trace completes), then content;
-        without parsing both, the content stream may appear empty when the
-        reasoning fills the budget — see Track A (PR #323) for the failure mode.
+        """Yield ``delta.content`` chunks. Accumulate ``delta.reasoning`` and
+        ``delta.reasoning_content`` chunks to ``self.last_reasoning`` (the
+        former is direct vLLM's wire format; the latter is LiteLLM's). Without
+        parsing both, content can appear empty when reasoning fills the budget
+        — see Track A (PR #323) for the failure mode.
         """
         url = f"{self.base_url}/v1/chat/completions"
         started = time.monotonic()
@@ -213,8 +294,10 @@ class BrainClient:
                         if finish is not None:
                             self.last_finish_reason = finish
                         delta = choice.get("delta") or {}
-                        # Defect 1: accumulate reasoning; do NOT yield (consumers expect content only)
-                        reasoning_chunk = delta.get("reasoning")
+                        # Accumulate reasoning from either field; do NOT yield
+                        reasoning_chunk = (
+                            delta.get("reasoning_content") or delta.get("reasoning")
+                        )
                         if reasoning_chunk:
                             self.last_reasoning += reasoning_chunk
                         # Yield content as before (backward-compatible)
@@ -238,3 +321,14 @@ class BrainClient:
             raise
         except Exception as exc:
             raise BrainClientError(f"BRAIN stream failed: {exc!s}") from exc
+
+
+_deprecation_warned: set[str] = set()
+
+
+def _warn_deprecated_once(message: str) -> None:
+    """Log a deprecation warning once per process per message."""
+    if message in _deprecation_warned:
+        return
+    _deprecation_warned.add(message)
+    logger.warning("brain_client_deprecated  %s", message)

--- a/fortress-guest-platform/backend/tests/test_brain_client.py
+++ b/fortress-guest-platform/backend/tests/test_brain_client.py
@@ -230,20 +230,22 @@ def test_default_max_tokens_is_8000():
     assert client.default_max_tokens == 8000
 
 
-def test_constructor_accepts_reasoning_kwargs():
-    """Defect 3 — constructor stores reasoning_effort + thinking kwargs."""
+def test_constructor_accepts_phase2_reasoning_kwargs():
+    """Phase 2 — constructor stores enable_thinking, low_effort, thinking_token_budget."""
     client = BrainClient(
         base_url="http://mock-brain",
-        reasoning_effort="high",
-        thinking=True,
+        enable_thinking=True,
+        low_effort=True,
+        thinking_token_budget=2048,
     )
-    assert client.reasoning_effort == "high"
-    assert client.thinking is True
+    assert client.enable_thinking is True
+    assert client.low_effort is True
+    assert client.thinking_token_budget == 2048
 
 
 @pytest.mark.asyncio
-async def test_extra_body_injection_when_reasoning_kwargs_set():
-    """Defect 3 — reasoning_effort + thinking land in payload."""
+async def test_chat_template_kwargs_at_top_level():
+    """Phase 2 — enable_thinking + low_effort serialize as top-level chat_template_kwargs."""
     captured_payloads: list[dict] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -253,8 +255,8 @@ async def test_extra_body_injection_when_reasoning_kwargs_set():
     transport = httpx.MockTransport(handler)
     client = BrainClient(
         base_url="http://mock-brain",
-        reasoning_effort="high",
-        thinking=True,
+        enable_thinking=True,
+        low_effort=True,
     )
     await client.chat(
         messages=[{"role": "user", "content": "x"}],
@@ -262,15 +264,15 @@ async def test_extra_body_injection_when_reasoning_kwargs_set():
         stream=False,
         transport=transport,
     )
-    assert len(captured_payloads) == 1
     body = captured_payloads[0]
-    assert body.get("reasoning_effort") == "high"
-    assert body.get("chat_template_kwargs") == {"thinking": True}
+    # Must be at top level — extra_body wrapper is silently dropped per PR #330 Probe E
+    assert "extra_body" not in body
+    assert body.get("chat_template_kwargs") == {"enable_thinking": True, "low_effort": True}
 
 
 @pytest.mark.asyncio
-async def test_extra_body_omitted_when_reasoning_kwargs_unset():
-    """Defect 3 — when neither constructor nor per-call sets the flags, they are NOT in payload."""
+async def test_thinking_token_budget_at_top_level():
+    """Phase 2 — thinking_token_budget is a top-level field, not nested."""
     captured_payloads: list[dict] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -278,7 +280,11 @@ async def test_extra_body_omitted_when_reasoning_kwargs_unset():
         return _ok_nonstream_response("x")
 
     transport = httpx.MockTransport(handler)
-    client = BrainClient(base_url="http://mock-brain")  # no reasoning kwargs
+    client = BrainClient(
+        base_url="http://mock-brain",
+        enable_thinking=True,
+        thinking_token_budget=2048,
+    )
     await client.chat(
         messages=[{"role": "user", "content": "x"}],
         max_tokens=500,
@@ -286,13 +292,39 @@ async def test_extra_body_omitted_when_reasoning_kwargs_unset():
         transport=transport,
     )
     body = captured_payloads[0]
-    assert "reasoning_effort" not in body
+    # Top-level placement — PR #330 Probe D vs E proved nesting in extra_body
+    # or chat_template_kwargs causes silent drop
+    assert body.get("thinking_token_budget") == 2048
+    assert "thinking_token_budget" not in body.get("chat_template_kwargs", {})
+    assert "extra_body" not in body
+
+
+@pytest.mark.asyncio
+async def test_reasoning_kwargs_omitted_when_unset():
+    """When no Phase 2 params set, neither chat_template_kwargs nor thinking_token_budget appears."""
+    captured_payloads: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_payloads.append(json.loads(request.content))
+        return _ok_nonstream_response("x")
+
+    transport = httpx.MockTransport(handler)
+    client = BrainClient(base_url="http://mock-brain")
+    await client.chat(
+        messages=[{"role": "user", "content": "x"}],
+        max_tokens=500,
+        stream=False,
+        transport=transport,
+    )
+    body = captured_payloads[0]
     assert "chat_template_kwargs" not in body
+    assert "thinking_token_budget" not in body
+    assert "reasoning_effort" not in body
 
 
 @pytest.mark.asyncio
-async def test_per_call_reasoning_kwargs_override_constructor():
-    """Defect 3 — per-call kwargs win over constructor defaults."""
+async def test_per_call_phase2_kwargs_override_constructor():
+    """Per-call Phase 2 kwargs win over constructor defaults."""
     captured_payloads: list[dict] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -302,20 +334,77 @@ async def test_per_call_reasoning_kwargs_override_constructor():
     transport = httpx.MockTransport(handler)
     client = BrainClient(
         base_url="http://mock-brain",
-        reasoning_effort="high",
-        thinking=True,
+        enable_thinking=True,
+        low_effort=True,
+        thinking_token_budget=4096,
     )
     await client.chat(
         messages=[{"role": "user", "content": "x"}],
         max_tokens=500,
         stream=False,
         transport=transport,
-        reasoning_effort="low",
-        thinking=False,
+        enable_thinking=False,
+        low_effort=False,
+        thinking_token_budget=2048,
     )
     body = captured_payloads[0]
-    assert body["reasoning_effort"] == "low"
-    assert body["chat_template_kwargs"]["thinking"] is False
+    assert body["chat_template_kwargs"] == {"enable_thinking": False, "low_effort": False}
+    assert body["thinking_token_budget"] == 2048
+
+
+@pytest.mark.asyncio
+async def test_reasoning_effort_deprecated_not_injected(caplog):
+    """Deprecated kwarg — reasoning_effort logs a warning and does NOT appear in payload."""
+    import logging
+    from backend.services import brain_client as _bc
+    _bc._deprecation_warned.clear()  # reset one-shot guard for this test
+
+    captured_payloads: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_payloads.append(json.loads(request.content))
+        return _ok_nonstream_response("x")
+
+    transport = httpx.MockTransport(handler)
+    with caplog.at_level(logging.WARNING, logger="backend.services.brain_client"):
+        client = BrainClient(base_url="http://mock-brain", reasoning_effort="high")
+        await client.chat(
+            messages=[{"role": "user", "content": "x"}],
+            max_tokens=500,
+            stream=False,
+            transport=transport,
+        )
+    assert "reasoning_effort" not in captured_payloads[0]
+    assert any("reasoning_effort" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_thinking_kwarg_deprecated_not_injected(caplog):
+    """Deprecated kwarg — thinking logs a warning and does NOT appear in payload."""
+    import logging
+    from backend.services import brain_client as _bc
+    _bc._deprecation_warned.clear()
+
+    captured_payloads: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_payloads.append(json.loads(request.content))
+        return _ok_nonstream_response("x")
+
+    transport = httpx.MockTransport(handler)
+    with caplog.at_level(logging.WARNING, logger="backend.services.brain_client"):
+        client = BrainClient(base_url="http://mock-brain", thinking=True)
+        await client.chat(
+            messages=[{"role": "user", "content": "x"}],
+            max_tokens=500,
+            stream=False,
+            transport=transport,
+        )
+    body = captured_payloads[0]
+    # `thinking` (the deprecated kwarg) must not land anywhere in the payload
+    assert "thinking" not in body
+    assert "thinking" not in body.get("chat_template_kwargs", {})
+    assert any("thinking" in r.getMessage() for r in caplog.records)
 
 
 @pytest.mark.asyncio
@@ -412,6 +501,85 @@ async def test_oneshot_captures_reasoning_and_finish_reason():
     assert isinstance(result, dict)
     assert result["choices"][0]["message"]["content"] == "## Defenses"
     assert client.last_reasoning == "Think through each defense theory under Georgia law."
+    assert client.last_finish_reason == "stop"
+
+
+@pytest.mark.asyncio
+async def test_oneshot_captures_reasoning_content_field():
+    """Phase 2 — via LiteLLM, reasoning lands at message.reasoning_content."""
+    body = {
+        "id": "cmpl-test",
+        "object": "chat.completion",
+        "model": "legal-reasoning",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "## Defenses",
+                    "reasoning_content": "Think through each defense theory.",
+                },
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 3, "total_tokens": 13},
+    }
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=body)
+
+    transport = httpx.MockTransport(handler)
+    client = BrainClient(base_url="http://mock-brain")
+    result = await client.chat(
+        messages=[{"role": "user", "content": "x"}],
+        max_tokens=500,
+        stream=False,
+        transport=transport,
+    )
+    assert isinstance(result, dict)
+    assert client.last_reasoning == "Think through each defense theory."
+    assert client.last_finish_reason == "stop"
+
+
+@pytest.mark.asyncio
+async def test_stream_parses_delta_reasoning_content_field():
+    """Phase 2 — LiteLLM streaming emits delta.reasoning_content (not delta.reasoning)."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        lines: list[str] = []
+        role_event = {"choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}]}
+        lines.append(f"data: {json.dumps(role_event)}")
+        lines.append("")
+        for r in ["We", " need", " to"]:
+            ev = {"choices": [{"index": 0, "delta": {"reasoning_content": r}, "finish_reason": None}]}
+            lines.append(f"data: {json.dumps(ev)}")
+            lines.append("")
+        for c in ["## Section", " 4"]:
+            ev = {"choices": [{"index": 0, "delta": {"content": c}, "finish_reason": None}]}
+            lines.append(f"data: {json.dumps(ev)}")
+            lines.append("")
+        finish = {"choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]}
+        lines.append(f"data: {json.dumps(finish)}")
+        lines.append("")
+        lines.append("data: [DONE]")
+        lines.append("")
+        body = ("\n".join(lines) + "\n").encode("utf-8")
+        return httpx.Response(200, content=body, headers={"content-type": "text/event-stream"})
+
+    transport = httpx.MockTransport(handler)
+    client = BrainClient(base_url="http://mock-brain")
+    iterator: AsyncIterator[str] = await client.chat(  # type: ignore[assignment]
+        messages=[{"role": "user", "content": "x"}],
+        stream=True,
+        transport=transport,
+    )
+
+    received: list[str] = []
+    async for chunk in iterator:
+        received.append(chunk)
+
+    assert received == ["## Section", " 4"]
+    assert client.last_reasoning == "We need to"
     assert client.last_finish_reason == "stop"
 
 


### PR DESCRIPTION
## Summary

Phase 2 of the [4-phase TP=2 stabilization plan](../blob/main/nemotron-3-super-tp2-stabilization-4-phase-plan-v2-2026-04-30.md). Builds on PR #330's empirical decision matrix.

Wires three reasoning-control kwargs (`enable_thinking`, `low_effort`, `thinking_token_budget`) into BrainClient at the **top level** of the request body — the schema vLLM's OpenAI-compat server actually reads. Deprecates the inert `reasoning_effort` and mis-keyed `thinking` kwargs from PR #326 Defect 3 (kept for backward compat, log warnings, not injected). Adds dual response-field parsing so direct-vLLM (`message.reasoning`) and via-LiteLLM (`message.reasoning_content`) shapes both surface in `last_reasoning`.

22 unit tests pass. Frontier health 200 throughout ~12 minutes of probes. Zero soak halts.

## §4 stress-test gate (Step 3) — PASS

Reconstructed §4 prompt at **25,291 chars (0.00% drift vs PR #329 19:45Z)** via `compose()`'s `stage_0_curate` + `stage_1_grounding_packet` + `_build_synthesis_user_prompt`. Two probes against this prompt:

| Path | wall_s | content | reasoning | reasoning tok | finish |
|---|---:|---:|---:|---:|---|
| 19:45Z baseline (no controls) | 306.1 | 7,818 | 21,656 | ~5,414 | stop |
| Direct vLLM (low_effort + budget=2048) | 137.5 | 10,253 | **1,337** | ~334 | stop |
| LiteLLM passthrough | 87.1 | 7,920 | **210** | ~52 | stop |

Hard stop §4 (reasoning >12,300 chars): not triggered.

## Three-run §4 single-section validation (Steps 6-7) — empirical knob attribution

| Run | enable_thinking | low_effort | budget | content | reasoning | wall | finish | grounding | first-person | think |
|---|---|---|---|---:|---:|---:|---|---:|---:|---:|
| Baseline | _(default)_ | — | — | 7,818 | 21,656 | 306.09 | stop | 4 | 0 | 0 |
| Run 1 | True | — | — | **7,818** | **21,656** | 308.12 | stop | 4 | 0 | 0 |
| Run 2 | True | True | — | **10,074** | **527** | 126.37 | stop | 4 | 0 | 0 |
| Run 3 | True | True | 2048 | 10,074 | 527 | 125.51 | stop | 4 | 0 | 0 |

**Per-knob attribution:**
- `enable_thinking=True` alone (Run 1): **byte-identical to baseline.** Chat template default is already True; the kwarg is a no-op when toggled to True.
- `low_effort=True` (Run 2 vs Run 1): **drives 100% of the behavior delta** — reasoning -97.57%, wall -59.0%, content +28.9%, citation format CJK `【】` → ASCII `[...]` (45 ASCII cits in Run 2 vs 0 in baseline; baseline used CJK fullwidth, an unbounded-reasoning artifact), 5 explicit causes-of-action enumerated vs baseline's narrative coverage.
- `thinking_token_budget=2048` (Run 3 vs Run 2): **byte-identical.** Empirically inert on this prompt class — `low_effort=True` already clamps reasoning to ~132 tokens, far under any 2,048-token cap.

## Hard stop §5 (content_chars >5% off baseline) — letter triggered, spirit not violated

The +28.9% content delta is fully attributable to `low_effort=True` engaging the chat template, not regression:

- Same 4 grounding citations as baseline (orchestrator-tracked)
- Same finish_reason (stop)
- Zero first-person bleed, zero `<think>` leakage
- ASCII bracket citations (45) vs baseline's CJK fullwidth `【...】` quirk
- More thorough enumeration (5 explicit causes vs narrative)

The plan's ±5% tolerance assumed byte-deterministic output at `temperature=0.0`, but engaging `low_effort` is itself a non-byte-equivalent input change to the model. Operator-confirmed proceed after three-run isolation surfaced the attribution.

## Phase 3 implication

Drop `thinking_token_budget` from the per-section policy table. Empirically inert on §4's 25 KB prompt class — `low_effort=True` clamps reasoning under any 2,048 budget. The kwarg stays in BrainClient as a defensive ceiling for hypothetical prompt classes where reasoning might naturally exceed 2,048 tokens, but Phase 3 routing should not include it.

`enable_thinking=True` for reasoning sections is a no-op (default already True) but kept in the policy table for explicitness — future readers can see the per-section intent without spelunking chat-template defaults.

Updated Phase 3 routing (vs original plan):
| Mode | Sections | Original plan | Post-Phase-2 plan |
|---|---|---|---|
| Mechanical / categorization | §1/§2/§3/§6/§7/§10 | enable_thinking=False | unchanged |
| Reasoning | §4/§5/§8/§9 | enable_thinking=True, low_effort=True, **budget=2048** | enable_thinking=True, **low_effort=True** (drop budget) |

## Deprecations (backward-compat preserved)

- `reasoning_effort`: log warning, not injected. Existing callers continue to work.
- `thinking`: log warning, not injected. Existing callers should switch to `enable_thinking`.

No production caller currently sets either kwarg (verified by grep).

## What's in

- `fortress-guest-platform/backend/services/brain_client.py` — surgery
- `fortress-guest-platform/backend/tests/test_brain_client.py` — 22 tests pass; new coverage for top-level placement, dual response-shape parsing, and deprecation warnings
- `docs/operational/brain-client-reasoning-control-validation-2026-04-30.md` — full validation report including stress test, three-run attribution, and Phase 3 implications

Single-use harnesses (prompt reconstruction, validation runner) lived in `/tmp` and are NOT committed per the plan's "remove if not needed long-term" instruction.

## References

- PR #326 — BrainClient TP=2 Path X (introduced now-deprecated `reasoning_effort`, `thinking`)
- PR #327 — synthesizer cap 8000 (unchanged)
- PR #329 — Track A v3 analysis (provided baseline metrics for §4)
- PR #330 — Phase 1 reasoning-control probes (decision matrix this PR builds on)
- vLLM bugs [#39103](https://github.com/vllm-project/vllm/issues/39103), [#39573](https://github.com/vllm-project/vllm/issues/39573), [#25714](https://github.com/vllm-project/vllm/issues/25714) — confirmed not exposed on this build

Refs #328 (Phase 3 closes it via `enable_thinking=False` for §2/§7).

## Test plan

- [ ] `cd fortress-guest-platform && .uv-venv/bin/python -m pytest backend/tests/test_brain_client.py` (22 pass)
- [ ] Spot-check `git diff` on `brain_client.py` lines 117-200 (request-body construction) — confirm `chat_template_kwargs` is top-level, `thinking_token_budget` is top-level, no `extra_body` wrapper
- [ ] Spot-check streaming + oneshot response parsing reads both `reasoning_content` and `reasoning` fields
- [ ] Phase 3 PR (next): apply per-section policy table, full Track A v3 re-run, compare vs PR #329 baseline