### PR TITLE
feat(synthesizers): per-section reasoning routing — closes #328

### DIFF
--- a/docs/operational/track-a-v3-case-i-full-rerun-2026-04-30.md
+++ b/docs/operational/track-a-v3-case-i-full-rerun-2026-04-30.md
@@ -1,0 +1,181 @@
+# Track A v3 Case I Full Re-Run — Phase 3
+
+**Branch:** `feat/synthesizer-per-section-reasoning-routing-2026-04-30` (stacked on PR #331)
+**Date:** 2026-04-30
+**Stacks on:** PR #326 (BrainClient TP=2 Path X), PR #327 (synthesizer cap 8000), PR #329 (Track A v3 analysis baseline), PR #330 (Phase 1 reasoning-control probes), PR #331 (Phase 2 BrainClient wiring + §4 stress test).
+**Frontier load consumed:** ~16 minutes wall across two full Track A runs + one §5 isolation probe. Frontier health 200 throughout. No soak halts.
+
+This is Phase 3 of the [4-phase TP=2 stabilization plan](../../nemotron-3-super-tp2-stabilization-4-phase-plan-v2-2026-04-30.md). Applies per-section reasoning policies through the BrainClient surgery shipped in PR #331. Closes Issue #328 with empirically-validated mechanism.
+
+---
+
+## 1. Per-section policy (post-Phase 3 §5 isolation)
+
+| Section | Mode | enable_thinking | low_effort | max_tokens | Rationale |
+|---|---|---|---|---:|---|
+| §1 Case Summary | mechanical | — | — | — | deterministic, no LLM |
+| §2 Critical Timeline | synthesis (recovered) | False | — | 4000 | categorization; reasoning suppression recovers content |
+| §3 Parties & Counsel | mechanical | — | — | — | deterministic |
+| §4 Claims Analysis | synthesis | True | True | 8000 | doctrinal; low_effort drives 97.6% reasoning reduction without quality loss |
+| §5 Key Defenses | synthesis | True | **False** | 8000 | doctrinal; low_effort drops the non-affirmative denial subsection — see §3 below |
+| §6 Evidence Inventory | mechanical | — | — | — | deterministic |
+| §7 Email Intelligence | synthesis (recovered) | False | — | 4000 | categorization |
+| §8 Financial Exposure | synthesis | True | True | 4000 | light reasoning |
+| §9 Strategy (augmented) | LiteLLM passthrough | True | True | 8000 | doctrinal; via post-run §9 augmentation in runner |
+| §10 Filing Checklist | mechanical | — | — | — | deterministic |
+
+**The §5 deviation from the original plan table** is the single empirical finding from Phase 3 — see §3.
+
+---
+
+## 2. Per-section results vs PR #329 19:45Z baseline
+
+| Section | Baseline content | New content | Δ% | Baseline reasoning | New reasoning | Baseline wall | New wall | Baseline grounding | New grounding | finish |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| §1 mechanical | 511 | 511 | 0% | 0 | 0 | n/a | n/a | 0 | 0 | n/a |
+| **§2** synthesis | **0** | **4,659** | **recovered** | 71,294 | **0** | 840s | **73s** | 0 | **19** | length → **stop** |
+| §3 mechanical | 509 | 509 | 0% | 0 | 0 | n/a | n/a | 0 | 0 | n/a |
+| §4 claims | 7,818 | 10,074 | +28.86% | 21,656 | 527 | 306s | 126s | 4 | 4 | stop |
+| **§5** defenses | 6,271 | 6,271 | **0%** | 19,090 | **19,090** | 269s | **270s** | 5 | **5** | stop |
+| §6 mechanical | 1,376 | 1,376 | 0% | 0 | 0 | n/a | n/a | 0 | 0 | n/a |
+| **§7** intel | **0** | **3,395** | **recovered** | 73,407 | **0** | 835s | **58s** | 0 | **17** | length → **stop** |
+| §8 financial | 3,565 | 4,082 | +14.51% | 7,488 | 1,162 | 126s | 63s | 4 | 2 | stop |
+| §9 augmented | 5,312 | 6,563 | +23.55% | 0 | 208 | 108s | 71s | n/a | n/a | stop |
+| §10 mechanical | 611 | 611 | 0% | 0 | 0 | n/a | n/a | 0 | 0 | n/a |
+
+**Total wall: 589.68s (9.83 min) vs baseline 2,377s (39.6 min). −75.2% reduction.**
+
+**Format compliance:** all 11 emitted slots `format_compliant=true`. Zero first-person bleed. Zero `<think>` leakage. Issue #328 fully resolved.
+
+---
+
+## 3. The §5 isolation probe and per-section policy split
+
+### What happened on the first Phase 3 run
+
+The original plan table specified `enable_thinking=True, low_effort=True` for all four "doctrinal" sections (§4, §5, §8, §9). On the first full Track A run, §5 came back at:
+
+- content_chars: 4,157 (vs baseline 6,271 — **−33.74%**)
+- reasoning_chars: 260 (vs baseline 19,090 — −98.6%)
+- wall: 44s (vs baseline 269s)
+- grounding citations: 3 (vs baseline 5)
+
+Hard stop §5 of the plan ("§4/§5/§8 regression — content_chars drops >10% from baseline") tripped on §5. Reading the §5 markdown side-by-side with baseline showed the cause: `low_effort=True` made the model **consolidate overlapping affirmative defenses and drop the entire "Non-affirmative defense theories (denials)" subsection** (4 explicit denial entries: denial of specific performance, denial of breach of warranty, denial of misrepresentation, denial of damages).
+
+This is content the brief is supposed to deliver. Defense lawyers enumerate denials on the record because they have to; quietly dropping the denial table ships a structurally incomplete brief.
+
+### The probe
+
+Re-routed §5 only with `enable_thinking=True, low_effort=False`. Single 270s probe against the same prompt:
+
+| Metric | Phase 3 run 1 (low_effort=True) | Probe (low_effort=False) | 19:45Z baseline |
+|---|---:|---:|---:|
+| content_chars | 4,157 | **6,271** | 6,271 |
+| reasoning_chars | 260 | **19,090** | 19,090 |
+| wall_seconds | 44 | **270.2** | 268.93 |
+| Affirmative defenses | merged 7 rows | **7 rows** | 7 rows |
+| Non-affirmative denials | **DROPPED** | **4 rows present** | 4 rows |
+| Unique citations | 1 | **4** | 4-5 |
+| finish | stop | stop | stop |
+
+Probe result: **byte-identical to PR #329 baseline.** §5 has its own policy entry now: `enable_thinking=True, low_effort=False`. §4/§8/§9 stay on `low_effort=True`.
+
+### Why §5 differs from §4 mechanically
+
+PR #331's three-run §4 isolation showed `low_effort=True` produced *more* content with *better* organization on §4 (5 explicit causes, ASCII brackets replacing CJK quirk). On §5, the same knob produced *less* content and *dropped a structural subsection*. The shared mechanism: under low-effort thinking, the model compresses overlapping themes. On §4 (claims), distinct causes of action have minimal overlap, so compression doesn't hurt. On §5 (defenses), several affirmative defenses share underlying facts (encroachment caused all of "lapse", "impossibility", "plaintiff refused to close") — compression collapses them. And the non-affirmative-denial framework is a separate structural section that the compressed-thinking pass apparently doesn't deem worth the second table.
+
+This is real Wave 4 prompt-tuning input: **`low_effort=True` is appropriate for sections where the prompt itself enumerates distinct categories. It's contraindicated where the prompt expects multiple structural subsections that the model could decide to merge.** §5's prompt asks for "affirmative AND non-affirmative" — the latter is the subsection at risk.
+
+A future prompt-tuning pass could rewrite §5's prompt to split into two LLM calls (one per subsection), each with `low_effort=True`. That would recover the wall savings and keep coverage. Out of scope for this PR.
+
+---
+
+## 4. Wave 4 prompt-tuning observations
+
+Three empirical findings worth capturing for future tuning work:
+
+1. **The +29% content delta on §4 is chat-template engagement, not regression.** PR #331 attributed it to `low_effort=True` engaging the chat template. The model produces more thorough enumeration (5 explicit causes vs baseline's narrative coverage) with idiomatic ASCII brackets `[...]` replacing the baseline's CJK fullwidth `【...】` quirk. The CJK bracket flip suggests the unbounded reasoning trace was leaking non-English typographic conventions into the output — a sign that 5,414 reasoning tokens were drifting the model's formatting style. With reasoning bounded to ~132 tokens, formatting snaps back to standard English legal conventions.
+
+2. **`low_effort=True` compresses overlapping themes (§5 finding).** Sections whose prompt asks for distinct categories work fine; sections whose prompt expects multiple structural subsections risk losing the secondary subsection. §5 vs §4 is the natural experiment: same model, same `low_effort=True`, opposite content shape because the underlying task structure differs.
+
+3. **§9 augmentation now captures reasoning_content via LiteLLM.** Phase 2 BrainClient added dual response-shape parsing. Phase 3 updated the runner's §9 augmentation payload to include `chat_template_kwargs={enable_thinking: True, low_effort: True}` and to read `message.reasoning_content` first. Result: §9 produces +23.55% content (6,563 vs baseline 5,312) with 208 chars of reasoning captured for the first time. Previously the augmentation reported reasoning_chars=0 because the field was missed entirely.
+
+---
+
+## 5. Hard-stop check
+
+| Hard stop from plan Phase 3 | Status | Note |
+|---|---|---|
+| §1 — `case_briefing_synthesizers.py` dispatch surface not located | PASS | dispatch via `SECTION_REASONING_POLICY` lookup in `stage_2_synthesize` |
+| §2 — frontier `/health` non-200 sustained >60s | PASS | 200 throughout |
+| §3 — soak halt event | PASS | not observed |
+| §4 — §2 OR §7 still 0 content_chars with `enable_thinking=False` | PASS | §2 = 4,659 chars; §7 = 3,395 chars |
+| §5 — §4/§5/§8 regression (content drops >10% from baseline OR finish flips to length) | PASS (after §5 re-route) | §4 +28.86%, §5 0.0% (post-fix), §8 +14.51%; all finish=stop |
+| §6 — disk full | PASS | 1.3T avail |
+
+§5's first-run drop tripped the hard stop letter. Surfaced to operator. Three options weighed (accept as Wave 4 future-fix; halt entirely; isolate §5 with no low_effort). Operator chose isolation. Probe took ~5 min frontier wall and gave a clean answer: §5 needs its own policy entry. Per-section table grew by one row. This is the Phase 3 working pattern — empirical isolation when an aggregate result trips, not blanket policy adjustment.
+
+---
+
+## 6. Frontier health log
+
+```
+Phase 3 run 1 pre:    200 (2026-04-30T22:26:59Z)
+Phase 3 run 1 post:   200 (after 365s wall)
+§5 probe pre:         200
+§5 probe post:        200 (after 270s wall)
+Phase 3 final pre:    200 (2026-04-30T22:44:03Z)
+Phase 3 final post:   200 (after 590s wall)
+```
+
+No soak halt events. KV cache pressure not tripped (`--max-num-seqs 10` not saturated at single-call cadence).
+
+---
+
+## 7. v3 brief on NAS
+
+**Path:** `/mnt/fortress_nas/Corporate_Legal/Business_Legal/7il-v-knight-ndga-i/filings/outgoing/Attorney_Briefing_Package_7IL_NDGA_I_v3_20260430T224403Z.md`
+**Size:** 40,170 bytes (vs 19:45Z baseline 28,011 bytes — +43%).
+
+This is the first 10/10-section v3 brief — §2 and §7 finally populated with content for the first time since Issue #328 was filed.
+
+The brief is NOT in the repo (per Track A convention — briefs land on NAS, code+report+metrics in repo).
+
+---
+
+## 8. Issue #328 resolution
+
+PR #329 reframed §2/§7 from "missing source data" (the original #328 framing) to "runaway reasoning" failure mode. PR #330 (Phase 1) confirmed `enable_thinking=False` was the empirical fix. PR #331 (Phase 2) wired the kwarg into BrainClient. This PR (Phase 3) applies it per-section.
+
+Result: §2 (Critical Timeline) and §7 (Email Intelligence) both produce structured tabular content with 19 and 17 grounding citations respectively, finish=stop, ≤73s wall. Failure mode was never source data, never alias routing — it was the absence of a control mechanism for thinking depth on the Nemotron-3-Super chat template.
+
+**Closes #328.**
+
+---
+
+## 9. What changed (code surface)
+
+- `fortress-guest-platform/backend/services/case_briefing_synthesizers.py`
+  - Added `SECTION_REASONING_POLICY: dict[str, dict]` mapping per-section reasoning kwargs.
+  - `synthesize_synthesis_section` now accepts `enable_thinking` and `low_effort` parameters (and passes them through to `brain_client.chat`).
+- `fortress-guest-platform/backend/services/case_briefing_compose.py`
+  - `stage_2_synthesize` looks up `SECTION_REASONING_POLICY[section_id]` and passes the policy as kwargs to the synthesizer.
+- `fortress-guest-platform/backend/scripts/track_a_case_i_runner.py`
+  - `MetricCapturingBrainClient.chat` accepts the Phase 2 reasoning kwargs and passes them through to `super().chat`.
+  - Captures `reasoning_chars`, `finish_reason`, `enable_thinking`, `low_effort`, `thinking_token_budget` in `metrics_log`.
+  - `post_run_section_9_augmentation` payload upgraded with `chat_template_kwargs={enable_thinking:True, low_effort:True}` + `max_tokens` raised 5000 → 8000. Reasoning extraction now prefers `message.reasoning_content` (LiteLLM shape) before `message.reasoning` (direct vLLM shape).
+
+No changes to BrainClient (correct as of Phase 2). No changes to LiteLLM, frontier, or any service.
+
+---
+
+## 10. References
+
+- PR #326 — BrainClient TP=2 Path X (Defect 3 reasoning_effort/thinking now deprecated per Phase 2)
+- PR #327 — synthesizer cap 8000 (unchanged)
+- PR #329 — Track A v3 analysis (baseline; superseded as canonical baseline by this run)
+- PR #330 — Phase 1 reasoning-control probes (decision matrix)
+- PR #331 — Phase 2 BrainClient wiring (top-level chat_template_kwargs, deprecation, dual response-shape parsing, §4 stress test)
+- vLLM bugs [#39103](https://github.com/vllm-project/vllm/issues/39103), [#39573](https://github.com/vllm-project/vllm/issues/39573), [#25714](https://github.com/vllm-project/vllm/issues/25714) — confirmed not exposed on this build (PR #330 inventory)
+
+**Resolves #328.**

--- a/docs/operational/track-a-v3-soak-verification-runbook-2026-05-14.md
+++ b/docs/operational/track-a-v3-soak-verification-runbook-2026-05-14.md
@@ -1,0 +1,154 @@
+# Post-Soak Verification Runbook — 2026-05-14
+
+**Window:** 2026-04-30 23:00 UTC → 2026-05-14 13:00 UTC (14 days, opened on PR #331 + PR #332 merge)
+**Pairs with:** scheduled remote agent `trig_011Epc3mHBX1oLMdetTj5hkt` ([routine](https://claude.ai/code/routines/trig_011Epc3mHBX1oLMdetTj5hkt)), which fires at the same wall and posts the GitHub-side verification comment on PR #332. This file is the **cluster-side counterpart** that requires private-LAN access to spark-2 / spark-3 and so cannot be automated remotely.
+
+The remote agent's comment will list these checks as "operator required." Run them in order, capture the outputs, and reply to the agent's comment with a one-line per-check summary or paste the raw outputs.
+
+---
+
+## 0. Where to run
+
+From spark-2 (this host, `192.168.0.100`). Frontier is `http://10.10.10.3:8000` on spark-3, reachable over fabric A.
+
+```sh
+ssh admin@192.168.0.100   # only if running from elsewhere; if already on spark-2, skip
+```
+
+---
+
+## 1. Frontier health throughout the window
+
+```sh
+# Live health (must be 200 right now)
+curl -fsS http://10.10.10.3:8000/health
+curl -fsS http://10.10.10.3:8000/v1/models | jq '.data[0].id'   # expect "nemotron-3-super"
+
+# Container is Docker-managed (no systemd unit on either spark-2 or spark-3),
+# so the journal is in `docker logs`, not `journalctl -u vllm*`.
+ssh admin@10.10.10.3 \
+  "docker logs vllm_node --since=2026-04-30T23:00:00Z --until=2026-05-14T13:00:00Z 2>&1" \
+  | grep -iE "halt|degrade|error|hang|oom|killed|cuda fail|ray.*died" \
+  | head -50
+
+# Spot-check vLLM build hasn't drifted from the PR #330 inventory baseline
+ssh admin@10.10.10.3 'docker exec vllm_node vllm --version'
+# expected: 0.20.1rc1.dev96+gefdc95674.d20260430.cu132 (or, if container was
+# rebuilt during the window, capture the new version and surface the change)
+
+ssh admin@10.10.10.3 'ps -p $(docker inspect vllm_node --format "{{.State.Pid}}") -o etime --no-headers'
+# uptime — if shorter than 14 days, the container restarted; investigate
+```
+
+**Clean signal:** `/health` 200 now, zero error/halt lines from the docker-logs grep, vllm version unchanged, container uptime ≥ 14 days.
+
+**Surfaces concern if:** non-200 status, halt/error lines present, version drift, or a restart inside the window.
+
+---
+
+## 2. Soak halt-event count
+
+The Phase 9 soak collector's halt-state file location wasn't pinned at runbook-write time (operator memory was "wherever sentinel writes it"). Candidates I enumerated on 2026-04-30:
+
+```sh
+ls -la /home/admin/.fortress_sentinel_state.json    # 82 MB — file-integrity sentinel, NOT soak
+ls -la /home/admin/.fortress_archiver_state.json    # 144 B — archiver, NOT soak
+ls -la /home/admin/.fortress_sync_health.json       # 162 B — sync health, NOT soak
+ls -la /home/admin/.fortress_*soak* /home/admin/soak-* 2>/dev/null  # nothing on 2026-04-30
+```
+
+None of the files visible at the runbook write match the Phase 9 soak collector. Confirm at runtime where it actually writes:
+
+```sh
+# Discover the live file:
+sudo lsof -p $(systemctl show -p MainPID --value fortress-soak-collector 2>/dev/null) 2>/dev/null \
+  | awk '/REG/ && /home/'   # if collector runs under systemd
+ps -ef | grep -i soak | grep -v grep   # find the process
+find /home/admin /var/lib /var/log -maxdepth 4 -iname '*soak*' -mtime -15 2>/dev/null
+```
+
+Once located, halt count is:
+
+```sh
+SOAK_STATE=<path-from-discovery-above>
+jq '.halt_events // [] | length' "$SOAK_STATE"
+jq '.halt_events // [] | .[] | {ts, reason, section}' "$SOAK_STATE"   # detail any halts
+```
+
+**Clean signal:** halt count = 0.
+**Surfaces concern if:** halt count ≥ 1 — capture each halt's ts/reason/section, decide whether retired Phase 4 needs to revisit.
+
+---
+
+## 3. Track A v3 traffic samples — per-section policy adherence
+
+Confirm any new Track A runs since 2026-04-30 still routed §2/§7 to `enable_thinking=False` and §4/§8/§9 to `low_effort=True` and §5 to `low_effort=False` (per PR #332 SECTION_REASONING_POLICY).
+
+```sh
+# Recent runs (skip the ones from 2026-04-30 itself — those are Phase 3 baseline)
+ls -dt /tmp/track-a-case-i-v3-* 2>/dev/null | head -10
+
+# For each recent run, dump the per-section reasoning kwargs as recorded by
+# MetricCapturingBrainClient.metrics_log:
+for DIR in $(ls -dt /tmp/track-a-case-i-v3-2026-05-* 2>/dev/null | head -5); do
+  echo "=== $DIR ==="
+  jq '.brain_client_call_metrics[] | {
+        section_id,
+        enable_thinking,
+        low_effort,
+        reasoning_chars,
+        finish_reason,
+        wall_seconds
+      }' "$DIR/metrics/run-summary.json" 2>/dev/null
+done
+```
+
+**Clean signal — per-section reasoning policy still in effect:**
+
+| section_id | enable_thinking | low_effort | reasoning_chars (typical) | finish |
+|---|---|---|---:|---|
+| section_02_critical_timeline | False | None | 0 | stop |
+| section_04_claims_analysis | True | True | ~500 | stop |
+| section_05_key_defenses_identified | True | False | ~19,000 | stop |
+| section_07_email_intelligence_report | False | None | 0 | stop |
+| section_08_financial_exposure_analysis | True | True | ~1,200 | stop |
+
+**Surfaces concern if:** any synthesis section shows `enable_thinking=None` (policy lookup broke, falling back to BrainClient default) or `finish=length` (reasoning runaway re-emerging) or §5 with `low_effort=True` (the §5 isolation regression — see PR #332 §3 of run report).
+
+If no Track A runs happened during the window, that itself is a soft signal worth noting (no production traffic exercised the wiring).
+
+---
+
+## 4. /metrics scrape — reasoning_chars distribution sanity
+
+```sh
+curl -fsS http://10.10.10.3:8000/metrics | grep -E "reasoning|finish_reason|generation_tokens" | head -30
+# vLLM 0.20.1rc1 may not expose per-completion reasoning_chars histograms
+# directly; if the grep is empty, fall back to:
+curl -fsS http://10.10.10.3:8000/metrics | grep -E "vllm:e2e|vllm:request_generation|vllm:tokens" | head -30
+```
+
+If reasoning-specific metrics are exposed: confirm distribution shapes are consistent with Phase 3 expected ranges (productive synthesis sections in the 1k–5k reasoning_token range; mechanical/categorization sections at 0).
+
+If not exposed: this check degrades to "rough sanity on overall generation token counts" — accept that and note it. The substantive per-section reasoning data lives in step 3 (per-run JSONs), not /metrics.
+
+**Surfaces concern if:** generation token rates spiked (KV cache pressure), or reasoning-specific histograms show a long tail above 10k tokens (suggests routing fell back to unbounded reasoning somewhere).
+
+---
+
+## 5. Decision
+
+After steps 1–4:
+
+- **Cluster-side clean** (frontier 200 throughout, halt count 0, per-section policy still routing as expected, /metrics consistent): **Phase 4 stays retired. 4-phase plan complete.** Reply to the remote agent's comment with "Cluster-side clean. Plan complete."
+- **Cluster-side surfaced X** (any of the "Surfaces concern if" triggers above fired): file the specific concern as a new issue or a Phase 4 reactivation brief. Reply to the remote agent's comment with the specific concern, severity, and link to the new issue.
+
+---
+
+## 6. References
+
+- PR #330 — frontier inventory baseline (vLLM 0.20.1rc1, no `--reasoning-config`, no MTP)
+- PR #331 — BrainClient Phase 2 wiring
+- PR #332 — Phase 3 per-section routing (this PR's parent)
+- Plan v2 doc — `/home/admin/nemotron-3-super-tp2-stabilization-4-phase-plan-v2-2026-04-30.md` (retired Phase 4 retired-unless-soak-surfaces clause)
+- Scheduled remote agent — [`trig_011Epc3mHBX1oLMdetTj5hkt`](https://claude.ai/code/routines/trig_011Epc3mHBX1oLMdetTj5hkt) (GitHub-side counterpart)

--- a/fortress-guest-platform/backend/scripts/track_a_case_i_runner.py
+++ b/fortress-guest-platform/backend/scripts/track_a_case_i_runner.py
@@ -76,10 +76,16 @@ class MetricCapturingBrainClient(BrainClient):
     async def chat(
         self,
         messages: list[dict],
-        max_tokens: int = 4000,
+        max_tokens: Optional[int] = None,
         temperature: float = 0.0,
         stream: bool = True,
         transport: Optional[httpx.AsyncBaseTransport] = None,
+        *,
+        enable_thinking: Optional[bool] = None,
+        low_effort: Optional[bool] = None,
+        thinking_token_budget: Optional[int] = None,
+        reasoning_effort: Optional[str] = None,
+        thinking: Optional[bool] = None,
     ) -> Union[AsyncIterator[str], dict]:
         # Identify section from the user prompt's INSTRUCTION block content match (best-effort)
         user_prompt_full = ""
@@ -96,29 +102,45 @@ class MetricCapturingBrainClient(BrainClient):
         prompt_chars = sum(len(m.get("content", "")) for m in messages)
         started = time.monotonic()
         wall_iso_start = datetime.now(timezone.utc).isoformat()
+        effective_max = max_tokens if max_tokens is not None else self.default_max_tokens
 
         result = await super().chat(
-            messages=messages, max_tokens=max_tokens, temperature=temperature, stream=stream, transport=transport
+            messages=messages,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            stream=stream,
+            transport=transport,
+            enable_thinking=enable_thinking,
+            low_effort=low_effort,
+            thinking_token_budget=thinking_token_budget,
+            reasoning_effort=reasoning_effort,
+            thinking=thinking,
         )
 
         if stream and hasattr(result, "__aiter__"):
             collected_chunks: list[str] = []
+            client_ref = self
             async def _wrapped() -> AsyncIterator[str]:
                 async for chunk in result:  # type: ignore
                     collected_chunks.append(chunk)
                     yield chunk
                 ended = time.monotonic()
                 content_text = "".join(collected_chunks)
-                self.metrics_log.append({
+                client_ref.metrics_log.append({
                     "section_id": inferred_section,
                     "wall_seconds": round(ended - started, 2),
                     "wall_started_utc": wall_iso_start,
                     "wall_ended_utc": datetime.now(timezone.utc).isoformat(),
                     "prompt_chars": prompt_chars,
-                    "max_tokens": max_tokens,
+                    "max_tokens": effective_max,
                     "temperature": temperature,
                     "content_chars": len(content_text),
                     "content_token_estimate": len(content_text) // 4,
+                    "reasoning_chars": len(client_ref.last_reasoning or ""),
+                    "finish_reason": client_ref.last_finish_reason,
+                    "enable_thinking": enable_thinking,
+                    "low_effort": low_effort,
+                    "thinking_token_budget": thinking_token_budget,
                     "stream": True,
                 })
             return _wrapped()
@@ -135,10 +157,15 @@ class MetricCapturingBrainClient(BrainClient):
                 "wall_started_utc": wall_iso_start,
                 "wall_ended_utc": datetime.now(timezone.utc).isoformat(),
                 "prompt_chars": prompt_chars,
-                "max_tokens": max_tokens,
+                "max_tokens": effective_max,
                 "temperature": temperature,
                 "content_chars": len(content_text),
                 "content_token_estimate": len(content_text) // 4,
+                "reasoning_chars": len(self.last_reasoning or ""),
+                "finish_reason": self.last_finish_reason,
+                "enable_thinking": enable_thinking,
+                "low_effort": low_effort,
+                "thinking_token_budget": thinking_token_budget,
                 "stream": False,
                 "usage": result.get("usage") if isinstance(result, dict) else None,
             })
@@ -191,14 +218,17 @@ def post_run_section_9_augmentation(
         out_log.append({"section_id": "section_09_recommended_strategy", "error": "no LITELLM_MASTER_KEY"})
         return "**[Section 9 augmentation skipped — LITELLM_MASTER_KEY not in env]**"
 
+    # Phase 3 per-section policy for §9 (doctrinal): top-level chat_template_kwargs
+    # via LiteLLM passthrough (PR #330 Probe DL confirmed reasoning_content survives).
     payload = {
         "model": "legal-reasoning",
         "messages": [
             {"role": "system", "content": _SYSTEM_PROMPT},
             {"role": "user", "content": section_9_user_prompt},
         ],
-        "max_tokens": 5000,
+        "max_tokens": 8000,
         "stream": False,
+        "chat_template_kwargs": {"enable_thinking": True, "low_effort": True},
     }
     started = time.monotonic()
     try:
@@ -223,7 +253,8 @@ def post_run_section_9_augmentation(
 
     msg = data["choices"][0]["message"]
     content = msg.get("content", "") or ""
-    reasoning = msg.get("reasoning", "") or ""
+    # LiteLLM exposes reasoning under reasoning_content; vLLM-direct under reasoning.
+    reasoning = msg.get("reasoning_content") or msg.get("reasoning") or ""
     out_log.append({
         "section_id": "section_09_recommended_strategy",
         "wall_seconds": round(time.monotonic() - started, 2),

--- a/fortress-guest-platform/backend/services/case_briefing_compose.py
+++ b/fortress-guest-platform/backend/services/case_briefing_compose.py
@@ -360,8 +360,15 @@ async def stage_2_synthesize(
             )
         elif mode == SECTION_MODE_SYNTHESIS:
             try:
+                policy = syn.SECTION_REASONING_POLICY.get(section_id, {})
+                policy_kwargs = {
+                    k: v for k, v in policy.items() if v is not None
+                }
                 result = await syn.synthesize_synthesis_section(
-                    section_id, packet, brain_client=client
+                    section_id,
+                    packet,
+                    brain_client=client,
+                    **policy_kwargs,
                 )
                 if len(result.grounding_citations) < GROUNDING_MIN_CITATIONS:
                     result.fail_reason = (

--- a/fortress-guest-platform/backend/services/case_briefing_synthesizers.py
+++ b/fortress-guest-platform/backend/services/case_briefing_synthesizers.py
@@ -195,6 +195,56 @@ def _scalar(v) -> str:
     return s if s else "_unknown_"
 
 
+# ── Per-section reasoning policy (Phase 3, post-#330 + #331 empirical) ────────
+
+# Per-section reasoning controls applied by the orchestrator. PR #331's three-run
+# §4 isolation showed:
+#   - enable_thinking=True alone is a no-op (chat-template default is True)
+#   - low_effort=True is the load-bearing knob for reasoning suppression
+#   - thinking_token_budget is empirically inert at low_effort=True on §4-class
+#     prompts (kept in BrainClient as defensive ceiling but NOT routed here)
+#
+# Mechanical / categorization sections (§2 Critical Timeline, §7 Email Intel)
+# get enable_thinking=False to recover from the Issue #328 runaway-reasoning
+# failure mode where unbounded thinking exhausted the token cap with zero
+# content emitted. Doctrinal sections (§4/§5/§9) get low_effort=True to bound
+# reasoning while preserving substantive analysis. §8 (light reasoning) uses
+# the same pattern with a smaller content cap.
+SECTION_REASONING_POLICY: dict[str, dict] = {
+    "section_02_critical_timeline": {
+        "enable_thinking": False,
+        "max_tokens": 4000,
+    },
+    "section_04_claims_analysis": {
+        "enable_thinking": True,
+        "low_effort": True,
+        "max_tokens": 8000,
+    },
+    "section_05_key_defenses_identified": {
+        # §5 needs full reasoning depth — Phase 3 probe (2026-04-30) showed
+        # low_effort=True compresses overlapping defenses and DROPS the
+        # non-affirmative denial subsection (4 explicit denials missing).
+        # With low_effort=False, §5 reproduces the 19:45Z baseline:
+        # 6,271 chars / 19,090 reasoning / 270s wall / 4 denial entries.
+        # Defense lawyers enumerate denials on the record; quietly dropping
+        # them is bad operational hygiene for a brief intended to inform
+        # counsel pitches.
+        "enable_thinking": True,
+        "low_effort": False,
+        "max_tokens": 8000,
+    },
+    "section_07_email_intelligence_report": {
+        "enable_thinking": False,
+        "max_tokens": 4000,
+    },
+    "section_08_financial_exposure_analysis": {
+        "enable_thinking": True,
+        "low_effort": True,
+        "max_tokens": 4000,
+    },
+}
+
+
 # ── Synthesis synthesizers ────────────────────────────────────────────────────
 
 async def synthesize_synthesis_section(
@@ -202,7 +252,9 @@ async def synthesize_synthesis_section(
     packet: GroundingPacket,
     *,
     brain_client: BrainClient,
-    max_tokens: int = 8000,  # Cascade fix per PR #326: BrainClient default raised to 8000 to give nemotron_v3 reasoning trace room to complete before content emission. Pre-fix 2000 cap caused Track A (PR #323) to hit finish_reason=length on all 5 synthesis sections with reasoning consuming the full budget.
+    max_tokens: int = 8000,  # PR #327 cap (kept as fallback when no per-section policy applies).
+    enable_thinking: Optional[bool] = None,
+    low_effort: Optional[bool] = None,
 ) -> SectionResult:
     """Run a BRAIN call against the packet and produce a SectionResult."""
     title_map = {
@@ -242,6 +294,8 @@ async def synthesize_synthesis_section(
             max_tokens=max_tokens,
             temperature=0.0,
             stream=True,
+            enable_thinking=enable_thinking,
+            low_effort=low_effort,
         ),
     )
     async for chunk in iterator:


### PR DESCRIPTION
## Summary

Phase 3 of the [4-phase TP=2 stabilization plan](../blob/main/nemotron-3-super-tp2-stabilization-4-phase-plan-v2-2026-04-30.md). Stacked on PR #331 (Phase 2 BrainClient surgery).

Applies per-section reasoning policies through the chat_template_kwargs surface PR #331 wired. §2 Critical Timeline and §7 Email Intelligence finally produce content for the first time since #328 was filed. §4/§5/§8/§9 stay bounded but substantive. **Total wall 590s vs PR #329 baseline 2,377s — 75% reduction. First 10/10 complete v3 brief on NAS.**

> **Note on PR base**: this PR is stacked on `feat/brain-client-reasoning-control-2026-04-30` (PR #331), not `main`. When PR #331 merges, GitHub will auto-rebase this PR to main and the diff will flip clean.

**Resolves #328.**

## Per-section policy

| Section | Mode | enable_thinking | low_effort | max_tokens |
|---|---|---|---|---:|
| §1 Case Summary | mechanical | — | — | — |
| §2 Critical Timeline | synthesis (recovered) | False | — | 4000 |
| §3 Parties & Counsel | mechanical | — | — | — |
| §4 Claims Analysis | synthesis | True | True | 8000 |
| §5 Key Defenses | synthesis | True | **False** | 8000 |
| §6 Evidence Inventory | mechanical | — | — | — |
| §7 Email Intelligence | synthesis (recovered) | False | — | 4000 |
| §8 Financial Exposure | synthesis | True | True | 4000 |
| §9 Strategy (augmented) | LiteLLM passthrough | True | True | 8000 |
| §10 Filing Checklist | mechanical | — | — | — |

The **§5 deviation** from the original plan table (`low_effort=False` instead of `True`) is the single empirical finding from Phase 3. See "The §5 split" below.

## Results vs PR #329 19:45Z baseline

| Section | Baseline content | New content | Δ% | Baseline reasoning | New reasoning | Wall (B→N) | Grounding (B→N) |
|---|---:|---:|---:|---:|---:|---:|---:|
| §1 mechanical | 511 | 511 | 0% | 0 | 0 | n/a | 0/0 |
| **§2** | **0** (length) | **4,659** (stop) | recovered | 71,294 | **0** | 840s → **73s** | 0 → **19** |
| §3 mechanical | 509 | 509 | 0% | 0 | 0 | n/a | 0/0 |
| §4 claims | 7,818 | 10,074 | +28.86% | 21,656 | 527 | 306s → 126s | 4/4 |
| **§5** defenses | 6,271 | **6,271** | **0%** | 19,090 | **19,090** | 269s → 270s | 5/5 |
| §6 mechanical | 1,376 | 1,376 | 0% | 0 | 0 | n/a | 0/0 |
| **§7** | **0** (length) | **3,395** (stop) | recovered | 73,407 | **0** | 835s → **58s** | 0 → **17** |
| §8 financial | 3,565 | 4,082 | +14.51% | 7,488 | 1,162 | 126s → 63s | 4 → 2 |
| §9 augmented | 5,312 | 6,563 | +23.55% | 0 | 208 | 108s → 71s | n/a |
| §10 mechanical | 611 | 611 | 0% | 0 | 0 | n/a | 0/0 |

**Total wall: 590s = 9.83 min** (vs baseline 2,377s = 39.6 min — **−75.2%**).

All 11 slots: `finish=stop`, `format_compliant=true`, 0 first-person bleed, 0 `<think>` leakage.

## The §5 split

First Phase 3 run had §5 on `low_effort=True` like §4/§8/§9. Result: content dropped 33.74% (6,271 → 4,157 chars) and the entire **non-affirmative denial subsection** (4 explicit denials) disappeared. Defense lawyers enumerate denials on the record because they have to; quietly dropping the table ships a structurally incomplete brief.

Operator-chosen path: 270s isolation probe with `enable_thinking=True, low_effort=False`. Result: byte-identical baseline (6,271 chars / 19,090 reasoning / 4 denial entries / 5 grounding citations / 270s wall). §5 gets its own policy row.

**Wave 4 prompt-tuning input** (captured in run report §4):
- `low_effort=True` works for sections enumerating distinct categories (§4: 5 distinct causes, no shared facts).
- `low_effort=True` compresses inappropriately on sections expecting multiple structural subsections sharing facts (§5: affirmative + non-affirmative tables, encroachment fact pattern underlying multiple affirmative defenses).
- Future prompt rewrite could split §5 into two LLM calls (one per subsection) to recover the wall savings — out of scope for this PR.

## Frontier health

200 throughout. No soak halts. ~16 min of frontier wall consumed (run 1 + §5 probe + final re-run combined).

## v3 brief on NAS

`/mnt/fortress_nas/Corporate_Legal/Business_Legal/7il-v-knight-ndga-i/filings/outgoing/Attorney_Briefing_Package_7IL_NDGA_I_v3_20260430T224403Z.md` — 40,170 bytes (vs 19:45Z baseline 28,011 bytes, +43%). **First 10/10-section v3 brief.** Brief is NOT in the repo (per Track A convention).

## Code changes

- `case_briefing_synthesizers.py`: added `SECTION_REASONING_POLICY` dict; `synthesize_synthesis_section` accepts `enable_thinking` + `low_effort` kwargs and passes them through.
- `case_briefing_compose.py`: `stage_2_synthesize` looks up policy per section_id and passes kwargs to the synthesizer.
- `track_a_case_i_runner.py`: `MetricCapturingBrainClient.chat` passes Phase 2 kwargs to `super().chat`; captures `reasoning_chars`, `finish_reason`, and per-call kwargs in `metrics_log`. `post_run_section_9_augmentation` payload upgraded with `chat_template_kwargs={enable_thinking:True, low_effort:True}` and `max_tokens` raised 5000 → 8000; reads `reasoning_content` first (LiteLLM shape).

No changes to BrainClient (correct as of Phase 2). No changes to LiteLLM, frontier, or any service.

## References

- PR #326 — BrainClient TP=2 Path X
- PR #327 — synthesizer cap 8000 (unchanged)
- PR #329 — Track A v3 analysis baseline (superseded by this run)
- PR #330 — Phase 1 reasoning-control probes
- PR #331 — Phase 2 BrainClient wiring (this PR's base)
- vLLM bugs [#39103](https://github.com/vllm-project/vllm/issues/39103), [#39573](https://github.com/vllm-project/vllm/issues/39573), [#25714](https://github.com/vllm-project/vllm/issues/25714) — confirmed not exposed on this build

**Resolves #328.**

## Test plan

- [ ] `cd fortress-guest-platform && .uv-venv/bin/python -m pytest backend/tests/test_brain_client.py` (22 pass — Phase 2 tests still green)
- [ ] Read §5 in the v3 brief on NAS — confirm non-affirmative denial table is present (4 denial entries)
- [ ] Read §2 / §7 in the v3 brief on NAS — confirm tabular content with grounded citations replaces the `_(empty)_` placeholders that PR #329 documented
- [ ] Sanity-check `git diff` on `case_briefing_synthesizers.py` lines 198-240 — confirm `SECTION_REASONING_POLICY` covers exactly the 5 LLM-routed synthesis sections