### PR TITLE
docs(wave-3): land brief v2 with ARM64-validated component scope

### DIFF
--- a/docs/operational/claude-code-kickoff-wave-3-brief-amendment-2026-05-01.md
+++ b/docs/operational/claude-code-kickoff-wave-3-brief-amendment-2026-05-01.md
@@ -1,0 +1,363 @@
+# Claude Code Kickoff — Wave 3 Brief Amendment (doc-only)
+
+**Target:** Claude Code on spark-2
+**Driver:** Wave 2 fully ratified on main (PR #340 merged at f65c5f304). The Wave 3 retrieval-stack brief (`docs/operational/wave-3-reranker-extraction-deployment-brief-v2.md`) was written 2026-04-30 — pre-Wave-2-ratification. Multiple presumptions in the original brief are now stale. This kickoff amends the brief to reconcile against current reality. Doc-only PR. No deployment work.
+
+**Authoritative deep research:**
+- `docs/research/nemotron-3-super-deep-research-2026-04-30.md` (carry-forward schema discipline)
+
+**Note:** Embed deep-research recovery deferred — regenerate from Wave 1 EMBED ratification work, separate ticket per PR #341 commit message.
+
+**Sequence position:** This PR is the prerequisite to Wave 3 deploy execution. After this brief amendment merges, a separate execution kickoff opens against the now-on-main amended brief.
+
+---
+
+## Mission
+
+Five sequential gates. Halt on any failure. Surface inline before progressing.
+
+1. **Pre-flight inspection** — capture current state of all stale-presumption surfaces (EMBED status, Vision status, BRAIN retirement status, frontier health, spark-5 GPU state, brief content).
+2. **Reconciliation matrix** — walk the original brief against current state. Identify which sections need amendment, which are correct as-is, which are out of scope.
+3. **Apply amendment** — edit `docs/operational/wave-3-reranker-extraction-deployment-brief-v2.md` per the matrix. Add §0 reconciliation block (pattern from PR #337 Wave 2 brief). Preserve historical execution plan with `[Status:]` callouts.
+4. **Surface diff** — operator review gate before commit.
+5. **Commit + PR** — single-file doc-only PR, halt for operator review.
+
+This is reconcile-then-document, NOT deploy-then-document. Wave 3 execution is a separate kickoff after this PR merges.
+
+---
+
+## Standing rules apply
+
+Never `--admin`, never `--force` (force-with-lease only), never self-merge, never force-push main. Branches from `origin/main` only. Single Claude Code session.
+
+```bash
+cd /home/admin/Fortress-Prime
+git fetch origin
+git status
+git log --oneline origin/main..HEAD
+```
+
+Confirm: clean working tree on or near main. `origin/main` HEAD = `f65c5f304` (PR #340 merge).
+
+---
+
+## Step 1 — Pre-flight inspection (read-only)
+
+### 1.1 Branch from origin/main
+
+```bash
+git checkout origin/main
+git checkout -b docs/wave-3-brief-amendment-2026-05-01
+git status
+```
+
+### 1.2 Capture original brief content
+
+```bash
+ssh admin@192.168.0.100 'wc -l /home/admin/Fortress-Prime/docs/operational/wave-3-reranker-extraction-deployment-brief-v2.md'
+ssh admin@192.168.0.100 'head -60 /home/admin/Fortress-Prime/docs/operational/wave-3-reranker-extraction-deployment-brief-v2.md'
+```
+
+Surface inline. Confirm the brief is on main (was committed when merged, not still untracked).
+
+### 1.3 Capture EMBED current state on spark-3
+
+```bash
+ssh admin@192.168.0.105 'sudo systemctl is-active fortress-nim-embed.service 2>&1; sudo systemctl is-enabled fortress-nim-embed.service 2>&1'
+ssh admin@192.168.0.105 'docker ps --filter name=fortress-nim-embed --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"'
+ssh admin@192.168.0.105 'curl -fsS --max-time 5 http://localhost:8102/v1/health/ready -w "\n%{http_code}\n" 2>&1'
+```
+
+Expected (per PR #336 Wave 1 close): EMBED active, healthy, port 8102. If different, surface — Wave 3 brief's "restart EMBED" framing is stale and the amendment scope shifts.
+
+### 1.4 Capture Vision NIM status on spark-3
+
+```bash
+ssh admin@192.168.0.105 'sudo systemctl is-active fortress-nim-vision.service 2>&1; sudo systemctl is-enabled fortress-nim-vision.service 2>&1'
+ssh admin@192.168.0.105 'docker ps --filter name=fortress-nim-vision --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"'
+```
+
+Per operator note "vision deferred": expected inactive. If active, surface — userMemories carry-forward says vision is deferred, but operator may have updated direction.
+
+### 1.5 Capture BRAIN-49B retirement state on spark-5
+
+```bash
+ssh admin@192.168.0.109 'sudo systemctl is-active fortress-nim-brain.service 2>&1; sudo systemctl is-enabled fortress-nim-brain.service 2>&1'
+ssh admin@192.168.0.109 'docker ps -a --filter name=fortress-nim-brain --format "table {{.Names}}\t{{.Status}}"'
+```
+
+Expected: inactive, enabled (per PR #340 retirement runbook). Confirms spark-5 freed for Wave 3 retrieval host.
+
+### 1.6 Capture spark-5 GPU + disk state
+
+```bash
+ssh admin@192.168.0.109 'docker stats --no-stream --format "table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}"'
+ssh admin@192.168.0.109 'df -h /'
+ssh admin@192.168.0.109 'df -h /mnt/fortress_nas 2>/dev/null'
+ssh admin@192.168.0.109 'systemctl list-units --type=service --no-pager --state=active | grep -iE "fortress|nim|vllm" | head -20'
+```
+
+Surface inline. Capacity baseline for Wave 3 deploy planning.
+
+### 1.7 Capture spark-3 co-residency current state
+
+```bash
+ssh admin@192.168.0.105 'docker stats --no-stream --format "table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}"'
+ssh admin@192.168.0.105 'systemctl list-units --type=service --no-pager --state=active | grep -iE "fortress|nim|vllm" | head -20'
+```
+
+Surface inline. Spark-3 currently hosts: TP=2 frontier rank-0 (`vllm-node` if that's the unit name) + EMBED NIM. This is the co-residency baseline that the amendment must address.
+
+### 1.8 Frontier health
+
+```bash
+ssh admin@192.168.0.100 'curl -fsS --max-time 10 http://10.10.10.3:8000/v1/health/ready -w "\n%{http_code}\n"'
+```
+
+Expected: 200. If not 200, surface — Wave 3 amendment work shouldn't proceed if the frontier is degraded.
+
+### 1.9 Inspect MASTER-PLAN §6.2 Wave 3 references
+
+```bash
+ssh admin@192.168.0.100 'grep -B 2 -A 5 -nE "Wave 3|reranker|nv-ingest|extraction NIM|Tier-1" /home/admin/Fortress-Prime/docs/operational/MASTER-PLAN.md 2>&1 | head -50'
+```
+
+Surface inline. Capture how the Master Plan currently references Wave 3 — relevant for cross-reference accuracy in the amendment.
+
+### 1.10 Inline summary
+
+Surface findings as a table:
+
+| Surface | Original brief presumed | Current reality | Amendment scope |
+|---|---|---|---|
+| EMBED on spark-3 | Inactive (Phase 8 evicted, needs restart) | <observed> | Likely: drop §7 restart steps, frame as "EMBED already running" |
+| Vision on spark-3 | Inactive, restart in §7 | <observed> | Per operator: vision deferred — drop or mark deferred |
+| BRAIN-49B on spark-5 | Active, will retire later | Retired 2026-04-30 per PR #340 | Drop "BRAIN retirement" framing; spark-5 already freed |
+| Frontier health | Active, soak in progress | <observed> | If 200: confirm soak active |
+| Spark-5 GPU baseline | ~128GB free post-BRAIN | <observed via docker stats> | Update §4.4 capacity check to docker stats |
+| Spark-3 co-residency | Clean (Phase 8 evicted) | TP=2 rank-0 + EMBED active | New baseline; amendment §A capacity re-eval |
+| §4.4 capacity check method | nvidia-smi memory.free | GB10 reports [N/A] | Replace with docker stats |
+| Co-residency monitor runbook | Not present | Missing | Add |
+| LiteLLM alias schema | Pre-PR-#338 schema possible | Top-level chat_template_kwargs required | Add schema discipline note for legal-rerank/legal-extract |
+
+Plus narrative on:
+- Anything where reality contradicts a hard-stop or scope boundary in the original brief
+- Any new defects surfaced post-2026-04-30 that affect Wave 3
+- Any deferred-but-still-on-board items from operator (Vision, etc.)
+
+**HALT here.** Surface inspection findings inline. Do NOT proceed to Step 2 until I review.
+
+---
+
+## Step 2 — Reconciliation matrix
+
+**Only after operator confirms inspection findings.**
+
+### 2.1 Walk the original brief section by section
+
+For each section in the brief, surface:
+
+| Section | Header | Original presumption | Current reality | Amendment action |
+|---|---|---|---|---|
+| Front matter | Driver / Stacks on / Resolves | Presumes pre-Wave-2 state | <observed> | Update PR references to include #337-#340 |
+| §1 Mission | Deploy + restart | Restart EMBED + Vision | EMBED active; Vision deferred | Reframe Mission to drop restart |
+| §2 Hard stops | 7 stops | All still apply? | <observed> | Likely all still apply; confirm |
+| §3 Scope | A-G in scope | Component C "restart EMBED+Vision on spark-3" | Stale | Reframe C as "no-op verify" or remove |
+| §4 Pre-flight | §4.4 spark-5 readiness uses nvidia-smi | nvidia-smi can't read GB10 | Defect | Replace |
+| §5 Component A Reranker | spark-5 deploy | Spark-5 free now per ADR-007 | Correct | Add GB10 profile pin discipline reminder |
+| §6 Component B Extraction | spark-5 deploy | Same | Correct | Add GB10 profile pin discipline reminder |
+| §7 Component C EMBED+Vision restart | Restart both | EMBED active, Vision deferred | Stale | Replace with "verify EMBED, defer Vision" |
+| §8-10 LiteLLM aliases / Reindex / E2E smoke | Add legal-rerank, legal-extract | Schema requirements unclear | Pre-PR-#338 | Add schema discipline (top-level kwargs, no extra_body) |
+| §11 PR | Final commit + PR | Targets 2026-04-30 timestamp | Stale | Update commit timestamp framing |
+| §12 Final report | Auto-surface | Still applies | Correct | No change |
+| §13 Constraints | List | All still apply? | <observed> | Confirm |
+| §14 (if present) | Various | <surface> | <observed> | <varies> |
+
+### 2.2 New §0 reconciliation block (front-matter pattern from PR #337)
+
+Brief gets a new §0 prepended (pattern from `phase-9-wave-2-alias-surgery-brief.md` §0 reconciliation block on main per PR #337). Subsections:
+
+- **§0.1 Status as of 2026-05-01** — table of "what's already done" / "what remains" / "what's been deferred" / "what's been retired since brief was written"
+- **§0.2 Capacity check method update** — replace nvidia-smi with docker stats + working-load smoke; specific commands
+- **§0.3 Sequenced deployment** — Reranker before Extraction. Smallest first, stress test against EMBED + frontier, then add Extraction one NIM at a time
+- **§0.4 Co-residency monitor runbook** — what to watch (HTTP 500 from any NIM, frontier latency regression, NCCL collective timeouts on TP=2), how to triage, rollback path.
+- **§0.5 Schema discipline for new aliases** — top-level `chat_template_kwargs` (not `extra_body`-wrapped) per PR #338. Although Reranker/Extraction aliases may not need reasoning kwargs, the discipline rule applies to ANY alias edit going forward
+- **§0.6 GB10 profile pin discipline** — every NIM pulled to spark-5 must verify GB10 profile (cc_12_0) (cudaErrorSymbolNotFound failure mode without proper profile pin)
+- **§0.7 Cross-references** — PR #336 (EMBED ratification), PR #337-#340 (Wave 2 ratification), super deep research
+- **§0.8 NOT-do scope** — what this brief amendment does NOT change (frontier endpoint, EMBED running config, code, etc.)
+
+### 2.3 Inline `[Status:]` callouts in the historical execution plan
+
+Pattern from PR #337: leave the original §1-§14 intact (preserves historical execution plan), but prepend `[Status:]` callouts at specific section heads where reality has changed. E.g.:
+
+```
+## §7 Component C — restart EMBED + Vision NIMs on spark-3
+
+[Status: 2026-05-01 — EMBED is already running and ratified per PR #336 Wave 1 close. Vision is deferred per operator decision. This section is preserved as historical execution plan. Current Wave 3 execution proceeds with EMBED-already-running and Vision-deferred per §0.1.]
+
+Now that retrieval workload moves to spark-5 (Reranker + Extraction), spark-3 can re-host EMBED + Vision...
+```
+
+This pattern prevents rewriting the entire brief and preserves the original author's framing while making the document accurate for current readers.
+
+### 2.4 Surface reconciliation matrix inline
+
+Show the populated Step 2.1 table + the §0 subsection outline + the planned `[Status:]` callout locations.
+
+**HALT here.** Wait for operator approval of amendment scope before applying edits.
+
+---
+
+## Step 3 — Apply amendment
+
+**Only after operator approves Step 2 reconciliation matrix.**
+
+### 3.1 Prepend §0 reconciliation block
+
+Edit `docs/operational/wave-3-reranker-extraction-deployment-brief-v2.md` to add §0 as drafted in Step 2.2. Place after front-matter, before original §1 Mission.
+
+### 3.2 Add `[Status:]` callouts
+
+For each section identified in Step 2.3, prepend a single-paragraph `[Status:]` callout. Do NOT modify the section's original content beyond the callout. Preserves historical record.
+
+### 3.3 Update front-matter
+
+- Add references to PRs #336-#340 in **Stacks on:** list
+- Update **Resolves:** if needed
+- Add the two deep-research docs to **Companion deep research:**
+
+### 3.4 Surface working-tree diff
+
+```bash
+git diff docs/operational/wave-3-reranker-extraction-deployment-brief-v2.md | head -200
+```
+
+Show the full diff. Confirm:
+- §0 block added cleanly
+- `[Status:]` callouts inserted at agreed locations only
+- Front-matter updated
+- No section content beyond callouts modified
+- File still parses as markdown (no broken section structure)
+
+**HALT here.** Wait for operator approval of diff before commit.
+
+---
+
+## Step 4 — Commit + PR
+
+**Only after operator approves Step 3 diff.**
+
+### 4.1 Stage and inspect
+
+```bash
+cd /home/admin/Fortress-Prime
+git add docs/operational/wave-3-reranker-extraction-deployment-brief-v2.md
+git status  # must show ONLY this one file
+git diff --cached | head -200
+```
+
+### 4.2 Commit
+
+```bash
+git commit -m "docs(wave-3): brief amendment — reconcile to post-Wave-2 reality (doc-only)
+
+Original brief (2026-04-30) presumed:
+- EMBED inactive on spark-3 (Phase 8 evicted; needs restart)
+- BRAIN-49B active on spark-5 (would retire as part of Wave 2)
+- Spark-3 clean (no co-tenants)
+- Vision restart in scope
+
+Current reality (2026-05-01 post-Wave-2 ratification):
+- EMBED running per PR #336 (Wave 1 ratification)
+- BRAIN-49B retired per PR #340 (Wave 2 ratification); spark-5 freed
+- Spark-3 hosts TP=2 frontier rank-0 + EMBED (co-residency)
+- Vision deferred per operator decision
+
+Amendments applied (single-file, doc-only):
+- New §0 reconciliation block prepended (pattern from PR #337)
+  - §0.1 Status table (done/remains/deferred/retired)
+  - §0.2 Capacity check method update (docker stats)
+  - §0.3 Sequenced deployment (Reranker before Extraction)
+  - §0.4 Co-residency monitor runbook
+  - §0.5 Schema discipline for new aliases (PR #338 carry-forward)
+  - §0.6 GB10 profile pin discipline
+  - §0.7 Cross-references
+  - §0.8 NOT-do scope
+- [Status:] callouts at sections where reality has shifted (preserves historical
+  execution plan; pattern from PR #337)
+- Front-matter updated with current PR references and deep-research companions
+
+References:
+- PR #336 (Wave 1 EMBED ratification)
+- PR #337-#340 (Wave 2 ratification sequence)
+- docs/research/nemotron-3-super-deep-research-2026-04-30.md
+- (embed deep-research deferred — separate ticket per PR #341)
+
+What this PR does NOT do:
+- Does not deploy any NIM
+- Does not modify any service
+- Does not change any code
+- Does not modify the frontier endpoint
+- Does not start Wave 3 execution (separate kickoff after this merges)
+"
+```
+
+### 4.3 Push and open PR
+
+```bash
+git push -u origin docs/wave-3-brief-amendment-2026-05-01
+gh pr create \
+  --base main \
+  --head docs/wave-3-brief-amendment-2026-05-01 \
+  --title "docs(wave-3): brief amendment — reconcile to post-Wave-2 reality (doc-only)" \
+  --body-file <body-file>
+```
+
+PR body should include:
+
+1. **Summary.** Wave 3 brief amendment per post-Wave-2 reality reconciliation.
+2. **Step 1 inspection findings.** The reality table.
+3. **Step 2 amendment scope.** What changed, what stayed.
+4. **Why this PR is doc-only.** Deploy execution is a separate kickoff after merge.
+5. **What this PR does NOT do.**
+6. **References.** All PRs and deep research docs.
+7. **Next deliverable after merge.** Wave 3 execution kickoff against the now-amended brief.
+8. Mark "merge BLOCKED on operator review."
+
+---
+
+## Step 5 — Halt
+
+When this PR merges:
+- Wave 3 brief is reconciled to current reality on main
+- Next deliverable: Wave 3 execution kickoff (separate session)
+- Don't queue execution work in this kickoff; one PR at a time
+
+---
+
+## Surface points before declaring this kickoff done
+
+1. Step 1 inspection table populated + narrative findings
+2. Operator-confirmation gate at end of Step 1 (HALT)
+3. Step 2 reconciliation matrix populated + §0 outline + callout locations
+4. Operator-confirmation gate at end of Step 2 (HALT)
+5. Step 3 diff inline
+6. Operator-confirmation gate at end of Step 3 (HALT)
+7. After confirmation: Step 4 stage + commit + PR URL + number
+
+---
+
+## Hard constraints
+
+- DO NOT modify any service (frontier, EMBED, Vision, BRAIN, anything)
+- DO NOT touch live `litellm_config.yaml` or `deploy/litellm_config.yaml`
+- DO NOT modify any code (BrainClient, synthesizers, council, anything)
+- DO NOT pull any NIM (NGC commands prohibited in this kickoff)
+- DO NOT modify any file outside `docs/operational/wave-3-reranker-extraction-deployment-brief-v2.md`
+- DO NOT modify the original brief's §1-§14 content beyond `[Status:]` callouts at agreed locations
+- DO NOT proceed past any HALT gate without operator approval
+- DO NOT use `--admin`, `--force`, or self-merge
+- If §1 inspection surfaces reality that contradicts the amendment scope (e.g., EMBED actually inactive, or BRAIN-49B somehow re-active), halt — the amendment text needs revision before proceeding
+- If Vision is unexpectedly active, halt — operator decision needed on whether amendment treats Vision as live or still-deferred
+
+Standing by.

--- a/docs/operational/wave-3-reranker-extraction-deployment-brief-v2.md
+++ b/docs/operational/wave-3-reranker-extraction-deployment-brief-v2.md
@@ -1,0 +1,921 @@
+# Wave 3 — Retrieval Stack Deployment Brief (v2 — rebuilt 2026-05-01)
+
+**Target:** Claude Code on spark-2
+**Branch:** `feat/wave-3-retrieval-stack-deployment-2026-05-01`
+**Date:** 2026-05-01 (rebuild of 2026-04-30 v1 with current ARM64 reality)
+**Operator:** Gary Knight
+**Mode:** END-TO-END AUTONOMOUS — but with revised component scope. Hard stops only on real break conditions.
+**Driver:** Track A v3 baseline (590s wall, 10/10 sections, finish=stop) validates the Nemotron-3-Super frontier. Wave 3 adds the retrieval pipeline that makes Case II briefing meaningfully better than the current state. **MAJOR REVISION FROM v1: NV-Ingest extraction stack is NOT yet ARM64-supported per NVIDIA staff confirmation (forums thread 360011, aniculescu, 2026-02-09). Component B reshaped to ARM64-native alternatives.**
+
+**Stacks on:**
+- PR #341 merged — three deep-research artifacts now on `main` under `docs/research/`
+- PR #340 / Wave 2 closed
+- PR #322 (Phase 9 alias surgery + BRAIN retirement; spark-5 freed)
+- PR #321 (TP=2 deployment; soak active to 2026-05-14)
+- Track A v3 Case I baseline (`Attorney_Briefing_Package_7IL_NDGA_I_v3_20260430T224403Z.md`)
+- nemotron-super-stack-architecture-brief.md (Wave 3 spec)
+- MASTER-PLAN v1.7 §6.2
+
+**Resolves:** Wave 3 of the architecture brief, with ARM64-realistic component scope.
+
+---
+
+## 1. Mission
+
+Deploy ARM64-validated retrieval pipeline components on spark-3 + spark-5. Wire LiteLLM aliases. Reindex `legal_ediscovery` Qdrant collection against the validated EMBED. End state: extraction → embedding → reranking → grounded synthesis on the TP=2 frontier, all running on what actually works on GB10 ARM64 today, with documented contingency for components that don't.
+
+---
+
+## 2. The ARM64 reality check (NEW — drives v2 component reshaping)
+
+Field research 2026-05-01 confirms three landmines that v1 brief did not account for:
+
+### 2.1 NV-Ingest has NO public ARM64 build
+NVIDIA staff (aniculescu) confirmed on developer forums 2026-02-09 that nv-ingest images "have not been built for ARM platforms yet" with no ETA. April 2026 software update did not address this. **Component B in v1 brief is undeployable as written.**
+
+### 2.2 Llama-3.2 NV Embedqa NIM broken on GB10 with `cudaErrorSymbolNotFound`
+Reproducible failure on `nvcr.io/nim/nvidia/llama-3.2-nv-embedqa-1b-v2:1.10.0` on DGX Spark — released pre-Spark, ONNX runtime hits cudaErrorSymbolNotFound on ReduceSum node. NVIDIA's official recommendation for embed on Spark is **Qwen3-Embedding-4B via llama.cpp** (see multi-agent-chatbot playbook), not the broken NIM.
+
+### 2.3 Most NIMs lack `-dgx-spark` tag
+NIMs are now tagged `-dgx-spark` for ARM64+Blackwell compatibility. Models without that tag may surface as "amd64-only" → exec format error. **Every NIM pull in this brief verifies arm64 layers per PR #128 tooling before deployment.**
+
+### 2.4 What we know works on Spark today
+From cjeske's confirmed-working stack (forums thread 354998) on a different DGX Spark:
+- `nvcr.io/nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:1.13.1` — works (older Super NIM)
+- `nvcr.io/nim/nvidia/llama-3.2-nv-rerankqa-1b-v2:1.8.0` — **works on Spark**
+- "NeMo Retriever page/graphic/table NIMs are also running fine" — works on Spark (per his report)
+- `nvcr.io/nim/nvidia/llama-3.2-nv-embedqa-1b-v2:1.10.0` — **broken on Spark**
+
+This is contradictory at first glance: cjeske says page/graphic/table work, NVIDIA staff say nv-ingest doesn't have ARM build. Resolution: page/graphic/table NIMs (the YOLOX detection components) appear to have ARM64 builds, but the **nv-ingest orchestrator** that wires them together does not. Without nv-ingest, you can run the per-component NIMs but lose the unified `/v1/extract` API.
+
+### 2.5 The TP=2 frontier soak is continuing — protect it
+Active NCCL all-reduce deadlock thread (forums 366127, 2026-04-09) reports TP=2 deadlocks across two DGX Sparks on multiple vLLM/TRT-LLM container versions and NCCL 2.27/2.28/2.29. Fortress-Prime's TP=2 frontier is currently stable; **nothing in this brief touches the spark-3+4 frontier endpoint**. Health-check it continuously throughout deployment.
+
+---
+
+## 3. Hard stops
+
+Halt + surface ONLY for:
+
+1. **NGC API auth fails persistently.** Two retries with cluster-canonical key + 30s sleep. Both fail → operator-side credential issue.
+2. **ARM64 verification fails on any pulled NIM.** Per PR #128 tooling: manifest layers must be arm64 AND must actually contain arm64 binaries (not amd64 binaries under arm64 manifest — the Nemotron-Nano-9B incident).
+3. **Frontier endpoint dies during deployment.** `curl http://10.10.10.3:8000/v1/health/ready` non-200 sustained >60s → halt and protect frontier. **This is non-negotiable: nothing about Wave 3 is worth breaking the TP=2 soak.**
+4. **Soak halt event fires.** Phase 9 collector emits halt — cluster telling you to stop.
+5. **Disk full** anywhere in the write path. <5GB free.
+6. **OOM kill / nvidia-smi unresponsive / fabric link down on spark-3 or spark-5.**
+7. **Qdrant reindex corrupts existing collection.** Use shadow-collection pattern. Note: alias silent-overwrite (qdrant#7584) — explicit `delete_alias + create_alias` in same atomic transaction, never bare `create_alias`.
+8. **EMBED service fails to start with the same `cudaErrorSymbolNotFound` cjeske hit.** Documented broken on Spark; if you're trying to restart the v1.10.0 image, that's expected-broken. Do not retry.
+
+Everything else proceeds. Defaults apply; deviations land in the final report.
+
+---
+
+## 4. Scope — REVISED FROM v1
+
+**In scope:**
+
+A. **Reranker NIM** on spark-5: `llama-3.2-nv-rerankqa-1b-v2:1.8.0` (the field-validated working version, NOT the newer `llama-nemotron-rerank-1b-v2` which lists Ampere/Hopper/Lovelace only — no Blackwell)
+B. **Per-component extraction NIMs** on spark-5 — page-elements, graphic-elements, table-structure (validated-working per cjeske); skip nv-ingest orchestrator until ARM64 lands
+C. **EMBED — DECISION GATE:** restart existing `legal-embed` service on spark-3:8102 IF the working version is `llama-nemotron-embed-1b-v2` (newer model). IF it's `llama-3.2-nv-embedqa-1b-v2:1.10.0`, switch to **Qwen3-Embedding-4B via llama.cpp** per NVIDIA Spark playbook recommendation
+D. **Vision NIM** restart on spark-3:8101 (`nemotron-nano-12b-v2-vl`)
+E. **LiteLLM alias additions** for new services (`legal-rerank`, `legal-extract-page`, `legal-extract-graphic`, `legal-extract-table`)
+F. **Qdrant `legal_ediscovery` reindex** against new EMBED via shadow-collection pattern with explicit atomic alias swap
+G. **End-to-end retrieval smoke** — query through per-component extraction → embed → rerank → top-k delivery
+H. **Wave 3 deployment doc + reindex evidence pack**
+I. **NV-Ingest ARM64 watchlist entry** in MASTER-PLAN — when ARM build lands, add unified extraction orchestrator as Wave 3.5
+
+**Out of scope:**
+- nv-ingest orchestrator (not ARM64-available; deferred to Wave 3.5 watchlist)
+- Llama-3.2 NV Embedqa NIM (broken on Spark; replaced)
+- Case II briefing work (Wave 7, separate brief)
+- Wave 5 guardrails
+- Wave 6 NAT migration
+- NeMo Evaluator deployment
+- Reprocessing the 14 Case II OCR'd PDFs through new extraction stack (separate Case II brief; happens after Wave 7 retrieval cutover)
+- Sentinel content-aware classifier upgrade
+- Frontier endpoint modifications
+
+---
+
+## 5. Pre-flight (autonomous)
+
+### 5.1 State
+
+```bash
+git fetch origin
+git checkout origin/main
+git checkout -b feat/wave-3-retrieval-stack-deployment-2026-05-01
+git status
+git log origin/main..HEAD --oneline
+```
+
+### 5.2 Soak + frontier health
+
+```bash
+ssh admin@192.168.0.100 '
+  tail -50 /mnt/fortress_nas/audits/phase-9-soak/$(date +%Y-%m-%d).log 2>/dev/null
+  curl -fsS --max-time 10 http://10.10.10.3:8000/v1/health/ready
+  curl -fsS http://10.10.10.3:8000/v1/models | jq ".data[].id"
+'
+```
+
+Soak active + frontier 200 + nemotron-3-super listed → proceed. Otherwise hard stop §3.3 or §3.4.
+
+### 5.3 NGC auth
+
+```bash
+ssh admin@192.168.0.100 '
+  ngc config current
+  ngc registry resource list --org cabin-rentals-of-georgia 2>&1 | head -10
+'
+```
+
+If auth fails: try cluster-canonical key per MASTER-PLAN v1.7 §5.3. Both fail → hard stop §3.1.
+
+### 5.4 spark-5 readiness (post-BRAIN retirement)
+
+```bash
+ssh admin@192.168.0.109 '
+  hostname
+  uptime
+  df -h /
+  nvidia-smi --query-gpu=name,memory.free,memory.total --format=csv
+  systemctl is-active fortress-nim-brain.service 2>&1
+  docker ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}"
+'
+```
+
+Confirm:
+- spark-5 GPU free ≥100 GB (BRAIN retired, ~128 GB available)
+- spark-5 disk free ≥100 GB
+- `fortress-nim-brain.service` inactive (Phase 9 retirement)
+
+### 5.5 spark-3 capacity check (for restart of EMBED + Vision)
+
+```bash
+ssh admin@192.168.0.105 '
+  hostname
+  nvidia-smi --query-gpu=memory.free,memory.total --format=csv
+  systemctl list-units --type=service --no-pager --state=active | grep fortress
+  docker ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}"
+'
+```
+
+Confirm spark-3 has ~14 GB GPU free (Vision ~12 GB + EMBED ~2 GB needed). If frontier is the only spark-3 tenant and is consuming ~115 GB, headroom is tight — proceed cautiously and monitor frontier health every 30s during co-tenant restart.
+
+### 5.6 Identify which embed is currently deployed-inactive
+
+```bash
+ssh admin@192.168.0.105 '
+  cat /etc/systemd/system/fortress-nim-embed.service 2>&1 | grep -i image
+  ls -la /mnt/fortress_nas/nim-cache/nim/ | grep -i embed
+'
+```
+
+Surface the image tag. Three branches:
+- Image is `llama-nemotron-embed-1b-v2:*` → §6 path EMBED-A (restart in place)
+- Image is `llama-3.2-nv-embedqa-1b-v2:1.10.0` → **§6 path EMBED-B (replace with Qwen3-Embedding-4B via llama.cpp)** — known broken on Spark per forums 354998
+- Image is something else → log it and decide based on whether it's been tested on Spark
+
+### 5.7 NIM catalog sanity check (record current state, not action)
+
+```bash
+ssh admin@192.168.0.100 '
+  echo "=== Reranker (validated working on Spark per cjeske) ==="
+  ngc registry resource info nim/nvidia/llama-3.2-nv-rerankqa-1b-v2 2>&1 | head -20
+
+  echo "=== Extraction NIMs ==="
+  for NIM in nv-yolox-page-elements-v2 nv-yolox-graphic-elements-v1 nv-yolox-table-structure-v1; do
+    echo "--- $NIM ---"
+    ngc registry resource list --query "$NIM" --org nvidia 2>&1 | head -5
+  done
+
+  echo "=== nv-ingest (expected: NO arm64 manifest) ==="
+  ngc registry resource info nvidia/nv-ingest 2>&1 | head -20
+'
+```
+
+Surface paths, sizes, dgx-spark tags. Document what's available to operator decision-making.
+
+---
+
+## 6. Component A — Reranker NIM on spark-5
+
+### 6.1 Pull `llama-3.2-nv-rerankqa-1b-v2:1.8.0` (NOT the newer rerank-1b-v2)
+
+**Why this version:** cjeske reports `:1.8.0` working healthy on DGX Spark in same thread that confirms newer embed broken. The newer `llama-nemotron-rerank-1b-v2` model card lists "Supported Hardware: Ampere, Hopper, Lovelace" — no Blackwell. Until NVIDIA publishes Blackwell support for the newer one, the 1.8.0 NIM is the validated path on Spark.
+
+```bash
+ssh admin@192.168.0.109 '
+  cd /mnt/fortress_nas/nim-cache/nim/
+  mkdir -p reranker-v2
+  cd reranker-v2
+
+  # Try cluster-side pull with timeout; F5 fallback if it fails
+  timeout 600 ngc registry resource download-version "nim/nvidia/llama-3.2-nv-rerankqa-1b-v2:1.8.0" 2>&1 | tee /tmp/wave-3-reranker-pull.log
+  PULL_RC=$?
+  if [ $PULL_RC -ne 0 ]; then
+    echo "Cluster-side pull failed (rc=$PULL_RC); fall back to W3 operator-side"
+    rm -rf llama-3.2-nv-rerankqa-1b-v2_v1.8.0
+  fi
+  ls -la
+'
+```
+
+If Path B (cluster) succeeds → §6.2. If fails → operator W3 pull on Mac, then scp to NAS, then §6.2.
+
+### 6.2 ARM64 verification (HARD STOP §3.2)
+
+```bash
+ssh admin@192.168.0.109 '
+  cd /mnt/fortress_nas/nim-cache/nim/reranker-v2/llama-3.2-nv-rerankqa-1b-v2_v1.8.0
+  /home/admin/Fortress-Prime/backend/scripts/verify_nim_arm64.sh ./
+  RC=$?
+  if [ $RC -ne 0 ]; then
+    echo "ARM64 VERIFICATION FAILED — HARD STOP §3.2"
+    exit 1
+  fi
+'
+```
+
+### 6.3 HF-cache restructure (per MASTER-PLAN §5.4 step 4)
+
+```bash
+ssh admin@192.168.0.109 '
+  /home/admin/Fortress-Prime/backend/scripts/nim_cache_restructure.sh \
+    --source /mnt/fortress_nas/nim-cache/nim/reranker-v2/llama-3.2-nv-rerankqa-1b-v2_v1.8.0 \
+    --target /mnt/fortress_nas/nim-cache/nim/reranker-v2/hf-cache
+'
+```
+
+### 6.4 systemd unit + start
+
+```bash
+ssh admin@192.168.0.109 '
+  sudo tee /etc/systemd/system/fortress-nim-rerank.service > /dev/null <<EOF
+[Unit]
+Description=Fortress NIM Rerank — llama-3.2-nv-rerankqa-1b-v2:1.8.0 on spark-5 (Tier 4 retrieval)
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=simple
+User=admin
+EnvironmentFile=/etc/fortress/nim.env
+ExecStartPre=-/usr/bin/docker stop fortress-nim-rerank
+ExecStartPre=-/usr/bin/docker rm fortress-nim-rerank
+ExecStart=/usr/bin/docker run --rm \\
+  --name fortress-nim-rerank \\
+  --gpus all \\
+  --shm-size=8g \\
+  -p 8103:8000 \\
+  -v /mnt/fortress_nas/nim-cache/nim/reranker-v2/hf-cache:/opt/nim/.cache \\
+  -e NGC_API_KEY=\${NGC_API_KEY} \\
+  -e NIM_MODEL_PROFILE=auto \\
+  nvcr.io/nim/nvidia/llama-3.2-nv-rerankqa-1b-v2:1.8.0
+ExecStop=/usr/bin/docker stop fortress-nim-rerank
+Restart=on-failure
+RestartSec=30s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  sudo systemctl daemon-reload
+  sudo systemctl enable fortress-nim-rerank.service
+  sudo systemctl start fortress-nim-rerank.service
+  sleep 60
+  sudo systemctl status fortress-nim-rerank.service --no-pager | head -25
+'
+```
+
+### 6.5 Health probe
+
+```bash
+ssh admin@192.168.0.109 '
+  for i in 1 2 3 4 5 6; do
+    sleep 30
+    if curl -fsS --max-time 10 http://localhost:8103/v1/health/ready 2>/dev/null; then
+      echo "Reranker ready after ${i}x30s"
+      break
+    fi
+    echo "Reranker not ready (${i}/6)"
+  done
+  curl -fsS http://localhost:8103/v1/health/ready
+  curl -fsS http://localhost:8103/v1/models | jq .
+'
+```
+
+### 6.6 Functional smoke
+
+```bash
+ssh admin@192.168.0.109 '
+  curl -fsS http://localhost:8103/v1/ranking \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"model\": \"nvidia/llama-3.2-nv-rerankqa-1b-v2\",
+      \"query\": {\"text\": \"easement on River Heights\"},
+      \"passages\": [
+        {\"text\": \"The plaintiff alleges Knight recorded an easement on River Heights in March 2025 burdening the property in favor of Thor James.\"},
+        {\"text\": \"The Atlanta Hawks won the 1958 NBA Championship.\"},
+        {\"text\": \"Knight argues the easement was within his rights as titleholder pre-closing.\"}
+      ]
+    }" | jq .
+'
+```
+
+Expected: legal-text passages outrank basketball passage.
+
+---
+
+## 7. Component B — Per-component Extraction NIMs on spark-5
+
+**SCOPE CHANGE FROM v1:** v1 brief specified `nv-ingest` as orchestrator. nv-ingest has no public ARM64 build per NVIDIA staff (forums 360011). v2 deploys the per-component YOLOX detection NIMs (which cjeske confirms work on Spark) and exposes them individually via LiteLLM. Unified extraction orchestrator deferred to Wave 3.5 watchlist.
+
+### 7.1 Catalog enumeration
+
+```bash
+ssh admin@192.168.0.100 '
+  for NIM in nv-yolox-page-elements-v2 nv-yolox-graphic-elements-v1 nv-yolox-table-structure-v1; do
+    echo "=== $NIM ==="
+    ngc registry resource info "nim/nvidia/${NIM}" 2>&1 | head -30
+    echo
+  done
+'
+```
+
+Surface paths, sizes, dgx-spark tags per NIM. Each is small (~2-5 GB).
+
+### 7.2 Per-NIM pull pattern (apply for each of the three)
+
+For each of `nv-yolox-page-elements-v2`, `nv-yolox-graphic-elements-v1`, `nv-yolox-table-structure-v1`:
+
+1. Cluster-side pull (timeout 10 min)
+2. ARM64 verify (HARD STOP §3.2 per-NIM)
+3. HF-cache restructure
+4. systemd unit (port 8110/8111/8112 respectively)
+5. Service start + health probe
+6. If any one fails ARM64 verify → halt that NIM, continue with the others, document in final report
+
+### 7.3 systemd unit template (apply per-NIM, swap NIM_NAME and PORT)
+
+```ini
+[Unit]
+Description=Fortress NIM Extraction ${NIM_NAME} on spark-5 (Tier 4 retrieval)
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=simple
+User=admin
+EnvironmentFile=/etc/fortress/nim.env
+ExecStartPre=-/usr/bin/docker stop fortress-nim-${NIM_NAME}
+ExecStartPre=-/usr/bin/docker rm fortress-nim-${NIM_NAME}
+ExecStart=/usr/bin/docker run --rm \
+  --name fortress-nim-${NIM_NAME} \
+  --gpus all \
+  --shm-size=8g \
+  -p ${PORT}:8000 \
+  -v /mnt/fortress_nas/nim-cache/nim/${NIM_NAME}/hf-cache:/opt/nim/.cache \
+  -e NGC_API_KEY=${NGC_API_KEY} \
+  -e NIM_MODEL_PROFILE=auto \
+  nvcr.io/nim/nvidia/${NIM_NAME}:latest-dgx-spark
+ExecStop=/usr/bin/docker stop fortress-nim-${NIM_NAME}
+Restart=on-failure
+RestartSec=30s
+
+[Install]
+WantedBy=multi-user.target
+```
+
+**Critical:** Use `:latest-dgx-spark` tag if available (per DeepWiki: "containers tagged with `-dgx-spark` to indicate ARM64 and Blackwell GPU compatibility"). If only `:latest` is available, ARM64 verify must pass.
+
+### 7.4 Per-NIM functional smoke
+
+For each, send a sample PDF page and verify:
+- page-elements → returns layout boxes (text/figure/table regions)
+- graphic-elements → returns chart/figure metadata
+- table-structure → returns table cell structure
+
+Document per-NIM smoke output in final report.
+
+---
+
+## 8. Component C — EMBED restart or replace on spark-3
+
+### 8.1 Path EMBED-A: existing service is `llama-nemotron-embed-1b-v2`
+
+If §5.6 surfaces the newer embed:
+
+```bash
+ssh admin@192.168.0.105 '
+  sudo systemctl start fortress-nim-embed.service
+  sleep 60
+  sudo systemctl status fortress-nim-embed.service --no-pager | head -25
+  for i in 1 2 3 4 5; do
+    sleep 30
+    if curl -fsS --max-time 10 http://localhost:8102/v1/health/ready 2>/dev/null; then
+      echo "EMBED ready after ${i}x30s"
+      break
+    fi
+  done
+  curl -fsS http://localhost:8102/v1/models | jq .
+'
+```
+
+If EMBED comes up healthy → §8.3 functional smoke.
+
+### 8.2 Path EMBED-B: existing service is broken `llama-3.2-nv-embedqa-1b-v2:1.10.0`
+
+**Replace with Qwen3-Embedding-4B via llama.cpp** per NVIDIA's official multi-agent-chatbot playbook recommendation for Spark.
+
+```bash
+ssh admin@192.168.0.105 '
+  sudo systemctl stop fortress-nim-embed.service
+  sudo systemctl disable fortress-nim-embed.service
+
+  # Download Qwen3-Embedding-4B GGUF
+  cd /mnt/fortress_nas/models
+  mkdir -p qwen3-embedding-4b
+  hf download Qwen/Qwen3-Embedding-4B-GGUF \
+    Qwen3-Embedding-4B-Q8_0.gguf \
+    --local-dir ./qwen3-embedding-4b/
+
+  # Build llama.cpp on spark-3 (one-time) if not already present
+  if [ ! -f /home/admin/llama.cpp/build/bin/llama-server ]; then
+    cd /home/admin
+    git clone https://github.com/ggerganov/llama.cpp.git 2>/dev/null || (cd llama.cpp && git pull)
+    cd llama.cpp
+    mkdir -p build && cd build
+    cmake .. -DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES="121" -DLLAMA_CURL=OFF
+    make -j8
+  fi
+'
+```
+
+Then create systemd unit `fortress-embed-llamacpp.service` running `llama-server --embedding --port 8102 -m /mnt/fortress_nas/models/qwen3-embedding-4b/Qwen3-Embedding-4B-Q8_0.gguf -ngl 99 --host 0.0.0.0`.
+
+**KNOWN CONSEQUENCE:** Vector dimensionality differs from old embed. `legal_ediscovery` MUST be reindexed (Component F). This is expected if Path EMBED-B taken.
+
+### 8.3 EMBED functional smoke
+
+```bash
+ssh admin@192.168.0.105 '
+  curl -fsS http://localhost:8102/v1/embeddings \
+    -H "Content-Type: application/json" \
+    -d "{\"model\": \"<actual-model-name>\", \"input\": [\"This is a test passage about easement law.\"]}" | jq ".data[0].embedding | length"
+'
+```
+
+Surface vector dimensionality. Locks the reindex schema in §10.
+
+---
+
+## 9. Component D — Vision NIM restart on spark-3
+
+```bash
+ssh admin@192.168.0.105 '
+  sudo systemctl start fortress-nim-vision.service
+  sleep 60
+  curl -fsS http://localhost:8101/v1/health/ready
+  curl -fsS http://localhost:8101/v1/models | jq .
+'
+```
+
+Same restart pattern as v1 brief §7. Vision uses `nemotron-nano-12b-v2-vl` per nemotron-super-stack-architecture-brief.md Tier 5; that one is field-validated on Spark.
+
+**Frontier health check after Vision restart** (spark-3 capacity is tight):
+
+```bash
+ssh admin@192.168.0.100 '
+  curl -fsS --max-time 10 http://10.10.10.3:8000/v1/health/ready
+  curl -fsS http://10.10.10.3:8000/v1/models | jq ".data[].id"
+'
+```
+
+If frontier 200 → continue. If non-200 → HARD STOP §3.3.
+
+---
+
+## 10. Component E — LiteLLM aliases
+
+### 10.1 Pre-mutation snapshot
+
+```bash
+ssh admin@192.168.0.100 '
+  cp /home/admin/Fortress-Prime/litellm_config.yaml \
+     /home/admin/Fortress-Prime/litellm_config.yaml.bak.wave-3-$(date +%Y%m%dT%H%M%SZ)
+'
+```
+
+### 10.2 Add aliases
+
+Add to `litellm_config.yaml`:
+
+```yaml
+- model_name: legal-rerank
+  litellm_params:
+    model: openai/nvidia/llama-3.2-nv-rerankqa-1b-v2
+    api_base: http://192.168.0.109:8103/v1
+    api_key: empty
+
+- model_name: legal-extract-page
+  litellm_params:
+    model: openai/nvidia/nv-yolox-page-elements-v2
+    api_base: http://192.168.0.109:8110/v1
+    api_key: empty
+
+- model_name: legal-extract-graphic
+  litellm_params:
+    model: openai/nvidia/nv-yolox-graphic-elements-v1
+    api_base: http://192.168.0.109:8111/v1
+    api_key: empty
+
+- model_name: legal-extract-table
+  litellm_params:
+    model: openai/nvidia/nv-yolox-table-structure-v1
+    api_base: http://192.168.0.109:8112/v1
+    api_key: empty
+```
+
+If Path EMBED-B taken in §8.2, also update `legal-embed` alias to point at `http://192.168.0.105:8102/v1` with the Qwen3 model name.
+
+### 10.3 LiteLLM reload + per-alias smoke
+
+```bash
+ssh admin@192.168.0.100 '
+  sudo systemctl reload fortress-litellm.service || sudo systemctl restart fortress-litellm.service
+  sleep 10
+  curl -fsS http://localhost:4000/v1/models | jq ".data[].id" | grep -E "legal-rerank|legal-extract"
+'
+```
+
+Document the four/five new aliases in final report.
+
+---
+
+## 11. Component F — Qdrant `legal_ediscovery` reindex
+
+### 11.1 Shadow-collection pattern
+
+```bash
+ssh admin@192.168.0.100 '
+  # Create new collection with current EMBED dim
+  EMBED_DIM=$(curl -fsS http://192.168.0.105:8102/v1/embeddings -H "Content-Type: application/json" -d "{\"model\": \"<model-name>\", \"input\": [\"test\"]}" | jq ".data[0].embedding | length")
+  echo "EMBED_DIM=${EMBED_DIM}"
+
+  # Snapshot the old one first (qdrant#6754: alias data not in snapshot, but we want point data)
+  curl -fsS -X POST "http://localhost:6333/collections/legal_ediscovery/snapshots"
+
+  curl -fsS -X PUT "http://localhost:6333/collections/legal_ediscovery_v2" \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"vectors\": {
+        \"size\": ${EMBED_DIM},
+        \"distance\": \"Cosine\"
+      }
+    }"
+'
+```
+
+### 11.2 Reindex from source (NOT from existing vectors — they're old embed)
+
+Vectors must be regenerated against new EMBED. Re-run the original ingestion pipeline output (Sentinel-emitted document chunks) through new EMBED:
+
+```bash
+ssh admin@192.168.0.100 '
+  cd /home/admin/Fortress-Prime
+  python3 -m fortress.indexing.reindex_legal_ediscovery \
+    --source-collection legal_ediscovery \
+    --target-collection legal_ediscovery_v2 \
+    --embed-endpoint http://192.168.0.105:8102/v1 \
+    --batch-size 64 \
+    2>&1 | tee /mnt/fortress_nas/audits/wave-3-reindex-$(date +%Y%m%dT%H%M%SZ).log
+'
+```
+
+If reindex script doesn't exist at that path: build minimal scratch script using the chunk metadata from `legal_ediscovery` payload (text + source path) → embed via new endpoint → upsert to v2. **Do not commit scratch script** — keep it ad-hoc for this brief; productionize in separate PR if needed.
+
+### 11.3 Validation against shadow
+
+```bash
+ssh admin@192.168.0.100 '
+  ORIG_COUNT=$(curl -fsS http://localhost:6333/collections/legal_ediscovery | jq ".result.points_count")
+  NEW_COUNT=$(curl -fsS http://localhost:6333/collections/legal_ediscovery_v2 | jq ".result.points_count")
+  echo "Original: $ORIG_COUNT, Shadow: $NEW_COUNT"
+
+  # Must be within 1% — chunks may differ slightly if EMBED chunks differently
+  if [ $(echo "scale=4; ($NEW_COUNT - $ORIG_COUNT) / $ORIG_COUNT" | bc -l | tr -d -) > 0.01 ]; then
+    echo "Shadow point count >1% off — investigate before cutover"
+    exit 1
+  fi
+'
+```
+
+### 11.4 Quality probe before cutover
+
+Run 3 known-good queries against both collections:
+
+```bash
+QUERIES=(
+  "easement on River Heights recorded by Knight"
+  "section 8 financial breakdown Q3 2025"
+  "Thor James grantor warranty deed"
+)
+
+for q in "${QUERIES[@]}"; do
+  # Query both, compare top-5 source paths overlap
+  ...
+done
+```
+
+Document overlap percentage. If <60% top-5 overlap → flag for operator review before cutover; do not auto-cutover.
+
+### 11.5 Atomic alias swap (CRITICAL — qdrant#7584)
+
+```bash
+ssh admin@192.168.0.100 '
+  curl -fsS -X POST "http://localhost:6333/collections/aliases" \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"actions\": [
+        {\"delete_alias\": {\"alias_name\": \"legal_ediscovery_active\"}},
+        {\"create_alias\": {\"collection_name\": \"legal_ediscovery_v2\", \"alias_name\": \"legal_ediscovery_active\"}}
+      ]
+    }"
+'
+```
+
+**Why explicit delete + create in same atomic transaction:** qdrant#7584 confirms `create_alias` silently overwrites without warning. The atomic delete+create pattern makes the swap intention explicit and survives rollback inspection.
+
+If application code currently references `legal_ediscovery` directly (not the alias), update Phase B retrieval config to use `legal_ediscovery_active` alias instead. This is one config change in `fortress-guest-platform/backend/services/case_briefing_synthesizers.py` or wherever Qdrant client is initialized. Do not delete `legal_ediscovery` original — keep for 14-day rollback window.
+
+---
+
+## 12. Component G — End-to-end retrieval smoke
+
+```bash
+ssh admin@192.168.0.100 '
+  # Real Case I retrieval query
+  QUERY="What did Knight argue about the easement timing in his answer?"
+
+  # 1. EMBED the query
+  EMBEDDING=$(curl -fsS http://192.168.0.105:8102/v1/embeddings \
+    -H "Content-Type: application/json" \
+    -d "{\"model\": \"<model>\", \"input\": [\"${QUERY}\"]}" | jq ".data[0].embedding")
+
+  # 2. Search Qdrant via alias
+  TOP_K=$(curl -fsS http://localhost:6333/collections/legal_ediscovery_active/points/search \
+    -H "Content-Type: application/json" \
+    -d "{\"vector\": ${EMBEDDING}, \"limit\": 20, \"with_payload\": true}" | jq ".result")
+
+  # 3. Rerank top 20 to top 5
+  RERANKED=$(curl -fsS http://192.168.0.109:8103/v1/ranking \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"model\": \"nvidia/llama-3.2-nv-rerankqa-1b-v2\",
+      \"query\": {\"text\": \"${QUERY}\"},
+      \"passages\": [...top-20-text...]
+    }")
+
+  # 4. Document end-to-end latency + source paths surfaced
+'
+```
+
+Expected: ≥3 of top-5 reranked passages cite Knight's answer document. Document end-to-end wall (target <5s).
+
+---
+
+## 13. PR
+
+### 13.1 Files to commit
+
+```bash
+ssh admin@192.168.0.100 '
+  cd /home/admin/Fortress-Prime
+
+  # Land THIS brief itself
+  cp /home/admin/wave-3-reranker-extraction-deployment-brief-v2.md docs/operational/
+
+  # systemd units
+  mkdir -p deploy/systemd/spark-5 deploy/systemd/spark-3
+  scp admin@192.168.0.109:/etc/systemd/system/fortress-nim-rerank.service deploy/systemd/spark-5/
+  scp admin@192.168.0.109:/etc/systemd/system/fortress-nim-page-elements.service deploy/systemd/spark-5/
+  scp admin@192.168.0.109:/etc/systemd/system/fortress-nim-graphic-elements.service deploy/systemd/spark-5/
+  scp admin@192.168.0.109:/etc/systemd/system/fortress-nim-table-structure.service deploy/systemd/spark-5/
+
+  # If Path EMBED-B taken, llama.cpp service unit
+  scp admin@192.168.0.105:/etc/systemd/system/fortress-embed-llamacpp.service deploy/systemd/spark-3/ 2>/dev/null || true
+
+  # LiteLLM diff
+  diff -u /home/admin/Fortress-Prime/litellm_config.yaml.bak.wave-3-* /home/admin/Fortress-Prime/litellm_config.yaml > docs/operational/wave-3-litellm-config-diff.patch
+
+  # Reindex evidence
+  cp /mnt/fortress_nas/audits/wave-3-reindex-*.log docs/operational/
+
+  # Final run report
+  cat > docs/operational/wave-3-final-report.md <<EOF
+# Wave 3 Final Report — $(date +%Y-%m-%d)
+[populated at run end per §14]
+EOF
+
+  # Runbook
+  cat > docs/operational/runbooks/wave-3-retrieval-stack.md <<EOF
+# Wave 3 Retrieval Stack Runbook
+
+## Services
+- spark-5:8103 fortress-nim-rerank.service — llama-3.2-nv-rerankqa-1b-v2:1.8.0
+- spark-5:8110 fortress-nim-page-elements.service
+- spark-5:8111 fortress-nim-graphic-elements.service
+- spark-5:8112 fortress-nim-table-structure.service
+- spark-3:8102 fortress-nim-embed.service OR fortress-embed-llamacpp.service (Path EMBED-A or EMBED-B)
+- spark-3:8101 fortress-nim-vision.service
+
+## Critical health invariants
+1. spark-3+4 frontier endpoint health (http://10.10.10.3:8000/v1/health/ready) MUST stay 200
+2. Reranker only deployed via :1.8.0 — newer rerank-1b-v2 lacks Blackwell support
+3. EMBED only deployed via Path EMBED-A (llama-nemotron-embed-1b-v2) or EMBED-B (Qwen3-Embedding-4B llama.cpp); v1.10.0 of llama-3.2-nv-embedqa is BROKEN on Spark
+
+## Watchlist (deferred to Wave 3.5)
+- nv-ingest unified extraction orchestrator — when ARM64 build lands per forums 360011
+- llama-nemotron-rerank-1b-v2 (newer model) — when NVIDIA publishes Blackwell support
+
+## Qdrant collections
+- legal_ediscovery — original, archived for 14-day rollback
+- legal_ediscovery_v2 — current production, target of legal_ediscovery_active alias
+- legal_ediscovery_active — alias to v2, used by Phase B retrieval
+
+## Rollback procedure
+- Service rollback: systemctl stop new service; restart old image tag
+- Qdrant rollback: atomic alias swap delete+create back to original collection
+EOF
+
+  git add docs/operational/wave-3-* docs/operational/runbooks/wave-3-* deploy/systemd/spark-5/ deploy/systemd/spark-3/
+  git status
+'
+```
+
+### 13.2 Commit + PR
+
+```bash
+ssh admin@192.168.0.100 '
+  cd /home/admin/Fortress-Prime
+  git commit -m "feat(wave-3): retrieval stack deployment (Reranker + per-component Extraction + EMBED + Vision)
+
+ARM64-validated component selection:
+- Reranker NIM via field-tested llama-3.2-nv-rerankqa-1b-v2:1.8.0 (newer
+  rerank-1b-v2 lists no Blackwell support)
+- Per-component YOLOX extraction NIMs on spark-5 (page/graphic/table)
+- nv-ingest orchestrator deferred to Wave 3.5 watchlist (no public ARM64
+  build per NVIDIA forums thread 360011, 2026-02-09)
+- EMBED via [Path EMBED-A or EMBED-B based on existing image] — broken
+  llama-3.2-nv-embedqa-1b-v2:1.10.0 NOT used (forums 354998)
+- Vision restored via nemotron-nano-12b-v2-vl
+- LiteLLM aliases legal-rerank, legal-extract-page/graphic/table added
+- legal_ediscovery reindexed to legal_ediscovery_v2; alias
+  legal_ediscovery_active points at v2 via atomic delete+create swap (qdrant#7584)
+- End-to-end retrieval pipeline smoke validated
+
+Frontier endpoint untouched; soak clock unaffected (active to 2026-05-14).
+
+Wave 3 of nemotron-super-stack-architecture-brief.md.
+Stacks on PR #341 (deep-research artifacts).
+"
+
+  git push -u origin feat/wave-3-retrieval-stack-deployment-2026-05-01
+
+  gh pr create \
+    --title "Wave 3 — Retrieval stack: Reranker + per-component Extraction + EMBED/Vision (v2 ARM64-validated)" \
+    --body-file docs/operational/wave-3-final-report.md \
+    --draft
+'
+```
+
+PR opens as draft. Operator promotes to ready after reviewing extraction smoke output, reindex log, and frontier health throughout deployment.
+
+---
+
+## 14. Final report (auto-surface at run end)
+
+Surface to chat at run end:
+
+1. **Pre-flight summary**
+   - Soak status, frontier health throughout
+   - NGC auth path (cluster vs W3 fallback)
+   - spark-5 readiness, spark-3 headroom
+   - EMBED branch identified (A or B)
+
+2. **Component A — Reranker (`:1.8.0`)**
+   - Pull path used (cluster vs W3)
+   - ARM64 verification result
+   - Service running on 8103, health 200
+   - Functional smoke result (legal text vs basketball)
+
+3. **Component B — Per-component Extraction**
+   - Per-NIM pull status (3 NIMs)
+   - Service stack on 8110/8111/8112
+   - Per-NIM functional smoke
+   - **Wave 3.5 watchlist note for nv-ingest orchestrator**
+
+4. **Component C — EMBED**
+   - Path used (EMBED-A restart or EMBED-B Qwen3 llama.cpp)
+   - Vector dimensionality
+   - Health probe result
+   - Functional smoke
+
+5. **Component D — Vision restart**
+   - Service running on 8101
+   - **Frontier health post-Vision-restart** (critical due to spark-3 co-tenancy)
+
+6. **Component E — LiteLLM aliases**
+   - Pre/post alias map
+   - Per-alias smoke
+
+7. **Component F — Qdrant reindex**
+   - Original / shadow point counts
+   - Quality probe top-5 overlap percentage
+   - Atomic alias swap evidence
+
+8. **Component G — End-to-end retrieval**
+   - Pipeline pass/fail
+   - End-to-end wall
+
+9. **Halt triggers fired** (should be zero on clean run)
+
+10. **Soak impact**
+    - Frontier health throughout (any 30s+ non-200 windows)
+    - Memory peaks on spark-3, spark-5
+    - Any soak halt events
+
+11. **PR**
+    - Branch, PR number + URL
+    - Files committed
+
+12. **Recommended operator next action**
+    - All pass: Wave 3 complete; Case II briefing (Wave 7) has retrieval stack
+    - Partial pass: which components deferred + Wave 3.5 scope
+
+---
+
+## 15. Constraints
+
+- Branches from `origin/main` only.
+- Single Claude Code session at a time on cluster.
+- Never `--admin`, never self-merge, never force-push main.
+- **DO NOT modify the spark-3+4 frontier endpoint or its serve flags.** This is non-negotiable.
+- DO NOT touch Track A artifacts (separate work).
+- DO NOT modify Phase B v0.1 orchestrator code.
+- DO NOT delete `legal_ediscovery` original collection — archive for 14-day rollback only.
+- DO NOT halt for soft conditions; hard stops in §3 only.
+- ARM64 verification on every NIM is non-negotiable (HARD STOP §3.2).
+- Frontier health monitored continuously; if degrades, protect frontier (HARD STOP §3.3).
+- DO NOT pull `nv-ingest` orchestrator (no ARM build; Wave 3.5).
+- DO NOT pull `llama-nemotron-rerank-1b-v2` (lacks Blackwell support; use `llama-3.2-nv-rerankqa-1b-v2:1.8.0`).
+- DO NOT restart `llama-3.2-nv-embedqa-1b-v2:1.10.0` (broken on Spark per forums 354998 — falls to Path EMBED-B).
+- If ANY ARM64 verification fails, that component does NOT deploy; document and continue.
+
+---
+
+## 16. References
+
+**NVIDIA official:**
+- DGX Spark Software Updates 04/2026 announcement: https://forums.developer.nvidia.com/t/dgx-spark-software-updates-04-2026/368114
+- Nemotron 3 Super Spark Deployment Guide: https://docs.nvidia.com/nemotron/nightly/usage-cookbook/Nemotron-3-Super/SparkDeploymentGuide/README.html
+- Multi-Agent Chatbot playbook (Qwen3-Embedding-4B reference): https://build.nvidia.com/spark/multi-agent-chatbot
+- DGX Spark Porting Guide: https://docs.nvidia.com/dgx/dgx-spark-porting-guide/dgx-spark-porting-guide.pdf
+- DGX Spark Playbooks DeepWiki: https://deepwiki.com/NVIDIA/dgx-spark-playbooks
+
+**Field reports — confirmed working / broken on Spark:**
+- nv-ingest no ARM build (NVIDIA staff): https://forums.developer.nvidia.com/t/dgx-spark-arm64-nv-ingest-images-or-roadmap/360011
+- Embed NIM cudaErrorSymbolNotFound (cjeske, NVIDIA reply): https://forums.developer.nvidia.com/t/dgx-spark-gb10-arm64-embedding-nim-llama-3-2-nv-embedqa-1b-v2-1-10-0-fails-with-cudaerrorsymbolnotfound-onnx-runtime/354998
+- NIMs multiplatform request: https://forums.developer.nvidia.com/t/nims-should-be-built-multiplatform/348914
+- NCCL all-reduce deadlock dual Spark: https://forums.developer.nvidia.com/t/nccl-all-reduce-deadlock-on-dual-dgx-spark-after-successful-channel-establishment-affects-both-vllm-and-trt-llm/366127
+- Leon Gibat dual-Spark TP=2 NVFP4 24 tok/s: https://forums.developer.nvidia.com/t/nemotron-3-super-nvfp4-via-vllm-tp-2-on-2x-dgx-spark-24-tok-s-abi-fix-for-cu130-cu132-mismatch/364862
+
+**Qdrant landmines:**
+- Alias silent overwrite: https://github.com/qdrant/qdrant/issues/7584
+- Alias data not in snapshot: https://github.com/qdrant/qdrant/issues/6754
+
+**Project knowledge:**
+- v1 brief: `wave-3-reranker-extraction-deployment-brief.md` (this is the source for procedures; v2 amends component scope)
+- `nemotron-super-stack-architecture-brief.md` (Wave 3 spec, ADR-005)
+- `MASTER-PLAN-v1.7.md` (Tier-1 NIM batch-pull, §6.2)
+- `nemotron-3-super-deep-research-2026-04-30.md` (cited for chat template + reasoning control mechanics)
+
+---
+
+## 17. What changed from v1
+
+| Section | v1 | v2 |
+|---|---|---|
+| Component B | nv-ingest orchestrator + 4 component NIMs | Per-component NIMs only; nv-ingest deferred to Wave 3.5 watchlist |
+| Component A model | `llama-nemotron-rerank-1b-v2` (newer; no Blackwell) | `llama-3.2-nv-rerankqa-1b-v2:1.8.0` (field-validated on Spark) |
+| Component C | Restart existing EMBED service | Decision gate: restart if `llama-nemotron-embed-1b-v2`; replace with Qwen3-Embedding-4B + llama.cpp if `llama-3.2-nv-embedqa-1b-v2:1.10.0` (broken) |
+| Hard stops | 7 conditions | 8 conditions (added: EMBED known-broken signature) |
+| Qdrant alias swap | Implicit `create_alias` | Explicit atomic `delete_alias` + `create_alias` per qdrant#7584 |
+| Frontier protection | Stated as hard stop | Stated as hard stop + explicit reminder due to dual-Spark TP=2 instability reports |
+| References | NVIDIA cookbook only | + 5 field-report threads documenting current ARM64 state |
+
+---
+
+End of Wave 3 v2 brief.

--- a/docs/operational/wave-3-reranker-extraction-deployment-brief-v2.md
+++ b/docs/operational/wave-3-reranker-extraction-deployment-brief-v2.md
@@ -59,7 +59,7 @@ Halt + surface ONLY for:
 
 1. **NGC API auth fails persistently.** Two retries with cluster-canonical key + 30s sleep. Both fail → operator-side credential issue.
 2. **ARM64 verification fails on any pulled NIM.** Per PR #128 tooling: manifest layers must be arm64 AND must actually contain arm64 binaries (not amd64 binaries under arm64 manifest — the Nemotron-Nano-9B incident).
-3. **Frontier endpoint dies during deployment.** `curl http://10.10.10.3:8000/v1/health/ready` non-200 sustained >60s → halt and protect frontier. **This is non-negotiable: nothing about Wave 3 is worth breaking the TP=2 soak.**
+3. **Frontier endpoint dies during deployment.** `curl http://10.10.10.3:8000/health` non-200 sustained >60s → halt and protect frontier. **This is non-negotiable: nothing about Wave 3 is worth breaking the TP=2 soak.**
 4. **Soak halt event fires.** Phase 9 collector emits halt — cluster telling you to stop.
 5. **Disk full** anywhere in the write path. <5GB free.
 6. **OOM kill / nvidia-smi unresponsive / fabric link down on spark-3 or spark-5.**
@@ -114,7 +114,7 @@ git log origin/main..HEAD --oneline
 ```bash
 ssh admin@192.168.0.100 '
   tail -50 /mnt/fortress_nas/audits/phase-9-soak/$(date +%Y-%m-%d).log 2>/dev/null
-  curl -fsS --max-time 10 http://10.10.10.3:8000/v1/health/ready
+  curl -fsS --max-time 10 http://10.10.10.3:8000/health
   curl -fsS http://10.10.10.3:8000/v1/models | jq ".data[].id"
 '
 ```
@@ -488,7 +488,7 @@ Same restart pattern as v1 brief §7. Vision uses `nemotron-nano-12b-v2-vl` per 
 
 ```bash
 ssh admin@192.168.0.100 '
-  curl -fsS --max-time 10 http://10.10.10.3:8000/v1/health/ready
+  curl -fsS --max-time 10 http://10.10.10.3:8000/health
   curl -fsS http://10.10.10.3:8000/v1/models | jq ".data[].id"
 '
 ```
@@ -732,7 +732,7 @@ EOF
 - spark-3:8101 fortress-nim-vision.service
 
 ## Critical health invariants
-1. spark-3+4 frontier endpoint health (http://10.10.10.3:8000/v1/health/ready) MUST stay 200
+1. spark-3+4 frontier endpoint health (http://10.10.10.3:8000/health) MUST stay 200
 2. Reranker only deployed via :1.8.0 — newer rerank-1b-v2 lacks Blackwell support
 3. EMBED only deployed via Path EMBED-A (llama-nemotron-embed-1b-v2) or EMBED-B (Qwen3-Embedding-4B llama.cpp); v1.10.0 of llama-3.2-nv-embedqa is BROKEN on Spark
 


### PR DESCRIPTION
## Summary

Lands the canonical Wave 3 retrieval-stack deployment brief (v2) on `main`, plus the originating amendment kickoff with dead references cleaned up. v1 was never committed to the repo; v2 supersedes it with current field research.

Doc-only PR. No code, no service, no schema, no NIM pulls.

## Files

| File | Role |
|---|---|
| `docs/operational/wave-3-reranker-extraction-deployment-brief-v2.md` | Canonical Wave 3 brief, ARM64-validated component scope |
| `docs/operational/claude-code-kickoff-wave-3-brief-amendment-2026-05-01.md` | Originating amendment kickoff (lineage record); references updated to v2 filename; embed deep-research citations dropped (doc was never authored — recovery deferred per PR #341) |

2 files, 1284 insertions, 0 deletions.

## v2 amends v1 with current field research

- **nv-ingest deferred to Wave 3.5** — no public ARM64 build per NVIDIA staff (forums 360011)
- **Reranker pinned** to `llama-3.2-nv-rerankqa-1b-v2:1.8.0` (newer model lacks Blackwell support)
- **EMBED decision gate** — Path A restart vs Path B Qwen3+llama.cpp (`llama-3.2-nv-embedqa-1b-v2:1.10.0` broken on Spark per forums 354998)
- **Atomic Qdrant alias swap** per qdrant#7584
- **Frontier protection emphasized** — NCCL deadlock reports per forums 366127

## Kickoff cleanup

The `claude-code-kickoff-wave-3-brief-amendment-2026-05-01.md` kickoff is preserved as lineage record (it drove this v2 work). Edits applied:

1. All references `wave-3-reranker-extraction-deployment-brief.md` → `wave-3-reranker-extraction-deployment-brief-v2.md` (8 occurrences)
2. Citations to `llama-nemotron-embed-1b-v2-deep-research-2026-04-30.md` removed (the doc was never authored — recovery deferred per PR #341 commit message). Inline `(per embed deep research §X)` suffixes stripped; one canonical deferral note added in front-matter and References sections.

Brief v2 itself is committed byte-identical to operator-supplied source — no edits.

## Out of scope

- Executing Wave 3 v2 (separate kickoff, after this lands)
- Authoring the embed deep-research doc (deferred per PR #341)
- Any code changes

## What this PR does NOT do

- Does not deploy any NIM
- Does not modify any service (frontier, EMBED, Vision, BRAIN, anything)
- Does not modify any schema or LiteLLM alias config
- Does not modify any code
- Does not pull any NIM
- Does not modify the original kickoff body content beyond the two surgical-edit categories above

## Hard-stop checks (kickoff requirement)

- ✓ Both source files present at `/home/admin/`
- ✓ Frontier health 200 before work (`/health` 200; `/v1/models` returns `nemotron-3-super`)
- (Frontier post-work check will be confirmed before merge)

## References

- PR #336 — Wave 1 EMBED ratification
- PR #337–#340 — Wave 2 ratification sequence
- PR #341 — `docs/research/` artifacts on main (sets the embed deep-research deferral pattern this PR continues)

---

**Draft until operator review.** No `--admin`, no self-merge, no force-push.