### PR TITLE
feat(case-briefing): activate §9 intel-layer augmentation in compose pipeline

### DIFF
--- a/fortress-guest-platform/backend/services/case_briefing_compose.py
+++ b/fortress-guest-platform/backend/services/case_briefing_compose.py
@@ -34,6 +34,7 @@ from sqlalchemy import text as sa_text
 
 from backend.api.legal_cases import _resolve_case_slug
 from backend.services.brain_client import BrainClient, BrainClientError
+from backend.services.case_briefing_augmentation import load_section_9_augmentation
 from backend.services.ediscovery_agent import LegacySession
 from backend.services.legal_council import (
     freeze_context,
@@ -351,11 +352,15 @@ async def stage_2_synthesize(
                 contains_privileged=False,
             )
         elif mode == SECTION_MODE_OPERATOR_WRITTEN:
+            if section_id == "section_09_recommended_strategy":
+                content = load_section_9_augmentation(case_slug=packet.case_slug_canonical)
+            else:
+                content = syn.operator_written_placeholder(title)
             results[section_id] = SectionResult(
                 section_id=section_id,
                 title=title,
                 mode=mode,
-                content=syn.operator_written_placeholder(title),
+                content=content,
                 contains_privileged=False,
             )
         elif mode == SECTION_MODE_SYNTHESIS:

--- a/fortress-guest-platform/backend/tests/conftest.py
+++ b/fortress-guest-platform/backend/tests/conftest.py
@@ -9,9 +9,10 @@ import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
-project_root_str = str(PROJECT_ROOT)
-if project_root_str not in sys.path:
-    sys.path.insert(0, project_root_str)
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+for _p in (str(PROJECT_ROOT), str(BACKEND_ROOT)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
 
 from backend.core.database import close_db
 from backend.core.config import settings


### PR DESCRIPTION
## Summary

Closes the activation gap left after PRs #349 (resolver + loader + tests) and #350 (augmentation file at orchestrator path). Flips the §9 dispatch in `stage_2_synthesize` from `operator_written_placeholder()` to `load_section_9_augmentation()`.

Saturday's Wave 7 Phase B v0.1 will now produce a §9 sourced from the intel layer instead of the static placeholder.

## What changed

`backend/services/case_briefing_compose.py` (+6 / -1):
- Import `load_section_9_augmentation` from `backend.services.case_briefing_augmentation`
- Inside the existing `SECTION_MODE_OPERATOR_WRITTEN` dispatch, branch on `section_id == "section_09_recommended_strategy"` and call the loader; everything else falls through to the placeholder synthesizer unchanged

`backend/tests/conftest.py` (+4 / -3):
- The compose module's import chain now pulls in `fortress.legal.intel_resolver` (via the augmentation loader). Conftest adds `BACKEND_ROOT` to `sys.path` alongside `PROJECT_ROOT`, matching the pattern already used by `test_intel_resolver.py` and `test_case_briefing_augmentation.py`. Without this, `pytest backend/tests/test_case_briefing_compose.py` fails at collection with `ModuleNotFoundError: No module named 'fortress'`

## Verification

**Existing test suites:**
- `backend/tests/legal/test_intel_resolver.py`: 19/19
- `backend/tests/legal/test_case_briefing_augmentation.py`: 5/5
- `backend/tests/test_case_briefing_compose.py`: 15/15 (incl. `test_stage_2_mechanical_section_passthrough`, which after the swap exercises the loader+resolver against the live NAS intel layer for case_slug `7il-v-knight-ndga-ii` and returns successfully)

**End-to-end §9 smoke** against `7il-v-knight-ndga-ii` via direct loader invocation (the brief's fallback path; no §9-only CLI flag exists):

| Check | Expected | Actual |
|---|---|---|
| Placeholder markers (`PLACEHOLDER — operator synthesis`) | 0 | 0 |
| Unresolved `{{...}}` tokens | 0 | 0 |
| Resolver halt markers | 0 | 0 |
| Same-judge insight present | ≥1 | 2 |
| Conflict-screening firm/attorney resolutions | ≥1 | 4 |

Smoke output captured at `/tmp/section-9-smoke.md` (250 lines, 14.5 KB).

**Regex note for the operator:** the brief's same-judge regex (`same plaintiff (7 IL Properties|same judge who presided over Case I`) was anchored on **body-text** phrasing, but the augmentation file's only same-judge token is `{{ judge:richard-w-story@operator_relevance.critical_context }}`, which pulls the **frontmatter** field. The strategic insight is fully present in the resolved output ("SAME JUDGE for Case I (2:21-CV-00226-RWS, judgment against operator) and Case II (2:26-CV-00113-RWS, active). Plaintiff entity is the same (7 IL Properties, LLC). ... incoming counsel must understand that Judge Story has prior factual findings against operator from Case I"), just phrased in the frontmatter's words rather than the body's. No action needed; flagging in case the operator wants the body-text phrasing surfaced too in a follow-up token.

## Out of scope (per brief §3)

- Resolver, loader, augmentation file, schemas — untouched
- Retrieval pipeline, frontier, LiteLLM, Qdrant — untouched
- Other sections' dispatch — untouched
- No new CLI flags
- No compose-pipeline refactoring

## Test plan

- [ ] Operator reviews §9 smoke output at `/tmp/section-9-smoke.md`
- [ ] Operator decides whether to add a body-text token to the augmentation file (separate PR; out of scope here)
- [ ] Saturday Wave 7 Phase B v0.1 dry-run confirms §9 reaches the intel-resolved path

🤖 Generated with [Claude Code](https://claude.com/claude-code)