### PR TITLE
Captain hardening + alembic reconciliation (#259, #260, #279)

### DIFF
--- a/fortress-guest-platform/backend/alembic/versions/824b70503495_merge_divergent_heads_d8e3_m8f9_t6e7.py
+++ b/fortress-guest-platform/backend/alembic/versions/824b70503495_merge_divergent_heads_d8e3_m8f9_t6e7.py
@@ -1,0 +1,48 @@
+"""merge divergent heads d8e3 m8f9 t6e7
+
+Revision ID: 824b70503495
+Revises: d8e3c1f5b9a6, m8f9a1b2c3d4, t6e7f8g9h0a1
+Create Date: 2026-05-01 20:50:10.433690
+
+Closes Issue #279 — divergent fortress_db heads.
+
+Issue #279 (filed 2026-04-29) named two heads: q2b3c4d5e6f7 and r3c4d5e6f7g8.
+Both became chain ancestors after FLOS Phase 0a-7 (s4d5e6f7g8h9) and 0a-8
+(t6e7f8g9h0a1) landed on top of r3c4d5e6f7g8. By the time of this merge
+(2026-05-01) three file-tree heads existed:
+
+  - d8e3c1f5b9a6  vault_documents schema integrity (PR D lineage)
+  - m8f9a1b2c3d4  NIM/NeMo container catalog inventory
+  - t6e7f8g9h0a1  FLOS Phase 0a-8 role grants on legal mail intake
+
+This revision merges all three into a single canonical head. Empty
+upgrade()/downgrade() — purely structural; no schema changes.
+
+Issue #204 (orphan stamp 7a1b2c3d4e5f on fortress_db.alembic_version) is
+NOT addressed here. That is a separate stamp-row problem, not a file-tree
+divergence, and is tracked separately.
+
+Unblocks: M3 activation step 4 (alembic upgrade head against
+SPARK1_DATABASE_URL).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '824b70503495'
+down_revision: Union[str, Sequence[str], None] = ('d8e3c1f5b9a6', 'm8f9a1b2c3d4', 't6e7f8g9h0a1')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/fortress-guest-platform/backend/services/captain_multi_mailbox.py
+++ b/fortress-guest-platform/backend/services/captain_multi_mailbox.py
@@ -30,6 +30,7 @@ and routing_tag are written into the capture_metadata JSONB column.
 from __future__ import annotations
 
 import asyncio
+import codecs
 import email as email_lib
 import imaplib
 import json
@@ -51,6 +52,30 @@ from backend.services.privilege_filter import (
 )
 
 logger = structlog.get_logger(service="captain_multi_mailbox")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Codec shim — Issue #259
+# ──────────────────────────────────────────────────────────────────────────────
+#
+# RFC 1428 / RFC 1652 'unknown-8bit' is a legitimate MIME encoding declaration
+# meaning '8-bit content of unknown character set'. Python's stdlib codecs
+# registry has no entry for it, so a raw .decode('unknown-8bit') raises
+# LookupError before errors='replace' has any chance to take effect. Captain's
+# IMAP fetch path was silently dropping ~10 messages per patrol on gary-crog
+# because of this.
+#
+# Map 'unknown-8bit' (and case/underscore variants) to the latin-1 codec.
+# latin-1 is the safe permissive fallback because every byte 0x00-0xff
+# round-trips without error.
+
+def _unknown_8bit_codec_search(name: str) -> Optional[codecs.CodecInfo]:
+    if name.lower().replace("_", "-") == "unknown-8bit":
+        return codecs.lookup("latin-1")
+    return None
+
+
+codecs.register(_unknown_8bit_codec_search)
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/fortress-guest-platform/backend/services/captain_multi_mailbox.py
+++ b/fortress-guest-platform/backend/services/captain_multi_mailbox.py
@@ -38,6 +38,7 @@ import os
 import re
 import uuid
 from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
 from email.header import decode_header
 from email.message import Message
 from typing import Any, Optional
@@ -481,11 +482,39 @@ class ImapTransport:
             )
         return []
 
-    def _fetch_with(self, conn: imaplib.IMAP4_SSL) -> list[FetchedEmail]:
-        _, msg_nums = conn.search(None, "UNSEEN")
-        if not msg_nums or not msg_nums[0]:
+    # Issue #260 — banded SEARCH defends against >1MB UID list overflow on
+    # long-history mailboxes (gary-gk). Mirrors legal_mail_ingester FLOS
+    # Phase 0a v1.1 §3.2 banded SEARCH pattern. Captain has no persistent
+    # last_patrol_at state today, so the floor is a hardcoded 30-day window.
+    # TODO: per-mailbox last_patrol_at tracking would tighten this to
+    # last_patrol_at - 1d; tracked separately.
+    _COLD_START_FLOOR_DAYS = 30
+
+    def _search_unseen_banded(
+        self, conn: imaplib.IMAP4_SSL
+    ) -> list[bytes]:
+        since_dt = datetime.now(timezone.utc) - timedelta(
+            days=self._COLD_START_FLOOR_DAYS
+        )
+        since_str = since_dt.strftime("%d-%b-%Y")
+        typ, data = conn.search(None, "UNSEEN", "SINCE", since_str)
+        if typ != "OK":
+            logger.warning(
+                "captain_imap_search_failed",
+                mailbox=self.mailbox.name,
+                since=since_str,
+                response_type=typ,
+            )
             return []
-        ids = msg_nums[0].split()[: self.max_messages]
+        if not data or not data[0]:
+            return []
+        return data[0].split()
+
+    def _fetch_with(self, conn: imaplib.IMAP4_SSL) -> list[FetchedEmail]:
+        ids_all = self._search_unseen_banded(conn)
+        if not ids_all:
+            return []
+        ids = ids_all[: self.max_messages]
         out: list[FetchedEmail] = []
         for mid in ids:
             try:

--- a/fortress-guest-platform/backend/tests/test_captain_banded_search.py
+++ b/fortress-guest-platform/backend/tests/test_captain_banded_search.py
@@ -1,0 +1,131 @@
+"""Issue #260 — Captain banded SEARCH for gary-gk overflow.
+
+Unbounded UNSEEN SEARCH against gary-gk returned >1MB UID list, overflowing
+the IMAP client buffer ('got more than 1000000 bytes'). Banded SEARCH
+(UNSEEN + SINCE date) bounds the result set per FLOS Phase 0a v1.1 §3.2
+(legal_mail_ingester precedent).
+"""
+from __future__ import annotations
+
+import inspect
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from backend.services.captain_multi_mailbox import ImapTransport, MailboxConfig
+
+
+@pytest.fixture
+def imap_transport() -> ImapTransport:
+    cfg = MailboxConfig(
+        name="gary-gk",
+        transport="imap",
+        address="gary@garyknight.com",
+        routing_tag="executive",
+        host="imap.example.test",
+        port=993,
+        credentials_ref="MAILPLUS_PASSWORD_GARY",
+        poll_interval_sec=120,
+    )
+    return ImapTransport(cfg, max_messages=25)
+
+
+def test_banded_search_uses_since_clause(imap_transport: ImapTransport) -> None:
+    """SEARCH command always pairs UNSEEN with SINCE."""
+    mock_conn = MagicMock()
+    mock_conn.search.return_value = ("OK", [b""])
+
+    imap_transport._search_unseen_banded(mock_conn)
+
+    args = mock_conn.search.call_args[0]
+    assert args[0] is None  # charset
+    assert "UNSEEN" in args
+    assert "SINCE" in args
+
+
+def test_banded_search_cold_start_uses_30_day_floor(
+    imap_transport: ImapTransport,
+) -> None:
+    """When no last_patrol_at state exists, SINCE = today - 30 days."""
+    mock_conn = MagicMock()
+    mock_conn.search.return_value = ("OK", [b""])
+
+    imap_transport._search_unseen_banded(mock_conn)
+
+    args = mock_conn.search.call_args[0]
+    since_idx = args.index("SINCE")
+    since_str = args[since_idx + 1]
+    since_dt = datetime.strptime(since_str, "%d-%b-%Y").replace(tzinfo=timezone.utc)
+    expected_floor = datetime.now(timezone.utc) - timedelta(days=30)
+
+    assert abs((since_dt - expected_floor).total_seconds()) < 86400
+
+
+def test_banded_search_returns_empty_on_search_failure(
+    imap_transport: ImapTransport,
+) -> None:
+    """If SEARCH returns non-OK, log warning and return []. Patrol continues."""
+    mock_conn = MagicMock()
+    mock_conn.search.return_value = ("NO", [b"some error"])
+
+    result = imap_transport._search_unseen_banded(mock_conn)
+
+    assert result == []
+
+
+def test_banded_search_returns_empty_when_no_results(
+    imap_transport: ImapTransport,
+) -> None:
+    """OK response with empty data returns empty list — no spurious fetches."""
+    mock_conn = MagicMock()
+    mock_conn.search.return_value = ("OK", [b""])
+
+    result = imap_transport._search_unseen_banded(mock_conn)
+
+    assert result == []
+
+
+def test_banded_search_parses_uid_list(imap_transport: ImapTransport) -> None:
+    """OK response with whitespace-delimited UIDs returns parsed list."""
+    mock_conn = MagicMock()
+    mock_conn.search.return_value = ("OK", [b"101 102 103"])
+
+    result = imap_transport._search_unseen_banded(mock_conn)
+
+    assert result == [b"101", b"102", b"103"]
+
+
+def test_no_unbounded_search_path_remains() -> None:
+    """Regression guard: no SEARCH call site issues UNSEEN without a SINCE clause."""
+    import backend.services.captain_multi_mailbox as captain_module
+
+    src = inspect.getsource(captain_module)
+    assert "SEARCH ALL" not in src.upper()
+
+    # Inspect every place where UNSEEN appears as a SEARCH argument.
+    # Allowed forms: ("UNSEEN", "SINCE", ...) sequence, or "(UNSEEN SINCE ...)"
+    upper = src.upper()
+    idx = 0
+    while True:
+        idx = upper.find('"UNSEEN"', idx)
+        if idx == -1:
+            break
+        window = upper[idx : idx + 200]
+        assert "SINCE" in window, (
+            f"'UNSEEN' arg found without nearby 'SINCE' clause near offset {idx}"
+        )
+        idx += len('"UNSEEN"')
+
+
+def test_fetch_with_uses_banded_search(imap_transport: ImapTransport) -> None:
+    """_fetch_with now routes through _search_unseen_banded."""
+    mock_conn = MagicMock()
+    mock_conn.search.return_value = ("OK", [b""])
+
+    imap_transport._fetch_with(mock_conn)
+
+    # search() must have been called with SINCE in the criteria
+    assert mock_conn.search.called
+    args = mock_conn.search.call_args[0]
+    assert "SINCE" in args

--- a/fortress-guest-platform/backend/tests/test_captain_unknown_8bit.py
+++ b/fortress-guest-platform/backend/tests/test_captain_unknown_8bit.py
@@ -1,0 +1,63 @@
+"""Issue #259 — Captain unknown-8bit codec shim.
+
+RFC 1428 / RFC 1652 'unknown-8bit' is a legitimate MIME encoding declaration
+meaning '8-bit content of unknown character set'. Python's stdlib codecs
+registry has no entry for it, so a raw .decode('unknown-8bit') raises
+LookupError before errors='replace' takes effect. Captain's IMAP fetch path
+was silently dropping ~10 messages per patrol on gary-crog before this fix.
+"""
+from __future__ import annotations
+
+import codecs
+
+from email import message_from_bytes
+
+
+def test_unknown_8bit_codec_resolves_to_latin1() -> None:
+    """After Captain module import, codecs.lookup('unknown-8bit') succeeds."""
+    import backend.services.captain_multi_mailbox  # noqa: F401
+
+    info = codecs.lookup("unknown-8bit")
+    assert info.name == "iso8859-1"  # latin-1's canonical Python codec name
+
+
+def test_unknown_8bit_decodes_arbitrary_bytes() -> None:
+    """Every byte 0x00-0xff round-trips through the unknown-8bit codec."""
+    import backend.services.captain_multi_mailbox  # noqa: F401
+
+    raw = bytes(range(256))
+    decoded = raw.decode("unknown-8bit")
+    assert len(decoded) == 256
+    assert decoded.encode("unknown-8bit") == raw
+
+
+def test_unknown_8bit_case_and_underscore_variants() -> None:
+    """Codec name lookup is case-insensitive and tolerates underscore variant."""
+    import backend.services.captain_multi_mailbox  # noqa: F401
+
+    canonical = codecs.lookup("unknown-8bit").name
+    assert codecs.lookup("UNKNOWN-8BIT").name == canonical
+    assert codecs.lookup("Unknown-8bit").name == canonical
+    assert codecs.lookup("unknown_8bit").name == canonical
+
+
+def test_email_parse_with_unknown_8bit_charset() -> None:
+    """Real-world: parse a message claiming charset='unknown-8bit'."""
+    import backend.services.captain_multi_mailbox  # noqa: F401
+
+    raw_msg = (
+        b"From: test@example.com\r\n"
+        b"Subject: Test\r\n"
+        b"Content-Type: text/plain; charset=\"unknown-8bit\"\r\n"
+        b"Content-Transfer-Encoding: 8bit\r\n"
+        b"\r\n"
+        b"Hello \xe9\xe8\xe0 world\r\n"  # bytes that fail strict utf-8
+    )
+    msg = message_from_bytes(raw_msg)
+    payload_bytes = msg.get_payload(decode=True)
+    assert isinstance(payload_bytes, (bytes, bytearray))
+    charset = msg.get_content_charset()
+    assert charset == "unknown-8bit"
+    payload = bytes(payload_bytes).decode(charset)
+    assert "Hello" in payload
+    assert "world" in payload

--- a/fortress-guest-platform/ci/schema.meta.json
+++ b/fortress-guest-platform/ci/schema.meta.json
@@ -1,11 +1,9 @@
 {
   "alembic_revisions": [
-    "d8e3c1f5b9a6",
-    "m8f9a1b2c3d4",
-    "t6e7f8g9h0a1"
+    "824b70503495"
   ],
-  "alembic_versions_tree": "7573b4d4263ec98191d9e12cf31cdf29c0813a67",
-  "generated_at": "2026-04-30T03:26:59Z",
+  "alembic_versions_tree": "dfb8154fe59cc72a5e6688ce85f543bfa632d5c0",
+  "generated_at": "2026-05-02T00:58:30Z",
   "source_db": "fortress_shadow",
-  "source_commit": "9b12c17b50ae4cb1a7f15b565700d26d0d61c371"
+  "source_commit": "ebc19f9329a468b493dbc63c8f1f23b909c65f81"
 }


### PR DESCRIPTION
## Summary

Three pre-counsel-hire fixes in one PR, phase-per-commit (plus one CI artifact refresh):

1. **#279** — alembic merge migration joining the 3 currently-divergent `fortress_db` file-tree heads (`d8e3c1f5b9a6`, `m8f9a1b2c3d4`, `t6e7f8g9h0a1`) into a single canonical head (`824b70503495`). Empty `upgrade()`/`downgrade()` — purely structural; no schema changes. Operator authorized merging all 3 (Option A) since the two heads named in #279 (q2b3c4d5e6f7, r3c4d5e6f7g8) had become chain ancestors after FLOS Phase 0a-7/0a-8 landed; original divergence has propagated.
2. **#259** — codec shim for MIME `unknown-8bit` on Captain. ~10 messages/patrol on `gary-crog` were dropping with `LookupError: unknown encoding: unknown-8bit`; now decoded via latin-1 fallback per RFC 1428 / RFC 1652.
3. **#260** — banded SEARCH (`UNSEEN` + `SINCE`) for Captain. `gary-gk`'s >1MB SEARCH overflow defended by mirroring `legal_mail_ingester`'s FLOS Phase 0a v1.1 §3.2 pattern. Captain has no persistent `last_patrol_at` state, so the floor is a hardcoded 30-day cold-start window with a TODO marker for future per-mailbox state.

Plus:

4. **chore(ci)** — refresh `fortress-guest-platform/ci/schema.meta.json` after #279 (the staleness check gate trips on any migration tree change).

## Why now

Counsel hire is **2026-05-08**. These three issues could surface in the first 48 hours of counsel review:
- Divergent alembic heads block any future schema work counsel's eDiscovery tools might need
- Captain dropping ~10 messages/patrol on `gary-crog` is a preservation gap worth closing
- `gary-gk` Captain disconnect per cycle means the `llm_training_captures` substrate is degraded for one custodian's mailbox

## Scope discipline

- `legal_mail_ingester` is **untouched**. Separate pipeline already using the right patterns.
- Issue #204 alembic orphan stamp (`7a1b2c3d4e5f` row on `fortress_db.alembic_version`) is **untouched**. Stamp-row problem, not file-tree divergence; separate resolution path.
- `MAILPLUS_PASSWORD_GARY` and other potentially-stale env keys (#261) — **untouched**.
- No new state tables on Captain. The 30-day floor is intentional scope discipline.

## Verification (CC-side, completed)

- 11 new unit tests across the three commits, all passing:
  - 4 tests in `test_captain_unknown_8bit.py` — codec lookup / byte round-trip / case-and-underscore variants / email parse with `charset='unknown-8bit'`
  - 7 tests in `test_captain_banded_search.py` — banded SINCE clause / cold-start 30-day floor / search-failure graceful degradation / empty / non-empty result parsing / `_fetch_with` integration / regression guard scanning module source for `UNSEEN` SEARCH args without nearby `SINCE`
- Combined Captain test suite (`test_captain_multi_mailbox.py` + `test_captain_junk_filter.py` + new files) — **56 passed, 0 regressions**
- Targeted regression set (Captain + `legal_mail_ingester` + `nim_migration`) — **76 passed, 0 regressions**
- `alembic heads` now reports a single head (`824b70503495`) consolidating the three prior heads
- `ci/check_schema_staleness.py` exits 0 (Schema snapshot is current at tree `dfb8154fe59c`)

### Pre-existing test environment issues (NOT caused by this PR, verified in `/tmp/baseline-fp-3` worktree off `origin/main`)

- `test_ci_schema_bootstrap.py::TestSchemaMetaJson::test_known_heads_present` asserts `c255801e28a0` is in stored heads; that ID is not present on `origin/main` either — pre-existing failure.
- ~180 broader-suite failures across `test_phase_f_cron`, `test_seo_area4`, `test_stripe_connect_flow`, `test_worker_seo_consumers`, `test_workorders_area5`, `test_acquisition_area6`, `test_vault_documents_integrity` — all caused by missing `TEST_DATABASE_URL` provisioning on this host (the codebase requires `setup_test_db.sh`); collection-error-blocked on `origin/main` baseline too.

## Operator-gated steps (deferred)

Brief §2.3-§2.8 specified DB-side verification that requires direct prod-DB access (gated by hook policy on this host). The migration file is purely structural so application is trivial:

- Pre/post `pg_dump --schema-only` diff against `fortress_db` (must show no schema changes — empty migration is structural-only)
- `alembic upgrade head` against `fortress_db` (one new row in `alembic_version`)
- `alembic upgrade head` against `SPARK1_DATABASE_URL` (per Issue #279 / M3 activation step 4)
- Refresh `/tmp/spark-2-fortress_prod-schema-cleaned.sql` on spark-1 if downstream M3 prep consumes it

## Post-merge verification (operator-driven)

- Tail Captain `journalctl` for 1-2 patrol cycles after merge:
  - Confirm zero `unknown encoding: unknown-8bit` errors (#259)
  - Confirm zero `got more than 1000000 bytes` errors (#260)
- Verify `gary-crog` ingestion volume returns to normal for next 7 days
- Verify `gary-gk` ingestion via Captain resumes (was 0/patrol due to overflow)

## Standing constraints respected

- Branched from `origin/main` at HEAD `5131f18ff`
- No `--admin`, no `--force`, no self-merge
- Single CC session on spark-2 throughout (only `email_pipeline` + this session)
- Frontier `10.10.10.3:8000/health` 200 throughout
- Phase-per-commit discipline (with one CI follow-on commit)
- `legal_mail_ingester` files untouched