### PR TITLE
Schema reconciliation: legal.cases + legal.ingest_runs (PART A of Wave 7 corpus rebuild)

### DIFF
--- a/fortress-guest-platform/backend/alembic.ini
+++ b/fortress-guest-platform/backend/alembic.ini
@@ -18,7 +18,7 @@ script_location = %(here)s/alembic
 # sys.path path, will be prepended to sys.path if present.
 # defaults to the current working directory.  for multiple paths, the path separator
 # is defined by "path_separator" below.
-prepend_sys_path = ..
+prepend_sys_path = .
 
 
 # timezone to use when rendering the date within the migration file

--- a/fortress-guest-platform/backend/alembic/versions/u7a8b9c0d1e2_reconcile_legal_cases_ingest_runs.py
+++ b/fortress-guest-platform/backend/alembic/versions/u7a8b9c0d1e2_reconcile_legal_cases_ingest_runs.py
@@ -1,0 +1,391 @@
+"""Reconcile legal.cases and legal.ingest_runs for Wave 7 ingest.
+
+Revision ID: u7a8b9c0d1e2
+Revises: 824b70503495
+Create Date: 2026-05-02
+
+PART A schema reconciliation for Constitution section 11.1. This migration is
+intentionally idempotent because production-like databases already carry parts
+of this schema from raw SQL/manual operational repairs, while shadow/test
+databases may only have the older legal.cases surface.
+"""
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "u7a8b9c0d1e2"
+down_revision = "824b70503495"
+branch_labels = None
+depends_on = None
+
+
+_CASE_I_LAYOUT = """
+{
+  "primary_root": "/mnt/fortress_nas/Corporate_Legal/Business_Legal/7il-v-knight-ndga-i",
+  "include_subdirs": ["curated", "case-i-context"],
+  "exclude_subdirs": []
+}
+"""
+
+_CASE_II_LAYOUT = """
+{
+  "primary_root": "/mnt/fortress_nas/Corporate_Legal/Business_Legal/7il-v-knight-ndga-ii",
+  "include_subdirs": ["curated"],
+  "exclude_subdirs": []
+}
+"""
+
+
+def upgrade() -> None:
+    op.execute("CREATE SCHEMA IF NOT EXISTS legal")
+    op.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS legal.cases (
+            case_slug TEXT PRIMARY KEY,
+            docket TEXT,
+            case_number TEXT,
+            case_name TEXT,
+            court TEXT,
+            judge TEXT,
+            case_type TEXT DEFAULT 'civil',
+            our_role TEXT,
+            status TEXT DEFAULT 'active',
+            case_phase TEXT,
+            opposing_counsel TEXT,
+            privileged_counsel_domains JSONB NOT NULL DEFAULT '[]'::jsonb,
+            related_matters JSONB NOT NULL DEFAULT '[]'::jsonb,
+            nas_layout JSONB NOT NULL DEFAULT '{}'::jsonb,
+            extracted_entities JSONB NOT NULL DEFAULT '{}'::jsonb,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+    """)
+
+    op.execute("ALTER TABLE legal.cases ADD COLUMN IF NOT EXISTS docket TEXT")
+    op.execute("ALTER TABLE legal.cases ADD COLUMN IF NOT EXISTS case_number TEXT")
+    op.execute("ALTER TABLE legal.cases ADD COLUMN IF NOT EXISTS case_name TEXT")
+    op.execute("ALTER TABLE legal.cases ADD COLUMN IF NOT EXISTS court TEXT")
+    op.execute("ALTER TABLE legal.cases ADD COLUMN IF NOT EXISTS judge TEXT")
+    op.execute("ALTER TABLE legal.cases ADD COLUMN IF NOT EXISTS case_type TEXT DEFAULT 'civil'")
+    op.execute("ALTER TABLE legal.cases ADD COLUMN IF NOT EXISTS our_role TEXT")
+    op.execute("ALTER TABLE legal.cases ADD COLUMN IF NOT EXISTS status TEXT DEFAULT 'active'")
+    op.execute("ALTER TABLE legal.cases ADD COLUMN IF NOT EXISTS case_phase TEXT")
+    op.execute("ALTER TABLE legal.cases ADD COLUMN IF NOT EXISTS opposing_counsel TEXT")
+    op.execute("ALTER TABLE legal.cases ADD COLUMN IF NOT EXISTS privileged_counsel_domains JSONB DEFAULT '[]'::jsonb")
+    op.execute("ALTER TABLE legal.cases ADD COLUMN IF NOT EXISTS related_matters JSONB DEFAULT '[]'::jsonb")
+    op.execute("ALTER TABLE legal.cases ADD COLUMN IF NOT EXISTS nas_layout JSONB DEFAULT '{}'::jsonb")
+    op.execute("ALTER TABLE legal.cases ADD COLUMN IF NOT EXISTS extracted_entities JSONB DEFAULT '{}'::jsonb")
+    op.execute("ALTER TABLE legal.cases ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT NOW()")
+    op.execute("ALTER TABLE legal.cases ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW()")
+
+    op.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1
+                FROM pg_constraint
+                WHERE conrelid = 'legal.cases'::regclass
+                  AND contype IN ('p', 'u')
+                  AND conkey = ARRAY[
+                    (SELECT attnum FROM pg_attribute
+                     WHERE attrelid = 'legal.cases'::regclass
+                       AND attname = 'case_slug')::smallint
+                  ]
+            ) THEN
+                ALTER TABLE legal.cases
+                ADD CONSTRAINT uq_cases_case_slug UNIQUE (case_slug);
+            END IF;
+        END $$;
+    """)
+
+    op.execute("""
+        UPDATE legal.cases
+           SET docket = COALESCE(docket, case_number),
+               case_number = COALESCE(case_number, docket),
+               privileged_counsel_domains = COALESCE(privileged_counsel_domains, '[]'::jsonb),
+               related_matters = COALESCE(related_matters, '[]'::jsonb),
+               nas_layout = COALESCE(nas_layout, '{}'::jsonb),
+               updated_at = COALESCE(updated_at, NOW())
+    """)
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS legal.case_slug_aliases (
+            old_slug TEXT PRIMARY KEY,
+            new_slug TEXT NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            CONSTRAINT fk_case_slug_aliases_new_slug
+                FOREIGN KEY (new_slug) REFERENCES legal.cases (case_slug)
+                DEFERRABLE INITIALLY IMMEDIATE
+        )
+    """)
+
+    op.execute("""
+        DO $$
+        DECLARE
+            fk_name TEXT;
+        BEGIN
+            SELECT conname INTO fk_name
+              FROM pg_constraint
+             WHERE conrelid = 'legal.case_slug_aliases'::regclass
+               AND contype = 'f'
+               AND condeferrable = FALSE
+             LIMIT 1;
+
+            IF fk_name IS NOT NULL THEN
+                EXECUTE format('ALTER TABLE legal.case_slug_aliases DROP CONSTRAINT %I', fk_name);
+                ALTER TABLE legal.case_slug_aliases
+                ADD CONSTRAINT fk_case_slug_aliases_new_slug
+                FOREIGN KEY (new_slug) REFERENCES legal.cases (case_slug)
+                DEFERRABLE INITIALLY IMMEDIATE;
+            END IF;
+        END $$;
+    """)
+
+    op.execute("""
+        INSERT INTO legal.cases (
+            case_slug, docket, case_number, case_name, court, judge,
+            case_type, our_role, status, case_phase, related_matters,
+            privileged_counsel_domains, nas_layout
+        ) VALUES
+            (
+                '7il-v-knight-ndga-i',
+                '2:21-CV-00226-RWS',
+                '2:21-CV-00226-RWS',
+                '7IL Properties LLC v. Knight (Case I)',
+                'U.S. District Court, Northern District of Georgia',
+                'Richard W. Story',
+                'civil',
+                'defendant',
+                'closed_judgment_against',
+                'closed',
+                '["7il-v-knight-ndga-ii"]'::jsonb,
+                '[]'::jsonb,
+                ($$""" + _CASE_I_LAYOUT + """$$)::jsonb
+            ),
+            (
+                '7il-v-knight-ndga-ii',
+                '2:26-CV-00113-RWS',
+                '2:26-CV-00113-RWS',
+                '7IL Properties LLC v. Knight + Thor James (Case II)',
+                'U.S. District Court, Northern District of Georgia',
+                'Richard W. Story',
+                'civil',
+                'defendant_pro_se',
+                'active',
+                'counsel_search',
+                '["7il-v-knight-ndga-i"]'::jsonb,
+                '[]'::jsonb,
+                ($$""" + _CASE_II_LAYOUT + """$$)::jsonb
+            ),
+            (
+                'vanderburge-v-knight-fannin',
+                'TBD',
+                'TBD',
+                'Karen Vanderburge v. Gary Knight + Lissa Knight',
+                'Superior Court of Fannin County, Georgia',
+                NULL,
+                'civil',
+                'defendant',
+                'closed_settled',
+                'closed_settled',
+                '["7il-v-knight-ndga-i", "7il-v-knight-ndga-ii"]'::jsonb,
+                '[]'::jsonb,
+                '{}'::jsonb
+            ),
+            (
+                'fish-trap-suv2026000013',
+                'SUV2026000013',
+                'SUV2026000013',
+                'Generali Global Assistance, Inc. v. Cabin Rentals of Georgia, LLC',
+                'Superior Court of Fannin County, State of Georgia (Appalachian Judicial Circuit)',
+                NULL,
+                'civil',
+                'defendant',
+                'active',
+                NULL,
+                '[]'::jsonb,
+                '[]'::jsonb,
+                '{}'::jsonb
+            ),
+            (
+                'prime-trust-23-11161',
+                '23-11161-JKS',
+                '23-11161-JKS',
+                'Prime Core Technologies, Inc. d/b/a Prime Trust',
+                'U.S. Bankruptcy Court, District of Delaware',
+                NULL,
+                'bankruptcy',
+                'creditor',
+                'active',
+                NULL,
+                '[]'::jsonb,
+                '[]'::jsonb,
+                '{}'::jsonb
+            )
+        ON CONFLICT (case_slug) DO UPDATE SET
+            docket = COALESCE(legal.cases.docket, EXCLUDED.docket, legal.cases.case_number),
+            case_number = COALESCE(legal.cases.case_number, EXCLUDED.case_number, legal.cases.docket),
+            case_name = COALESCE(legal.cases.case_name, EXCLUDED.case_name),
+            court = COALESCE(legal.cases.court, EXCLUDED.court),
+            judge = COALESCE(legal.cases.judge, EXCLUDED.judge),
+            case_type = COALESCE(legal.cases.case_type, EXCLUDED.case_type),
+            our_role = COALESCE(legal.cases.our_role, EXCLUDED.our_role),
+            status = COALESCE(legal.cases.status, EXCLUDED.status),
+            case_phase = COALESCE(legal.cases.case_phase, EXCLUDED.case_phase),
+            related_matters = CASE
+                WHEN EXCLUDED.case_slug IN ('7il-v-knight-ndga-i', '7il-v-knight-ndga-ii')
+                    THEN EXCLUDED.related_matters
+                ELSE COALESCE(legal.cases.related_matters, EXCLUDED.related_matters)
+            END,
+            privileged_counsel_domains = COALESCE(
+                legal.cases.privileged_counsel_domains,
+                EXCLUDED.privileged_counsel_domains
+            ),
+            nas_layout = CASE
+                WHEN EXCLUDED.case_slug IN ('7il-v-knight-ndga-i', '7il-v-knight-ndga-ii')
+                    THEN EXCLUDED.nas_layout
+                ELSE COALESCE(legal.cases.nas_layout, EXCLUDED.nas_layout)
+            END,
+            updated_at = NOW()
+    """)
+
+    op.execute("""
+        INSERT INTO legal.case_slug_aliases (old_slug, new_slug)
+        VALUES ('7il-v-knight-ndga', '7il-v-knight-ndga-i')
+        ON CONFLICT (old_slug) DO UPDATE SET new_slug = EXCLUDED.new_slug
+    """)
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS legal.ingest_runs (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            run_id UUID UNIQUE DEFAULT gen_random_uuid(),
+            case_slug TEXT NOT NULL,
+            script_name TEXT NOT NULL,
+            invocation_args JSONB NOT NULL DEFAULT '{}'::jsonb,
+            args JSONB NOT NULL DEFAULT '{}'::jsonb,
+            started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            completed_at TIMESTAMPTZ,
+            ended_at TIMESTAMPTZ,
+            status TEXT NOT NULL DEFAULT 'running'
+                CHECK (status IN ('running', 'complete', 'completed', 'error', 'failed', 'interrupted')),
+            files_processed INTEGER NOT NULL DEFAULT 0,
+            files_succeeded INTEGER NOT NULL DEFAULT 0,
+            files_failed INTEGER NOT NULL DEFAULT 0,
+            total_files INTEGER,
+            processed INTEGER NOT NULL DEFAULT 0,
+            errored INTEGER NOT NULL DEFAULT 0,
+            skipped INTEGER NOT NULL DEFAULT 0,
+            error_summary TEXT,
+            manifest_path TEXT,
+            host TEXT,
+            pid INTEGER,
+            runtime_seconds NUMERIC(12, 3),
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            CONSTRAINT fk_ingest_runs_case_slug
+                FOREIGN KEY (case_slug) REFERENCES legal.cases (case_slug)
+                ON DELETE CASCADE
+        )
+    """)
+
+    op.execute("ALTER TABLE legal.ingest_runs ADD COLUMN IF NOT EXISTS run_id UUID")
+    op.execute("ALTER TABLE legal.ingest_runs ADD COLUMN IF NOT EXISTS invocation_args JSONB DEFAULT '{}'::jsonb")
+    op.execute("ALTER TABLE legal.ingest_runs ADD COLUMN IF NOT EXISTS args JSONB DEFAULT '{}'::jsonb")
+    op.execute("ALTER TABLE legal.ingest_runs ADD COLUMN IF NOT EXISTS completed_at TIMESTAMPTZ")
+    op.execute("ALTER TABLE legal.ingest_runs ADD COLUMN IF NOT EXISTS ended_at TIMESTAMPTZ")
+    op.execute("ALTER TABLE legal.ingest_runs ADD COLUMN IF NOT EXISTS files_processed INTEGER DEFAULT 0")
+    op.execute("ALTER TABLE legal.ingest_runs ADD COLUMN IF NOT EXISTS files_succeeded INTEGER DEFAULT 0")
+    op.execute("ALTER TABLE legal.ingest_runs ADD COLUMN IF NOT EXISTS files_failed INTEGER DEFAULT 0")
+    op.execute("ALTER TABLE legal.ingest_runs ADD COLUMN IF NOT EXISTS total_files INTEGER")
+    op.execute("ALTER TABLE legal.ingest_runs ADD COLUMN IF NOT EXISTS processed INTEGER DEFAULT 0")
+    op.execute("ALTER TABLE legal.ingest_runs ADD COLUMN IF NOT EXISTS errored INTEGER DEFAULT 0")
+    op.execute("ALTER TABLE legal.ingest_runs ADD COLUMN IF NOT EXISTS skipped INTEGER DEFAULT 0")
+    op.execute("ALTER TABLE legal.ingest_runs ADD COLUMN IF NOT EXISTS error_summary TEXT")
+    op.execute("ALTER TABLE legal.ingest_runs ADD COLUMN IF NOT EXISTS manifest_path TEXT")
+    op.execute("ALTER TABLE legal.ingest_runs ADD COLUMN IF NOT EXISTS host TEXT")
+    op.execute("ALTER TABLE legal.ingest_runs ADD COLUMN IF NOT EXISTS pid INTEGER")
+    op.execute("ALTER TABLE legal.ingest_runs ADD COLUMN IF NOT EXISTS runtime_seconds NUMERIC(12, 3)")
+    op.execute("ALTER TABLE legal.ingest_runs ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT NOW()")
+    op.execute("ALTER TABLE legal.ingest_runs ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW()")
+
+    op.execute("UPDATE legal.ingest_runs SET run_id = COALESCE(run_id, id)")
+    op.execute("UPDATE legal.ingest_runs SET invocation_args = COALESCE(invocation_args, args, '{}'::jsonb)")
+    op.execute("UPDATE legal.ingest_runs SET args = COALESCE(args, invocation_args, '{}'::jsonb)")
+    op.execute("UPDATE legal.ingest_runs SET completed_at = COALESCE(completed_at, ended_at)")
+    op.execute("UPDATE legal.ingest_runs SET ended_at = COALESCE(ended_at, completed_at)")
+    op.execute("UPDATE legal.ingest_runs SET files_processed = COALESCE(files_processed, processed, 0)")
+    op.execute("""
+        UPDATE legal.ingest_runs
+           SET files_succeeded = COALESCE(
+                   files_succeeded,
+                   GREATEST(COALESCE(processed, 0) - COALESCE(errored, 0), 0),
+                   0
+               ),
+               files_failed = COALESCE(files_failed, errored, 0)
+    """)
+    op.execute("ALTER TABLE legal.ingest_runs ALTER COLUMN run_id SET DEFAULT gen_random_uuid()")
+    op.execute("ALTER TABLE legal.ingest_runs ALTER COLUMN invocation_args SET DEFAULT '{}'::jsonb")
+    op.execute("ALTER TABLE legal.ingest_runs ALTER COLUMN args SET DEFAULT '{}'::jsonb")
+
+    op.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conrelid = 'legal.ingest_runs'::regclass
+                  AND conname = 'uq_ingest_runs_run_id'
+            ) THEN
+                ALTER TABLE legal.ingest_runs
+                ADD CONSTRAINT uq_ingest_runs_run_id UNIQUE (run_id);
+            END IF;
+        END $$;
+    """)
+
+    op.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conrelid = 'legal.ingest_runs'::regclass
+                  AND conname = 'fk_ingest_runs_case_slug'
+            ) THEN
+                ALTER TABLE legal.ingest_runs
+                ADD CONSTRAINT fk_ingest_runs_case_slug
+                FOREIGN KEY (case_slug) REFERENCES legal.cases (case_slug)
+                ON DELETE CASCADE;
+            END IF;
+        END $$;
+    """)
+
+    op.execute("CREATE INDEX IF NOT EXISTS idx_ingest_runs_case_slug ON legal.ingest_runs (case_slug)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_ingest_runs_status ON legal.ingest_runs (status)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_ingest_runs_started_at ON legal.ingest_runs (started_at DESC)")
+
+    op.execute("""
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1
+                FROM pg_constraint
+                WHERE conrelid = 'legal.vault_documents'::regclass
+                  AND conname = 'fk_vault_documents_case_slug'
+                  AND condeferrable = FALSE
+            ) THEN
+                ALTER TABLE legal.vault_documents
+                DROP CONSTRAINT fk_vault_documents_case_slug;
+                ALTER TABLE legal.vault_documents
+                ADD CONSTRAINT fk_vault_documents_case_slug
+                FOREIGN KEY (case_slug) REFERENCES legal.cases (case_slug)
+                ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE;
+            END IF;
+        END $$;
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS legal.ingest_runs")
+    op.execute("DROP TABLE IF EXISTS legal.case_slug_aliases")
+    op.execute("ALTER TABLE legal.cases DROP COLUMN IF EXISTS docket")
+    op.execute("ALTER TABLE legal.cases DROP COLUMN IF EXISTS run_id")

--- a/fortress-guest-platform/backend/scripts/ocr_legal_case.py
+++ b/fortress-guest-platform/backend/scripts/ocr_legal_case.py
@@ -152,18 +152,32 @@ def _normalize_layout(case_slug: str, raw: dict | None) -> dict[str, Any]:
             },
             "recursive": False,
         }
-    root = Path(str(raw.get("root") or "")).expanduser()
-    subs = raw.get("subdirs") or {}
-    if not isinstance(subs, dict):
-        subs = {}
-    subdirs = {
-        str(k): str(v) for k, v in subs.items()
-        if v is not None and v != ""
-    }
+    if raw.get("primary_root") or raw.get("include_subdirs"):
+        root = Path(str(raw.get("primary_root") or raw.get("root") or "")).expanduser()
+        includes = raw.get("include_subdirs") or []
+        if isinstance(includes, str):
+            includes = [includes]
+        subdirs = {str(v): str(v) for v in includes if v not in (None, "")}
+        recursive_raw = raw.get("recursive")
+        recursive = True if recursive_raw is None else bool(recursive_raw)
+    else:
+        root = Path(str(raw.get("root") or "")).expanduser()
+        subs = raw.get("subdirs") or {}
+        if not isinstance(subs, dict):
+            subs = {}
+        subdirs = {
+            str(k): str(v) for k, v in subs.items()
+            if v is not None and v != ""
+        }
+        recursive = bool(raw.get("recursive"))
+    excludes = raw.get("exclude_subdirs") or []
+    if isinstance(excludes, str):
+        excludes = [excludes]
     return {
         "root":      root,
         "subdirs":   subdirs,
-        "recursive": bool(raw.get("recursive")),
+        "recursive": recursive,
+        "exclude_subdirs": {str(v).strip("/") for v in excludes if v not in (None, "")},
     }
 
 
@@ -176,6 +190,7 @@ def iter_case_pdfs(layout: dict[str, Any]) -> list[Path]:
     """
     root: Path = layout["root"]
     recursive: bool = layout["recursive"]
+    exclude_subdirs: set[str] = set(layout.get("exclude_subdirs") or set())
     seen: set[Path] = set()
     out: list[Path] = []
     for relpath in layout["subdirs"].values():
@@ -190,6 +205,14 @@ def iter_case_pdfs(layout: dict[str, Any]) -> list[Path]:
                 continue
             if any(part == "@eaDir" or part.startswith(".") for part in p.parts):
                 continue
+            if exclude_subdirs:
+                try:
+                    rel_name = str(p.relative_to(root)).strip("/")
+                except ValueError:
+                    rel_name = ""
+                if any(rel_name == ex or rel_name.startswith(f"{ex}/")
+                       for ex in exclude_subdirs):
+                    continue
             try:
                 rp = p.resolve()
             except OSError:

--- a/fortress-guest-platform/backend/scripts/vault_ingest_legal_case.py
+++ b/fortress-guest-platform/backend/scripts/vault_ingest_legal_case.py
@@ -324,17 +324,31 @@ def _normalize_layout(raw: Any) -> dict[str, Any]:
             raw = None
     if not raw:
         raise PreflightError("nas_layout is empty after normalize")
-    root = Path(str(raw.get("root") or "")).expanduser()
-    subs = raw.get("subdirs") or {}
-    if not isinstance(subs, dict):
-        subs = {}
-    subdirs = {
-        str(k): str(v) for k, v in subs.items() if v not in (None, "")
-    }
+    if raw.get("primary_root") or raw.get("include_subdirs"):
+        root = Path(str(raw.get("primary_root") or raw.get("root") or "")).expanduser()
+        includes = raw.get("include_subdirs") or []
+        if isinstance(includes, str):
+            includes = [includes]
+        subdirs = {str(v): str(v) for v in includes if v not in (None, "")}
+        recursive_raw = raw.get("recursive")
+        recursive = True if recursive_raw is None else bool(recursive_raw)
+    else:
+        root = Path(str(raw.get("root") or "")).expanduser()
+        subs = raw.get("subdirs") or {}
+        if not isinstance(subs, dict):
+            subs = {}
+        subdirs = {
+            str(k): str(v) for k, v in subs.items() if v not in (None, "")
+        }
+        recursive = bool(raw.get("recursive"))
+    excludes = raw.get("exclude_subdirs") or []
+    if isinstance(excludes, str):
+        excludes = [excludes]
     return {
         "root": root,
         "subdirs": subdirs,
-        "recursive": bool(raw.get("recursive")),
+        "recursive": recursive,
+        "exclude_subdirs": {str(v).strip("/") for v in excludes if v not in (None, "")},
     }
 
 
@@ -346,6 +360,7 @@ def walk_unique_physical_files(layout: dict[str, Any]):
     referenced from any logical subdir. Skips Synology @eaDir + dotfiles."""
     root: Path = layout["root"]
     recursive: bool = layout["recursive"]
+    exclude_subdirs: set[str] = set(layout.get("exclude_subdirs") or set())
     seen: set[Path] = set()
     for logical, rel in layout["subdirs"].items():
         walk_root = root / rel
@@ -360,6 +375,14 @@ def walk_unique_physical_files(layout: dict[str, Any]):
                 continue
             if any(part == "@eaDir" or part.startswith(".") for part in p.parts):
                 continue
+            if exclude_subdirs:
+                try:
+                    rel_name = str(p.relative_to(root)).strip("/")
+                except ValueError:
+                    rel_name = ""
+                if any(rel_name == ex or rel_name.startswith(f"{ex}/")
+                       for ex in exclude_subdirs):
+                    continue
             try:
                 canonical = p.resolve()
             except OSError:

--- a/fortress-guest-platform/ci/schema.meta.json
+++ b/fortress-guest-platform/ci/schema.meta.json
@@ -1,9 +1,9 @@
 {
   "alembic_revisions": [
-    "824b70503495"
+    "u7a8b9c0d1e2"
   ],
-  "alembic_versions_tree": "dfb8154fe59cc72a5e6688ce85f543bfa632d5c0",
-  "generated_at": "2026-05-02T00:58:30Z",
-  "source_db": "fortress_shadow",
-  "source_commit": "ebc19f9329a468b493dbc63c8f1f23b909c65f81"
+  "alembic_versions_tree": "0e3e3a0668fde0e76e076e7fc65ab7ceb44cfb58",
+  "generated_at": "2026-05-02T15:46:45Z",
+  "source_db": "fortress_pr366_schema_tmp",
+  "source_commit": "f9f0b20d7fb6df1ac67b02c616e28a3341b64ab7"
 }

--- a/fortress-guest-platform/ci/schema.sql
+++ b/fortress-guest-platform/ci/schema.sql
@@ -1,8 +1,8 @@
 -- CI schema snapshot for fortress-guest-platform
--- Generated: 2026-04-30T03:26:59Z
--- Source:    fortress_shadow
--- Commit:    9b12c17b50ae4cb1a7f15b565700d26d0d61c371
--- Alembic:   d8e3c1f5b9a6,m8f9a1b2c3d4,t6e7f8g9h0a1
+-- Generated: 2026-05-02T15:46:45Z
+-- Source:    fortress_pr366_schema_tmp
+-- Commit:    f9f0b20d7fb6df1ac67b02c616e28a3341b64ab7
+-- Alembic:   u7a8b9c0d1e2
 -- NOTE: geometry/vector types replaced with text for CI compatibility.
 --       postgis/vector extensions omitted (postgres:16 has pgcrypto/uuid-ossp).
 
@@ -18,7 +18,7 @@ SET ROLE TO fortress_admin;
 -- PostgreSQL database dump
 --
 
-\restrict 8Tbewx8mDsZ50zdgMMItGSuVglQb8T5SWHYQWi2tAYPJ332mjAX4cQYTRn4qRpX
+\restrict oPqb4ygg1oPyiqePKVPyVXYUyoPI3fxdGFdAAgBah9BgzJcCa1R5k6eDNeVMugp
 
 -- Dumped from database version 16.13 (Ubuntu 16.13-0ubuntu0.24.04.1)
 -- Dumped by pg_dump version 16.13 (Ubuntu 16.13-0ubuntu0.24.04.1)
@@ -84,22 +84,10 @@ CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
 
 
 --
--- Name: postgis; Type: EXTENSION; Schema: -; Owner: -
---
-
-
-
---
 -- Name: uuid-ossp; Type: EXTENSION; Schema: -; Owner: -
 --
 
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA public;
-
-
---
--- Name: vector; Type: EXTENSION; Schema: -; Owner: -
---
-
 
 
 --
@@ -305,7 +293,7 @@ CREATE TABLE crog_acquisition.due_diligence (
     completed_by character varying(255),
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    CONSTRAINT chk_dd_status CHECK (((status)::text = ANY ((ARRAY['pending'::character varying, 'passed'::character varying, 'failed'::character varying, 'waived'::character varying])::text[])))
+    CONSTRAINT chk_dd_status CHECK (((status)::text = ANY (ARRAY[('pending'::character varying)::text, ('passed'::character varying)::text, ('failed'::character varying)::text, ('waived'::character varying)::text])))
 );
 
 
@@ -336,7 +324,7 @@ CREATE TABLE crog_acquisition.owner_contacts (
     confidence_score numeric(3,2),
     is_dnc boolean DEFAULT false NOT NULL,
     CONSTRAINT ck_acquisition_owner_contacts_confidence_score CHECK (((confidence_score >= 0.00) AND (confidence_score <= 1.00))),
-    CONSTRAINT ck_acquisition_owner_contacts_contact_type CHECK (((contact_type)::text = ANY ((ARRAY['CELL'::character varying, 'LANDLINE'::character varying, 'EMAIL'::character varying])::text[])))
+    CONSTRAINT ck_acquisition_owner_contacts_contact_type CHECK (((contact_type)::text = ANY (ARRAY[('CELL'::character varying)::text, ('LANDLINE'::character varying)::text, ('EMAIL'::character varying)::text])))
 );
 
 
@@ -552,6 +540,17 @@ CREATE TABLE legal.case_graph_nodes_v2 (
 
 
 --
+-- Name: case_slug_aliases; Type: TABLE; Schema: legal; Owner: -
+--
+
+CREATE TABLE legal.case_slug_aliases (
+    old_slug text NOT NULL,
+    new_slug text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
 -- Name: case_statements; Type: TABLE; Schema: legal; Owner: -
 --
 
@@ -618,7 +617,13 @@ CREATE TABLE legal.cases (
     status text DEFAULT 'active'::text,
     extracted_entities jsonb DEFAULT '{}'::jsonb,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    docket text,
+    case_phase text,
+    opposing_counsel text,
+    privileged_counsel_domains jsonb DEFAULT '[]'::jsonb,
+    related_matters jsonb DEFAULT '[]'::jsonb,
+    nas_layout jsonb DEFAULT '{}'::jsonb
 );
 
 
@@ -711,6 +716,39 @@ CREATE TABLE legal.entities (
     name character varying(255) NOT NULL,
     type character varying(100) NOT NULL,
     role character varying(100)
+);
+
+
+--
+-- Name: ingest_runs; Type: TABLE; Schema: legal; Owner: -
+--
+
+CREATE TABLE legal.ingest_runs (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    run_id uuid DEFAULT gen_random_uuid(),
+    case_slug text NOT NULL,
+    script_name text NOT NULL,
+    invocation_args jsonb DEFAULT '{}'::jsonb NOT NULL,
+    args jsonb DEFAULT '{}'::jsonb NOT NULL,
+    started_at timestamp with time zone DEFAULT now() NOT NULL,
+    completed_at timestamp with time zone,
+    ended_at timestamp with time zone,
+    status text DEFAULT 'running'::text NOT NULL,
+    files_processed integer DEFAULT 0 NOT NULL,
+    files_succeeded integer DEFAULT 0 NOT NULL,
+    files_failed integer DEFAULT 0 NOT NULL,
+    total_files integer,
+    processed integer DEFAULT 0 NOT NULL,
+    errored integer DEFAULT 0 NOT NULL,
+    skipped integer DEFAULT 0 NOT NULL,
+    error_summary text,
+    manifest_path text,
+    host text,
+    pid integer,
+    runtime_seconds numeric(12,3),
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT ingest_runs_status_check CHECK ((status = ANY (ARRAY['running'::text, 'complete'::text, 'completed'::text, 'error'::text, 'failed'::text, 'interrupted'::text])))
 );
 
 
@@ -909,7 +947,7 @@ CREATE TABLE public.agent_queue (
     error_log text,
     created_at timestamp with time zone NOT NULL,
     updated_at timestamp with time zone NOT NULL,
-    CONSTRAINT ck_agent_queue_status CHECK (((status)::text = ANY ((ARRAY['pending_review'::character varying, 'approved'::character varying, 'edited'::character varying, 'rejected'::character varying, 'sending'::character varying, 'delivered'::character varying, 'failed'::character varying])::text[])))
+    CONSTRAINT ck_agent_queue_status CHECK (((status)::text = ANY (ARRAY[('pending_review'::character varying)::text, ('approved'::character varying)::text, ('edited'::character varying)::text, ('rejected'::character varying)::text, ('sending'::character varying)::text, ('delivered'::character varying)::text, ('failed'::character varying)::text])))
 );
 
 
@@ -967,7 +1005,7 @@ CREATE TABLE public.agent_runs (
     status character varying(9) DEFAULT 'queued'::character varying NOT NULL,
     started_at timestamp with time zone DEFAULT now() NOT NULL,
     completed_at timestamp with time zone,
-    CONSTRAINT agent_run_status CHECK (((status)::text = ANY ((ARRAY['queued'::character varying, 'running'::character varying, 'completed'::character varying, 'failed'::character varying, 'escalated'::character varying, 'blocked'::character varying])::text[])))
+    CONSTRAINT agent_run_status CHECK (((status)::text = ANY (ARRAY[('queued'::character varying)::text, ('running'::character varying)::text, ('completed'::character varying)::text, ('failed'::character varying)::text, ('escalated'::character varying)::text, ('blocked'::character varying)::text])))
 );
 
 
@@ -1041,7 +1079,7 @@ CREATE TABLE public.async_job_runs (
     started_at timestamp with time zone,
     finished_at timestamp with time zone,
     updated_at timestamp with time zone NOT NULL,
-    CONSTRAINT ck_async_job_runs_status CHECK (((status)::text = ANY ((ARRAY['queued'::character varying, 'running'::character varying, 'succeeded'::character varying, 'failed'::character varying, 'cancelled'::character varying])::text[])))
+    CONSTRAINT ck_async_job_runs_status CHECK (((status)::text = ANY (ARRAY[('queued'::character varying)::text, ('running'::character varying)::text, ('succeeded'::character varying)::text, ('failed'::character varying)::text, ('cancelled'::character varying)::text])))
 );
 
 
@@ -1220,7 +1258,7 @@ CREATE TABLE public.competitor_listings (
     last_observed timestamp with time zone DEFAULT now() NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    CONSTRAINT ota_provider CHECK (((platform)::text = ANY ((ARRAY['airbnb'::character varying, 'vrbo'::character varying, 'booking_com'::character varying])::text[])))
+    CONSTRAINT ota_provider CHECK (((platform)::text = ANY (ARRAY[('airbnb'::character varying)::text, ('vrbo'::character varying)::text, ('booking_com'::character varying)::text])))
 );
 
 
@@ -1242,7 +1280,7 @@ CREATE TABLE public.concierge_queue (
     status character varying(30) NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    CONSTRAINT ck_concierge_queue_status CHECK (((status)::text = ANY ((ARRAY['pending_review'::character varying, 'approved'::character varying, 'rejected'::character varying, 'sent'::character varying, 'failed'::character varying])::text[])))
+    CONSTRAINT ck_concierge_queue_status CHECK (((status)::text = ANY (ARRAY[('pending_review'::character varying)::text, ('approved'::character varying)::text, ('rejected'::character varying)::text, ('sent'::character varying)::text, ('failed'::character varying)::text])))
 );
 
 
@@ -1419,8 +1457,8 @@ CREATE TABLE public.email_messages (
     extra_data jsonb,
     has_attachments boolean DEFAULT false NOT NULL,
     image_descriptions jsonb,
-    CONSTRAINT ck_email_messages_approval_status CHECK (((approval_status)::text = ANY ((ARRAY['pending_approval'::character varying, 'approved'::character varying, 'rejected'::character varying, 'sent'::character varying, 'send_failed'::character varying, 'no_draft_needed'::character varying])::text[]))),
-    CONSTRAINT ck_email_messages_direction CHECK (((direction)::text = ANY ((ARRAY['inbound'::character varying, 'outbound'::character varying])::text[])))
+    CONSTRAINT ck_email_messages_approval_status CHECK (((approval_status)::text = ANY (ARRAY[('pending_approval'::character varying)::text, ('approved'::character varying)::text, ('rejected'::character varying)::text, ('sent'::character varying)::text, ('send_failed'::character varying)::text, ('no_draft_needed'::character varying)::text]))),
+    CONSTRAINT ck_email_messages_direction CHECK (((direction)::text = ANY (ARRAY[('inbound'::character varying)::text, ('outbound'::character varying)::text])))
 );
 
 
@@ -1895,7 +1933,7 @@ CREATE TABLE public.hunter_queue (
     last_error text,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    CONSTRAINT ck_hunter_queue_status CHECK (((status)::text = ANY ((ARRAY['queued'::character varying, 'processing'::character varying, 'sent'::character varying, 'failed'::character varying, 'cancelled'::character varying])::text[])))
+    CONSTRAINT ck_hunter_queue_status CHECK (((status)::text = ANY (ARRAY[('queued'::character varying)::text, ('processing'::character varying)::text, ('sent'::character varying)::text, ('failed'::character varying)::text, ('cancelled'::character varying)::text])))
 );
 
 
@@ -2367,7 +2405,7 @@ CREATE TABLE public.operator_overrides (
     override_action character varying(7) NOT NULL,
     final_payload jsonb NOT NULL,
     "timestamp" timestamp with time zone DEFAULT now() NOT NULL,
-    CONSTRAINT operator_override_action CHECK (((override_action)::text = ANY ((ARRAY['approve'::character varying, 'reject'::character varying, 'modify'::character varying])::text[])))
+    CONSTRAINT operator_override_action CHECK (((override_action)::text = ANY (ARRAY[('approve'::character varying)::text, ('reject'::character varying)::text, ('modify'::character varying)::text])))
 );
 
 
@@ -2702,8 +2740,8 @@ CREATE TABLE public.owner_statement_sends (
     error_message text,
     is_test boolean DEFAULT false NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
-    CONSTRAINT owner_statement_sends_comparison_status_check CHECK (((comparison_status)::text = ANY ((ARRAY['match'::character varying, 'mismatch'::character varying, 'streamline_unavailable'::character varying, 'not_compared'::character varying])::text[]))),
-    CONSTRAINT owner_statement_sends_source_used_check CHECK (((source_used)::text = ANY ((ARRAY['crog'::character varying, 'streamline'::character varying, 'failed'::character varying])::text[])))
+    CONSTRAINT owner_statement_sends_comparison_status_check CHECK (((comparison_status)::text = ANY (ARRAY[('match'::character varying)::text, ('mismatch'::character varying)::text, ('streamline_unavailable'::character varying)::text, ('not_compared'::character varying)::text]))),
+    CONSTRAINT owner_statement_sends_source_used_check CHECK (((source_used)::text = ANY (ARRAY[('crog'::character varying)::text, ('streamline'::character varying)::text, ('failed'::character varying)::text])))
 );
 
 
@@ -2897,7 +2935,7 @@ CREATE TABLE public.property_images (
     alt_text character varying(512) DEFAULT ''::character varying NOT NULL,
     is_hero boolean DEFAULT false NOT NULL,
     status character varying(20) DEFAULT 'pending'::character varying NOT NULL,
-    CONSTRAINT ck_property_images_status CHECK (((status)::text = ANY ((ARRAY['pending'::character varying, 'ingested'::character varying, 'failed'::character varying])::text[])))
+    CONSTRAINT ck_property_images_status CHECK (((status)::text = ANY (ARRAY[('pending'::character varying)::text, ('ingested'::character varying)::text, ('failed'::character varying)::text])))
 );
 
 
@@ -3106,7 +3144,7 @@ CREATE TABLE public.reservation_holds (
     created_at timestamp with time zone NOT NULL,
     updated_at timestamp with time zone NOT NULL,
     CONSTRAINT ck_reservation_holds_date_order CHECK ((check_out_date > check_in_date)),
-    CONSTRAINT ck_reservation_holds_status CHECK (((status)::text = ANY ((ARRAY['active'::character varying, 'expired'::character varying, 'converted'::character varying])::text[])))
+    CONSTRAINT ck_reservation_holds_status CHECK (((status)::text = ANY (ARRAY[('active'::character varying)::text, ('expired'::character varying)::text, ('converted'::character varying)::text])))
 );
 
 
@@ -3268,8 +3306,8 @@ CREATE TABLE public.seo_patch_queue (
     deployed_at timestamp without time zone,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    CONSTRAINT ck_seo_patch_queue_status CHECK (((status)::text = ANY ((ARRAY['proposed'::character varying, 'needs_revision'::character varying, 'approved'::character varying, 'rejected'::character varying, 'deployed'::character varying, 'superseded'::character varying])::text[]))),
-    CONSTRAINT ck_seo_patch_queue_target_type CHECK (((target_type)::text = ANY ((ARRAY['property'::character varying, 'archive_review'::character varying])::text[])))
+    CONSTRAINT ck_seo_patch_queue_status CHECK (((status)::text = ANY (ARRAY[('proposed'::character varying)::text, ('needs_revision'::character varying)::text, ('approved'::character varying)::text, ('rejected'::character varying)::text, ('deployed'::character varying)::text, ('superseded'::character varying)::text]))),
+    CONSTRAINT ck_seo_patch_queue_target_type CHECK (((target_type)::text = ANY (ARRAY[('property'::character varying)::text, ('archive_review'::character varying)::text])))
 );
 
 
@@ -3359,7 +3397,7 @@ CREATE TABLE public.seo_redirect_remap_queue (
     approved_at timestamp without time zone,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    CONSTRAINT ck_seo_redirect_remap_queue_status CHECK (((status)::text = ANY ((ARRAY['proposed'::character varying, 'promoted'::character varying, 'rejected'::character varying, 'applied'::character varying, 'superseded'::character varying])::text[])))
+    CONSTRAINT ck_seo_redirect_remap_queue_status CHECK (((status)::text = ANY (ARRAY[('proposed'::character varying)::text, ('promoted'::character varying)::text, ('rejected'::character varying)::text, ('applied'::character varying)::text, ('superseded'::character varying)::text])))
 );
 
 
@@ -3454,7 +3492,7 @@ CREATE TABLE public.staff_users (
     notify_workorders boolean DEFAULT true NOT NULL,
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL,
-    CONSTRAINT staff_role CHECK (((role)::text = ANY ((ARRAY['super_admin'::character varying, 'admin'::character varying, 'manager'::character varying, 'reviewer'::character varying, 'operator'::character varying, 'staff'::character varying, 'maintenance'::character varying])::text[])))
+    CONSTRAINT staff_role CHECK (((role)::text = ANY (ARRAY[('super_admin'::character varying)::text, ('admin'::character varying)::text, ('manager'::character varying)::text, ('reviewer'::character varying)::text, ('operator'::character varying)::text, ('staff'::character varying)::text, ('maintenance'::character varying)::text])))
 );
 
 
@@ -3569,7 +3607,7 @@ CREATE TABLE public.swarm_escalations (
     decision_id uuid NOT NULL,
     reason_code character varying(100) NOT NULL,
     status character varying(8) DEFAULT 'pending'::character varying NOT NULL,
-    CONSTRAINT swarm_escalation_status CHECK (((status)::text = ANY ((ARRAY['pending'::character varying, 'resolved'::character varying])::text[])))
+    CONSTRAINT swarm_escalation_status CHECK (((status)::text = ANY (ARRAY[('pending'::character varying)::text, ('resolved'::character varying)::text])))
 );
 
 
@@ -3633,7 +3671,7 @@ CREATE TABLE public.trust_accounts (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     name character varying(255) NOT NULL,
     type character varying(9) NOT NULL,
-    CONSTRAINT trust_account_type CHECK (((type)::text = ANY ((ARRAY['asset'::character varying, 'liability'::character varying])::text[])))
+    CONSTRAINT trust_account_type CHECK (((type)::text = ANY (ARRAY[('asset'::character varying)::text, ('liability'::character varying)::text])))
 );
 
 
@@ -3683,7 +3721,7 @@ CREATE TABLE public.trust_decisions (
     policy_evaluation jsonb NOT NULL,
     status character varying(13) NOT NULL,
     CONSTRAINT ck_trust_decisions_deterministic_score_nonnegative CHECK ((deterministic_score >= (0)::double precision)),
-    CONSTRAINT trust_decision_status CHECK (((status)::text = ANY ((ARRAY['auto_approved'::character varying, 'escalated'::character varying, 'blocked'::character varying])::text[])))
+    CONSTRAINT trust_decision_status CHECK (((status)::text = ANY (ARRAY[('auto_approved'::character varying)::text, ('escalated'::character varying)::text, ('blocked'::character varying)::text])))
 );
 
 
@@ -3698,7 +3736,7 @@ CREATE TABLE public.trust_ledger_entries (
     amount_cents integer NOT NULL,
     entry_type character varying(6) NOT NULL,
     CONSTRAINT ck_trust_ledger_entries_amount_positive CHECK ((amount_cents > 0)),
-    CONSTRAINT trust_ledger_entry_type CHECK (((entry_type)::text = ANY ((ARRAY['debit'::character varying, 'credit'::character varying])::text[])))
+    CONSTRAINT trust_ledger_entry_type CHECK (((entry_type)::text = ANY (ARRAY[('debit'::character varying)::text, ('credit'::character varying)::text])))
 );
 
 
@@ -3840,8 +3878,8 @@ CREATE TABLE public.vrs_add_ons (
     updated_at timestamp without time zone NOT NULL,
     CONSTRAINT ck_vrs_add_ons_price_nonnegative CHECK ((price >= (0)::numeric)),
     CONSTRAINT ck_vrs_add_ons_scope_property_consistency CHECK (((((scope)::text = 'global'::text) AND (property_id IS NULL)) OR (((scope)::text = 'property_specific'::text) AND (property_id IS NOT NULL)))),
-    CONSTRAINT vrs_add_on_pricing_model CHECK (((pricing_model)::text = ANY ((ARRAY['flat_fee'::character varying, 'per_night'::character varying, 'per_guest'::character varying])::text[]))),
-    CONSTRAINT vrs_add_on_scope CHECK (((scope)::text = ANY ((ARRAY['global'::character varying, 'property_specific'::character varying])::text[])))
+    CONSTRAINT vrs_add_on_pricing_model CHECK (((pricing_model)::text = ANY (ARRAY[('flat_fee'::character varying)::text, ('per_night'::character varying)::text, ('per_guest'::character varying)::text]))),
+    CONSTRAINT vrs_add_on_scope CHECK (((scope)::text = ANY (ARRAY[('global'::character varying)::text, ('property_specific'::character varying)::text])))
 );
 
 
@@ -4337,6 +4375,14 @@ ALTER TABLE ONLY legal.case_graph_nodes_v2
 
 
 --
+-- Name: case_slug_aliases case_slug_aliases_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.case_slug_aliases
+    ADD CONSTRAINT case_slug_aliases_pkey PRIMARY KEY (old_slug);
+
+
+--
 -- Name: case_statements case_statements_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
 --
 
@@ -4409,6 +4455,22 @@ ALTER TABLE ONLY legal.entities
 
 
 --
+-- Name: ingest_runs ingest_runs_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.ingest_runs
+    ADD CONSTRAINT ingest_runs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ingest_runs ingest_runs_run_id_key; Type: CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.ingest_runs
+    ADD CONSTRAINT ingest_runs_run_id_key UNIQUE (run_id);
+
+
+--
 -- Name: legal_cases legal_cases_pkey; Type: CONSTRAINT; Schema: legal; Owner: -
 --
 
@@ -4454,6 +4516,14 @@ ALTER TABLE ONLY legal.sanctions_tripwire_runs_v2
 
 ALTER TABLE ONLY legal.timeline_events
     ADD CONSTRAINT timeline_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ingest_runs uq_ingest_runs_run_id; Type: CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.ingest_runs
+    ADD CONSTRAINT uq_ingest_runs_run_id UNIQUE (run_id);
 
 
 --
@@ -5845,12 +5915,6 @@ CREATE INDEX idx_acquisition_parcels_assessed ON crog_acquisition.parcels USING 
 
 
 --
--- Name: idx_acquisition_parcels_geom; Type: INDEX; Schema: crog_acquisition; Owner: -
---
-
-
-
---
 -- Name: idx_acquisition_pipeline_next_action_date; Type: INDEX; Schema: crog_acquisition; Owner: -
 --
 
@@ -5960,6 +6024,27 @@ CREATE UNIQUE INDEX ix_iot_schema_digital_twins_device_id ON iot_schema.digital_
 --
 
 CREATE INDEX ix_iot_schema_digital_twins_property_id ON iot_schema.digital_twins USING btree (property_id);
+
+
+--
+-- Name: idx_ingest_runs_case_slug; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX idx_ingest_runs_case_slug ON legal.ingest_runs USING btree (case_slug);
+
+
+--
+-- Name: idx_ingest_runs_started_at; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX idx_ingest_runs_started_at ON legal.ingest_runs USING btree (started_at DESC);
+
+
+--
+-- Name: idx_ingest_runs_status; Type: INDEX; Schema: legal; Owner: -
+--
+
+CREATE INDEX idx_ingest_runs_status ON legal.ingest_runs USING btree (status);
 
 
 --
@@ -9206,6 +9291,22 @@ ALTER TABLE ONLY legal.discovery_draft_items_v2
 
 
 --
+-- Name: case_slug_aliases fk_case_slug_aliases_new_slug; Type: FK CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.case_slug_aliases
+    ADD CONSTRAINT fk_case_slug_aliases_new_slug FOREIGN KEY (new_slug) REFERENCES legal.cases(case_slug) DEFERRABLE;
+
+
+--
+-- Name: ingest_runs fk_ingest_runs_case_slug; Type: FK CONSTRAINT; Schema: legal; Owner: -
+--
+
+ALTER TABLE ONLY legal.ingest_runs
+    ADD CONSTRAINT fk_ingest_runs_case_slug FOREIGN KEY (case_slug) REFERENCES legal.cases(case_slug) ON DELETE CASCADE;
+
+
+--
 -- Name: timeline_events timeline_events_source_evidence_id_fkey; Type: FK CONSTRAINT; Schema: legal; Owner: -
 --
 
@@ -10121,4 +10222,4 @@ ALTER TABLE ONLY public.yield_simulations
 -- PostgreSQL database dump complete
 --
 
-\unrestrict 8Tbewx8mDsZ50zdgMMItGSuVglQb8T5SWHYQWi2tAYPJ332mjAX4cQYTRn4qRpX
+\unrestrict oPqb4ygg1oPyiqePKVPyVXYUyoPI3fxdGFdAAgBah9BgzJcCa1R5k6eDNeVMugp


### PR DESCRIPTION
## What this PR does

Authors / fixes alembic migration to create and reconcile `legal.cases` and `legal.ingest_runs` tables required by `process_vault_upload`, `IngestRunTracker`, and `vault_ingest_legal_case.py`.

## Path taken

Path alpha. Alembic CLI was failing in `backend/alembic/env.py` with `ModuleNotFoundError: No module named backend`; `backend/alembic.ini` now prepends the `fortress-guest-platform` root. With CLI clean, this PR adds a new head migration and keeps ingest/OCR layout parsing aligned with the clean curated-path `nas_layout` contract.

## Schema details

Per Constitution section 11.1 locked schema surfaces.

`legal.cases` is keyed on `case_slug` with `related_matters` and `nas_layout` JSONB. `nas_layout` is populated to point Case I and Case II at `Corporate_Legal/Business_Legal/<slug>/curated` subdirs only, explicitly excluding the legacy `legal_vault/7il-v-knight-ndga/` mixed dump that was source of the case_slug poisoning resolved in PR #365.

`legal.ingest_runs` has `run_id` UNIQUE, status lifecycle, file counts, plus compatibility columns used by PR D-pre1 `IngestRunTracker`.

## Operator action required at merge time

Run from iMac:
```bash
cd ~/Fortress-Prime/fortress-guest-platform
.uv-venv/bin/alembic -c backend/alembic.ini upgrade head
```

If alembic CLI is still broken, apply via raw psql:
```bash
psql $POSTGRES_URI -c "$(extract_upgrade_sql_from_migration_file)"
```

## Cross-references
- Constitution section 11.1, section 11.2
- GH #363 (schema reconciliation tracker)
- PR #365 (corpus purge, landed first)
- Blocks PARTS C/D/E of Wave 7 corpus rebuild brief

## Out of scope
- Catalog backfill of pre-existing Case I content (PART D handles)
- Broader Alembic housekeeping beyond the import-path fix needed for Path alpha