### PR TITLE
Harden legal vault retry + ingest run counters

### DIFF
--- a/fortress-guest-platform/backend/services/ingest_run_tracker.py
+++ b/fortress-guest-platform/backend/services/ingest_run_tracker.py
@@ -126,17 +126,18 @@ class IngestRunTracker:
         self._started_monotonic = time.monotonic()
         host = socket.gethostname()
         pid = os.getpid()
+        args_json = json.dumps(self.args, default=str)
         ok = self._exec_with_retry(
             """
             INSERT INTO legal.ingest_runs (
-                case_slug, script_name, args, host, pid, status,
+                case_slug, script_name, args, invocation_args, host, pid, status,
                 started_at
-            ) VALUES (%s, %s, %s::jsonb, %s, %s, 'running', NOW())
+            ) VALUES (%s, %s, %s::jsonb, %s::jsonb, %s, %s, 'running', NOW())
             RETURNING id
             """,
             (
                 self.case_slug, self.script_name,
-                json.dumps(self.args, default=str),
+                args_json, args_json,
                 host, pid,
             ),
             fetch_one=True,
@@ -174,21 +175,32 @@ class IngestRunTracker:
 
     def inc_processed(self, n: int = 1) -> None:
         self._counters.processed += n
-        self._update_counters(processed=self._counters.processed)
+        self._update_counters(
+            processed=self._counters.processed,
+            **self._locked_counter_fields(),
+        )
 
     def inc_errored(self, n: int = 1) -> None:
         self._counters.errored += n
-        self._update_counters(errored=self._counters.errored)
+        self._update_counters(
+            errored=self._counters.errored,
+            **self._locked_counter_fields(),
+        )
 
     def inc_skipped(self, n: int = 1) -> None:
         self._counters.skipped += n
-        self._update_counters(skipped=self._counters.skipped)
+        self._update_counters(
+            skipped=self._counters.skipped,
+            **self._locked_counter_fields(),
+        )
 
     def update(self, **fields: Any) -> None:
         """Bulk update. Keys must be column names of legal.ingest_runs."""
         if "processed" in fields: self._counters.processed = int(fields["processed"])
         if "errored"   in fields: self._counters.errored   = int(fields["errored"])
         if "skipped"   in fields: self._counters.skipped   = int(fields["skipped"])
+        if {"processed", "errored", "skipped"} & fields.keys():
+            fields = {**fields, **self._locked_counter_fields()}
         self._update_counters(**fields)
 
     # ─── private: writes ───────────────────────────────────────────────────
@@ -199,7 +211,12 @@ class IngestRunTracker:
     ) -> None:
         if self.run_id is None:
             return                          # tracker degraded at __enter__
-        sets = ["status = %s", "ended_at = NOW()", "updated_at = NOW()"]
+        sets = [
+            "status = %s",
+            "ended_at = NOW()",
+            "completed_at = NOW()",
+            "updated_at = NOW()",
+        ]
         params: list[Any] = [status]
         if runtime is not None:
             sets.append("runtime_seconds = %s")
@@ -212,6 +229,18 @@ class IngestRunTracker:
             f"UPDATE legal.ingest_runs SET {', '.join(sets)} WHERE id = %s",
             tuple(params),
         )
+
+    def _locked_counter_fields(self) -> dict[str, int]:
+        files_seen = (
+            self._counters.processed
+            + self._counters.skipped
+            + self._counters.errored
+        )
+        return {
+            "files_processed": files_seen,
+            "files_succeeded": self._counters.processed,
+            "files_failed": self._counters.errored,
+        }
 
     def _update_counters(self, **fields: Any) -> None:
         if self.run_id is None or not fields:

--- a/fortress-guest-platform/backend/services/legal_ediscovery.py
+++ b/fortress-guest-platform/backend/services/legal_ediscovery.py
@@ -544,6 +544,13 @@ async def _upsert_to_qdrant_privileged(
 
 # ── Main Ingestion Pipeline ──────────────────────────────────────
 
+_DUPLICATE_TERMINAL_STATUSES = {"completed", "ocr_failed", "locked_privileged"}
+
+
+def _strip_postgres_nuls(text_value: str) -> str:
+    return text_value.replace("\x00", "")
+
+
 async def process_vault_upload(
     db: AsyncSession,
     case_slug: str,
@@ -557,8 +564,29 @@ async def process_vault_upload(
         text("SELECT id FROM legal.vault_documents WHERE case_slug = :slug AND file_hash = :hash"),
         {"slug": case_slug, "hash": fhash},
     )
-    if fast_dup.fetchone():
-        return {"status": "duplicate", "file_name": file_name, "file_hash": fhash}
+    duplicate_row = fast_dup.fetchone()
+    if duplicate_row:
+        existing_id = duplicate_row[0]
+        status_result = await db.execute(
+            text(
+                "SELECT processing_status FROM legal.vault_documents "
+                "WHERE id = :id AND case_slug = :slug"
+            ),
+            {"id": existing_id, "slug": case_slug},
+        )
+        status_row = status_result.fetchone()
+        existing_status = status_row[0] if status_row else None
+        if existing_status not in _DUPLICATE_TERMINAL_STATUSES:
+            await db.execute(
+                text(
+                    "DELETE FROM legal.vault_documents "
+                    "WHERE id = :id AND case_slug = :slug"
+                ),
+                {"id": existing_id, "slug": case_slug},
+            )
+            await db.commit()
+        else:
+            return {"status": "duplicate", "file_name": file_name, "file_hash": fhash}
 
     doc_id = str(uuid4())
     vault_dir = _resolve_vault_dir(case_slug)
@@ -600,7 +628,9 @@ async def process_vault_upload(
     )
 
     try:
-        raw_text = _extract_text(file_bytes, mime_type, file_name)
+        raw_text = _strip_postgres_nuls(
+            _extract_text(file_bytes, mime_type, file_name)
+        )
 
         # ── Image-only PDF guard ──────────────────────────────
         # If text extraction yields nothing on a PDF, there is no signal
@@ -911,11 +941,43 @@ async def process_vault_upload(
         }
 
     except Exception as exc:
-        await db.execute(
-            text("UPDATE legal.vault_documents SET processing_status = 'failed', error_detail = :err WHERE id = :id"),
-            {"id": doc_id, "err": str(exc)[:1000]},
-        )
-        await db.commit()
+        try:
+            await db.rollback()
+        except Exception as rollback_exc:
+            logger.warning(
+                "vault_upload_failure_rollback_failed",
+                doc_id=doc_id,
+                error=str(rollback_exc)[:300],
+            )
+
+        try:
+            await db.execute(
+                text(
+                    "UPDATE legal.vault_documents "
+                    "SET processing_status = 'failed', error_detail = :err "
+                    "WHERE id = :id"
+                ),
+                {"id": doc_id, "err": str(exc)[:1000]},
+            )
+            await db.commit()
+        except Exception as mark_exc:
+            try:
+                await db.rollback()
+            except Exception:
+                pass
+            logger.error(
+                "vault_upload_failed_mark_failed_failed",
+                doc_id=doc_id,
+                original_error=str(exc)[:300],
+                mark_error=str(mark_exc)[:300],
+            )
+            return {
+                "status": "failed",
+                "document_id": doc_id,
+                "error": str(exc)[:200],
+                "mark_failed_error": str(mark_exc)[:200],
+            }
+
         logger.error("vault_upload_failed", doc_id=doc_id, error=str(exc)[:300])
         return {"status": "failed", "document_id": doc_id, "error": str(exc)[:200]}
 

--- a/fortress-guest-platform/backend/tests/test_ingest_run_tracker.py
+++ b/fortress-guest-platform/backend/tests/test_ingest_run_tracker.py
@@ -167,9 +167,26 @@ class TestIncCountersAtomic:
         # Inspect the last UPDATE for each counter — should reflect the
         # cumulative running total, not the delta.
         all_calls = [c for conn in state["connections"] for c in conn.calls]
-        proc_updates = [c for c in all_calls if "processed = %s" in c[0]]
+        proc_updates = [c for c in all_calls if "SET processed = %s" in c[0]]
         # Last processed-update should carry the total (6).
         assert proc_updates and proc_updates[-1][1][0] == 6
+
+        locked_counter_updates = [
+            c for c in all_calls
+            if "files_processed = %s" in c[0]
+            and "files_succeeded = %s" in c[0]
+            and "files_failed = %s" in c[0]
+        ]
+        assert locked_counter_updates
+        last_locked_sql, last_locked_params = locked_counter_updates[-1]
+        locked_fields = [
+            part.strip().split(" = ")[0]
+            for part in last_locked_sql.split("SET", 1)[1].split("WHERE", 1)[0].split(",")
+        ]
+        locked_values = dict(zip(locked_fields, last_locked_params))
+        assert locked_values["files_processed"] == 10
+        assert locked_values["files_succeeded"] == 6
+        assert locked_values["files_failed"] == 1
 
 
 class TestSetManifestPath:
@@ -342,3 +359,4 @@ class TestInvalidCaseSlugFailsFast:
             pass
 
         assert seen and seen[0][0] == "ghost-case"
+        assert seen[0][2] == seen[0][3]

--- a/fortress-guest-platform/backend/tests/test_legal_ediscovery_vault.py
+++ b/fortress-guest-platform/backend/tests/test_legal_ediscovery_vault.py
@@ -91,6 +91,8 @@ async def test_process_vault_upload_dedups_by_case_hash(
         sql_text = str(stmt)
         if "SELECT id FROM legal.vault_documents" in sql_text:
             return _FakeResult(fetch_value=_FakeRow("existing-id"))
+        if "SELECT processing_status FROM legal.vault_documents" in sql_text:
+            return _FakeResult(fetch_value=_FakeRow("completed"))
         if "INSERT INTO legal.vault_documents" in sql_text:
             seen_inserts.append(sql_text)
         return _FakeResult()
@@ -140,7 +142,7 @@ async def test_process_vault_upload_different_cases_same_hash(
     )
     monkeypatch.setattr(
         legal_ediscovery, "_upsert_to_qdrant",
-        AsyncMock(return_value=2),
+        AsyncMock(return_value=(["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"], None)),
     )
     monkeypatch.setattr(
         legal_ediscovery, "_emit_docket_updated_event",
@@ -178,16 +180,10 @@ async def test_process_vault_upload_different_cases_same_hash(
 
 
 @pytest.mark.asyncio
-async def test_process_vault_upload_qdrant_failure_marks_completed_with_zero_indexed(
+async def test_process_vault_upload_qdrant_failure_marks_qdrant_upsert_failed(
     monkeypatch: pytest.MonkeyPatch, tmp_path,
 ) -> None:
-    """Vector store failure must not orphan the row.
-
-    Spec wording was 'leaves pending' but the live code's design is to mark
-    it completed with vectors_indexed=0 — operators get an actionable signal
-    via vectors_indexed rather than chasing pending rows. We assert the
-    actual contract.
-    """
+    """Vector store failure must not orphan the row in pending."""
     monkeypatch.setattr(
         legal_ediscovery, "_resolve_vault_dir", lambda _slug: tmp_path,
     )
@@ -211,7 +207,7 @@ async def test_process_vault_upload_qdrant_failure_marks_completed_with_zero_ind
     )
     monkeypatch.setattr(
         legal_ediscovery, "_upsert_to_qdrant",
-        AsyncMock(return_value=0),  # qdrant down / failed
+        AsyncMock(return_value=([], {"batch_index": 0, "error": "qdrant down"})),
     )
     monkeypatch.setattr(
         legal_ediscovery, "_emit_docket_updated_event",
@@ -236,8 +232,8 @@ async def test_process_vault_upload_qdrant_failure_marks_completed_with_zero_ind
         mime_type="application/pdf",
     )
 
-    assert result["status"] == "completed"
-    assert result["vectors_indexed"] == 0
+    assert result["status"] == "qdrant_upsert_failed"
+    assert result["partial_indexed"] == 0
 
 
 # ── 4. image-only PDF → ocr_failed early exit ───────────────────────
@@ -293,6 +289,174 @@ async def test_process_vault_upload_image_only_pdf_marks_ocr_failed(
     privilege_mock.assert_not_awaited()
     embed_mock.assert_not_awaited()
     qdrant_mock.assert_not_awaited()
+
+
+
+
+@pytest.mark.asyncio
+async def test_process_vault_upload_retries_non_terminal_same_hash(
+    monkeypatch: pytest.MonkeyPatch, tmp_path,
+) -> None:
+    """A failed/pending row with the same hash should not mask a retry."""
+    monkeypatch.setattr(
+        legal_ediscovery, "_resolve_vault_dir", lambda _slug: tmp_path,
+    )
+    monkeypatch.setattr(
+        legal_ediscovery, "_extract_text",
+        lambda _b, _m, _n: "retry body text",
+    )
+    monkeypatch.setattr(
+        legal_ediscovery, "_classify_privilege",
+        AsyncMock(return_value=(MagicMock(
+            is_privileged=False, confidence=0.0,
+            privilege_type=None, reasoning=None,
+        ), 1)),
+    )
+    monkeypatch.setattr(
+        legal_ediscovery, "_chunk_document", lambda _t: ["chunk1"],
+    )
+    monkeypatch.setattr(
+        legal_ediscovery, "_embed_chunks",
+        AsyncMock(return_value=[[0.1] * 8]),
+    )
+    monkeypatch.setattr(
+        legal_ediscovery, "_upsert_to_qdrant",
+        AsyncMock(return_value=(["00000000-0000-0000-0000-000000000001"], None)),
+    )
+    monkeypatch.setattr(
+        legal_ediscovery, "_emit_docket_updated_event",
+        AsyncMock(return_value=False),
+    )
+
+    deletes_seen = 0
+    inserts_seen = 0
+
+    def _exec_side_effect(stmt, *args, **kwargs):
+        nonlocal deletes_seen, inserts_seen
+        sql_text = str(stmt)
+        if "SELECT id FROM legal.vault_documents" in sql_text:
+            return _FakeResult(fetch_value=_FakeRow("stale-id"))
+        if "SELECT processing_status FROM legal.vault_documents" in sql_text:
+            return _FakeResult(fetch_value=_FakeRow("failed"))
+        if "DELETE FROM legal.vault_documents" in sql_text:
+            deletes_seen += 1
+            return _FakeResult()
+        if "INSERT INTO legal.vault_documents" in sql_text:
+            inserts_seen += 1
+            return _FakeResult(fetch_value=_FakeRow("new-id"))
+        return _FakeResult()
+
+    db = _make_db_session(_exec_side_effect)
+
+    result = await legal_ediscovery.process_vault_upload(
+        db=db,
+        case_slug="retry-case",
+        file_bytes=b"same bytes",
+        file_name="retry.ptx",
+        mime_type="application/octet-stream",
+    )
+
+    assert result["status"] == "completed"
+    assert deletes_seen == 1
+    assert inserts_seen == 1
+
+
+@pytest.mark.asyncio
+async def test_process_vault_upload_strips_postgres_nuls(
+    monkeypatch: pytest.MonkeyPatch, tmp_path,
+) -> None:
+    monkeypatch.setattr(
+        legal_ediscovery, "_resolve_vault_dir", lambda _slug: tmp_path,
+    )
+    monkeypatch.setattr(
+        legal_ediscovery, "_extract_text",
+        lambda _b, _m, _n: "hello\x00world",
+    )
+    classifier = AsyncMock(return_value=(MagicMock(
+        is_privileged=False, confidence=0.0,
+        privilege_type=None, reasoning=None,
+    ), 1))
+    monkeypatch.setattr(legal_ediscovery, "_classify_privilege", classifier)
+    monkeypatch.setattr(
+        legal_ediscovery, "_chunk_document", lambda text: [text],
+    )
+    monkeypatch.setattr(
+        legal_ediscovery, "_embed_chunks", AsyncMock(return_value=[[0.1] * 8]),
+    )
+    monkeypatch.setattr(
+        legal_ediscovery, "_upsert_to_qdrant",
+        AsyncMock(return_value=(["00000000-0000-0000-0000-000000000001"], None)),
+    )
+    monkeypatch.setattr(
+        legal_ediscovery, "_emit_docket_updated_event",
+        AsyncMock(return_value=False),
+    )
+
+    def _exec_side_effect(stmt, *args, **kwargs):
+        sql_text = str(stmt)
+        if "SELECT id FROM legal.vault_documents" in sql_text:
+            return _FakeResult(fetch_value=None)
+        if "INSERT INTO legal.vault_documents" in sql_text:
+            return _FakeResult(fetch_value=_FakeRow("new-id"))
+        return _FakeResult()
+
+    db = _make_db_session(_exec_side_effect)
+
+    result = await legal_ediscovery.process_vault_upload(
+        db=db,
+        case_slug="nul-case",
+        file_bytes=b"nul bytes",
+        file_name="nul.ptx",
+        mime_type="application/octet-stream",
+    )
+
+    assert result["status"] == "completed"
+    assert "\x00" not in classifier.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_process_vault_upload_rolls_back_before_marking_failed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path,
+) -> None:
+    """An aborted transaction must not leave the row stuck in pending."""
+    monkeypatch.setattr(
+        legal_ediscovery, "_resolve_vault_dir", lambda _slug: tmp_path,
+    )
+    monkeypatch.setattr(
+        legal_ediscovery, "_extract_text", MagicMock(side_effect=RuntimeError("bad transcript")),
+    )
+    monkeypatch.setattr(
+        legal_ediscovery, "_emit_docket_updated_event",
+        AsyncMock(return_value=False),
+    )
+
+    failure_update_seen = False
+
+    def _exec_side_effect(stmt, *args, **kwargs):
+        nonlocal failure_update_seen
+        sql_text = str(stmt)
+        if "SELECT id FROM legal.vault_documents" in sql_text:
+            return _FakeResult(fetch_value=None)
+        if "INSERT INTO legal.vault_documents" in sql_text:
+            return _FakeResult(fetch_value=_FakeRow("new-id"))
+        if "SET processing_status = 'failed'" in sql_text:
+            failure_update_seen = True
+        return _FakeResult()
+
+    db = _make_db_session(_exec_side_effect)
+    db.rollback = AsyncMock()
+
+    result = await legal_ediscovery.process_vault_upload(
+        db=db,
+        case_slug="bad-transcript-case",
+        file_bytes=b"bad transcript bytes",
+        file_name="bad.ptx",
+        mime_type="application/octet-stream",
+    )
+
+    assert result["status"] == "failed"
+    db.rollback.assert_awaited()
+    assert failure_update_seen, "expected failed status update after rollback"
 
 
 # ── 5. CHECK constraint integration is asserted in the DB-level test


### PR DESCRIPTION
## What this PR does

Fixes two issues surfaced during the Case II PART C ingest after PR #366 merged:

- IngestRunTracker now writes both legacy columns and PR #366 locked columns: invocation_args, completed_at, files_processed, files_succeeded, files_failed.
- process_vault_upload now strips Postgres-incompatible null bytes from extracted text.
- process_vault_upload rolls back an aborted async transaction before marking a vault document failed, preventing stuck pending rows.
- non-terminal same-hash rows no longer mask retries as duplicates; failed/pending rows can be cleared and reprocessed.

## Live verification already performed

- Case II Thatcher PTX retry completed after this patch: 76 chunks, 0 errors.
- fortress_db and fortress_prod now show 817 Case II vault_documents rows.
- No Case II pending/failed vault_documents remain.
- Qdrant legal_ediscovery Case II count is 214612; privileged count is 81188.
- Historical Case II ingest_runs rows were backfilled from manifests with completed_at and locked counter columns.

## Tests

Ran with TEST_DATABASE_URL loaded from .env so pytest did not fall back to fortress_shadow:



Result: 36 passed.

## Out of scope

- Alembic Issue #354 remains separate.
- No .gitignore or operator docs touched.