### PR TITLE
Fortress Legal Case II inspection scope addendum

### DIFF
--- a/docs/operational/fortress-legal/matter-control/case-ii-2026-05-02/evidence-traceability/evidence-gap-action-list-7il-ndga-ii-2026-05-02.md
+++ b/docs/operational/fortress-legal/matter-control/case-ii-2026-05-02/evidence-traceability/evidence-gap-action-list-7il-ndga-ii-2026-05-02.md
@@ -7,7 +7,7 @@ This is the action list for closing evidence gaps before filing or transmitting 
 
 | Priority | Gap | Why It Matters | Action | Owner | Status |
 |---:|---|---|---|---|---|
-| P1 | Exhibit G - 2025 River Heights Inspection missing from curated complaint exhibits | Complaint uses Exhibit G to support repair/breach allegations; answer/Rule 12/counsel package needs the exact document. | Locate original Exhibit G, re-copy into curated complaint exhibits, or document that plaintiff omitted it. | Operator / Codex | Open |
+| P1 | Exhibit G - 2025 River Heights Inspection not curated into complaint exhibits | Operator clarified the underlying inspection reports, notes, and Argo-related communications exist on NAS/operator copies; answer/Rule 12/counsel package needs the exact source-verified report. | Locate/copy the actual 2025 River Heights inspection into privileged staging first, then curate as Exhibit G only after source and privilege review. | Operator / Codex | Open |
 | P1 | Closing file / waiver-reservation record not mapped | May control repair survival, merger, waiver, title, and Wilson theory. | Build closing-file inventory and privilege classification. | Operator / Codex | Open |
 | P1 | Case I contempt / post-judgment overlap map incomplete | Central to preclusion and abuse-of-process posture. | Create Case I-to-Case II overlap chart. | Codex | Open |
 | P1 | Easement validity source map incomplete | Counts II-V and VII depend on easement enforceability/recording theory. | Build easement instrument + right-of-way + drafting record memo. | Codex / counsel | Open |

--- a/docs/operational/fortress-legal/matter-control/case-ii-2026-05-02/evidence-traceability/inspection-reports-closing-scope-addendum-7il-ndga-ii-2026-05-02.md
+++ b/docs/operational/fortress-legal/matter-control/case-ii-2026-05-02/evidence-traceability/inspection-reports-closing-scope-addendum-7il-ndga-ii-2026-05-02.md
@@ -1,0 +1,37 @@
+# Inspection Reports and Closing-Scope Addendum - 7IL Case II
+
+Date: 2026-05-02
+Classification: Repo-safe sanitized workbench note. Privileged email details are intentionally not included.
+Operator service status: Gary Knight has not been served as of 2026-05-02.
+
+## Update
+
+The prior evidence traceability pack found that Exhibit G was missing from the curated Case II complaint-exhibits folder. The operator has clarified that the underlying inspection reports, notes, and Alicia Argo-related emails exist on the NAS and/or in operator copies.
+
+The evidence status is therefore refined:
+
+- Exhibit G should not be treated as factually nonexistent.
+- Exhibit G should be treated as not-yet-curated into the Case II complaint-exhibits lane.
+- Related inspection/closing communications must be privilege-classified before repo inclusion, counsel transmission, or filing use.
+
+## Why This Matters
+
+The inspection reports are tied to a merits question, not just a missing-file question. The response workbench must test:
+
+- which inspection items were actually incorporated into the PSAs or amendments;
+- which obligations, if any, survived the Case I judgment and closing;
+- whether post-judgment inspection demands were permitted by the PSAs/judgment or were new conditions;
+- plaintiff's pre-trial and post-judgment closing conduct, including 92 Fish Trap closing timing;
+- whether plaintiff's conduct supports waiver, estoppel, laches, causation, damages, equity, or bad-faith defenses.
+
+## Required Follow-Up Artifacts
+
+1. PSA repair-obligation matrix: 2021 inspection item -> PSA/amendment clause -> alleged 2025 issue -> response evidence.
+2. Judgment-scope matrix: what Case I ordered, what it did not order, and whether new inspection demands were permitted.
+3. Closing-delay chronology: pre-trial Fish Trap closing conduct, post-judgment closing communications, inspection scheduling, and final closing sequence.
+4. Privilege-classified Argo/closing email index retained on NAS work-product path only.
+5. Exhibit G curation task: locate/copy the 2025 River Heights inspection into privileged staging first, then into curated complaint exhibits only if nonprivileged and source-verified.
+
+## Current Evidence Control Rule
+
+Do not send inspection/Argo/closing email materials to counsel until conflicts clear. Do not commit privileged email content to the repo. Use only sanitized issue framing in repo docs.


### PR DESCRIPTION
## What this PR does\n\nAdds a sanitized inspection/closing-scope addendum to the Case II evidence-traceability docs and refines the Exhibit G evidence gap language.\n\n## Key update\n\nThe operator clarified that the inspection reports, notes, and Alicia Argo-related emails exist on NAS/operator copies. Exhibit G is therefore treated as a curation and privilege-classification gap, not as a factually nonexistent document.\n\n## Privilege handling\n\nPrivileged Argo/inspection/closing email details were written only to NAS work-product/privileged and are not included in this repo PR.\n\n## Scope\n\nDocs only. No code, schema, CI, .gitignore, or operator scratch files touched.