### PR TITLE
feat(financial): sync v0.2 chart overlays

### DIFF
--- a/crog-ai-backend/README.md
+++ b/crog-ai-backend/README.md
@@ -54,12 +54,14 @@ Current Financial / Hedge Fund endpoints:
 | `GET /api/financial/signals/transitions` | recent signal-change alert feed |
 | `GET /api/financial/signals/watchlist-candidates` | portfolio-lens lanes with legacy watchlist context |
 | `GET /api/financial/signals/calibration/daily` | daily MarketClub truth calibration metrics |
-| `GET /api/financial/signals/{ticker}/chart` | EOD bars, rolling channels, and triangle overlay events |
+| `GET /api/financial/signals/{ticker}/chart` | EOD bars, rolling channels, and parameter-set aware triangle overlay events |
 | `GET /api/financial/signals/{ticker}` | symbol-level latest score plus recent transitions |
 
 Internal candidate reads can pass `parameter_set=dochia_v0_2_range_daily` to
-`latest`, `transitions`, `watchlist-candidates`, and symbol detail. Omitting the
-parameter keeps the production filter.
+`latest`, `transitions`, `watchlist-candidates`, symbol detail, and symbol chart.
+Omitting the parameter keeps the production filter. The chart endpoint uses
+close-break daily events for production and range-trigger daily events for the
+v0.2 candidate.
 
 Systemd service on spark-node-2:
 

--- a/crog-ai-backend/app/api/signals.py
+++ b/crog-ai-backend/app/api/signals.py
@@ -197,6 +197,8 @@ class SymbolChartEvent(BaseModel):
 
 class SymbolSignalChart(BaseModel):
     ticker: str
+    parameter_set_name: str
+    daily_trigger_mode: str
     sessions: int
     bars: list[SymbolChartBar]
     events: list[SymbolChartEvent]
@@ -319,8 +321,14 @@ def symbol_signal_chart(
     store: Annotated[SignalDataStore, Depends(get_signal_store)],
     sessions: Annotated[int, Query(ge=30, le=500)] = 180,
     as_of: dt.date | None = None,
+    parameter_set: Annotated[str | None, Query(min_length=1, max_length=100)] = None,
 ) -> dict[str, object]:
-    chart = store.symbol_chart(ticker=ticker.upper(), sessions=sessions, as_of=as_of)
+    chart = store.symbol_chart(
+        ticker=ticker.upper(),
+        sessions=sessions,
+        as_of=as_of,
+        parameter_set=parameter_set,
+    )
     if not chart["bars"]:
         raise HTTPException(status_code=404, detail=f"chart data not found for {ticker.upper()}")
     return chart

--- a/crog-ai-backend/app/signals/chart_repository.py
+++ b/crog-ai-backend/app/signals/chart_repository.py
@@ -15,10 +15,19 @@ from app.signals.trade_triangles import (
     EodBar,
     TriangleEvent,
     TriangleTimeframe,
+    TriangleTriggerMode,
     detect_triangle_events,
 )
 
 CHART_LOOKBACK_BUFFER = max(LOOKBACK_SESSIONS.values())
+PRODUCTION_PARAMETER_SET = "dochia_v0_estimated"
+RANGE_DAILY_PARAMETER_SET = "dochia_v0_2_range_daily"
+
+
+def daily_trigger_mode_for_parameter_set(parameter_set: str | None) -> TriangleTriggerMode:
+    if parameter_set == RANGE_DAILY_PARAMETER_SET:
+        return TriangleTriggerMode.RANGE
+    return TriangleTriggerMode.CLOSE
 
 
 def _channel_for(
@@ -55,11 +64,21 @@ def build_symbol_chart(
     ticker: str,
     bars: list[EodBar],
     sessions: int,
+    parameter_set: str | None = None,
 ) -> dict[str, Any]:
+    parameter_set_name = parameter_set or PRODUCTION_PARAMETER_SET
+    daily_trigger_mode = daily_trigger_mode_for_parameter_set(parameter_set)
     ordered = sorted(bars, key=lambda bar: bar.bar_date)
     visible_bars = ordered[-sessions:]
     if not visible_bars:
-        return {"ticker": ticker.upper(), "sessions": sessions, "bars": [], "events": []}
+        return {
+            "ticker": ticker.upper(),
+            "parameter_set_name": parameter_set_name,
+            "daily_trigger_mode": daily_trigger_mode.value,
+            "sessions": sessions,
+            "bars": [],
+            "events": [],
+        }
 
     first_visible_date = visible_bars[0].bar_date
     index_by_date = {bar.bar_date: index for index, bar in enumerate(ordered)}
@@ -90,12 +109,22 @@ def build_symbol_chart(
     events = [
         _event_to_dict(event)
         for timeframe in TriangleTimeframe
-        for event in detect_triangle_events(ordered, timeframe)
+        for event in detect_triangle_events(
+            ordered,
+            timeframe,
+            trigger_mode=(
+                daily_trigger_mode
+                if timeframe is TriangleTimeframe.DAILY
+                else TriangleTriggerMode.CLOSE
+            ),
+        )
         if event.bar_date >= first_visible_date
     ]
     events.sort(key=lambda item: (item["bar_date"], item["timeframe"]))
     return {
         "ticker": ticker.upper(),
+        "parameter_set_name": parameter_set_name,
+        "daily_trigger_mode": daily_trigger_mode.value,
         "sessions": len(visible_bars),
         "bars": chart_bars,
         "events": events,
@@ -108,6 +137,7 @@ def fetch_symbol_chart(
     ticker: str,
     sessions: int,
     as_of: dt.date | None = None,
+    parameter_set: str | None = None,
 ) -> dict[str, Any]:
     normalized = ticker.upper()
     fetch_limit = sessions + CHART_LOOKBACK_BUFFER
@@ -128,4 +158,9 @@ def fetch_symbol_chart(
             {"ticker": normalized, "as_of": as_of, "limit": fetch_limit},
         )
         bars = [eod_row_to_bar(dict(row)) for row in cur.fetchall()]
-    return build_symbol_chart(ticker=normalized, bars=bars, sessions=sessions)
+    return build_symbol_chart(
+        ticker=normalized,
+        bars=bars,
+        sessions=sessions,
+        parameter_set=parameter_set,
+    )

--- a/crog-ai-backend/app/signals/repository.py
+++ b/crog-ai-backend/app/signals/repository.py
@@ -59,6 +59,7 @@ class SignalDataStore(Protocol):
         ticker: str,
         sessions: int,
         as_of: dt.date | None = None,
+        parameter_set: str | None = None,
     ) -> dict[str, Any]: ...
 
 
@@ -436,7 +437,14 @@ class PostgresSignalDataStore:
         ticker: str,
         sessions: int,
         as_of: dt.date | None = None,
+        parameter_set: str | None = None,
     ) -> dict[str, Any]:
         with connect() as conn:
             conn.execute("SET default_transaction_read_only = on")
-            return fetch_symbol_chart(conn, ticker=ticker, sessions=sessions, as_of=as_of)
+            return fetch_symbol_chart(
+                conn,
+                ticker=ticker,
+                sessions=sessions,
+                as_of=as_of,
+                parameter_set=parameter_set,
+            )

--- a/crog-ai-backend/docs/MARKETCLUB-DOCHIA-BUILD-PLAN.md
+++ b/crog-ai-backend/docs/MARKETCLUB-DOCHIA-BUILD-PLAN.md
@@ -168,13 +168,17 @@ Useful query params:
 - Persisted v0.2 candidate scores/transitions under the non-production
   parameter set: 328 `signal_scores` rows and 1,624 `signal_transitions` rows.
   Added internal `parameter_set` selectors for scanner, transition feed, symbol
-  detail, and Portfolio Lens reads. Defaults still use production only.
+  detail, Portfolio Lens, and chart-overlay reads. Defaults still use
+  production only.
 - Added the internal Command Center parameter-set toggle on the Hedge Fund page.
   The cockpit defaults to Production and can switch scanner, transition feed,
-  symbol detail, and Portfolio Lens reads to v0.2 Range.
+  symbol detail, Portfolio Lens, and chart overlays to v0.2 Range.
 - Surfaced the calibration baseline in the Hedge Fund UI.
 - Added chart-data endpoint and UI chart overlay with close, daily/weekly
   channel bands, and generated triangle event markers.
+- Added v0.2 chart-overlay parity: the chart endpoint accepts `parameter_set`
+  and switches daily event markers from close-break production mode to
+  range-trigger v0.2 candidate mode.
 - Added and enabled `crog-ai-backend.service` on spark-node-2.
 - Promoted the Command Center production build and restarted
   `crog-ai-frontend.service`; `/financial/hedge-fund` is live through
@@ -184,5 +188,6 @@ Useful query params:
   status, and live backend/BFF reads for both production and v0.2 candidate
   selectors. `/financial/hedge-fund` returns 200 after frontend restart.
 
-Next clean build step: add v0.2 chart-overlay parity so the symbol chart can
-show range-trigger daily events when the v0.2 candidate mode is selected.
+Next clean build step: run v0.2 promotion review across top-lane symbols,
+whipsaw clusters, and chart-level candidate events before deciding whether the
+range trigger can become the next production parameter set.

--- a/crog-ai-backend/tests/test_api_signals.py
+++ b/crog-ai-backend/tests/test_api_signals.py
@@ -178,9 +178,12 @@ class FakeSignalStore:
         ticker: str,
         sessions: int,
         as_of: dt.date | None = None,
+        parameter_set: str | None = None,
     ) -> dict[str, Any]:
         return {
             "ticker": ticker,
+            "parameter_set_name": parameter_set or "dochia_v0_estimated",
+            "daily_trigger_mode": "range" if parameter_set else "close",
             "sessions": 2,
             "bars": [
                 {
@@ -372,8 +375,25 @@ def test_symbol_chart_endpoint_returns_overlay_data() -> None:
     assert response.status_code == 200
     payload = response.json()
     assert payload["ticker"] == "AA"
+    assert payload["parameter_set_name"] == "dochia_v0_estimated"
+    assert payload["daily_trigger_mode"] == "close"
     assert payload["bars"][0]["daily_channel_high"] == "67.00"
     assert payload["events"][0]["timeframe"] == "daily"
+
+
+def test_symbol_chart_endpoint_accepts_parameter_set_selector() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/financial/signals/aa/chart?sessions=30&parameter_set=dochia_v0_2_range_daily"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["parameter_set_name"] == "dochia_v0_2_range_daily"
+    assert payload["daily_trigger_mode"] == "range"
 
 
 def test_symbol_signal_detail_404_when_no_latest_score() -> None:

--- a/crog-ai-backend/tests/test_chart_repository.py
+++ b/crog-ai-backend/tests/test_chart_repository.py
@@ -17,6 +17,18 @@ def _bar(index: int, close: int) -> EodBar:
     )
 
 
+def _range_bar(index: int, *, open_: int, high: int, low: int, close: int) -> EodBar:
+    return EodBar(
+        ticker="AA",
+        bar_date=dt.date(2026, 1, 1) + dt.timedelta(days=index),
+        open=Decimal(open_),
+        high=Decimal(high),
+        low=Decimal(low),
+        close=Decimal(close),
+        volume=1000,
+    )
+
+
 def test_build_symbol_chart_returns_visible_bars_channels_and_events() -> None:
     bars = [_bar(index, 100 + index) for index in range(70)]
 
@@ -29,3 +41,29 @@ def test_build_symbol_chart_returns_visible_bars_channels_and_events() -> None:
     assert chart["bars"][0]["daily_channel_high"] == Decimal("159")
     assert {event["timeframe"] for event in chart["events"]} == {"monthly"}
     assert chart["events"][0]["state"] == "green"
+
+
+def test_build_symbol_chart_uses_range_daily_events_for_v0_2_candidate() -> None:
+    bars = [
+        _range_bar(0, open_=10, high=10, low=9, close=10),
+        _range_bar(1, open_=11, high=11, low=10, close=11),
+        _range_bar(2, open_=12, high=12, low=11, close=12),
+        _range_bar(3, open_=11, high=13, low=11, close=12),
+    ]
+
+    production_chart = build_symbol_chart(ticker="AA", bars=bars, sessions=4)
+    candidate_chart = build_symbol_chart(
+        ticker="AA",
+        bars=bars,
+        sessions=4,
+        parameter_set="dochia_v0_2_range_daily",
+    )
+
+    assert production_chart["parameter_set_name"] == "dochia_v0_estimated"
+    assert production_chart["daily_trigger_mode"] == "close"
+    assert production_chart["events"] == []
+    assert candidate_chart["parameter_set_name"] == "dochia_v0_2_range_daily"
+    assert candidate_chart["daily_trigger_mode"] == "range"
+    assert candidate_chart["events"][0]["timeframe"] == "daily"
+    assert candidate_chart["events"][0]["state"] == "green"
+    assert candidate_chart["events"][0]["trigger_price"] == Decimal("13")

--- a/docs/operational/MASTER-PLAN.md
+++ b/docs/operational/MASTER-PLAN.md
@@ -259,10 +259,10 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 | Legacy watchlist context | `watchlist` has 431 rows; `market_signals` has 1,105 rows through 2026-02-12; read-only grant applied for app overlays |
 | Calibration baseline | 24,204 daily observations; 91.44% coverage; 62.05% carried daily color accuracy; 40.67% exact alert match; 52.54% ±3-day alert match; score MAE 43.94 |
 | Calibration sweep | Best validated candidate: 3-session intraday range trigger; exact alert F1 76.64% vs 44.59% baseline, exact recall 91.93% vs 40.67%, precision 65.71%, ±3-day recall 95.21%; holdout after 2025-09-25 scores 83.18% F1 vs 46.26% baseline |
-| Candidate persisted state | v0.2 candidate has 328 `signal_scores` rows and 1,624 `signal_transitions` rows under non-production parameter set; internal API/BFF selector live for scanner, transitions, symbol detail, and Portfolio Lens |
+| Candidate persisted state | v0.2 candidate has 328 `signal_scores` rows and 1,624 `signal_transitions` rows under non-production parameter set; internal API/BFF selector live for scanner, transitions, symbol detail, Portfolio Lens, and chart overlays |
 | Candidate lane comparison | v0.2 bullish lane unchanged at 129, risk unchanged at 47, re-entry 164→145, mixed 202→203, 61 daily states/scores change |
 | Promotion contract | Fresh Dochia scores still staged; legacy `market_signals` remains contextual until calibration/promotion |
-| UI state | Hedge Fund route live in production at `https://crog-ai.com/financial/hedge-fund` with scanner, chart overlays, alert feed, symbol panel, Portfolio Lens, Calibration Baseline, and internal Production/v0.2 Range toggle |
+| UI state | Hedge Fund route live in production at `https://crog-ai.com/financial/hedge-fund` with scanner, synced chart overlays, alert feed, symbol panel, Portfolio Lens, Calibration Baseline, and internal Production/v0.2 Range toggle |
 
 **Signal doctrine:**
 
@@ -291,7 +291,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 - Do not call generated weekly/monthly states "MarketClub truth"; they are Dochia-derived.
 - Avoid gamified trading prompts; build an evidence cockpit.
 
-**Immediate next step:** Add v0.2 chart-overlay parity so the symbol chart can show range-trigger daily events when the v0.2 candidate mode is selected.
+**Immediate next step:** Run v0.2 promotion review: compare top-lane symbols, whipsaw clusters, and chart-level candidate events before deciding whether the range trigger can become the next production parameter set.
 
 ### 6.6 Architectural follow-ups
 
@@ -347,7 +347,8 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 - Added read-only daily calibration harness and FastAPI endpoint. Baseline: 24,204 observations, 91.44% coverage, 62.05% daily color accuracy, score MAE 43.94.
 - Added read-only daily parameter sweep harness and candidate validation report. Best candidate is the 3-session intraday range trigger: exact alert F1 76.64%, exact recall 91.93%, precision 65.71%, ±3-day recall 95.21%, and carried-state agreement 94.91%. Chronological holdout after 2025-09-25 scores 83.18% F1 vs 46.26% baseline.
 - Registered non-production `dochia_v0_2_range_daily` and wired daily trigger mode through score/transition previews. Dry run: 328 candidate score rows, 1,624 candidate transitions since 2026-03-25, bullish/risk lane counts unchanged, 61 daily states/scores changed.
-- Persisted v0.2 candidate scores/transitions under non-production parameter set and added internal `parameter_set` selectors to scanner, transitions, symbol detail, and Portfolio Lens API reads. Production remains default.
+- Persisted v0.2 candidate scores/transitions under non-production parameter set and added internal `parameter_set` selectors to scanner, transitions, symbol detail, Portfolio Lens, and chart-overlay API reads. Production remains default.
+- Added v0.2 chart-overlay parity: the symbol chart now follows the active Production/v0.2 Range mode, using close-break daily events for production and range-trigger daily events for the v0.2 candidate.
 - Added internal Production/v0.2 Range toggle to the Command Center Hedge Fund page and promoted the production frontend build.
 - Added chart-data endpoint and chart overlay with close, daily/weekly channel bands, and generated triangle event markers.
 - Refined calibration metrics to separate carried-state agreement from exact new-alert agreement: 40.67% same-day alert match and 52.54% ±3-day alert match.

--- a/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
+++ b/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
@@ -791,7 +791,10 @@ function SymbolPanel({
         <div className="space-y-3">
           <div className="flex items-center justify-between gap-3">
             <h2 className="text-sm font-semibold">Chart Overlay</h2>
-            <span className="text-xs text-muted-foreground">{chart?.sessions ?? 0} sessions</span>
+            <span className="text-xs text-muted-foreground">
+              {chart?.daily_trigger_mode === "range" ? "range daily" : "close daily"} ·{" "}
+              {chart?.sessions ?? 0} sessions
+            </span>
           </div>
           <SignalChart chart={chart} loading={chartLoading} error={chartError} />
         </div>
@@ -871,7 +874,10 @@ export function HedgeFundSignalsShell() {
     lookback_days: 30,
     parameter_set: activeParameterSet,
   });
-  const chart = useFinancialSignalChart(activeTicker, { sessions: 180 });
+  const chart = useFinancialSignalChart(activeTicker, {
+    sessions: 180,
+    parameter_set: activeParameterSet,
+  });
 
   const selectedSignal =
     detail.data?.latest ?? signals.find((signal) => signal.ticker === activeTicker) ?? null;

--- a/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
@@ -133,6 +133,7 @@ export function useFinancialSignalChart(
   params?: {
     sessions?: number;
     as_of?: string;
+    parameter_set?: string;
   },
 ) {
   const normalized = ticker?.trim().toUpperCase() ?? "";

--- a/fortress-guest-platform/apps/command-center/src/lib/types.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/types.ts
@@ -223,6 +223,8 @@ export interface FinancialSignalChartEvent {
 
 export interface FinancialSignalChartResponse {
   ticker: string;
+  parameter_set_name: string;
+  daily_trigger_mode: "close" | "range";
   sessions: number;
   bars: FinancialSignalChartBar[];
   events: FinancialSignalChartEvent[];


### PR DESCRIPTION
## Summary
- thread `parameter_set` through the symbol chart API, SignalDataStore, and Command Center chart hook
- switch daily chart event markers to range-trigger mode when `dochia_v0_2_range_daily` is selected, while production remains close-break mode
- update MarketClub/Dochia docs and master plan to mark chart-overlay parity complete and set the next step as v0.2 promotion review

## Verification
- `PYTHONPATH=. /home/admin/.local/bin/uv run pytest tests/test_chart_repository.py tests/test_api_signals.py` — 14 passed
- `PYTHONPATH=. /home/admin/.local/bin/uv run pytest tests/test_trade_triangles.py tests/test_calibration.py tests/test_calibration_sweep.py tests/test_db_preview.py tests/test_db_sync.py tests/test_chart_repository.py tests/test_api_signals.py` — 30 passed
- `/home/admin/.local/bin/uv run ruff check app/signals/chart_repository.py app/signals/repository.py app/api/signals.py tests/test_chart_repository.py tests/test_api_signals.py` — passed
- `vitest run src/__tests__/components/financial-hedge-fund-shell.test.tsx` — 2 passed
- `tsc --noEmit` — passed
