### PR TITLE
feat(financial): add Dochia promotion review

### DIFF
--- a/crog-ai-backend/README.md
+++ b/crog-ai-backend/README.md
@@ -105,6 +105,7 @@ Daily event parameter sweeps and candidate validation are also read-only:
 uv run python scripts/sweep_daily_signal_parameters.py --lookback-min 2 --lookback-max 10 --top 12
 uv run python scripts/validate_daily_signal_candidate.py --top-tickers 15 --min-slice-observations 50
 uv run python scripts/compare_signal_candidate_lanes.py --limit-tickers 500 --top 12
+uv run python scripts/review_signal_candidate_promotion.py --lane-limit 50 --chart-ticker-limit 24
 ```
 
 Best 2026-05-02 research candidate: 3-session intraday range trigger. It
@@ -125,6 +126,14 @@ transition rows since 2026-03-25 under the non-production parameter set.
 Portfolio-lane comparison over 328 fresh tickers keeps
 bullish alignment at 129 and risk alignment at 47; re-entry moves 164 to 145,
 mixed timeframes 202 to 203, and 61 daily states/scores change.
+
+The promotion-review script is read-only and combines persisted top-lane churn,
+recent transition pressure, and chart-level candidate-only daily events into one
+review packet. It is the required gate before flipping a candidate parameter set
+to production.
+
+First report: `docs/reports/dochia-v0-2-promotion-review-2026-05-03.md`.
+Decision: do not promote v0.2 yet; add guardrail research first.
 
 ## Relationship to Fortress-Prime
 

--- a/crog-ai-backend/app/signals/promotion_review.py
+++ b/crog-ai-backend/app/signals/promotion_review.py
@@ -1,0 +1,275 @@
+"""Promotion review helpers for Dochia signal candidates."""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections import Counter
+from dataclasses import asdict, dataclass
+from decimal import Decimal
+from typing import Any
+
+LANE_ORDER = ("bullish_alignment", "risk_alignment", "reentry", "mixed_timeframes")
+
+
+@dataclass(frozen=True, slots=True)
+class LaneReview:
+    lane: str
+    baseline_count: int
+    candidate_count: int
+    overlap_count: int
+    entered_count: int
+    exited_count: int
+    entered: list[str]
+    exited: list[str]
+
+    @property
+    def churn_rate(self) -> float:
+        denominator = max(self.baseline_count + self.candidate_count - self.overlap_count, 1)
+        return (self.entered_count + self.exited_count) / denominator
+
+
+@dataclass(frozen=True, slots=True)
+class WhipsawCluster:
+    ticker: str
+    baseline_transition_count: int
+    candidate_transition_count: int
+    transition_delta: int
+    baseline_daily_transition_count: int
+    candidate_daily_transition_count: int
+    candidate_transition_types: dict[str, int]
+    latest_candidate_transition_date: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ChartEventReview:
+    ticker: str
+    baseline_daily_event_count: int
+    candidate_daily_event_count: int
+    daily_event_delta: int
+    candidate_only_count: int
+    candidate_only_events: list[dict[str, Any]]
+
+
+def _event_sort_key(event: dict[str, Any]) -> tuple[str, str]:
+    return (str(event.get("bar_date") or ""), str(event.get("state") or ""))
+
+
+def _jsonable(value: object) -> object:
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, dt.date | dt.datetime):
+        return value.isoformat()
+    if isinstance(value, list | tuple):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if hasattr(value, "__dataclass_fields__"):
+        out = asdict(value)
+        if isinstance(value, LaneReview):
+            out["churn_rate"] = value.churn_rate
+        return _jsonable(out)
+    return value
+
+
+def as_jsonable(value: object) -> object:
+    return _jsonable(value)
+
+
+def _ticker_set(rows: list[dict[str, Any]]) -> set[str]:
+    return {str(row.get("ticker", "")).upper() for row in rows if row.get("ticker")}
+
+
+def build_lane_reviews(
+    baseline_lanes: dict[str, list[dict[str, Any]]],
+    candidate_lanes: dict[str, list[dict[str, Any]]],
+    *,
+    sample_size: int = 12,
+) -> list[LaneReview]:
+    reviews: list[LaneReview] = []
+    for lane in LANE_ORDER:
+        baseline = _ticker_set(baseline_lanes.get(lane, []))
+        candidate = _ticker_set(candidate_lanes.get(lane, []))
+        entered = sorted(candidate - baseline)
+        exited = sorted(baseline - candidate)
+        reviews.append(
+            LaneReview(
+                lane=lane,
+                baseline_count=len(baseline),
+                candidate_count=len(candidate),
+                overlap_count=len(baseline & candidate),
+                entered_count=len(entered),
+                exited_count=len(exited),
+                entered=entered[:sample_size],
+                exited=exited[:sample_size],
+            )
+        )
+    return reviews
+
+
+def _is_daily_transition(row: dict[str, Any]) -> bool:
+    notes = str(row.get("notes") or "").lower()
+    return notes.startswith("daily triangle") or " daily triangle " in notes
+
+
+def _transition_date(row: dict[str, Any]) -> str | None:
+    value = row.get("to_bar_date")
+    if value is None:
+        return None
+    if isinstance(value, dt.date | dt.datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def _transition_groups(rows: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        ticker = str(row.get("ticker", "")).upper()
+        if not ticker:
+            continue
+        grouped.setdefault(ticker, []).append(row)
+    return grouped
+
+
+def build_whipsaw_clusters(
+    baseline_transitions: list[dict[str, Any]],
+    candidate_transitions: list[dict[str, Any]],
+    *,
+    min_candidate_transitions: int = 4,
+    min_transition_delta: int = 2,
+    top: int = 15,
+) -> list[WhipsawCluster]:
+    baseline_by_ticker = _transition_groups(baseline_transitions)
+    candidate_by_ticker = _transition_groups(candidate_transitions)
+    clusters: list[WhipsawCluster] = []
+    for ticker in sorted(set(baseline_by_ticker) | set(candidate_by_ticker)):
+        baseline_rows = baseline_by_ticker.get(ticker, [])
+        candidate_rows = candidate_by_ticker.get(ticker, [])
+        baseline_count = len(baseline_rows)
+        candidate_count = len(candidate_rows)
+        delta = candidate_count - baseline_count
+        if candidate_count < min_candidate_transitions and delta < min_transition_delta:
+            continue
+        candidate_type_counts = Counter(
+            str(row.get("transition_type") or "unknown") for row in candidate_rows
+        )
+        candidate_dates = [date for row in candidate_rows if (date := _transition_date(row))]
+        clusters.append(
+            WhipsawCluster(
+                ticker=ticker,
+                baseline_transition_count=baseline_count,
+                candidate_transition_count=candidate_count,
+                transition_delta=delta,
+                baseline_daily_transition_count=sum(_is_daily_transition(row) for row in baseline_rows),
+                candidate_daily_transition_count=sum(_is_daily_transition(row) for row in candidate_rows),
+                candidate_transition_types=dict(sorted(candidate_type_counts.items())),
+                latest_candidate_transition_date=max(candidate_dates) if candidate_dates else None,
+            )
+        )
+    clusters.sort(
+        key=lambda item: (
+            item.candidate_transition_count,
+            item.transition_delta,
+            item.candidate_daily_transition_count,
+            item.ticker,
+        ),
+        reverse=True,
+    )
+    return clusters[:top]
+
+
+def _daily_event_keys(chart: dict[str, Any]) -> set[tuple[str, str]]:
+    keys = set()
+    for event in chart.get("events", []):
+        if event.get("timeframe") != "daily":
+            continue
+        keys.add((str(event.get("bar_date")), str(event.get("state"))))
+    return keys
+
+
+def _candidate_only_events(
+    candidate_chart: dict[str, Any],
+    baseline_keys: set[tuple[str, str]],
+    *,
+    sample_size: int,
+) -> list[dict[str, Any]]:
+    events = []
+    for event in candidate_chart.get("events", []):
+        if event.get("timeframe") != "daily":
+            continue
+        key = (str(event.get("bar_date")), str(event.get("state")))
+        if key in baseline_keys:
+            continue
+        events.append(
+            {
+                "bar_date": event.get("bar_date"),
+                "state": event.get("state"),
+                "trigger_price": event.get("trigger_price"),
+                "reason": event.get("reason"),
+            }
+        )
+    events.sort(key=_event_sort_key, reverse=True)
+    return events[:sample_size]
+
+
+def build_chart_event_reviews(
+    baseline_charts: dict[str, dict[str, Any]],
+    candidate_charts: dict[str, dict[str, Any]],
+    *,
+    sample_size: int = 5,
+) -> list[ChartEventReview]:
+    reviews: list[ChartEventReview] = []
+    for ticker in sorted(set(baseline_charts) & set(candidate_charts)):
+        baseline_keys = _daily_event_keys(baseline_charts[ticker])
+        candidate_keys = _daily_event_keys(candidate_charts[ticker])
+        candidate_only = _candidate_only_events(
+            candidate_charts[ticker],
+            baseline_keys,
+            sample_size=sample_size,
+        )
+        delta = len(candidate_keys) - len(baseline_keys)
+        if delta == 0 and not candidate_only:
+            continue
+        reviews.append(
+            ChartEventReview(
+                ticker=ticker,
+                baseline_daily_event_count=len(baseline_keys),
+                candidate_daily_event_count=len(candidate_keys),
+                daily_event_delta=delta,
+                candidate_only_count=len(candidate_keys - baseline_keys),
+                candidate_only_events=candidate_only,
+            )
+        )
+    reviews.sort(
+        key=lambda item: (
+            abs(item.daily_event_delta),
+            item.candidate_only_count,
+            item.ticker,
+        ),
+        reverse=True,
+    )
+    return reviews
+
+
+def focus_tickers_for_chart_review(
+    *,
+    lane_reviews: list[LaneReview],
+    whipsaw_clusters: list[WhipsawCluster],
+    candidate_lanes: dict[str, list[dict[str, Any]]],
+    limit: int,
+) -> list[str]:
+    ordered: list[str] = []
+
+    def add(ticker: str) -> None:
+        normalized = ticker.upper()
+        if normalized and normalized not in ordered:
+            ordered.append(normalized)
+
+    for review in lane_reviews:
+        for ticker in review.entered + review.exited:
+            add(ticker)
+    for cluster in whipsaw_clusters:
+        add(cluster.ticker)
+    for lane in LANE_ORDER:
+        for row in candidate_lanes.get(lane, []):
+            add(str(row.get("ticker") or ""))
+    return ordered[:limit]

--- a/crog-ai-backend/docs/MARKETCLUB-DOCHIA-BUILD-PLAN.md
+++ b/crog-ai-backend/docs/MARKETCLUB-DOCHIA-BUILD-PLAN.md
@@ -179,6 +179,15 @@ Useful query params:
 - Added v0.2 chart-overlay parity: the chart endpoint accepts `parameter_set`
   and switches daily event markers from close-break production mode to
   range-trigger v0.2 candidate mode.
+- Added a read-only promotion-review harness that combines persisted top-lane
+  churn, recent whipsaw/transition pressure, and chart-level candidate-only
+  daily events before any production flip.
+- First promotion-review run is tracked at
+  `docs/reports/dochia-v0-2-promotion-review-2026-05-03.md`. Decision: do not
+  promote v0.2 yet. Re-entry lane churn is 66.7%, mixed-timeframe churn is
+  52.9%, top whipsaw tickers show 8-9 candidate transitions in the 30-day
+  window, and reviewed chart overlays add up to 29 candidate-only daily events
+  on some symbols.
 - Added and enabled `crog-ai-backend.service` on spark-node-2.
 - Promoted the Command Center production build and restarted
   `crog-ai-frontend.service`; `/financial/hedge-fund` is live through
@@ -188,6 +197,6 @@ Useful query params:
   status, and live backend/BFF reads for both production and v0.2 candidate
   selectors. `/financial/hedge-fund` returns 200 after frontend restart.
 
-Next clean build step: run v0.2 promotion review across top-lane symbols,
-whipsaw clusters, and chart-level candidate events before deciding whether the
-range trigger can become the next production parameter set.
+Next clean build step: add v0.3 guardrail research for the range trigger:
+reduce whipsaw pressure with debounce, close-confirmation, or volatility
+filters before any production promotion.

--- a/crog-ai-backend/docs/reports/dochia-v0-2-promotion-review-2026-05-03.md
+++ b/crog-ai-backend/docs/reports/dochia-v0-2-promotion-review-2026-05-03.md
@@ -1,0 +1,316 @@
+# Dochia Candidate Promotion Review
+
+Generated: 2026-05-03T05:09:43.956880+00:00
+Baseline: `production`
+Candidate: `dochia_v0_2_range_daily`
+Transition lookback: 30 days
+Chart sessions: 180
+
+## Lane Churn
+
+| Lane | Baseline | Candidate | Overlap | Entered | Exited | Churn |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| bullish_alignment | 50 | 50 | 42 | ACLX, AEP, ASRT, CARG, ET, UTG, WELL, WES | AA, CGON, IBP, NTAP, RUM, TD, ULBI, ULH | 27.6% |
+| risk_alignment | 47 | 47 | 47 | - | - | 0.0% |
+| reentry | 50 | 50 | 25 | ACLX, AEP, CPRX, DCI, DLR, DTE, EIPI, FMB | AA, ASRT, CAT, COP, DBC, EME, EPD, ETN | 66.7% |
+| mixed_timeframes | 50 | 50 | 32 | AA, ALL, BDTX, BWLP, CGON, GCT, GKOS, GOLD | ACLX, AEP, BBAI, BNDX, ET, JCI, MDB, MNDY | 52.9% |
+
+## Whipsaw Pressure
+
+| Ticker | Baseline | Candidate | Delta | Candidate daily | Latest |
+| --- | ---: | ---: | ---: | ---: | --- |
+| LPX | 3 | 9 | +6 | 8 | 2026-04-21 |
+| PNR | 4 | 9 | +5 | 8 | 2026-04-24 |
+| IR | 4 | 9 | +5 | 7 | 2026-04-22 |
+| DTE | 4 | 9 | +5 | 7 | 2026-04-24 |
+| UEC | 5 | 9 | +4 | 8 | 2026-04-23 |
+| NTAP | 5 | 9 | +4 | 6 | 2026-04-24 |
+| VRT | 7 | 9 | +2 | 7 | 2026-04-23 |
+| BNDX | 1 | 8 | +7 | 8 | 2026-04-23 |
+| CGON | 2 | 8 | +6 | 8 | 2026-04-23 |
+| BDX | 2 | 8 | +6 | 8 | 2026-04-22 |
+| XLI | 2 | 8 | +6 | 7 | 2026-04-23 |
+| OLED | 2 | 8 | +6 | 7 | 2026-04-24 |
+| LII | 3 | 8 | +5 | 7 | 2026-04-21 |
+| CMCSA | 3 | 8 | +5 | 7 | 2026-04-24 |
+| DIVO | 3 | 8 | +5 | 6 | 2026-04-23 |
+| RUN | 4 | 8 | +4 | 7 | 2026-04-22 |
+| ISRG | 4 | 8 | +4 | 7 | 2026-04-22 |
+| GM | 4 | 8 | +4 | 7 | 2026-04-22 |
+| BSX | 4 | 8 | +4 | 7 | 2026-04-23 |
+| BLD | 4 | 8 | +4 | 7 | 2026-04-17 |
+| RUM | 4 | 8 | +4 | 6 | 2026-04-24 |
+| NAMS | 4 | 8 | +4 | 6 | 2026-04-23 |
+| URA | 6 | 8 | +2 | 7 | 2026-04-22 |
+| NVDA | 6 | 8 | +2 | 5 | 2026-04-24 |
+
+## Chart Event Deltas
+
+| Ticker | Baseline daily | Candidate daily | Delta | Candidate-only |
+| --- | ---: | ---: | ---: | ---: |
+| CGON | 11 | 40 | +29 | 31 |
+| DTE | 17 | 42 | +25 | 29 |
+| DLR | 15 | 39 | +24 | 30 |
+| CPRX | 16 | 40 | +24 | 27 |
+| AA | 17 | 39 | +22 | 26 |
+| EIPI | 12 | 32 | +20 | 28 |
+| ASRT | 14 | 34 | +20 | 25 |
+| CAT | 16 | 35 | +19 | 27 |
+| WES | 23 | 40 | +17 | 25 |
+| IBP | 14 | 31 | +17 | 20 |
+| NTAP | 15 | 31 | +16 | 19 |
+| UTG | 19 | 34 | +15 | 24 |
+| RUM | 19 | 34 | +15 | 24 |
+| WELL | 15 | 30 | +15 | 22 |
+| DCI | 16 | 31 | +15 | 19 |
+| TD | 21 | 35 | +14 | 18 |
+| ACLX | 13 | 27 | +14 | 17 |
+| FMB | 16 | 29 | +13 | 19 |
+| ULH | 17 | 30 | +13 | 17 |
+| AEP | 21 | 34 | +13 | 16 |
+| ET | 20 | 32 | +12 | 21 |
+| ULBI | 21 | 33 | +12 | 20 |
+| CARG | 15 | 27 | +12 | 16 |
+| COP | 17 | 28 | +11 | 18 |
+
+## Candidate-Only Event Samples
+
+### CGON
+- 2026-04-23 red @ 67.8600: low 67.8600 broke below prior low 69.2800 over prior 3-session channel
+- 2026-04-17 green @ 73.5600: high 73.5600 broke above prior high 70.6200 over prior 3-session channel
+- 2026-04-15 red @ 65.8900: low 65.8900 broke below prior low 66.7500 over prior 3-session channel
+- 2026-04-14 green @ 70.6200: high 70.6200 broke above prior high 69.4000 over prior 3-session channel
+- 2026-04-13 red @ 66.7500: low 66.7500 broke below prior low 67.5000 over prior 3-session channel
+- 2026-03-31 green @ 69.0700: high 69.0700 broke above prior high 67.9000 over prior 3-session channel
+- 2026-03-26 green @ 67.9000: high 67.9000 broke above prior high 66.6200 over prior 3-session channel
+- 2026-03-19 red @ 63.3000: low 63.3000 broke below prior low 63.5000 over prior 3-session channel
+
+### DTE
+- 2026-04-24 green @ 148.1500: high 148.1500 broke above prior high 147.6550 over prior 3-session channel
+- 2026-04-20 green @ 148.1800: high 148.1800 broke above prior high 147.3450 over prior 3-session channel
+- 2026-04-13 red @ 146.5100: low 146.5100 broke below prior low 146.7800 over prior 3-session channel
+- 2026-04-09 green @ 151.4000: high 151.4000 broke above prior high 149.4600 over prior 3-session channel
+- 2026-04-08 red @ 146.7800: low 146.7800 broke below prior low 147.1200 over prior 3-session channel
+- 2026-03-27 green @ 145.7900: high 145.7900 broke above prior high 145.2450 over prior 3-session channel
+- 2026-02-09 red @ 134.0300: low 134.0300 broke below prior low 134.0850 over prior 3-session channel
+- 2026-02-04 green @ 137.5400: high 137.5400 broke above prior high 136.7200 over prior 3-session channel
+
+### DLR
+- 2026-04-24 green @ 208.1400: high 208.1400 broke above prior high 204.9400 over prior 3-session channel
+- 2026-04-23 red @ 198.0501: low 198.0501 broke below prior low 199.8900 over prior 3-session channel
+- 2026-03-30 green @ 178.7000: high 178.7000 broke above prior high 178.0900 over prior 3-session channel
+- 2026-03-10 green @ 183.1350: high 183.1350 broke above prior high 182.1350 over prior 3-session channel
+- 2026-03-09 red @ 172.9101: low 172.9101 broke below prior low 175.9800 over prior 3-session channel
+- 2026-03-04 green @ 183.1800: high 183.1800 broke above prior high 179.1300 over prior 3-session channel
+- 2026-02-27 red @ 174.2770: low 174.2770 broke below prior low 174.4700 over prior 3-session channel
+- 2026-02-05 green @ 168.0000: high 168.0000 broke above prior high 167.4000 over prior 3-session channel
+
+### CPRX
+- 2026-04-23 green @ 27.7100: high 27.7100 broke above prior high 26.4200 over prior 3-session channel
+- 2026-04-22 red @ 25.5500: low 25.5500 broke below prior low 25.6000 over prior 3-session channel
+- 2026-04-14 green @ 26.4458: high 26.4458 broke above prior high 25.8200 over prior 3-session channel
+- 2026-04-13 red @ 24.6900: low 24.6900 broke below prior low 24.8300 over prior 3-session channel
+- 2026-03-31 green @ 24.8300: high 24.8300 broke above prior high 24.5800 over prior 3-session channel
+- 2026-03-30 red @ 23.0500: low 23.0500 broke below prior low 23.2100 over prior 3-session channel
+- 2026-03-23 green @ 23.7100: high 23.7100 broke above prior high 23.3400 over prior 3-session channel
+- 2026-03-12 red @ 23.3600: low 23.3600 broke below prior low 23.9850 over prior 3-session channel
+
+### AA
+- 2026-04-23 red @ 65.1500: low 65.1500 broke below prior low 65.2100 over prior 3-session channel
+- 2026-04-09 green @ 75.6999: high 75.6999 broke above prior high 73.3794 over prior 3-session channel
+- 2026-04-08 red @ 68.1700: low 68.1700 broke below prior low 68.9200 over prior 3-session channel
+- 2026-03-26 green @ 59.3300: high 59.3300 broke above prior high 59.1700 over prior 3-session channel
+- 2026-03-11 green @ 66.4600: high 66.4600 broke above prior high 62.2200 over prior 3-session channel
+- 2026-03-06 red @ 56.7500: low 56.7500 broke below prior low 57.8500 over prior 3-session channel
+- 2026-03-04 green @ 68.4000: high 68.4000 broke above prior high 65.2300 over prior 3-session channel
+- 2026-03-03 red @ 57.8500: low 57.8500 broke below prior low 61.1101 over prior 3-session channel
+
+### EIPI
+- 2026-04-23 green @ 22.1900: high 22.1900 broke above prior high 22.1600 over prior 3-session channel
+- 2026-04-14 red @ 22.0100: low 22.0100 broke below prior low 22.1800 over prior 3-session channel
+- 2026-04-09 green @ 22.7900: high 22.7900 broke above prior high 22.6600 over prior 3-session channel
+- 2026-03-31 red @ 22.2000: low 22.2000 broke below prior low 22.4300 over prior 3-session channel
+- 2026-03-24 green @ 22.7200: high 22.7200 broke above prior high 22.4900 over prior 3-session channel
+- 2026-03-19 red @ 22.1300: low 22.1300 broke below prior low 22.1500 over prior 3-session channel
+- 2026-03-12 green @ 22.2800: high 22.2800 broke above prior high 22.2799 over prior 3-session channel
+- 2026-03-09 red @ 22.0200: low 22.0200 broke below prior low 22.0600 over prior 3-session channel
+
+### ASRT
+- 2026-03-16 green @ 11.9900: high 11.9900 broke above prior high 11.8150 over prior 3-session channel
+- 2026-03-13 red @ 11.2000: range broke both sides; close 11.5400 < open 11.7600, choosing red below 11.2750 over prior 3-session channel
+- 2026-03-12 green @ 11.7800: high 11.7800 broke above prior high 11.7313 over prior 3-session channel
+- 2026-03-09 red @ 11.1146: low 11.1146 broke below prior low 11.5000 over prior 3-session channel
+- 2026-03-04 green @ 12.3500: high 12.3500 broke above prior high 12.2300 over prior 3-session channel
+- 2026-02-24 green @ 12.2000: high 12.2000 broke above prior high 12.1900 over prior 3-session channel
+- 2026-02-19 red @ 11.6500: low 11.6500 broke below prior low 11.7000 over prior 3-session channel
+- 2026-02-06 green @ 12.9500: high 12.9500 broke above prior high 12.4900 over prior 3-session channel
+
+### CAT
+- 2026-04-17 green @ 801.7700: high 801.7700 broke above prior high 797.9999 over prior 3-session channel
+- 2026-03-27 red @ 692.3300: low 692.3300 broke below prior low 693.0300 over prior 3-session channel
+- 2026-03-23 green @ 712.0000: high 712.0000 broke above prior high 711.8400 over prior 3-session channel
+- 2026-03-19 red @ 669.0000: low 669.0000 broke below prior low 692.7000 over prior 3-session channel
+- 2026-03-10 green @ 730.7909: high 730.7909 broke above prior high 728.0700 over prior 3-session channel
+- 2026-02-26 red @ 728.4000: low 728.4000 broke below prior low 751.6900 over prior 3-session channel
+- 2026-02-24 green @ 773.9400: high 773.9400 broke above prior high 771.9699 over prior 3-session channel
+- 2026-02-19 red @ 744.1500: low 744.1500 broke below prior low 747.4200 over prior 3-session channel
+
+### WES
+- 2026-04-23 green @ 41.4100: high 41.4100 broke above prior high 41.1900 over prior 3-session channel
+- 2026-04-14 red @ 40.4100: low 40.4100 broke below prior low 40.7000 over prior 3-session channel
+- 2026-04-09 green @ 41.8900: high 41.8900 broke above prior high 41.6800 over prior 3-session channel
+- 2026-04-08 red @ 40.2000: low 40.2000 broke below prior low 40.7000 over prior 3-session channel
+- 2026-04-07 green @ 41.6800: high 41.6800 broke above prior high 41.3500 over prior 3-session channel
+- 2026-03-16 green @ 41.3700: high 41.3700 broke above prior high 41.1850 over prior 3-session channel
+- 2026-03-09 red @ 40.9300: low 40.9300 broke below prior low 41.2700 over prior 3-session channel
+- 2026-02-06 green @ 41.5700: high 41.5700 broke above prior high 41.2700 over prior 3-session channel
+
+### IBP
+- 2026-04-24 red @ 301.3400: low 301.3400 broke below prior low 302.3800 over prior 3-session channel
+- 2026-04-08 green @ 287.3700: high 287.3700 broke above prior high 274.3800 over prior 3-session channel
+- 2026-04-07 red @ 259.5216: low 259.5216 broke below prior low 261.8250 over prior 3-session channel
+- 2026-03-19 red @ 268.1200: low 268.1200 broke below prior low 276.6000 over prior 3-session channel
+- 2026-03-16 green @ 292.0902: high 292.0902 broke above prior high 288.5800 over prior 3-session channel
+- 2026-03-05 red @ 306.7890: low 306.7890 broke below prior low 311.8001 over prior 3-session channel
+- 2026-02-26 green @ 333.3050: high 333.3050 broke above prior high 328.7700 over prior 3-session channel
+- 2026-02-12 green @ 346.7250: high 346.7250 broke above prior high 341.6000 over prior 3-session channel
+
+### NTAP
+- 2026-04-24 red @ 106.3000: low 106.3000 broke below prior low 106.6400 over prior 3-session channel
+- 2026-04-07 red @ 95.7600: low 95.7600 broke below prior low 100.2350 over prior 3-session channel
+- 2026-04-06 green @ 104.0000: high 104.0000 broke above prior high 103.9597 over prior 3-session channel
+- 2026-03-25 green @ 107.4050: high 107.4050 broke above prior high 104.5850 over prior 3-session channel
+- 2026-03-20 red @ 100.1500: low 100.1500 broke below prior low 100.4100 over prior 3-session channel
+- 2026-03-09 red @ 97.6800: low 97.6800 broke below prior low 98.2900 over prior 3-session channel
+- 2026-02-26 red @ 99.0000: range broke both sides; close 99.1400 < open 103.2400, choosing red below 99.3400 over prior 3-session channel
+- 2026-02-20 green @ 104.7500: high 104.7500 broke above prior high 102.8000 over prior 3-session channel
+
+### UTG
+- 2026-04-24 green @ 42.3000: high 42.3000 broke above prior high 42.2800 over prior 3-session channel
+- 2026-04-01 green @ 40.0999: high 40.0999 broke above prior high 39.8450 over prior 3-session channel
+- 2026-03-18 red @ 40.1017: low 40.1017 broke below prior low 40.1600 over prior 3-session channel
+- 2026-03-13 green @ 40.7400: high 40.7400 broke above prior high 40.6900 over prior 3-session channel
+- 2026-02-05 red @ 37.1200: low 37.1200 broke below prior low 37.3200 over prior 3-session channel
+- 2026-02-04 green @ 38.1400: high 38.1400 broke above prior high 38.0000 over prior 3-session channel
+- 2026-01-30 red @ 37.3900: low 37.3900 broke below prior low 37.5100 over prior 3-session channel
+- 2026-01-28 green @ 38.2000: high 38.2000 broke above prior high 38.0647 over prior 3-session channel
+
+### RUM
+- 2026-04-24 red @ 6.2800: low 6.2800 broke below prior low 6.3450 over prior 3-session channel
+- 2026-04-14 green @ 5.4100: high 5.4100 broke above prior high 5.1900 over prior 3-session channel
+- 2026-04-13 red @ 4.9000: low 4.9000 broke below prior low 4.9800 over prior 3-session channel
+- 2026-04-07 red @ 4.7800: low 4.7800 broke below prior low 4.8000 over prior 3-session channel
+- 2026-04-01 green @ 5.2150: high 5.2150 broke above prior high 5.1100 over prior 3-session channel
+- 2026-03-18 red @ 5.2702: low 5.2702 broke below prior low 5.2750 over prior 3-session channel
+- 2026-03-06 red @ 4.6700: low 4.6700 broke below prior low 5.3120 over prior 3-session channel
+- 2026-03-05 green @ 5.6750: high 5.6750 broke above prior high 5.6397 over prior 3-session channel
+
+### WELL
+- 2026-04-24 green @ 211.5900: high 211.5900 broke above prior high 209.3900 over prior 3-session channel
+- 2026-04-20 red @ 208.1250: low 208.1250 broke below prior low 208.4500 over prior 3-session channel
+- 2026-03-30 green @ 198.6700: high 198.6700 broke above prior high 198.5300 over prior 3-session channel
+- 2026-03-09 green @ 208.2400: high 208.2400 broke above prior high 208.1100 over prior 3-session channel
+- 2026-03-03 red @ 205.3700: low 205.3700 broke below prior low 207.0900 over prior 3-session channel
+- 2026-02-27 green @ 211.1400: high 211.1400 broke above prior high 210.8500 over prior 3-session channel
+- 2026-02-19 red @ 207.0100: low 207.0100 broke below prior low 207.8300 over prior 3-session channel
+- 2026-02-05 green @ 192.1000: high 192.1000 broke above prior high 189.6000 over prior 3-session channel
+
+### DCI
+- 2026-04-24 green @ 90.7325: high 90.7325 broke above prior high 89.8600 over prior 3-session channel
+- 2026-04-17 green @ 90.3050: high 90.3050 broke above prior high 89.4700 over prior 3-session channel
+- 2026-04-15 red @ 87.0200: low 87.0200 broke below prior low 87.5300 over prior 3-session channel
+- 2026-03-26 red @ 84.4300: low 84.4300 broke below prior low 84.7200 over prior 3-session channel
+- 2026-02-03 green @ 103.4985: high 103.4985 broke above prior high 103.3200 over prior 3-session channel
+- 2026-02-02 red @ 99.2800: low 99.2800 broke below prior low 99.9600 over prior 3-session channel
+- 2026-01-28 green @ 102.9700: range broke both sides; close 101.7500 >= open 100.6800, choosing green above 102.5850 over prior 3-session channel
+- 2026-01-26 red @ 100.1600: low 100.1600 broke below prior low 100.4000 over prior 3-session channel
+
+### TD
+- 2026-04-22 red @ 104.4330: low 104.4330 broke below prior low 104.4550 over prior 3-session channel
+- 2026-03-27 red @ 91.0450: low 91.0450 broke below prior low 92.4100 over prior 3-session channel
+- 2026-03-26 green @ 94.6600: high 94.6600 broke above prior high 94.6250 over prior 3-session channel
+- 2026-03-02 red @ 95.1400: low 95.1400 broke below prior low 95.1500 over prior 3-session channel
+- 2026-02-23 red @ 95.1400: range broke both sides; close 95.8200 < open 96.9700, choosing red below 95.4300 over prior 3-session channel
+- 2026-02-03 green @ 95.6300: high 95.6300 broke above prior high 95.5400 over prior 3-session channel
+- 2026-01-22 green @ 95.0150: high 95.0150 broke above prior high 94.4200 over prior 3-session channel
+- 2026-01-07 red @ 93.7500: low 93.7500 broke below prior low 93.8600 over prior 3-session channel
+
+### ACLX
+- 2026-04-23 green @ 115.1250: high 115.1250 broke above prior high 115.0900 over prior 3-session channel
+- 2026-03-20 green @ 114.9100: high 114.9100 broke above prior high 114.7700 over prior 3-session channel
+- 2026-02-02 green @ 69.9800: high 69.9800 broke above prior high 69.2400 over prior 3-session channel
+- 2026-01-22 red @ 66.0000: low 66.0000 broke below prior low 66.5000 over prior 3-session channel
+- 2026-01-07 green @ 66.0800: high 66.0800 broke above prior high 65.9700 over prior 3-session channel
+- 2025-12-30 red @ 63.3900: low 63.3900 broke below prior low 64.6580 over prior 3-session channel
+- 2025-12-24 green @ 66.7900: high 66.7900 broke above prior high 66.3000 over prior 3-session channel
+- 2025-12-15 red @ 67.0200: low 67.0200 broke below prior low 68.6400 over prior 3-session channel
+
+### FMB
+- 2026-04-24 green @ 51.2400: high 51.2400 broke above prior high 51.2300 over prior 3-session channel
+- 2026-04-21 red @ 51.1482: low 51.1482 broke below prior low 51.1500 over prior 3-session channel
+- 2026-04-17 green @ 51.3500: high 51.3500 broke above prior high 51.2300 over prior 3-session channel
+- 2026-04-15 red @ 51.0800: low 51.0800 broke below prior low 51.1000 over prior 3-session channel
+- 2026-03-02 red @ 51.8300: low 51.8300 broke below prior low 51.8500 over prior 3-session channel
+- 2025-12-24 green @ 51.1785: high 51.1785 broke above prior high 51.1100 over prior 3-session channel
+- 2025-12-23 red @ 50.9300: low 50.9300 broke below prior low 50.9700 over prior 3-session channel
+- 2025-12-09 green @ 51.1300: high 51.1300 broke above prior high 51.1100 over prior 3-session channel
+
+### ULH
+- 2026-04-24 red @ 21.9521: low 21.9521 broke below prior low 23.6400 over prior 3-session channel
+- 2026-04-16 green @ 22.8900: high 22.8900 broke above prior high 22.4400 over prior 3-session channel
+- 2026-04-13 red @ 20.8000: low 20.8000 broke below prior low 21.1800 over prior 3-session channel
+- 2026-04-01 green @ 22.4700: high 22.4700 broke above prior high 21.4000 over prior 3-session channel
+- 2026-03-30 red @ 18.9901: low 18.9901 broke below prior low 19.2800 over prior 3-session channel
+- 2026-02-26 green @ 16.7650: high 16.7650 broke above prior high 16.6100 over prior 3-session channel
+- 2026-02-23 red @ 14.9100: low 14.9100 broke below prior low 16.2000 over prior 3-session channel
+- 2026-02-18 green @ 17.6499: high 17.6499 broke above prior high 17.6050 over prior 3-session channel
+
+### AEP
+- 2026-04-24 green @ 135.5600: high 135.5600 broke above prior high 135.3700 over prior 3-session channel
+- 2026-04-20 green @ 135.4200: high 135.4200 broke above prior high 135.1600 over prior 3-session channel
+- 2026-04-14 red @ 132.7500: low 132.7500 broke below prior low 133.5800 over prior 3-session channel
+- 2026-03-10 green @ 133.2800: high 133.2800 broke above prior high 133.0000 over prior 3-session channel
+- 2026-03-03 red @ 129.6000: low 129.6000 broke below prior low 131.1500 over prior 3-session channel
+- 2026-02-11 green @ 122.5900: high 122.5900 broke above prior high 122.4400 over prior 3-session channel
+- 2026-02-10 red @ 119.7140: low 119.7140 broke below prior low 119.8000 over prior 3-session channel
+- 2026-01-02 red @ 114.4200: low 114.4200 broke below prior low 115.1600 over prior 3-session channel
+
+### ET
+- 2026-04-21 green @ 19.1700: high 19.1700 broke above prior high 19.0100 over prior 3-session channel
+- 2026-04-09 green @ 19.5700: high 19.5700 broke above prior high 19.3650 over prior 3-session channel
+- 2026-04-08 red @ 18.6000: low 18.6000 broke below prior low 18.9000 over prior 3-session channel
+- 2026-04-07 green @ 19.3650: high 19.3650 broke above prior high 19.3200 over prior 3-session channel
+- 2026-03-31 red @ 19.0100: low 19.0100 broke below prior low 19.1400 over prior 3-session channel
+- 2026-03-12 green @ 18.9600: high 18.9600 broke above prior high 18.8000 over prior 3-session channel
+- 2026-03-04 red @ 18.6050: low 18.6050 broke below prior low 18.6600 over prior 3-session channel
+- 2026-02-24 red @ 18.6050: low 18.6050 broke below prior low 18.7305 over prior 3-session channel
+
+### ULBI
+- 2026-04-22 red @ 7.3364: low 7.3364 broke below prior low 7.5701 over prior 3-session channel
+- 2026-04-01 green @ 6.8273: high 6.8273 broke above prior high 6.7800 over prior 3-session channel
+- 2026-03-27 red @ 6.2305: low 6.2305 broke below prior low 6.3100 over prior 3-session channel
+- 2026-02-18 red @ 6.0200: low 6.0200 broke below prior low 6.2000 over prior 3-session channel
+- 2026-02-17 green @ 6.4999: high 6.4999 broke above prior high 6.4850 over prior 3-session channel
+- 2026-02-11 red @ 6.2600: low 6.2600 broke below prior low 6.3000 over prior 3-session channel
+- 2026-02-10 green @ 6.6700: high 6.6700 broke above prior high 6.6600 over prior 3-session channel
+- 2026-01-28 green @ 6.4900: high 6.4900 broke above prior high 6.4600 over prior 3-session channel
+
+### CARG
+- 2026-02-26 green @ 31.3200: high 31.3200 broke above prior high 30.5250 over prior 3-session channel
+- 2026-02-24 red @ 27.5700: low 27.5700 broke below prior low 27.6900 over prior 3-session channel
+- 2026-01-27 red @ 33.3701: low 33.3701 broke below prior low 33.6300 over prior 3-session channel
+- 2026-01-22 green @ 35.0500: high 35.0500 broke above prior high 35.0000 over prior 3-session channel
+- 2026-01-13 red @ 35.9100: low 35.9100 broke below prior low 37.7100 over prior 3-session channel
+- 2026-01-07 green @ 39.0200: high 39.0200 broke above prior high 38.7900 over prior 3-session channel
+- 2025-12-29 red @ 38.2900: low 38.2900 broke below prior low 38.4100 over prior 3-session channel
+- 2025-12-05 green @ 36.5700: high 36.5700 broke above prior high 36.2800 over prior 3-session channel
+
+### COP
+- 2026-03-31 red @ 128.3450: low 128.3450 broke below prior low 129.6350 over prior 3-session channel
+- 2026-02-27 green @ 113.7900: high 113.7900 broke above prior high 111.6900 over prior 3-session channel
+- 2026-02-24 red @ 108.4000: low 108.4000 broke below prior low 109.5800 over prior 3-session channel
+- 2026-02-19 green @ 113.8000: high 113.8000 broke above prior high 112.9700 over prior 3-session channel
+- 2026-02-17 red @ 107.8750: range broke both sides; close 108.7800 < open 111.6600, choosing red below 108.4300 over prior 3-session channel
+- 2026-01-23 green @ 99.4100: high 99.4100 broke above prior high 98.6700 over prior 3-session channel
+- 2025-12-15 red @ 93.3100: low 93.3100 broke below prior low 93.5600 over prior 3-session channel
+- 2025-11-17 red @ 88.1000: low 88.1000 broke below prior low 88.6370 over prior 3-session channel

--- a/crog-ai-backend/scripts/review_signal_candidate_promotion.py
+++ b/crog-ai-backend/scripts/review_signal_candidate_promotion.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Build a read-only promotion review for a Dochia signal candidate."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import psycopg
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from app.signals.chart_repository import fetch_symbol_chart  # noqa: E402
+from app.signals.promotion_review import (  # noqa: E402
+    as_jsonable,
+    build_chart_event_reviews,
+    build_lane_reviews,
+    build_whipsaw_clusters,
+    focus_tickers_for_chart_review,
+)
+from app.signals.repository import (  # noqa: E402
+    fetch_recent_transitions,
+    fetch_watchlist_candidates,
+)
+from scripts.sync_signal_scores import _database_url  # noqa: E402
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Review whether a non-production signal candidate is ready for promotion."
+    )
+    parser.add_argument("--baseline-parameter-set", default=None)
+    parser.add_argument("--candidate-parameter-set", default="dochia_v0_2_range_daily")
+    parser.add_argument("--lane-limit", type=int, default=50)
+    parser.add_argument("--lookback-days", type=int, default=30)
+    parser.add_argument("--transition-limit", type=int, default=5000)
+    parser.add_argument("--chart-sessions", type=int, default=180)
+    parser.add_argument("--chart-ticker-limit", type=int, default=24)
+    parser.add_argument("--sample-size", type=int, default=8)
+    parser.add_argument("--min-whipsaw-transitions", type=int, default=4)
+    parser.add_argument("--min-whipsaw-delta", type=int, default=2)
+    parser.add_argument("--ticker", action="append", dest="tickers")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--output", type=Path, default=None)
+    return parser.parse_args()
+
+
+def _label(parameter_set: str | None) -> str:
+    return parameter_set or "production"
+
+
+def _pct(value: float) -> str:
+    return f"{value * 100:.1f}%"
+
+
+def _table_row(values: list[object]) -> str:
+    return "| " + " | ".join(str(value) for value in values) + " |"
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Dochia Candidate Promotion Review",
+        "",
+        f"Generated: {payload['generated_at']}",
+        f"Baseline: `{payload['baseline_parameter_set']}`",
+        f"Candidate: `{payload['candidate_parameter_set']}`",
+        f"Transition lookback: {payload['lookback_days']} days",
+        f"Chart sessions: {payload['chart_sessions']}",
+        "",
+        "## Lane Churn",
+        "",
+        _table_row(["Lane", "Baseline", "Candidate", "Overlap", "Entered", "Exited", "Churn"]),
+        _table_row(["---", "---:", "---:", "---:", "---:", "---:", "---:"]),
+    ]
+    for row in payload["lane_reviews"]:
+        lines.append(
+            _table_row(
+                [
+                    row["lane"],
+                    row["baseline_count"],
+                    row["candidate_count"],
+                    row["overlap_count"],
+                    ", ".join(row["entered"]) or "-",
+                    ", ".join(row["exited"]) or "-",
+                    _pct(row["churn_rate"]),
+                ]
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Whipsaw Pressure",
+            "",
+            _table_row(["Ticker", "Baseline", "Candidate", "Delta", "Candidate daily", "Latest"]),
+            _table_row(["---", "---:", "---:", "---:", "---:", "---"]),
+        ]
+    )
+    for row in payload["whipsaw_clusters"]:
+        lines.append(
+            _table_row(
+                [
+                    row["ticker"],
+                    row["baseline_transition_count"],
+                    row["candidate_transition_count"],
+                    f"{row['transition_delta']:+d}",
+                    row["candidate_daily_transition_count"],
+                    row["latest_candidate_transition_date"] or "-",
+                ]
+            )
+        )
+    if not payload["whipsaw_clusters"]:
+        lines.append("_No whipsaw clusters crossed the configured thresholds._")
+
+    lines.extend(
+        [
+            "",
+            "## Chart Event Deltas",
+            "",
+            _table_row(["Ticker", "Baseline daily", "Candidate daily", "Delta", "Candidate-only"]),
+            _table_row(["---", "---:", "---:", "---:", "---:"]),
+        ]
+    )
+    for row in payload["chart_event_reviews"]:
+        lines.append(
+            _table_row(
+                [
+                    row["ticker"],
+                    row["baseline_daily_event_count"],
+                    row["candidate_daily_event_count"],
+                    f"{row['daily_event_delta']:+d}",
+                    row["candidate_only_count"],
+                ]
+            )
+        )
+    if not payload["chart_event_reviews"]:
+        lines.append("_No chart event deltas found for the reviewed focus tickers._")
+
+    lines.extend(["", "## Candidate-Only Event Samples", ""])
+    for row in payload["chart_event_reviews"]:
+        if not row["candidate_only_events"]:
+            continue
+        lines.append(f"### {row['ticker']}")
+        for event in row["candidate_only_events"]:
+            lines.append(
+                "- "
+                f"{event['bar_date']} {event['state']} @ {event['trigger_price']}: "
+                f"{event['reason']}"
+            )
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _fetch_charts(
+    conn: psycopg.Connection,
+    *,
+    tickers: list[str],
+    sessions: int,
+    parameter_set: str | None,
+) -> dict[str, dict[str, Any]]:
+    charts: dict[str, dict[str, Any]] = {}
+    for ticker in tickers:
+        chart = fetch_symbol_chart(
+            conn,
+            ticker=ticker,
+            sessions=sessions,
+            parameter_set=parameter_set,
+        )
+        if chart["bars"]:
+            charts[ticker] = chart
+    return charts
+
+
+def build_payload(args: argparse.Namespace) -> dict[str, Any]:
+    if args.lane_limit < 1:
+        raise SystemExit("lane-limit must be at least 1")
+    if args.lookback_days < 1:
+        raise SystemExit("lookback-days must be at least 1")
+    if args.chart_ticker_limit < 1:
+        raise SystemExit("chart-ticker-limit must be at least 1")
+
+    with psycopg.connect(_database_url()) as conn:
+        conn.execute("SET default_transaction_read_only = on")
+        baseline_lanes = fetch_watchlist_candidates(
+            conn,
+            limit=args.lane_limit,
+            parameter_set=args.baseline_parameter_set,
+        )
+        candidate_lanes = fetch_watchlist_candidates(
+            conn,
+            limit=args.lane_limit,
+            parameter_set=args.candidate_parameter_set,
+        )
+        lane_reviews = build_lane_reviews(
+            baseline_lanes,
+            candidate_lanes,
+            sample_size=args.sample_size,
+        )
+        baseline_transitions = fetch_recent_transitions(
+            conn,
+            limit=args.transition_limit,
+            lookback_days=args.lookback_days,
+            parameter_set=args.baseline_parameter_set,
+        )
+        candidate_transitions = fetch_recent_transitions(
+            conn,
+            limit=args.transition_limit,
+            lookback_days=args.lookback_days,
+            parameter_set=args.candidate_parameter_set,
+        )
+        whipsaw_clusters = build_whipsaw_clusters(
+            baseline_transitions,
+            candidate_transitions,
+            min_candidate_transitions=args.min_whipsaw_transitions,
+            min_transition_delta=args.min_whipsaw_delta,
+            top=args.chart_ticker_limit,
+        )
+        focus_tickers = (
+            [ticker.upper() for ticker in args.tickers]
+            if args.tickers
+            else focus_tickers_for_chart_review(
+                lane_reviews=lane_reviews,
+                whipsaw_clusters=whipsaw_clusters,
+                candidate_lanes=candidate_lanes,
+                limit=args.chart_ticker_limit,
+            )
+        )
+        baseline_charts = _fetch_charts(
+            conn,
+            tickers=focus_tickers,
+            sessions=args.chart_sessions,
+            parameter_set=args.baseline_parameter_set,
+        )
+        candidate_charts = _fetch_charts(
+            conn,
+            tickers=focus_tickers,
+            sessions=args.chart_sessions,
+            parameter_set=args.candidate_parameter_set,
+        )
+
+    chart_reviews = build_chart_event_reviews(
+        baseline_charts,
+        candidate_charts,
+        sample_size=args.sample_size,
+    )
+    return {
+        "generated_at": dt.datetime.now(dt.UTC).isoformat(),
+        "baseline_parameter_set": _label(args.baseline_parameter_set),
+        "candidate_parameter_set": args.candidate_parameter_set,
+        "lookback_days": args.lookback_days,
+        "chart_sessions": args.chart_sessions,
+        "focus_tickers": focus_tickers,
+        "lane_reviews": lane_reviews,
+        "whipsaw_clusters": whipsaw_clusters,
+        "chart_event_reviews": chart_reviews,
+    }
+
+
+def main() -> None:
+    args = parse_args()
+    payload = as_jsonable(build_payload(args))
+    text = (
+        json.dumps(payload, indent=2, sort_keys=True)
+        if args.json
+        else _render_markdown(payload)  # type: ignore[arg-type]
+    )
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text)
+    else:
+        print(text, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/crog-ai-backend/tests/test_promotion_review.py
+++ b/crog-ai-backend/tests/test_promotion_review.py
@@ -1,0 +1,155 @@
+import datetime as dt
+from decimal import Decimal
+
+from app.signals.promotion_review import (
+    build_chart_event_reviews,
+    build_lane_reviews,
+    build_whipsaw_clusters,
+    focus_tickers_for_chart_review,
+)
+
+
+def test_build_lane_reviews_reports_candidate_churn() -> None:
+    reviews = build_lane_reviews(
+        {"bullish_alignment": [{"ticker": "AA"}, {"ticker": "MSFT"}]},
+        {"bullish_alignment": [{"ticker": "AA"}, {"ticker": "NVDA"}]},
+        sample_size=5,
+    )
+
+    bullish = reviews[0]
+    assert bullish.lane == "bullish_alignment"
+    assert bullish.baseline_count == 2
+    assert bullish.candidate_count == 2
+    assert bullish.overlap_count == 1
+    assert bullish.entered == ["NVDA"]
+    assert bullish.exited == ["MSFT"]
+    assert bullish.churn_rate == 2 / 3
+
+
+def test_build_whipsaw_clusters_prioritizes_candidate_transition_pressure() -> None:
+    baseline = [
+        {
+            "ticker": "AA",
+            "transition_type": "breakout_bullish",
+            "to_bar_date": dt.date(2026, 4, 1),
+            "notes": "daily triangle green",
+        }
+    ]
+    candidate = [
+        {
+            "ticker": "AA",
+            "transition_type": "breakout_bullish",
+            "to_bar_date": dt.date(2026, 4, 2),
+            "notes": "daily triangle green",
+        },
+        {
+            "ticker": "AA",
+            "transition_type": "peak_to_exit",
+            "to_bar_date": dt.date(2026, 4, 5),
+            "notes": "daily triangle red",
+        },
+        {
+            "ticker": "AA",
+            "transition_type": "exit_to_reentry",
+            "to_bar_date": dt.date(2026, 4, 8),
+            "notes": "weekly triangle green",
+        },
+    ]
+
+    clusters = build_whipsaw_clusters(
+        baseline,
+        candidate,
+        min_candidate_transitions=3,
+        min_transition_delta=2,
+    )
+
+    assert clusters[0].ticker == "AA"
+    assert clusters[0].baseline_transition_count == 1
+    assert clusters[0].candidate_transition_count == 3
+    assert clusters[0].transition_delta == 2
+    assert clusters[0].candidate_daily_transition_count == 2
+    assert clusters[0].candidate_transition_types["peak_to_exit"] == 1
+    assert clusters[0].latest_candidate_transition_date == "2026-04-08"
+
+
+def test_build_chart_event_reviews_surfaces_candidate_only_events() -> None:
+    baseline_chart = {
+        "events": [
+            {
+                "timeframe": "daily",
+                "state": "green",
+                "bar_date": "2026-04-01",
+                "trigger_price": Decimal("10"),
+                "reason": "close break",
+            }
+        ]
+    }
+    candidate_chart = {
+        "events": [
+            {
+                "timeframe": "daily",
+                "state": "green",
+                "bar_date": "2026-04-01",
+                "trigger_price": Decimal("10"),
+                "reason": "close break",
+            },
+            {
+                "timeframe": "daily",
+                "state": "red",
+                "bar_date": "2026-04-03",
+                "trigger_price": Decimal("9"),
+                "reason": "range break",
+            },
+            {
+                "timeframe": "weekly",
+                "state": "red",
+                "bar_date": "2026-04-04",
+                "trigger_price": Decimal("8"),
+                "reason": "weekly break",
+            },
+        ]
+    }
+
+    reviews = build_chart_event_reviews({"AA": baseline_chart}, {"AA": candidate_chart})
+
+    assert reviews[0].ticker == "AA"
+    assert reviews[0].baseline_daily_event_count == 1
+    assert reviews[0].candidate_daily_event_count == 2
+    assert reviews[0].daily_event_delta == 1
+    assert reviews[0].candidate_only_count == 1
+    assert reviews[0].candidate_only_events[0]["bar_date"] == "2026-04-03"
+
+
+def test_focus_tickers_prefers_churn_whipsaws_then_candidate_lanes() -> None:
+    lane_reviews = build_lane_reviews(
+        {"bullish_alignment": [{"ticker": "AA"}]},
+        {"bullish_alignment": [{"ticker": "AA"}, {"ticker": "NVDA"}]},
+        sample_size=5,
+    )
+    whipsaws = build_whipsaw_clusters(
+        [],
+        [
+            {
+                "ticker": "TSLA",
+                "transition_type": "peak_to_exit",
+                "to_bar_date": "2026-04-05",
+                "notes": "daily triangle red",
+            },
+            {
+                "ticker": "TSLA",
+                "transition_type": "exit_to_reentry",
+                "to_bar_date": "2026-04-08",
+                "notes": "daily triangle green",
+            },
+        ],
+        min_candidate_transitions=2,
+    )
+
+    focus = focus_tickers_for_chart_review(
+        lane_reviews=lane_reviews,
+        whipsaw_clusters=whipsaws,
+        candidate_lanes={"bullish_alignment": [{"ticker": "AA"}]},
+        limit=5,
+    )
+
+    assert focus[:3] == ["NVDA", "TSLA", "AA"]

--- a/docs/operational/MASTER-PLAN.md
+++ b/docs/operational/MASTER-PLAN.md
@@ -291,7 +291,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 - Do not call generated weekly/monthly states "MarketClub truth"; they are Dochia-derived.
 - Avoid gamified trading prompts; build an evidence cockpit.
 
-**Immediate next step:** Run v0.2 promotion review: compare top-lane symbols, whipsaw clusters, and chart-level candidate events before deciding whether the range trigger can become the next production parameter set.
+**Immediate next step:** Add v0.3 guardrail research for the range trigger: reduce whipsaw pressure with debounce, close-confirmation, or volatility filters before any production promotion.
 
 ### 6.6 Architectural follow-ups
 
@@ -349,6 +349,8 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 - Registered non-production `dochia_v0_2_range_daily` and wired daily trigger mode through score/transition previews. Dry run: 328 candidate score rows, 1,624 candidate transitions since 2026-03-25, bullish/risk lane counts unchanged, 61 daily states/scores changed.
 - Persisted v0.2 candidate scores/transitions under non-production parameter set and added internal `parameter_set` selectors to scanner, transitions, symbol detail, Portfolio Lens, and chart-overlay API reads. Production remains default.
 - Added v0.2 chart-overlay parity: the symbol chart now follows the active Production/v0.2 Range mode, using close-break daily events for production and range-trigger daily events for the v0.2 candidate.
+- Added read-only v0.2 promotion-review harness covering top-lane churn, recent whipsaw/transition pressure, and chart-level candidate event deltas.
+- Ran first v0.2 promotion-review report. Decision: do not promote range trigger yet. Risk lane is stable, but re-entry lane churn is 66.7%, mixed-timeframe churn is 52.9%, top whipsaw tickers show 8-9 candidate transitions in the 30-day window, and reviewed chart overlays add up to 29 candidate-only daily events on some symbols.
 - Added internal Production/v0.2 Range toggle to the Command Center Hedge Fund page and promoted the production frontend build.
 - Added chart-data endpoint and chart overlay with close, daily/weekly channel bands, and generated triangle event markers.
 - Refined calibration metrics to separate carried-state agreement from exact new-alert agreement: 40.67% same-day alert match and 52.54% ±3-day alert match.


### PR DESCRIPTION
## Summary
- add a read-only promotion-review harness for Dochia candidate parameter sets
- compare persisted top-lane churn, recent transition/whipsaw pressure, and chart-level candidate-only daily events
- add the first v0.2 promotion review report and record the decision not to promote v0.2 without guardrail research

## Key report result
- Risk lane stayed stable, but v0.2 range mode showed high re-entry/mixed-timeframe churn and elevated daily event pressure.
- Decision captured in docs: do not promote v0.2 yet; next step is v0.3 guardrail research.

## Verification
- `PYTHONPATH=. /home/admin/.local/bin/uv run pytest tests/test_promotion_review.py` — 4 passed
- `PYTHONPATH=. /home/admin/.local/bin/uv run pytest tests/test_trade_triangles.py tests/test_calibration.py tests/test_calibration_sweep.py tests/test_db_preview.py tests/test_db_sync.py tests/test_chart_repository.py tests/test_api_signals.py tests/test_promotion_review.py` — 34 passed
- `/home/admin/.local/bin/uv run ruff check app/signals/promotion_review.py scripts/review_signal_candidate_promotion.py tests/test_promotion_review.py` — passed
- `PYTHONPATH=. /home/admin/.local/bin/uv run python scripts/review_signal_candidate_promotion.py --lane-limit 50 --chart-ticker-limit 24 --output docs/reports/dochia-v0-2-promotion-review-2026-05-03.md` — report generated
