### PR TITLE
feat(financial): add Dochia v0.3 guardrail research

### DIFF
--- a/crog-ai-backend/README.md
+++ b/crog-ai-backend/README.md
@@ -106,6 +106,7 @@ uv run python scripts/sweep_daily_signal_parameters.py --lookback-min 2 --lookba
 uv run python scripts/validate_daily_signal_candidate.py --top-tickers 15 --min-slice-observations 50
 uv run python scripts/compare_signal_candidate_lanes.py --limit-tickers 500 --top 12
 uv run python scripts/review_signal_candidate_promotion.py --lane-limit 50 --chart-ticker-limit 24
+uv run python scripts/research_range_trigger_guardrails.py --output docs/reports/dochia-v0-3-guardrail-research-2026-05-03.md
 ```
 
 Best 2026-05-02 research candidate: 3-session intraday range trigger. It
@@ -134,6 +135,15 @@ to production.
 
 First report: `docs/reports/dochia-v0-2-promotion-review-2026-05-03.md`.
 Decision: do not promote v0.2 yet; add guardrail research first.
+
+v0.3 guardrail research is read-only and sweeps range-trigger buffers,
+same-direction close confirmation, and post-event debounce windows against the
+same MarketClub daily alert corpus. First report:
+`docs/reports/dochia-v0-3-guardrail-research-2026-05-03.md`. Decision: no
+simple guardrail cleared the default quality bar of at least 85% of raw-range
+F1 while cutting generated events by at least 15%. Next research moves to
+ATR-normalized buffers and ticker-specific cooldowns before creating another
+non-production parameter set.
 
 ## Relationship to Fortress-Prime
 

--- a/crog-ai-backend/app/signals/guardrail_sweep.py
+++ b/crog-ai-backend/app/signals/guardrail_sweep.py
@@ -1,0 +1,303 @@
+"""Guardrail sweeps for noisy MarketClub range-trigger candidates."""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+from decimal import Decimal
+
+from app.signals.calibration import CalibrationObservation, normalize_triangle_color
+from app.signals.calibration_sweep import DailyEventHistory
+from app.signals.trade_triangles import EodBar, TriangleState
+
+
+@dataclass(frozen=True, slots=True)
+class GuardedRangeCandidate:
+    lookback_sessions: int
+    min_break_pct: Decimal = Decimal("0")
+    debounce_sessions: int = 0
+    require_directional_close: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class GuardrailSweepResult:
+    lookback_sessions: int
+    min_break_pct: Decimal
+    debounce_sessions: int
+    require_directional_close: bool
+    total_observations: int
+    covered_observations: int
+    generated_events: int
+    raw_range_generated_events: int | None
+    generated_event_reduction: float | None
+    carried_state_matches: int
+    exact_event_matches: int
+    window_event_matches: int
+    opposite_event_observations: int
+    no_event_observations: int
+    carried_state_accuracy: float | None
+    exact_event_recall: float | None
+    exact_event_precision: float | None
+    exact_event_f1: float | None
+    window_event_recall: float | None
+
+    def as_json_dict(self) -> dict[str, object]:
+        payload = asdict(self)
+        payload["min_break_pct"] = str(self.min_break_pct)
+        return payload
+
+
+def _channel(reference_bars: list[EodBar]) -> tuple[Decimal, Decimal]:
+    return (
+        max(bar.high for bar in reference_bars),
+        min(bar.low for bar in reference_bars),
+    )
+
+
+def _safe_rate(numerator: int, denominator: int) -> float | None:
+    if denominator == 0:
+        return None
+    return numerator / denominator
+
+
+def _f1(precision: float | None, recall: float | None) -> float | None:
+    if precision is None or recall is None or precision + recall == 0:
+        return None
+    return 2 * precision * recall / (precision + recall)
+
+
+def _validate_candidate(candidate: GuardedRangeCandidate) -> None:
+    if candidate.lookback_sessions < 1:
+        raise ValueError("lookback_sessions must be at least 1")
+    if candidate.min_break_pct < 0:
+        raise ValueError("min_break_pct must be non-negative")
+    if candidate.min_break_pct >= 1:
+        raise ValueError("min_break_pct must be less than 1")
+    if candidate.debounce_sessions < 0:
+        raise ValueError("debounce_sessions must be non-negative")
+
+
+def _guarded_range_break_state(
+    bar: EodBar,
+    *,
+    channel_high: Decimal,
+    channel_low: Decimal,
+    candidate: GuardedRangeCandidate,
+) -> int:
+    high_threshold = channel_high * (Decimal("1") + candidate.min_break_pct)
+    low_threshold = channel_low * (Decimal("1") - candidate.min_break_pct)
+    broke_high = bar.high > high_threshold
+    broke_low = bar.low < low_threshold
+
+    if candidate.require_directional_close:
+        broke_high = broke_high and bar.close >= bar.open
+        broke_low = broke_low and bar.close < bar.open
+
+    if broke_high and broke_low:
+        return TriangleState.GREEN.numeric if bar.close >= bar.open else TriangleState.RED.numeric
+    if broke_high:
+        return TriangleState.GREEN.numeric
+    if broke_low:
+        return TriangleState.RED.numeric
+    return TriangleState.NEUTRAL.numeric
+
+
+def generated_guarded_range_event_history(
+    bars: list[EodBar],
+    *,
+    candidate: GuardedRangeCandidate,
+) -> DailyEventHistory | None:
+    """Generate range-trigger events after applying v0.3 research guardrails.
+
+    `debounce_sessions` suppresses flips for that many full sessions after a
+    generated event. For example, a value of 1 suppresses the next-session flip.
+    """
+    _validate_candidate(candidate)
+    ordered = sorted(bars, key=lambda bar: (bar.ticker, bar.bar_date))
+    if not ordered:
+        return None
+    ticker = ordered[0].ticker
+    if any(bar.ticker != ticker for bar in ordered):
+        raise ValueError("bars must contain exactly one ticker")
+
+    current_state = TriangleState.NEUTRAL.numeric
+    last_event_index: int | None = None
+    state_by_date: dict[dt.date, int] = {}
+    event_by_date: dict[dt.date, int] = {}
+    event_dates_by_state: dict[int, list[dt.date]] = defaultdict(list)
+    dates: list[dt.date] = []
+
+    for index, bar in enumerate(ordered):
+        if index >= candidate.lookback_sessions:
+            channel_high, channel_low = _channel(
+                ordered[index - candidate.lookback_sessions : index]
+            )
+            next_state = _guarded_range_break_state(
+                bar,
+                channel_high=channel_high,
+                channel_low=channel_low,
+                candidate=candidate,
+            )
+            if next_state != TriangleState.NEUTRAL.numeric and next_state != current_state:
+                within_debounce = (
+                    last_event_index is not None
+                    and index - last_event_index <= candidate.debounce_sessions
+                )
+                if not within_debounce:
+                    current_state = next_state
+                    last_event_index = index
+                    event_by_date[bar.bar_date] = next_state
+                    event_dates_by_state[next_state].append(bar.bar_date)
+
+        state_by_date[bar.bar_date] = current_state
+        dates.append(bar.bar_date)
+
+    return DailyEventHistory(
+        ticker=ticker,
+        dates=tuple(dates),
+        state_by_date=state_by_date,
+        event_by_date=event_by_date,
+        event_dates_by_state={
+            state: tuple(sorted(event_dates)) for state, event_dates in event_dates_by_state.items()
+        },
+    )
+
+
+def evaluate_guarded_range_candidate(
+    observations: list[CalibrationObservation],
+    bars_by_ticker: dict[str, list[EodBar]],
+    *,
+    candidate: GuardedRangeCandidate,
+    raw_range_generated_events: int | None = None,
+    event_window_days: int = 3,
+) -> GuardrailSweepResult:
+    histories = {
+        ticker: history
+        for ticker, bars in bars_by_ticker.items()
+        if (history := generated_guarded_range_event_history(bars, candidate=candidate))
+        is not None
+    }
+    if observations:
+        since = min(observation.trading_day for observation in observations)
+        until = max(observation.trading_day for observation in observations)
+    else:
+        since = until = None
+
+    covered = 0
+    state_matches = 0
+    exact_matches = 0
+    window_matches = 0
+    opposite_events = 0
+    no_events = 0
+    generated_events = 0
+    matched_generated_events: set[tuple[str, dt.date]] = set()
+
+    for history in histories.values():
+        for event_date in history.event_by_date:
+            if since is not None and event_date < since:
+                continue
+            if until is not None and event_date > until:
+                continue
+            generated_events += 1
+
+    for observation in observations:
+        actual = normalize_triangle_color(observation.triangle_color)
+        actual_state = TriangleState.GREEN.numeric if actual == "green" else TriangleState.RED.numeric
+        history = histories.get(observation.ticker)
+        if history is None:
+            continue
+
+        state = history.state_as_of(observation.trading_day)
+        if state is None:
+            continue
+        covered += 1
+        if state == actual_state:
+            state_matches += 1
+
+        event = history.event_on(observation.trading_day)
+        if event is None:
+            no_events += 1
+        elif event == actual_state:
+            exact_matches += 1
+            matched_generated_events.add((observation.ticker, observation.trading_day))
+        else:
+            opposite_events += 1
+
+        if history.has_event_within(
+            trading_day=observation.trading_day,
+            state=actual_state,
+            window_days=event_window_days,
+        ):
+            window_matches += 1
+
+    recall = _safe_rate(exact_matches, covered)
+    precision = _safe_rate(len(matched_generated_events), generated_events)
+    generated_event_reduction = (
+        _safe_rate(raw_range_generated_events - generated_events, raw_range_generated_events)
+        if raw_range_generated_events
+        else None
+    )
+    return GuardrailSweepResult(
+        lookback_sessions=candidate.lookback_sessions,
+        min_break_pct=candidate.min_break_pct,
+        debounce_sessions=candidate.debounce_sessions,
+        require_directional_close=candidate.require_directional_close,
+        total_observations=len(observations),
+        covered_observations=covered,
+        generated_events=generated_events,
+        raw_range_generated_events=raw_range_generated_events,
+        generated_event_reduction=generated_event_reduction,
+        carried_state_matches=state_matches,
+        exact_event_matches=exact_matches,
+        window_event_matches=window_matches,
+        opposite_event_observations=opposite_events,
+        no_event_observations=no_events,
+        carried_state_accuracy=_safe_rate(state_matches, covered),
+        exact_event_recall=recall,
+        exact_event_precision=precision,
+        exact_event_f1=_f1(precision, recall),
+        window_event_recall=_safe_rate(window_matches, covered),
+    )
+
+
+def _sort_key(result: GuardrailSweepResult) -> tuple[float, float, float, float, int]:
+    return (
+        result.exact_event_f1 or 0,
+        result.generated_event_reduction or 0,
+        result.exact_event_precision or 0,
+        result.window_event_recall or 0,
+        -result.generated_events,
+    )
+
+
+def sweep_guarded_range_candidates(
+    observations: list[CalibrationObservation],
+    bars_by_ticker: dict[str, list[EodBar]],
+    *,
+    candidates: list[GuardedRangeCandidate],
+    event_window_days: int = 3,
+) -> list[GuardrailSweepResult]:
+    raw_generated_by_lookback: dict[int, int] = {}
+    for lookback in sorted({candidate.lookback_sessions for candidate in candidates}):
+        raw_candidate = GuardedRangeCandidate(lookback_sessions=lookback)
+        raw_result = evaluate_guarded_range_candidate(
+            observations,
+            bars_by_ticker,
+            candidate=raw_candidate,
+            event_window_days=event_window_days,
+        )
+        raw_generated_by_lookback[lookback] = raw_result.generated_events
+
+    results = [
+        evaluate_guarded_range_candidate(
+            observations,
+            bars_by_ticker,
+            candidate=candidate,
+            raw_range_generated_events=raw_generated_by_lookback.get(candidate.lookback_sessions),
+            event_window_days=event_window_days,
+        )
+        for candidate in candidates
+    ]
+    results.sort(key=_sort_key, reverse=True)
+    return results

--- a/crog-ai-backend/docs/MARKETCLUB-DOCHIA-BUILD-PLAN.md
+++ b/crog-ai-backend/docs/MARKETCLUB-DOCHIA-BUILD-PLAN.md
@@ -188,6 +188,16 @@ Useful query params:
   52.9%, top whipsaw tickers show 8-9 candidate transitions in the 30-day
   window, and reviewed chart overlays add up to 29 candidate-only daily events
   on some symbols.
+- Added a read-only v0.3 guardrail research harness for the range trigger. It
+  sweeps minimum intraday break buffers, same-direction close confirmation, and
+  post-event debounce windows against the MarketClub daily alert corpus before
+  creating another non-production parameter set.
+- First v0.3 guardrail report is tracked at
+  `docs/reports/dochia-v0-3-guardrail-research-2026-05-03.md`. Decision: do
+  not promote or parameterize these simple filters yet. Raw v0.2 range remains
+  the strongest F1 candidate at 76.64%. The best simple reductions cut events
+  by 15-27%, but exact F1 falls to roughly 56-60%, below the default quality
+  bar.
 - Added and enabled `crog-ai-backend.service` on spark-node-2.
 - Promoted the Command Center production build and restarted
   `crog-ai-frontend.service`; `/financial/hedge-fund` is live through
@@ -197,6 +207,6 @@ Useful query params:
   status, and live backend/BFF reads for both production and v0.2 candidate
   selectors. `/financial/hedge-fund` returns 200 after frontend restart.
 
-Next clean build step: add v0.3 guardrail research for the range trigger:
-reduce whipsaw pressure with debounce, close-confirmation, or volatility
-filters before any production promotion.
+Next clean build step: expand v0.3 research to ATR-normalized buffers and
+ticker-specific cooldowns, then persist only a candidate that preserves enough
+raw-range F1 while materially reducing whipsaw pressure.

--- a/crog-ai-backend/docs/reports/dochia-v0-3-guardrail-research-2026-05-03.md
+++ b/crog-ai-backend/docs/reports/dochia-v0-3-guardrail-research-2026-05-03.md
@@ -1,0 +1,36 @@
+# Dochia v0.3 Range Guardrail Research
+
+Generated: 2026-05-03T05:27:09.301327+00:00
+Scope: ticker=all since=beginning until=latest
+Event window: ±3 days
+Candidates tested: 40
+
+## Baselines
+
+| Rule | F1 | Precision | Recall | ±3d recall | Carried | Generated |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| production close | 44.59% | 49.35% | 40.67% | 52.54% | 62.05% | 18158 |
+| v0.2 raw range | 76.64% | 65.71% | 91.93% | 95.21% | 94.91% | 30806 |
+
+## Top Guardrail Candidates
+
+| Rank | Lookback | Break buffer | Debounce | Directional close | F1 | Precision | Recall | ±3d recall | Carried | Generated | Event reduction |
+| ---: | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 3 | 0.00% | 0 | no | 76.64% | 65.71% | 91.93% | 95.21% | 94.91% | 30806 | 0.00% |
+| 2 | 3 | 0.10% | 0 | no | 73.12% | 63.77% | 85.69% | 91.48% | 90.16% | 29582 | 3.97% |
+| 3 | 3 | 0.00% | 1 | no | 69.47% | 60.88% | 80.88% | 90.42% | 86.12% | 29247 | 5.06% |
+| 4 | 3 | 0.25% | 0 | no | 66.93% | 60.19% | 75.36% | 84.39% | 82.79% | 27539 | 10.61% |
+| 5 | 3 | 0.10% | 1 | no | 66.65% | 59.35% | 75.99% | 87.08% | 82.54% | 28179 | 8.53% |
+| 6 | 3 | 0.25% | 1 | no | 61.44% | 56.35% | 67.53% | 80.51% | 76.68% | 26358 | 14.44% |
+| 7 | 3 | 0.00% | 2 | no | 60.16% | 55.36% | 65.88% | 78.11% | 75.58% | 26209 | 14.92% |
+| 8 | 3 | 0.00% | 0 | yes | 59.65% | 57.97% | 61.44% | 70.79% | 75.06% | 23343 | 24.23% |
+| 9 | 3 | 0.50% | 0 | no | 58.79% | 55.83% | 62.09% | 73.67% | 73.94% | 24434 | 20.68% |
+| 10 | 3 | 0.10% | 2 | no | 57.84% | 53.96% | 62.33% | 75.84% | 72.89% | 25436 | 17.43% |
+| 11 | 3 | 0.10% | 0 | yes | 57.37% | 56.88% | 57.88% | 67.85% | 72.55% | 22404 | 27.27% |
+| 12 | 3 | 0.00% | 1 | yes | 56.15% | 55.55% | 56.75% | 68.01% | 71.50% | 22500 | 26.96% |
+
+## Recommendation
+
+No v0.3 guardrail cleared the default quality bar of at least 85% of raw-range F1 while cutting generated events by at least 15%. Keep v0.2 in candidate-only mode and expand the research grid before promotion.
+
+Next move: test ATR-normalized buffers and ticker-specific cooldowns against the same promotion-review churn packet.

--- a/crog-ai-backend/scripts/research_range_trigger_guardrails.py
+++ b/crog-ai-backend/scripts/research_range_trigger_guardrails.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Research v0.3 guardrails for the MarketClub daily range trigger."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import psycopg
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from app.signals.calibration_repository import fetch_daily_sweep_inputs  # noqa: E402
+from app.signals.calibration_sweep import (  # noqa: E402
+    DailySweepCandidate,
+    evaluate_daily_sweep_candidate,
+)
+from app.signals.guardrail_sweep import (  # noqa: E402
+    GuardedRangeCandidate,
+    GuardrailSweepResult,
+    sweep_guarded_range_candidates,
+)
+from scripts.sweep_daily_signal_parameters import _database_url  # noqa: E402
+
+DEFAULT_BREAK_PCTS = (Decimal("0"), Decimal("0.001"), Decimal("0.0025"), Decimal("0.005"), Decimal("0.01"))
+DEFAULT_DEBOUNCE_SESSIONS = (0, 1, 2, 3)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Sweep range-trigger guardrails against MarketClub daily alerts."
+    )
+    parser.add_argument("--since", type=dt.date.fromisoformat, default=None)
+    parser.add_argument("--until", type=dt.date.fromisoformat, default=None)
+    parser.add_argument("--ticker", default=None)
+    parser.add_argument("--lookback", action="append", type=int, default=None)
+    parser.add_argument("--min-break-pct", action="append", type=Decimal, default=None)
+    parser.add_argument("--debounce-sessions", action="append", type=int, default=None)
+    parser.add_argument(
+        "--directional-close-mode",
+        choices=["both", "none", "required"],
+        default="both",
+        help="Whether intraday breaks must close in the breakout direction.",
+    )
+    parser.add_argument("--event-window-days", type=int, default=3)
+    parser.add_argument("--top", type=int, default=12)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--output", type=Path, default=None)
+    return parser.parse_args()
+
+
+def _pct(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value * 100:.2f}%"
+
+
+def _break_pct(value: str | Decimal) -> str:
+    return f"{Decimal(str(value)) * Decimal('100'):.2f}%"
+
+
+def _table_row(values: list[object]) -> str:
+    return "| " + " | ".join(str(value) for value in values) + " |"
+
+
+def _directional_options(mode: str) -> list[bool]:
+    if mode == "none":
+        return [False]
+    if mode == "required":
+        return [True]
+    return [False, True]
+
+
+def _candidate_grid(args: argparse.Namespace) -> list[GuardedRangeCandidate]:
+    lookbacks = args.lookback or [3]
+    min_break_pcts = args.min_break_pct or list(DEFAULT_BREAK_PCTS)
+    debounce_sessions = args.debounce_sessions or list(DEFAULT_DEBOUNCE_SESSIONS)
+    directional_options = _directional_options(args.directional_close_mode)
+    return [
+        GuardedRangeCandidate(
+            lookback_sessions=lookback,
+            min_break_pct=min_break_pct,
+            debounce_sessions=debounce,
+            require_directional_close=require_directional_close,
+        )
+        for lookback in lookbacks
+        for min_break_pct in min_break_pcts
+        for debounce in debounce_sessions
+        for require_directional_close in directional_options
+    ]
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if args.since is not None and args.until is not None and args.since > args.until:
+        raise SystemExit("since cannot be after until")
+    if args.top < 1:
+        raise SystemExit("top must be at least 1")
+    for lookback in args.lookback or [3]:
+        if lookback < 1:
+            raise SystemExit("lookback must be at least 1")
+    for min_break_pct in args.min_break_pct or list(DEFAULT_BREAK_PCTS):
+        if min_break_pct < 0 or min_break_pct >= 1:
+            raise SystemExit("min-break-pct must be >= 0 and < 1")
+    for debounce in args.debounce_sessions or list(DEFAULT_DEBOUNCE_SESSIONS):
+        if debounce < 0:
+            raise SystemExit("debounce-sessions must be non-negative")
+
+
+def _pick_recommendation(
+    results: list[GuardrailSweepResult],
+    *,
+    raw_range: GuardrailSweepResult,
+) -> GuardrailSweepResult | None:
+    raw_f1 = raw_range.exact_event_f1 or 0
+    minimum_f1 = raw_f1 * 0.85
+    eligible = [
+        result
+        for result in results
+        if not (
+            result.lookback_sessions == raw_range.lookback_sessions
+            and result.min_break_pct == raw_range.min_break_pct
+            and result.debounce_sessions == raw_range.debounce_sessions
+            and result.require_directional_close == raw_range.require_directional_close
+        )
+        and (result.exact_event_f1 or 0) >= minimum_f1
+        and (result.generated_event_reduction or 0) >= 0.15
+    ]
+    if not eligible:
+        return None
+    eligible.sort(
+        key=lambda result: (
+            result.generated_event_reduction or 0,
+            result.exact_event_f1 or 0,
+            result.exact_event_precision or 0,
+        ),
+        reverse=True,
+    )
+    return eligible[0]
+
+
+def _render_result_row(result: dict[str, Any], rank: int | str) -> str:
+    return _table_row(
+        [
+            rank,
+            result["lookback_sessions"],
+            _break_pct(result["min_break_pct"]),
+            result["debounce_sessions"],
+            "yes" if result["require_directional_close"] else "no",
+            _pct(result["exact_event_f1"]),
+            _pct(result["exact_event_precision"]),
+            _pct(result["exact_event_recall"]),
+            _pct(result["window_event_recall"]),
+            _pct(result["carried_state_accuracy"]),
+            result["generated_events"],
+            _pct(result["generated_event_reduction"]),
+        ]
+    )
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    close_baseline = payload["production_close_baseline"]
+    raw_range = payload["raw_range_baseline"]
+    recommendation = payload["recommendation"]
+    lines = [
+        "# Dochia v0.3 Range Guardrail Research",
+        "",
+        f"Generated: {payload['generated_at']}",
+        f"Scope: ticker={payload['ticker'] or 'all'} since={payload['since'] or 'beginning'} until={payload['until'] or 'latest'}",
+        f"Event window: ±{payload['event_window_days']} days",
+        f"Candidates tested: {payload['candidate_count']}",
+        "",
+        "## Baselines",
+        "",
+        _table_row(["Rule", "F1", "Precision", "Recall", "±3d recall", "Carried", "Generated"]),
+        _table_row(["---", "---:", "---:", "---:", "---:", "---:", "---:"]),
+        _table_row(
+            [
+                "production close",
+                _pct(close_baseline["exact_event_f1"]),
+                _pct(close_baseline["exact_event_precision"]),
+                _pct(close_baseline["exact_event_recall"]),
+                _pct(close_baseline["window_event_recall"]),
+                _pct(close_baseline["carried_state_accuracy"]),
+                close_baseline["generated_events"],
+            ]
+        ),
+        _table_row(
+            [
+                "v0.2 raw range",
+                _pct(raw_range["exact_event_f1"]),
+                _pct(raw_range["exact_event_precision"]),
+                _pct(raw_range["exact_event_recall"]),
+                _pct(raw_range["window_event_recall"]),
+                _pct(raw_range["carried_state_accuracy"]),
+                raw_range["generated_events"],
+            ]
+        ),
+        "",
+        "## Top Guardrail Candidates",
+        "",
+        _table_row(
+            [
+                "Rank",
+                "Lookback",
+                "Break buffer",
+                "Debounce",
+                "Directional close",
+                "F1",
+                "Precision",
+                "Recall",
+                "±3d recall",
+                "Carried",
+                "Generated",
+                "Event reduction",
+            ]
+        ),
+        _table_row(["---:", "---:", "---:", "---:", "---", "---:", "---:", "---:", "---:", "---:", "---:", "---:"]),
+    ]
+    for rank, result in enumerate(payload["top_results"], start=1):
+        lines.append(_render_result_row(result, rank))
+
+    lines.extend(["", "## Recommendation", ""])
+    if recommendation is None:
+        lines.extend(
+            [
+                "No v0.3 guardrail cleared the default quality bar of at least 85% of raw-range F1 while cutting generated events by at least 15%. Keep v0.2 in candidate-only mode and expand the research grid before promotion.",
+                "",
+                "Next move: test ATR-normalized buffers and ticker-specific cooldowns against the same promotion-review churn packet.",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "Use this as the next non-production v0.3 research candidate:",
+                "",
+                _table_row(
+                    [
+                        "Lookback",
+                        "Break buffer",
+                        "Debounce",
+                        "Directional close",
+                        "F1",
+                        "Precision",
+                        "Recall",
+                        "Generated",
+                        "Event reduction",
+                    ]
+                ),
+                _table_row(["---:", "---:", "---:", "---", "---:", "---:", "---:", "---:", "---:"]),
+                _table_row(
+                    [
+                        recommendation["lookback_sessions"],
+                        _break_pct(recommendation["min_break_pct"]),
+                        recommendation["debounce_sessions"],
+                        "yes" if recommendation["require_directional_close"] else "no",
+                        _pct(recommendation["exact_event_f1"]),
+                        _pct(recommendation["exact_event_precision"]),
+                        _pct(recommendation["exact_event_recall"]),
+                        recommendation["generated_events"],
+                        _pct(recommendation["generated_event_reduction"]),
+                    ]
+                ),
+                "",
+                "Decision: keep production on close-break v0 until this v0.3 candidate is persisted as a separate parameter set and reviewed through lane churn, whipsaw pressure, and chart-event deltas.",
+            ]
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_payload(args: argparse.Namespace) -> dict[str, Any]:
+    _validate_args(args)
+    candidates = _candidate_grid(args)
+    with psycopg.connect(_database_url()) as conn:
+        conn.execute("SET default_transaction_read_only = on")
+        observations, bars_by_ticker = fetch_daily_sweep_inputs(
+            conn,
+            since=args.since,
+            until=args.until,
+            ticker=args.ticker,
+        )
+
+    results = sweep_guarded_range_candidates(
+        observations,
+        bars_by_ticker,
+        candidates=candidates,
+        event_window_days=args.event_window_days,
+    )
+    raw_range = next(
+        result
+        for result in results
+        if result.lookback_sessions == 3
+        and result.min_break_pct == Decimal("0")
+        and result.debounce_sessions == 0
+        and not result.require_directional_close
+    )
+    close_baseline = evaluate_daily_sweep_candidate(
+        observations,
+        bars_by_ticker,
+        candidate=DailySweepCandidate(lookback_sessions=3, trigger_mode="close"),
+        event_window_days=args.event_window_days,
+    )
+    recommendation = _pick_recommendation(results, raw_range=raw_range)
+    top_results = [result.as_json_dict() for result in results[: args.top]]
+    raw_range_payload = raw_range.as_json_dict()
+    close_payload = close_baseline.as_json_dict()
+    return {
+        "generated_at": dt.datetime.now(dt.UTC).isoformat(),
+        "since": args.since.isoformat() if args.since else None,
+        "until": args.until.isoformat() if args.until else None,
+        "ticker": args.ticker.upper() if args.ticker else None,
+        "event_window_days": args.event_window_days,
+        "candidate_count": len(candidates),
+        "observation_count": len(observations),
+        "production_close_baseline": close_payload,
+        "raw_range_baseline": raw_range_payload,
+        "top_results": top_results,
+        "recommendation": recommendation.as_json_dict() if recommendation else None,
+    }
+
+
+def main() -> None:
+    args = parse_args()
+    payload = build_payload(args)
+    text = (
+        json.dumps(payload, indent=2, sort_keys=True)
+        if args.json
+        else _render_markdown(payload)
+    )
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text)
+    else:
+        print(text, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/crog-ai-backend/tests/test_guardrail_sweep.py
+++ b/crog-ai-backend/tests/test_guardrail_sweep.py
@@ -1,0 +1,138 @@
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+
+from app.signals.calibration import CalibrationObservation
+from app.signals.guardrail_sweep import (
+    GuardedRangeCandidate,
+    generated_guarded_range_event_history,
+    sweep_guarded_range_candidates,
+)
+from app.signals.trade_triangles import EodBar
+
+
+def _bar(index: int, *, open_: str, high: str, low: str, close: str) -> EodBar:
+    return EodBar(
+        ticker="AA",
+        bar_date=dt.date(2026, 1, 1) + dt.timedelta(days=index),
+        open=Decimal(open_),
+        high=Decimal(high),
+        low=Decimal(low),
+        close=Decimal(close),
+        volume=1000,
+    )
+
+
+def test_directional_close_suppresses_faded_intraday_breakout() -> None:
+    bars = [
+        _bar(0, open_="10", high="10", low="9", close="10"),
+        _bar(1, open_="11", high="11", low="10", close="11"),
+        _bar(2, open_="10", high="12", low="9", close="9"),
+    ]
+
+    raw_history = generated_guarded_range_event_history(
+        bars,
+        candidate=GuardedRangeCandidate(lookback_sessions=2),
+    )
+    guarded_history = generated_guarded_range_event_history(
+        bars,
+        candidate=GuardedRangeCandidate(lookback_sessions=2, require_directional_close=True),
+    )
+
+    event_date = dt.date(2026, 1, 3)
+    assert raw_history is not None
+    assert guarded_history is not None
+    assert raw_history.event_on(event_date) == 1
+    assert guarded_history.event_on(event_date) is None
+    assert guarded_history.state_as_of(event_date) == 0
+
+
+def test_min_break_pct_suppresses_tiny_range_break() -> None:
+    bars = [
+        _bar(0, open_="10", high="10", low="9", close="10"),
+        _bar(1, open_="11", high="11", low="10", close="11"),
+        _bar(2, open_="11", high="11.02", low="10", close="11.01"),
+    ]
+
+    raw_history = generated_guarded_range_event_history(
+        bars,
+        candidate=GuardedRangeCandidate(lookback_sessions=2),
+    )
+    buffered_history = generated_guarded_range_event_history(
+        bars,
+        candidate=GuardedRangeCandidate(
+            lookback_sessions=2,
+            min_break_pct=Decimal("0.005"),
+        ),
+    )
+
+    event_date = dt.date(2026, 1, 3)
+    assert raw_history is not None
+    assert buffered_history is not None
+    assert raw_history.event_on(event_date) == 1
+    assert buffered_history.event_on(event_date) is None
+
+
+def test_debounce_suppresses_immediate_flip_after_event() -> None:
+    bars = [
+        _bar(0, open_="10", high="10", low="9", close="10"),
+        _bar(1, open_="11", high="11", low="10", close="11"),
+        _bar(2, open_="11", high="12", low="10", close="12"),
+        _bar(3, open_="10", high="10", low="8", close="8"),
+    ]
+
+    raw_history = generated_guarded_range_event_history(
+        bars,
+        candidate=GuardedRangeCandidate(lookback_sessions=2),
+    )
+    debounced_history = generated_guarded_range_event_history(
+        bars,
+        candidate=GuardedRangeCandidate(lookback_sessions=2, debounce_sessions=1),
+    )
+
+    flip_date = dt.date(2026, 1, 4)
+    assert raw_history is not None
+    assert debounced_history is not None
+    assert raw_history.event_on(flip_date) == -1
+    assert debounced_history.event_on(flip_date) is None
+    assert debounced_history.state_as_of(flip_date) == 1
+
+
+def test_guardrail_sweep_reports_event_reduction_and_ranks_quality() -> None:
+    bars = [
+        _bar(0, open_="10", high="10", low="9", close="10"),
+        _bar(1, open_="11", high="11", low="10", close="11"),
+        _bar(2, open_="10", high="12", low="9", close="9"),
+        _bar(3, open_="10", high="10", low="7", close="8"),
+    ]
+    observations = [
+        CalibrationObservation(
+            ticker="AA",
+            trading_day=dt.date(2026, 1, 3),
+            triangle_color="red",
+            score=-15,
+        ),
+        CalibrationObservation(
+            ticker="AA",
+            trading_day=dt.date(2026, 1, 4),
+            triangle_color="red",
+            score=-15,
+        )
+    ]
+
+    results = sweep_guarded_range_candidates(
+        observations,
+        {"AA": bars},
+        candidates=[
+            GuardedRangeCandidate(lookback_sessions=2),
+            GuardedRangeCandidate(lookback_sessions=2, require_directional_close=True),
+        ],
+    )
+
+    assert results[0].require_directional_close is True
+    assert results[0].exact_event_matches == 1
+    assert results[0].exact_event_f1 == pytest.approx(2 / 3)
+    assert results[0].generated_events == 1
+    assert results[0].raw_range_generated_events == 2
+    assert results[0].generated_event_reduction == 0.5

--- a/docs/operational/MASTER-PLAN.md
+++ b/docs/operational/MASTER-PLAN.md
@@ -259,6 +259,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 | Legacy watchlist context | `watchlist` has 431 rows; `market_signals` has 1,105 rows through 2026-02-12; read-only grant applied for app overlays |
 | Calibration baseline | 24,204 daily observations; 91.44% coverage; 62.05% carried daily color accuracy; 40.67% exact alert match; 52.54% ±3-day alert match; score MAE 43.94 |
 | Calibration sweep | Best validated candidate: 3-session intraday range trigger; exact alert F1 76.64% vs 44.59% baseline, exact recall 91.93% vs 40.67%, precision 65.71%, ±3-day recall 95.21%; holdout after 2025-09-25 scores 83.18% F1 vs 46.26% baseline |
+| v0.3 guardrail research | First simple-filter report complete: raw v0.2 range remains strongest at 76.64% F1; simple buffers/debounce/directional close cut events by 15-27% only after F1 falls to ~56-60%, so next research moves to ATR-normalized buffers and ticker-specific cooldowns |
 | Candidate persisted state | v0.2 candidate has 328 `signal_scores` rows and 1,624 `signal_transitions` rows under non-production parameter set; internal API/BFF selector live for scanner, transitions, symbol detail, Portfolio Lens, and chart overlays |
 | Candidate lane comparison | v0.2 bullish lane unchanged at 129, risk unchanged at 47, re-entry 164→145, mixed 202→203, 61 daily states/scores change |
 | Promotion contract | Fresh Dochia scores still staged; legacy `market_signals` remains contextual until calibration/promotion |
@@ -291,7 +292,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 - Do not call generated weekly/monthly states "MarketClub truth"; they are Dochia-derived.
 - Avoid gamified trading prompts; build an evidence cockpit.
 
-**Immediate next step:** Add v0.3 guardrail research for the range trigger: reduce whipsaw pressure with debounce, close-confirmation, or volatility filters before any production promotion.
+**Immediate next step:** Expand v0.3 research to ATR-normalized buffers and ticker-specific cooldowns, then persist only a candidate that preserves enough raw-range F1 while materially reducing whipsaw pressure.
 
 ### 6.6 Architectural follow-ups
 
@@ -351,6 +352,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 - Added v0.2 chart-overlay parity: the symbol chart now follows the active Production/v0.2 Range mode, using close-break daily events for production and range-trigger daily events for the v0.2 candidate.
 - Added read-only v0.2 promotion-review harness covering top-lane churn, recent whipsaw/transition pressure, and chart-level candidate event deltas.
 - Ran first v0.2 promotion-review report. Decision: do not promote range trigger yet. Risk lane is stable, but re-entry lane churn is 66.7%, mixed-timeframe churn is 52.9%, top whipsaw tickers show 8-9 candidate transitions in the 30-day window, and reviewed chart overlays add up to 29 candidate-only daily events on some symbols.
+- Added and ran read-only v0.3 range-trigger guardrail research for break buffers, same-direction close confirmation, and debounce windows. Decision: no simple guardrail clears the quality/reduction bar; next research moves to ATR-normalized buffers and ticker-specific cooldowns.
 - Added internal Production/v0.2 Range toggle to the Command Center Hedge Fund page and promoted the production frontend build.
 - Added chart-data endpoint and chart overlay with close, daily/weekly channel bands, and generated triangle event markers.
 - Refined calibration metrics to separate carried-state agreement from exact new-alert agreement: 40.67% same-day alert match and 52.54% ±3-day alert match.


### PR DESCRIPTION
## Summary
- adds a read-only v0.3 guardrail sweep for the MarketClub daily range trigger
- adds a live-data report runner and tracked 2026-05-03 report
- updates the backend README, MarketClub build plan, and master plan with the v0.3 result and next research step

## Result
- raw v0.2 range remains strongest at 76.64% exact-event F1
- simple buffers/debounce/directional close cut events, but only clear 15%+ reduction after F1 falls to roughly 56-60%
- next research should test ATR-normalized buffers and ticker-specific cooldowns before another parameter set is persisted

## Verification
- PYTHONPATH=. /home/admin/.local/bin/uv run pytest tests/test_trade_triangles.py tests/test_calibration.py tests/test_calibration_sweep.py tests/test_guardrail_sweep.py tests/test_promotion_review.py
- /home/admin/.local/bin/uv run ruff check app/signals/guardrail_sweep.py scripts/research_range_trigger_guardrails.py tests/test_guardrail_sweep.py
- PYTHONPATH=. /home/admin/.local/bin/uv run python scripts/research_range_trigger_guardrails.py --output docs/reports/dochia-v0-3-guardrail-research-2026-05-03.md