### PR TITLE
feat(financial): add Dochia return outcome review

### DIFF
--- a/crog-ai-backend/README.md
+++ b/crog-ai-backend/README.md
@@ -107,6 +107,7 @@ uv run python scripts/validate_daily_signal_candidate.py --top-tickers 15 --min-
 uv run python scripts/compare_signal_candidate_lanes.py --limit-tickers 500 --top 12
 uv run python scripts/review_signal_candidate_promotion.py --lane-limit 50 --chart-ticker-limit 24
 uv run python scripts/research_range_trigger_guardrails.py --output docs/reports/dochia-v0-3-atr-cooldown-research-2026-05-03.md
+uv run python scripts/review_signal_outcomes.py --output docs/reports/dochia-v0-3-return-outcome-review-2026-05-03.md
 ```
 
 Best 2026-05-02 research candidate: 3-session intraday range trigger. It
@@ -151,6 +152,14 @@ not parameterize this grid either. A light 14-session ATR buffer at 0.025 keeps
 F1 close to raw range at 74.40% but cuts only 2.23% of events. The best
 adaptive cooldown row cuts 21.48% of events but drops F1 to 56.22%. Next
 research moves to return-conditioned outcomes and per-ticker whipsaw clusters.
+
+Return-outcome report:
+`docs/reports/dochia-v0-3-return-outcome-review-2026-05-03.md`. Directional
+forward returns are flat for both production close and v0.2 raw range: v0.2
+5-session win rate is 50.33% with +0.01% average directional return. The worst
+v0.2 whipsaw clusters are ticker-specific, led by MOD, ISRG, MRVL, DLR, and HD.
+Future candidates must preserve alert quality, reduce whipsaw clusters, and
+avoid degrading forward directional returns.
 
 ## Relationship to Fortress-Prime
 

--- a/crog-ai-backend/app/signals/outcome_review.py
+++ b/crog-ai-backend/app/signals/outcome_review.py
@@ -1,0 +1,214 @@
+"""Forward-return and whipsaw review helpers for Dochia signal candidates."""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+from statistics import median
+
+from app.signals.calibration_sweep import DailyEventHistory
+from app.signals.trade_triangles import EodBar
+
+
+@dataclass(frozen=True, slots=True)
+class SignalEvent:
+    ticker: str
+    event_date: dt.date
+    index: int
+    state: int
+
+
+@dataclass(frozen=True, slots=True)
+class ReturnOutcomeSummary:
+    horizon_sessions: int
+    evaluated_events: int
+    win_count: int
+    win_rate: float | None
+    average_directional_return: float | None
+    median_directional_return: float | None
+    p25_directional_return: float | None
+    p75_directional_return: float | None
+
+    def as_json_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class TickerWhipsawOutcome:
+    ticker: str
+    event_count: int
+    whipsaw_count: int
+    whipsaw_rate: float
+    evaluated_horizon_events: int
+    average_directional_return: float | None
+    latest_whipsaw_date: str | None
+
+    def as_json_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def _ordered_bars(bars: list[EodBar]) -> list[EodBar]:
+    return sorted(bars, key=lambda bar: (bar.ticker, bar.bar_date))
+
+
+def _safe_rate(numerator: int, denominator: int) -> float | None:
+    if denominator == 0:
+        return None
+    return numerator / denominator
+
+
+def _percentile(values: list[float], percentile: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    index = round((len(ordered) - 1) * percentile)
+    return ordered[index]
+
+
+def events_from_histories(
+    histories: dict[str, DailyEventHistory],
+    bars_by_ticker: dict[str, list[EodBar]],
+    *,
+    since: dt.date | None = None,
+    until: dt.date | None = None,
+) -> list[SignalEvent]:
+    events: list[SignalEvent] = []
+    for ticker, history in histories.items():
+        bars = _ordered_bars(bars_by_ticker.get(ticker, []))
+        index_by_date = {bar.bar_date: index for index, bar in enumerate(bars)}
+        for event_date, state in sorted(history.event_by_date.items()):
+            if since is not None and event_date < since:
+                continue
+            if until is not None and event_date > until:
+                continue
+            index = index_by_date.get(event_date)
+            if index is None:
+                continue
+            events.append(
+                SignalEvent(
+                    ticker=ticker,
+                    event_date=event_date,
+                    index=index,
+                    state=state,
+                )
+            )
+    return sorted(events, key=lambda event: (event.ticker, event.index))
+
+
+def _directional_return(
+    event: SignalEvent,
+    bars_by_ticker: dict[str, list[EodBar]],
+    *,
+    horizon_sessions: int,
+) -> float | None:
+    bars = _ordered_bars(bars_by_ticker.get(event.ticker, []))
+    future_index = event.index + horizon_sessions
+    if future_index >= len(bars):
+        return None
+    entry_close = bars[event.index].close
+    future_close = bars[future_index].close
+    if entry_close == 0:
+        return None
+    raw_return = (future_close - entry_close) / entry_close
+    return float(raw_return) * event.state
+
+
+def summarize_forward_returns(
+    events: list[SignalEvent],
+    bars_by_ticker: dict[str, list[EodBar]],
+    *,
+    horizons: list[int],
+) -> list[ReturnOutcomeSummary]:
+    summaries: list[ReturnOutcomeSummary] = []
+    for horizon in horizons:
+        returns = [
+            value
+            for event in events
+            if (
+                value := _directional_return(
+                    event,
+                    bars_by_ticker,
+                    horizon_sessions=horizon,
+                )
+            )
+            is not None
+        ]
+        win_count = sum(value > 0 for value in returns)
+        summaries.append(
+            ReturnOutcomeSummary(
+                horizon_sessions=horizon,
+                evaluated_events=len(returns),
+                win_count=win_count,
+                win_rate=_safe_rate(win_count, len(returns)),
+                average_directional_return=(
+                    sum(returns) / len(returns) if returns else None
+                ),
+                median_directional_return=median(returns) if returns else None,
+                p25_directional_return=_percentile(returns, 0.25),
+                p75_directional_return=_percentile(returns, 0.75),
+            )
+        )
+    return summaries
+
+
+def build_ticker_whipsaw_outcomes(
+    events: list[SignalEvent],
+    bars_by_ticker: dict[str, list[EodBar]],
+    *,
+    whipsaw_window_sessions: int,
+    outcome_horizon_sessions: int,
+    top: int,
+) -> list[TickerWhipsawOutcome]:
+    grouped: dict[str, list[SignalEvent]] = defaultdict(list)
+    for event in events:
+        grouped[event.ticker].append(event)
+
+    outcomes: list[TickerWhipsawOutcome] = []
+    for ticker, ticker_events in grouped.items():
+        ordered = sorted(ticker_events, key=lambda event: event.index)
+        whipsaw_dates: list[dt.date] = []
+        for previous, current in zip(ordered, ordered[1:], strict=False):
+            if current.state == previous.state:
+                continue
+            if current.index - previous.index <= whipsaw_window_sessions:
+                whipsaw_dates.append(current.event_date)
+        if not whipsaw_dates:
+            continue
+
+        returns = [
+            value
+            for event in ordered
+            if (
+                value := _directional_return(
+                    event,
+                    bars_by_ticker,
+                    horizon_sessions=outcome_horizon_sessions,
+                )
+            )
+            is not None
+        ]
+        outcomes.append(
+            TickerWhipsawOutcome(
+                ticker=ticker,
+                event_count=len(ordered),
+                whipsaw_count=len(whipsaw_dates),
+                whipsaw_rate=len(whipsaw_dates) / max(len(ordered) - 1, 1),
+                evaluated_horizon_events=len(returns),
+                average_directional_return=(
+                    sum(returns) / len(returns) if returns else None
+                ),
+                latest_whipsaw_date=max(whipsaw_dates).isoformat(),
+            )
+        )
+
+    outcomes.sort(
+        key=lambda item: (
+            item.whipsaw_count,
+            item.whipsaw_rate,
+            item.event_count,
+            item.ticker,
+        ),
+        reverse=True,
+    )
+    return outcomes[:top]

--- a/crog-ai-backend/docs/MARKETCLUB-DOCHIA-BUILD-PLAN.md
+++ b/crog-ai-backend/docs/MARKETCLUB-DOCHIA-BUILD-PLAN.md
@@ -204,6 +204,12 @@ Useful query params:
   do not persist this grid as a parameter set. A 14-session ATR buffer at
   0.025 keeps F1 at 74.40% but cuts only 2.23% of events. The best adaptive
   cooldown row cuts 21.48% of events but drops F1 to 56.22%.
+- Added a return-outcome and ticker whipsaw-cluster review layer. Report is
+  tracked at `docs/reports/dochia-v0-3-return-outcome-review-2026-05-03.md`.
+  Directional forward returns are flat for both production close and v0.2 raw
+  range: v0.2 5-session win rate is 50.33% with +0.01% average directional
+  return. The worst v0.2 whipsaw clusters are concentrated in MOD, ISRG, MRVL,
+  DLR, and HD.
 - Added and enabled `crog-ai-backend.service` on spark-node-2.
 - Promoted the Command Center production build and restarted
   `crog-ai-frontend.service`; `/financial/hedge-fund` is live through
@@ -213,5 +219,6 @@ Useful query params:
   status, and live backend/BFF reads for both production and v0.2 candidate
   selectors. `/financial/hedge-fund` returns 200 after frontend restart.
 
-Next clean build step: research return-conditioned outcomes and per-ticker
-whipsaw clusters before persisting any v0.3 parameter set.
+Next clean build step: design a ticker-cluster exclusion/cooldown candidate
+that targets the worst whipsaw names without degrading forward directional
+returns on the broader universe.

--- a/crog-ai-backend/docs/reports/dochia-v0-3-return-outcome-review-2026-05-03.md
+++ b/crog-ai-backend/docs/reports/dochia-v0-3-return-outcome-review-2026-05-03.md
@@ -1,0 +1,40 @@
+# Dochia v0.3 Return Outcome Review
+
+Generated: 2026-05-03T06:11:22.428810+00:00
+Scope: ticker=all since=beginning until=latest
+Whipsaw window: 5 sessions
+
+## Forward Directional Returns
+
+| Rule | Horizon | Events | Win rate | Average | Median | P25 | P75 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| production close | 5 | 18091 | 50.25% | -0.03% | +0.04% | -3.01% | +2.95% |
+| production close | 10 | 17959 | 50.15% | +0.05% | +0.03% | -4.23% | +4.42% |
+| production close | 20 | 17588 | 49.45% | -0.16% | -0.07% | -6.18% | +6.13% |
+| v0.2 raw range | 5 | 30692 | 50.33% | +0.01% | +0.04% | -2.97% | +3.03% |
+| v0.2 raw range | 10 | 30384 | 50.18% | +0.06% | +0.04% | -4.28% | +4.39% |
+| v0.2 raw range | 20 | 29721 | 49.99% | -0.05% | -0.00% | -6.31% | +6.31% |
+
+## v0.2 Whipsaw Clusters
+
+| Ticker | Events | Whipsaws | Rate | 5-session events | Avg 5-session return | Latest |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| MOD | 111 | 82 | 74.55% | 110 | -1.29% | 2026-04-21 |
+| ISRG | 112 | 82 | 73.87% | 110 | -0.57% | 2026-04-22 |
+| MRVL | 107 | 78 | 73.58% | 107 | -1.81% | 2026-04-17 |
+| DLR | 108 | 78 | 72.90% | 106 | -0.37% | 2026-04-24 |
+| HD | 104 | 75 | 72.82% | 103 | -0.01% | 2026-04-08 |
+| VRT | 105 | 75 | 72.12% | 102 | -1.12% | 2026-04-23 |
+| GFS | 104 | 74 | 71.84% | 104 | -0.31% | 2026-04-16 |
+| APG | 104 | 74 | 71.84% | 104 | -0.44% | 2026-04-01 |
+| RUN | 105 | 74 | 71.15% | 104 | -0.87% | 2026-04-13 |
+| WMB | 103 | 73 | 71.57% | 102 | -0.27% | 2026-04-20 |
+| DT | 104 | 73 | 70.87% | 103 | -0.44% | 2026-04-15 |
+| SIG | 107 | 73 | 68.87% | 106 | -0.29% | 2026-04-22 |
+| DBC | 104 | 72 | 69.90% | 103 | -0.12% | 2026-04-21 |
+| AVGO | 104 | 72 | 69.90% | 104 | -0.38% | 2026-04-01 |
+| CME | 101 | 71 | 71.00% | 101 | -0.03% | 2026-04-09 |
+
+## Recommendation
+
+Do not promote or suppress v0.2 only from alert-match F1. Use this return-outcome layer with the promotion-review churn packet: candidates must preserve alert quality, reduce whipsaw clusters, and avoid degrading forward directional returns.

--- a/crog-ai-backend/scripts/review_signal_outcomes.py
+++ b/crog-ai-backend/scripts/review_signal_outcomes.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Review forward returns and whipsaw clusters for Dochia daily signals."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import psycopg
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from app.signals.calibration_repository import fetch_daily_sweep_inputs  # noqa: E402
+from app.signals.calibration_sweep import generated_daily_event_history  # noqa: E402
+from app.signals.guardrail_sweep import (  # noqa: E402
+    GuardedRangeCandidate,
+    generated_guarded_range_event_history,
+)
+from app.signals.outcome_review import (  # noqa: E402
+    build_ticker_whipsaw_outcomes,
+    events_from_histories,
+    summarize_forward_returns,
+)
+from scripts.sweep_daily_signal_parameters import _database_url  # noqa: E402
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Review forward returns and whipsaw clusters for daily signal candidates."
+    )
+    parser.add_argument("--since", type=dt.date.fromisoformat, default=None)
+    parser.add_argument("--until", type=dt.date.fromisoformat, default=None)
+    parser.add_argument("--ticker", default=None)
+    parser.add_argument("--horizon", action="append", type=int, default=None)
+    parser.add_argument("--whipsaw-window-sessions", type=int, default=5)
+    parser.add_argument("--whipsaw-outcome-horizon", type=int, default=5)
+    parser.add_argument("--top-whipsaws", type=int, default=15)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--output", type=Path, default=None)
+    return parser.parse_args()
+
+
+def _pct(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value * 100:.2f}%"
+
+
+def _signed_pct(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value * 100:+.2f}%"
+
+
+def _table_row(values: list[object]) -> str:
+    return "| " + " | ".join(str(value) for value in values) + " |"
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if args.since is not None and args.until is not None and args.since > args.until:
+        raise SystemExit("since cannot be after until")
+    for horizon in args.horizon or [5, 10, 20]:
+        if horizon < 1:
+            raise SystemExit("horizon must be at least 1")
+    if args.whipsaw_window_sessions < 1:
+        raise SystemExit("whipsaw-window-sessions must be at least 1")
+    if args.whipsaw_outcome_horizon < 1:
+        raise SystemExit("whipsaw-outcome-horizon must be at least 1")
+    if args.top_whipsaws < 1:
+        raise SystemExit("top-whipsaws must be at least 1")
+
+
+def _histories_for_mode(
+    bars_by_ticker: dict[str, list[Any]],
+    *,
+    mode: str,
+) -> dict[str, Any]:
+    histories: dict[str, Any] = {}
+    for ticker, bars in bars_by_ticker.items():
+        if mode == "production_close":
+            history = generated_daily_event_history(
+                bars,
+                lookback_sessions=3,
+                trigger_mode="close",
+            )
+        elif mode == "v0_2_raw_range":
+            history = generated_guarded_range_event_history(
+                bars,
+                candidate=GuardedRangeCandidate(lookback_sessions=3),
+            )
+        else:
+            raise ValueError(f"unknown mode: {mode}")
+        if history is not None:
+            histories[ticker] = history
+    return histories
+
+
+def _render_outcomes(rule_name: str, rows: list[dict[str, Any]]) -> list[str]:
+    lines = []
+    for row in rows:
+        lines.append(
+            _table_row(
+                [
+                    rule_name,
+                    row["horizon_sessions"],
+                    row["evaluated_events"],
+                    _pct(row["win_rate"]),
+                    _signed_pct(row["average_directional_return"]),
+                    _signed_pct(row["median_directional_return"]),
+                    _signed_pct(row["p25_directional_return"]),
+                    _signed_pct(row["p75_directional_return"]),
+                ]
+            )
+        )
+    return lines
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Dochia v0.3 Return Outcome Review",
+        "",
+        f"Generated: {payload['generated_at']}",
+        f"Scope: ticker={payload['ticker'] or 'all'} since={payload['since'] or 'beginning'} until={payload['until'] or 'latest'}",
+        f"Whipsaw window: {payload['whipsaw_window_sessions']} sessions",
+        "",
+        "## Forward Directional Returns",
+        "",
+        _table_row(
+            [
+                "Rule",
+                "Horizon",
+                "Events",
+                "Win rate",
+                "Average",
+                "Median",
+                "P25",
+                "P75",
+            ]
+        ),
+        _table_row(["---", "---:", "---:", "---:", "---:", "---:", "---:", "---:"]),
+    ]
+    lines.extend(_render_outcomes("production close", payload["production_close"]["outcomes"]))
+    lines.extend(_render_outcomes("v0.2 raw range", payload["v0_2_raw_range"]["outcomes"]))
+
+    lines.extend(
+        [
+            "",
+            "## v0.2 Whipsaw Clusters",
+            "",
+            _table_row(
+                [
+                    "Ticker",
+                    "Events",
+                    "Whipsaws",
+                    "Rate",
+                    "5-session events",
+                    "Avg 5-session return",
+                    "Latest",
+                ]
+            ),
+            _table_row(["---", "---:", "---:", "---:", "---:", "---:", "---"]),
+        ]
+    )
+    for row in payload["v0_2_raw_range"]["whipsaw_clusters"]:
+        lines.append(
+            _table_row(
+                [
+                    row["ticker"],
+                    row["event_count"],
+                    row["whipsaw_count"],
+                    _pct(row["whipsaw_rate"]),
+                    row["evaluated_horizon_events"],
+                    _signed_pct(row["average_directional_return"]),
+                    row["latest_whipsaw_date"] or "-",
+                ]
+            )
+        )
+    if not payload["v0_2_raw_range"]["whipsaw_clusters"]:
+        lines.append("_No whipsaw clusters crossed the configured window._")
+
+    lines.extend(
+        [
+            "",
+            "## Recommendation",
+            "",
+            "Do not promote or suppress v0.2 only from alert-match F1. Use this return-outcome layer with the promotion-review churn packet: candidates must preserve alert quality, reduce whipsaw clusters, and avoid degrading forward directional returns.",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _rule_payload(
+    bars_by_ticker: dict[str, list[Any]],
+    *,
+    mode: str,
+    horizons: list[int],
+    since: dt.date | None,
+    until: dt.date | None,
+    whipsaw_window_sessions: int,
+    whipsaw_outcome_horizon: int,
+    top_whipsaws: int,
+) -> dict[str, Any]:
+    histories = _histories_for_mode(bars_by_ticker, mode=mode)
+    events = events_from_histories(histories, bars_by_ticker, since=since, until=until)
+    outcomes = summarize_forward_returns(events, bars_by_ticker, horizons=horizons)
+    whipsaws = build_ticker_whipsaw_outcomes(
+        events,
+        bars_by_ticker,
+        whipsaw_window_sessions=whipsaw_window_sessions,
+        outcome_horizon_sessions=whipsaw_outcome_horizon,
+        top=top_whipsaws,
+    )
+    return {
+        "event_count": len(events),
+        "outcomes": [row.as_json_dict() for row in outcomes],
+        "whipsaw_clusters": [row.as_json_dict() for row in whipsaws],
+    }
+
+
+def build_payload(args: argparse.Namespace) -> dict[str, Any]:
+    _validate_args(args)
+    horizons = args.horizon or [5, 10, 20]
+    with psycopg.connect(_database_url()) as conn:
+        conn.execute("SET default_transaction_read_only = on")
+        _, bars_by_ticker = fetch_daily_sweep_inputs(
+            conn,
+            since=args.since,
+            until=args.until,
+            ticker=args.ticker,
+        )
+
+    return {
+        "generated_at": dt.datetime.now(dt.UTC).isoformat(),
+        "since": args.since.isoformat() if args.since else None,
+        "until": args.until.isoformat() if args.until else None,
+        "ticker": args.ticker.upper() if args.ticker else None,
+        "horizons": horizons,
+        "whipsaw_window_sessions": args.whipsaw_window_sessions,
+        "production_close": _rule_payload(
+            bars_by_ticker,
+            mode="production_close",
+            horizons=horizons,
+            since=args.since,
+            until=args.until,
+            whipsaw_window_sessions=args.whipsaw_window_sessions,
+            whipsaw_outcome_horizon=args.whipsaw_outcome_horizon,
+            top_whipsaws=args.top_whipsaws,
+        ),
+        "v0_2_raw_range": _rule_payload(
+            bars_by_ticker,
+            mode="v0_2_raw_range",
+            horizons=horizons,
+            since=args.since,
+            until=args.until,
+            whipsaw_window_sessions=args.whipsaw_window_sessions,
+            whipsaw_outcome_horizon=args.whipsaw_outcome_horizon,
+            top_whipsaws=args.top_whipsaws,
+        ),
+    }
+
+
+def main() -> None:
+    args = parse_args()
+    payload = build_payload(args)
+    text = (
+        json.dumps(payload, indent=2, sort_keys=True)
+        if args.json
+        else _render_markdown(payload)
+    )
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text)
+    else:
+        print(text, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/crog-ai-backend/tests/test_outcome_review.py
+++ b/crog-ai-backend/tests/test_outcome_review.py
@@ -1,0 +1,78 @@
+import datetime as dt
+from decimal import Decimal
+
+from app.signals.guardrail_sweep import (
+    GuardedRangeCandidate,
+    generated_guarded_range_event_history,
+)
+from app.signals.outcome_review import (
+    build_ticker_whipsaw_outcomes,
+    events_from_histories,
+    summarize_forward_returns,
+)
+from app.signals.trade_triangles import EodBar
+
+
+def _bar(index: int, *, open_: str, high: str, low: str, close: str) -> EodBar:
+    return EodBar(
+        ticker="AA",
+        bar_date=dt.date(2026, 1, 1) + dt.timedelta(days=index),
+        open=Decimal(open_),
+        high=Decimal(high),
+        low=Decimal(low),
+        close=Decimal(close),
+        volume=1000,
+    )
+
+
+def test_summarize_forward_returns_scores_directionally() -> None:
+    bars = [
+        _bar(0, open_="10", high="10", low="9", close="10"),
+        _bar(1, open_="11", high="11", low="10", close="11"),
+        _bar(2, open_="12", high="12", low="11", close="12"),
+        _bar(3, open_="13", high="13", low="12", close="13"),
+        _bar(4, open_="14", high="14", low="13", close="14"),
+    ]
+    history = generated_guarded_range_event_history(
+        bars,
+        candidate=GuardedRangeCandidate(lookback_sessions=2),
+    )
+    assert history is not None
+
+    events = events_from_histories({"AA": history}, {"AA": bars})
+    summaries = summarize_forward_returns(events, {"AA": bars}, horizons=[2])
+
+    assert summaries[0].evaluated_events == 1
+    assert summaries[0].win_count == 1
+    assert summaries[0].win_rate == 1
+    assert summaries[0].average_directional_return == float(Decimal("2") / Decimal("12"))
+
+
+def test_build_ticker_whipsaw_outcomes_counts_fast_reversals() -> None:
+    bars = [
+        _bar(0, open_="10", high="10", low="9", close="10"),
+        _bar(1, open_="11", high="11", low="10", close="11"),
+        _bar(2, open_="12", high="12", low="10", close="12"),
+        _bar(3, open_="9", high="10", low="8", close="8"),
+        _bar(4, open_="13", high="13", low="9", close="12"),
+        _bar(5, open_="14", high="14", low="12", close="13"),
+    ]
+    history = generated_guarded_range_event_history(
+        bars,
+        candidate=GuardedRangeCandidate(lookback_sessions=2),
+    )
+    assert history is not None
+
+    events = events_from_histories({"AA": history}, {"AA": bars})
+    clusters = build_ticker_whipsaw_outcomes(
+        events,
+        {"AA": bars},
+        whipsaw_window_sessions=2,
+        outcome_horizon_sessions=1,
+        top=5,
+    )
+
+    assert clusters[0].ticker == "AA"
+    assert clusters[0].event_count == 3
+    assert clusters[0].whipsaw_count == 2
+    assert clusters[0].whipsaw_rate == 1

--- a/docs/operational/MASTER-PLAN.md
+++ b/docs/operational/MASTER-PLAN.md
@@ -259,7 +259,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 | Legacy watchlist context | `watchlist` has 431 rows; `market_signals` has 1,105 rows through 2026-02-12; read-only grant applied for app overlays |
 | Calibration baseline | 24,204 daily observations; 91.44% coverage; 62.05% carried daily color accuracy; 40.67% exact alert match; 52.54% ±3-day alert match; score MAE 43.94 |
 | Calibration sweep | Best validated candidate: 3-session intraday range trigger; exact alert F1 76.64% vs 44.59% baseline, exact recall 91.93% vs 40.67%, precision 65.71%, ±3-day recall 95.21%; holdout after 2025-09-25 scores 83.18% F1 vs 46.26% baseline |
-| v0.3 guardrail research | ATR/cooldown report complete: light ATR buffer keeps F1 at 74.40% but cuts only 2.23% of events; best adaptive cooldown cuts 21.48% of events but drops F1 to 56.22%; next research moves to return-conditioned outcomes and per-ticker whipsaw clusters |
+| v0.3 guardrail research | Return-outcome report complete: v0.2 raw range has flat 5-session forward directional return (+0.01%, 50.33% win rate); worst whipsaw clusters are ticker-specific (MOD, ISRG, MRVL, DLR, HD); next research targets ticker-cluster exclusion/cooldown without degrading broader returns |
 | Candidate persisted state | v0.2 candidate has 328 `signal_scores` rows and 1,624 `signal_transitions` rows under non-production parameter set; internal API/BFF selector live for scanner, transitions, symbol detail, Portfolio Lens, and chart overlays |
 | Candidate lane comparison | v0.2 bullish lane unchanged at 129, risk unchanged at 47, re-entry 164→145, mixed 202→203, 61 daily states/scores change |
 | Promotion contract | Fresh Dochia scores still staged; legacy `market_signals` remains contextual until calibration/promotion |
@@ -292,7 +292,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 - Do not call generated weekly/monthly states "MarketClub truth"; they are Dochia-derived.
 - Avoid gamified trading prompts; build an evidence cockpit.
 
-**Immediate next step:** Research return-conditioned outcomes and per-ticker whipsaw clusters before persisting any v0.3 parameter set.
+**Immediate next step:** Design a ticker-cluster exclusion/cooldown candidate that targets the worst whipsaw names without degrading forward directional returns on the broader universe.
 
 ### 6.6 Architectural follow-ups
 
@@ -352,7 +352,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 - Added v0.2 chart-overlay parity: the symbol chart now follows the active Production/v0.2 Range mode, using close-break daily events for production and range-trigger daily events for the v0.2 candidate.
 - Added read-only v0.2 promotion-review harness covering top-lane churn, recent whipsaw/transition pressure, and chart-level candidate event deltas.
 - Ran first v0.2 promotion-review report. Decision: do not promote range trigger yet. Risk lane is stable, but re-entry lane churn is 66.7%, mixed-timeframe churn is 52.9%, top whipsaw tickers show 8-9 candidate transitions in the 30-day window, and reviewed chart overlays add up to 29 candidate-only daily events on some symbols.
-- Added and ran read-only v0.3 range-trigger guardrail research for break buffers, same-direction close confirmation, ATR-normalized buffers, and trailing per-symbol adaptive cooldowns. Decision: no tested v0.3 guardrail clears the quality/reduction bar; next research moves to return-conditioned outcomes and per-ticker whipsaw clusters.
+- Added and ran read-only v0.3 range-trigger guardrail research for break buffers, same-direction close confirmation, ATR-normalized buffers, trailing per-symbol adaptive cooldowns, return-conditioned outcomes, and ticker whipsaw clusters. Decision: no tested v0.3 guardrail clears the quality/reduction bar; next research targets ticker-cluster exclusion/cooldown without degrading broader returns.
 - Added internal Production/v0.2 Range toggle to the Command Center Hedge Fund page and promoted the production frontend build.
 - Added chart-data endpoint and chart overlay with close, daily/weekly channel bands, and generated triangle event markers.
 - Refined calibration metrics to separate carried-state agreement from exact new-alert agreement: 40.67% same-day alert match and 52.54% ±3-day alert match.


### PR DESCRIPTION
## Summary
- adds read-only forward directional return review for production close and v0.2 raw range daily events
- adds per-ticker v0.2 whipsaw cluster reporting
- tracks the 2026-05-03 return outcome report and updates MarketClub plans

## Result
- v0.2 raw range 5-session win rate is 50.33% with +0.01% average directional return
- production close 5-session win rate is 50.25% with -0.03% average directional return
- worst v0.2 whipsaw clusters are ticker-specific: MOD, ISRG, MRVL, DLR, HD
- next candidate should target ticker-cluster exclusion/cooldown without degrading broader returns

## Verification
- PYTHONPATH=. /home/admin/.local/bin/uv run pytest tests/test_trade_triangles.py tests/test_calibration.py tests/test_calibration_sweep.py tests/test_guardrail_sweep.py tests/test_outcome_review.py tests/test_promotion_review.py
- /home/admin/.local/bin/uv run ruff check app/signals/outcome_review.py scripts/review_signal_outcomes.py tests/test_outcome_review.py
- PYTHONPATH=. /home/admin/.local/bin/uv run python scripts/review_signal_outcomes.py --output docs/reports/dochia-v0-3-return-outcome-review-2026-05-03.md
- PYTHONPATH=. /home/admin/.local/bin/uv run python scripts/review_signal_outcomes.py --ticker AAPL --json