### PR TITLE
Legal docs: Wilson Pruitt actor dossier

### DIFF
--- a/docs/operational/fortress-legal/matter-control/case-ii-2026-05-02/actor-dossiers/README.md
+++ b/docs/operational/fortress-legal/matter-control/case-ii-2026-05-02/actor-dossiers/README.md
@@ -1,0 +1,33 @@
+# Actor Dossiers - 7IL Case II
+
+Date: 2026-05-03
+Operator service status: not served as of 2026-05-03
+Classification: Repo-safe actor-control pack. Not a filing, not legal advice, and not a finding of liability.
+
+## Purpose
+
+Actor dossiers keep Fortress Legal disciplined when a person, firm, entity, witness, title actor, closing actor, or opposing-side participant may matter to defenses, discovery, counterclaims, or counsel strategy. The dossier is a control surface, not a place for unsourced accusations.
+
+## Use Order
+
+1. Confirm actor identity and name variants.
+2. Confirm matter role and source basis.
+3. Run public-record / litigation-history checks.
+4. Route source evidence through custody, privilege, and issue tagging.
+5. Map any theory to proof gates before promotion.
+6. Ask counsel to decide discovery-only, counterclaim, third-party, separate-action, or no-action posture.
+
+## Current Dossiers
+
+| Dossier | Path | Current Disposition |
+|---|---|---|
+| Wilson Pruitt / Terry Wilson | `wilson-pruitt-actor-dossier-7il-ndga-ii-2026-05-03.md` | `DISCOVERY-TARGET` plus `COUNSEL-MEMO`; no pleading decision. |
+| Wilson Pruitt public-record check | `wilson-pruitt-public-record-check-workbench-7il-ndga-ii-2026-05-03.md` | Public-record verification workflow; county/PACER checks still open. |
+
+## No-Go Rules
+
+- Do not use a dossier as a pleading substitute.
+- Do not promote an allegation without a source ID, source path, docket citation, or public-record citation.
+- Do not treat a public web search as a complete litigation-history check.
+- Do not put raw email bodies, privileged legal advice, or counsel mental impressions in repo docs.
+- Do not name a nonparty professional in a filing without procedural-route, duty, causation, damages, expert/affidavit, and privilege review.

--- a/docs/operational/fortress-legal/matter-control/case-ii-2026-05-02/actor-dossiers/wilson-pruitt-actor-dossier-7il-ndga-ii-2026-05-03.md
+++ b/docs/operational/fortress-legal/matter-control/case-ii-2026-05-02/actor-dossiers/wilson-pruitt-actor-dossier-7il-ndga-ii-2026-05-03.md
@@ -1,0 +1,79 @@
+# Wilson Pruitt / Terry Wilson Actor Dossier - 7IL Case II
+
+Date: 2026-05-03
+Operator service status: not served as of 2026-05-03
+Classification: Repo-safe actor dossier. Not a pleading, not legal advice, and not a liability finding.
+
+## Operating Position
+
+Wilson Pruitt / Terry Wilson remain a `DISCOVERY-TARGET` and `COUNSEL-MEMO` lane unless the proof gates in the claim-evaluation workbench and adverse-alignment proof matrix pass. The dossier is designed to prevent premature pleading while preserving every source-backed question that may matter to Case II.
+
+Current default: do not name Wilson Pruitt, Terry Wilson, or related professional entities in a counterclaim or third-party pleading unless counsel clears procedural route, duty/scope, breach, causation, damages, expert/affidavit, and privilege-waiver gates.
+
+## Identity Control
+
+| Actor / Entity | Working Role | Source Basis | Verification Status |
+|---|---|---|---|
+| Terry Wilson | Closing/title/drafting actor under review; possible witness or discovery target. | Wilson Pruitt public profile; Case II closing documents; Terry Wilson production references. | Identity confirmed for workbench purposes; full role/scope remains open. |
+| Wilson Pruitt LLC | Closing firm tied to File No. 25-0170 and 2025 property closings. | Deed references, outbound file request draft, attorney package notes. | Source packet pending full closing file. |
+| Wilson Hamilton / Terry Lee Wilson LLC | Name variants or related entities to check before any public-record conclusion. | Operator concern and prior record references. | Alias/entity verification open. |
+| Other firm lawyers/staff | Potential custodians or witnesses only if source-backed. | Closing file, emails, title/escrow records. | Do not add without source. |
+
+## Role Lanes
+
+| Lane | Question | Source Targets | Current Status |
+|---|---|---|---|
+| Closing attorney / closing firm | What exactly did Wilson Pruitt undertake for Gary, 7IL, or the transaction? | Engagement letter, closing instructions, invoices, settlement statements, title file. | Open. |
+| Title / easement / crossing | Did title/easement work account for the recorded easement, railroad crossing, GDOT/right-of-way limits, and client-authorized changes? | Title commitment, title exceptions, easement drafts, DOT/GNRR records, closing correspondence. | Source-pending. |
+| Inspection report provenance | Was the report a Case I / 2021-origin report, and how was it transmitted or characterized later? | Dee McBee emails, Terry Wilson production, report attachments, complaint exhibits. | Source-pending but known as a key gap. |
+| Closing delay / reservation / waiver | Did closing conduct affect delay, reservation of rights, repair obligations, or later exposure? | Pre-closing emails, closing package, calendars, settlement statements, post-closing demands. | Open. |
+| Post-closing conduct | Did any post-closing communication materially affect Case II posture? | Wilson Pruitt email Batch 001, demand chains, issue tags. | Pending email exports. |
+| Public litigation / discipline history | Has any subject been sued, countersued, disciplined, or publicly accused in a docketed matter since 2020? | Official court indexes, PACER, appellate records, State Bar, docket documents. | Initial web scan inconclusive; official checks open. |
+
+## Claim-Readiness Board
+
+| Theory / Use | Current Disposition | Required Gate Before Promotion |
+|---|---|---|
+| Discovery target | Active. | Source-specific requests, custody controls, and privilege screen. |
+| Professional-negligence hypothesis | `DO-NOT-PLEAD-YET`. | Duty/scope, standard of care, breach, causation, damages, expert/affidavit, privilege waiver. |
+| Fiduciary-duty hypothesis | `COUNSEL-REVIEW`. | Relationship/duty and conflict/loyalty proof; privilege consequences. |
+| Fraud / misrepresentation hypothesis | `COUNSEL-REVIEW`. | False statement, materiality, knowledge/recklessness, intent, reliance, damages. |
+| Coordinated-conduct / civil-conspiracy gate | `NO-PLEAD` on current record. | Underlying tort/wrong, common design, overt acts, causation, damages. |
+| Rule 14 third-party route | `COUNSEL-REVIEW`. | Derivative liability for all or part of the claim against operator. |
+| Separate professional-liability action | Reserved. | Limitations, affidavit/expert gate, privilege strategy, damages proof, counsel review. |
+| Public-record impeachment / pattern use | Open. | Official docket confirmation and relevance/admissibility review. |
+
+## Source Packet Index
+
+| Packet | Source Location | Use | Status |
+|---|---|---|---|
+| Wilson Pruitt Email Batch 001 | `/mnt/fortress_nas/Corporate_Legal/Business_Legal/7il-v-knight-ndga-ii/incoming/wilson-pruitt-email-intake-20260503/` | Email custody, privilege, issue tagging, proof matrix. | Awaiting exports. |
+| Batch 001 manifest generator | `tools/wpe_batch_manifest.py` | Creates source hash manifest, privilege queue, issue queue. | Ready after source files land. |
+| Wilson Pruitt claim evaluation workbench | `../filing-readiness/wilson-pruitt-claim-evaluation-workbench-7il-ndga-ii-2026-05-03.md` | Legal/procedural proof gates. | Active. |
+| Wilson Pruitt adverse-alignment proof matrix | `../evidence-traceability/wilson-pruitt-adverse-alignment-proof-matrix-7il-ndga-ii-2026-05-03.md` | Source-to-gate matrix. | Active. |
+| Public-record check workbench | `wilson-pruitt-public-record-check-workbench-7il-ndga-ii-2026-05-03.md` | Litigation-history and counterclaim verification. | Open. |
+| Closing package | Wilson Pruitt File No. 25-0170 / operator records / third-party request. | Duty, scope, title, reservation, waiver, damages. | Pending. |
+| Terry Wilson production | Case I production lane; repair-reference pin already identified. | Inspection/source provenance and Amendment #2 repair reference. | Located in part; link through custody registry. |
+
+## Public-Record Snapshot
+
+Initial public web-indexed checking has not produced a confirmed post-2020 lawsuit, outcome, or countersuit naming Terry Wilson, Wilson Pruitt LLC, Terry Lee Wilson LLC, or Wilson Hamilton LLC. This is not a final clearance. The correct statement is: no confirmed hit in checked public web-indexed sources as of 2026-05-03; official county, PACER, appellate, and discipline checks remain open.
+
+## Counsel Questions
+
+| Question | Why It Matters |
+|---|---|
+| Who was Wilson Pruitt's client or principal for each task: Gary, 7IL, both sides as closing agent, title insurer, or another role? | Controls duty, privilege, and standing. |
+| Did the closing file contain title/easement exceptions, escrow instructions, or reservations that contradict Case II allegations? | Supports defenses and possible discovery. |
+| Did any source show conduct beyond ordinary closing/title work into adverse alignment or coordinated conduct? | Controls whether this stays discovery-only or becomes a counsel memo. |
+| Does any claim belong in first response, Rule 14 practice, later amendment, or separate action? | Avoids procedural overreach. |
+| Would asserting professional liability waive privileged communications from Case I or closing work? | Controls risk and sequencing. |
+| Is an expert affidavit or standard-of-care review required before any pleading? | Avoids dismissal and weak pleading. |
+
+## Next Actions
+
+1. Copy Wilson Pruitt exports into Batch 001 NAS folders.
+2. Run `tools/wpe_batch_manifest.py` to generate source, privilege, and issue queues.
+3. Complete the public-record check workbench using official court/bar sources.
+4. Fill this dossier only with WPE IDs, source paths, docket citations, hashes, or counsel-approved summaries.
+5. Keep pleading status at `DISCOVERY-TARGET` / `COUNSEL-MEMO` until the gates pass.

--- a/docs/operational/fortress-legal/matter-control/case-ii-2026-05-02/actor-dossiers/wilson-pruitt-public-record-check-workbench-7il-ndga-ii-2026-05-03.md
+++ b/docs/operational/fortress-legal/matter-control/case-ii-2026-05-02/actor-dossiers/wilson-pruitt-public-record-check-workbench-7il-ndga-ii-2026-05-03.md
@@ -1,0 +1,86 @@
+# Wilson Pruitt Public-Record Check Workbench - 7IL Case II
+
+Date: 2026-05-03
+Operator service status: not served as of 2026-05-03
+Classification: Repo-safe public-record verification workflow. Not legal advice and not a litigation-history conclusion.
+
+## Purpose
+
+This workbench answers, in a repeatable way, whether Terry Wilson, Wilson Pruitt, or related entities have been sued, countersued, disciplined, or named in public litigation records from 2020-present. It prevents Fortress Legal from relying on search snippets, name collisions, or incomplete web-indexed results.
+
+## Search Subjects
+
+| Subject | Variants To Check | Notes |
+|---|---|---|
+| Terry Wilson | Terry Wilson; Terry Lee Wilson; Terry L. Wilson | Confirm exact bar/profile identity before treating a hit as responsive. |
+| Wilson Pruitt LLC | Wilson Pruitt; Wilson Pruitt, LLC; Wilson Pruitt Law | Firm entity and trade-name variants. |
+| Terry Lee Wilson LLC | Terry Lee Wilson, LLC; Terry Wilson LLC | Possible related entity/name variant; verify before use. |
+| Wilson Hamilton LLC | Wilson Hamilton; Wilson Hamilton LLC | Possible related firm/name variant; verify before use. |
+| Firm lawyers/staff | Only source-backed names | Do not broaden without a reason. |
+
+## Source Checklist
+
+| Priority | Source | What To Check | Capture Standard | Status |
+|---:|---|---|---|---|
+| P1 | Fannin County Superior Court / Clerk index | Civil suits, counterclaims, third-party complaints, malpractice, title/closing disputes. | Caption, docket number, filing date, role, outcome, document source. | Open. |
+| P1 | PACER / N.D. Ga. | Federal cases naming any subject since 2020. | Docket number, party role, nature of suit, key pleadings, outcome. | Open. |
+| P1 | Georgia appellate opinions/orders | Appeals involving any subject or firm. | Case name, citation/docket, court, disposition, issue. | Open. |
+| P1 | State Bar of Georgia membership/discipline sources | Discipline history, public orders, membership status. | Official profile/order citation only. | Open. |
+| P2 | Neighboring county Superior Court indexes | Gilmer, Pickens, Union, and other counties if name/venue facts point there. | Same as Fannin. | Open. |
+| P2 | Georgia Secretary of State entity search | Exact legal names, entity status, registered agent, historical names. | Entity control number and status date. | Open. |
+| P2 | CourtListener / Justia / other web-indexed dockets | Supplemental search, not final authority. | Treat as lead only until docket/source verified. | Initial web-indexed scan found no confirmed responsive hit. |
+
+## Result Log Template
+
+| Date Checked | Source | Search Term | Hit? | Caption / Matter | Docket / ID | Subject Role | Filing Date | Outcome | Counterclaim / Third-Party? | Verification Status | Notes |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| 2026-05-03 | Public web-indexed search | Terry Wilson / Wilson Pruitt variants | No confirmed responsive hit | N/A | N/A | N/A | N/A | N/A | No confirmed counterclaim found | Lead-only; official checks open | Do not treat as no-lawsuit clearance. |
+
+## Outcome Codes
+
+| Code | Meaning |
+|---|---|
+| `NO-CONFIRMED-HIT` | No responsive hit in the specific source checked; not a universal clearance. |
+| `HIT-UNVERIFIED` | Possible name match; needs docket/profile/entity confirmation. |
+| `FILED-PENDING` | Case appears active or unresolved. |
+| `DISMISSED` | Case dismissed; capture with/without prejudice if available. |
+| `SETTLED` | Settlement shown by docket or order; do not infer terms unless public. |
+| `JUDGMENT` | Judgment entered; capture winner/loser and relief only from docket/order. |
+| `COUNTERCLAIM-NAMED` | Subject was named in a counterclaim or crossclaim; capture pleading. |
+| `THIRD-PARTY-NAMED` | Subject was impleaded or joined as third-party defendant. |
+| `DISCIPLINE-HIT` | Public bar discipline/source hit; capture official order only. |
+
+## Counterclaim-Specific Protocol
+
+A case is not enough. To answer whether a subject was named in a countersuit, check the pleadings:
+
+1. Complaint.
+2. Answer.
+3. Counterclaim.
+4. Crossclaim.
+5. Third-party complaint.
+6. Amended pleadings.
+7. Dismissal/settlement/judgment orders.
+
+Record the exact pleading title and docket entry. Do not infer counterclaim status from case captions alone.
+
+## Repo / NAS Handling
+
+- Repo may store metadata, docket citations, official links, and hash values.
+- NAS should store downloaded docket documents, courthouse exports, screenshots, and PDFs if obtained.
+- Do not store raw privileged emails or counsel analysis in this public-record workbench.
+- If a source is only a paid-access docket, record the access path and document ID without copying restricted content into repo.
+
+## Initial Working Answer
+
+As of 2026-05-03, there is no confirmed repo-safe public-record hit showing that Terry Wilson, Wilson Pruitt LLC, Terry Lee Wilson LLC, or Wilson Hamilton LLC was sued, countersued, or named in a counterclaim from 2020-present. That answer is provisional because official county/PACER/appellate/bar checks have not been completed.
+
+Use this phrasing until the checklist is complete: `No confirmed hit in the sources checked so far; official record checks remain open.`
+
+## Next Actions
+
+1. Verify exact subject names through bar/profile/entity sources.
+2. Check Fannin County first because the closing and property facts point there.
+3. Check N.D. Ga. PACER because Case II is in federal court.
+4. Check Georgia appellate and State Bar discipline sources.
+5. If any hit appears, save source documents to NAS, hash them, and update the result log before using the fact in any workbench.

--- a/docs/operational/fortress-legal/matter-control/case-ii-2026-05-02/evidence-traceability/README.md
+++ b/docs/operational/fortress-legal/matter-control/case-ii-2026-05-02/evidence-traceability/README.md
@@ -10,16 +10,17 @@ Use order:
 4. Wilson Pruitt email Batch 001 intake kit
 5. Wilson Pruitt email Batch 001 manifest generator
 6. Wilson Pruitt email evidence register
-7. Wilson Pruitt adverse-alignment proof matrix
-8. Count-to-evidence trace map
-9. Paragraph evidence trace matrix
-10. Inspection reports and closing-scope addendum
-11. Inspection comments spreadsheet curation addendum
-12. River Heights inspection source status
-13. Terry Wilson River Heights repair reference pin
-14. Evidence gap action list
-15. DOT / GNRR response intake tracker
-16. DOT / GNRR outbound send log
+7. Wilson Pruitt actor dossier and public-record check workbench
+8. Wilson Pruitt adverse-alignment proof matrix
+9. Count-to-evidence trace map
+10. Paragraph evidence trace matrix
+11. Inspection reports and closing-scope addendum
+12. Inspection comments spreadsheet curation addendum
+13. River Heights inspection source status
+14. Terry Wilson River Heights repair reference pin
+15. Evidence gap action list
+16. DOT / GNRR response intake tracker
+17. DOT / GNRR outbound send log
 
 Current controlling fact: Gary Knight has not been served as of 2026-05-03.
 
@@ -33,3 +34,5 @@ Wilson Pruitt claim-evaluation lane: Wilson Pruitt / Terry Wilson concerns are t
 Wilson Pruitt Batch 001 lane: use the Batch 001 intake kit before opening, normalizing, or analyzing newly copied Wilson Pruitt email exports.
 
 Wilson Pruitt manifest-generator lane: after source exports land in Batch 001, run `tools/wpe_batch_manifest.py` to produce timestamped source, privilege-screen, and issue-tagging TSVs on NAS.
+
+Wilson Pruitt actor-dossier lane: use `../actor-dossiers/wilson-pruitt-actor-dossier-7il-ndga-ii-2026-05-03.md` to track identity, role, source packets, public-record checks, and claim-readiness status without promoting raw accusations.

--- a/docs/operational/fortress-legal/matter-control/case-ii-2026-05-02/filing-readiness/wilson-pruitt-claim-evaluation-workbench-7il-ndga-ii-2026-05-03.md
+++ b/docs/operational/fortress-legal/matter-control/case-ii-2026-05-02/filing-readiness/wilson-pruitt-claim-evaluation-workbench-7il-ndga-ii-2026-05-03.md
@@ -8,6 +8,10 @@ Classification: Repo-safe counsel-review workbench. Not a pleading, not legal ad
 
 This workbench converts the operator's Wilson Pruitt concerns into proof gates for counsel review. The working hypothesis is that Wilson Pruitt / Terry Wilson conduct may be relevant to professional negligence, fiduciary-duty, fraud/misrepresentation, civil conspiracy, adverse-alignment, discovery, or impeachment issues. No claim is treated as pleading-ready until the gates below pass.
 
+## Actor Dossier Link
+
+Use `../actor-dossiers/wilson-pruitt-actor-dossier-7il-ndga-ii-2026-05-03.md` as the status dashboard for identity, role, source packets, public-record checks, and claim-readiness. This workbench remains the proof-gate layer; the dossier should not promote any theory beyond the gates below.
+
 ## Terminology Discipline
 
 Use controlled language:

--- a/docs/operational/fortress-legal/matter-control/case-ii-2026-05-02/matter-command-center-7il-ndga-ii-2026-05-02.md
+++ b/docs/operational/fortress-legal/matter-control/case-ii-2026-05-02/matter-command-center-7il-ndga-ii-2026-05-02.md
@@ -47,6 +47,8 @@ While not served, build the evidence machine: run Wilson Pruitt email intake con
 | Wilson Pruitt manifest generator | `tools/wpe_batch_manifest.py` | Generates Batch 001 source hash manifest, privilege-screen queue, and issue-tagging queue after source files are copied |
 | Wilson Pruitt claim evaluation workbench | `docs/operational/fortress-legal/matter-control/case-ii-2026-05-02/filing-readiness/wilson-pruitt-claim-evaluation-workbench-7il-ndga-ii-2026-05-03.md` | Counsel-review gates for professional-negligence, coordinated-conduct, procedural route, causation, damages, and privilege risk |
 | Wilson Pruitt adverse-alignment proof matrix | `docs/operational/fortress-legal/matter-control/case-ii-2026-05-02/evidence-traceability/wilson-pruitt-adverse-alignment-proof-matrix-7il-ndga-ii-2026-05-03.md` | Source-to-gate matrix for Wilson Pruitt / Terry Wilson evidence intake and pleading discipline |
+| Wilson Pruitt actor dossier | `docs/operational/fortress-legal/matter-control/case-ii-2026-05-02/actor-dossiers/wilson-pruitt-actor-dossier-7il-ndga-ii-2026-05-03.md` | Identity, role, source-packet, public-record, and claim-readiness control for Wilson Pruitt / Terry Wilson |
+| Wilson Pruitt public-record check workbench | `docs/operational/fortress-legal/matter-control/case-ii-2026-05-02/actor-dossiers/wilson-pruitt-public-record-check-workbench-7il-ndga-ii-2026-05-03.md` | Litigation-history and counterclaim verification workflow for 2020-present checks |
 | Answer matrix | `/mnt/fortress_nas/Corporate_Legal/Business_Legal/7il-v-knight-ndga-ii/filings/outgoing/First_Response_Answer_Matrix_7IL_NDGA_II_20260502.md` | Paragraph-by-paragraph workbench |
 | First-response readiness gate | `docs/operational/fortress-legal/matter-control/case-ii-2026-05-02/filing-readiness/first-response-readiness-gate-7il-ndga-ii-2026-05-02.md` | Release gate before answer, Rule 12, extension, or counterclaim filing path |
 | Issue matrix | `/mnt/fortress_nas/Corporate_Legal/Business_Legal/7il-v-knight-ndga-ii/filings/outgoing/Issue_Matrix_7IL_NDGA_II_20260502.md` | Claims/defenses/counterclaims control |
@@ -67,4 +69,5 @@ While not served, build the evidence machine: run Wilson Pruitt email intake con
 2. Update counsel conflict tracker.
 3. Add any new evidence to the evidence-to-pleading map only after custody, privilege, and source controls clear.
 4. Review answer matrix gaps.
-5. Record decisions in the decision log.
+5. Complete actor-dossier/public-record checks only through official or source-controlled records.
+6. Record decisions in the decision log.


### PR DESCRIPTION
## What this PR does

Adds a repo-safe Wilson Pruitt / Terry Wilson actor dossier pack for 7IL Case II.

## Contents

- Actor-dossiers README
- Wilson Pruitt / Terry Wilson actor dossier
- Public-record and counterclaim check workbench for 2020-present verification
- Links from the matter command center, evidence traceability pack, and Wilson Pruitt claim evaluation workbench

## Operating posture

This does not plead or conclude liability. It keeps Wilson Pruitt / Terry Wilson in DISCOVERY-TARGET and COUNSEL-MEMO status unless procedural route, duty/scope, breach, causation, damages, expert/affidavit, and privilege gates pass.

## Verification

- Whitespace check passed
- ASCII check passed
- Repo-safe scan confirmed no raw email bodies or privileged material added

## Next operator action

Copy Wilson Pruitt email exports into the Batch 001 NAS folders, then run the manifest generator so the dossier can be filled from WPE IDs, hashes, source paths, and docket citations only.