### PR TITLE
feat(financial): add Dochia ticker cluster review

### DIFF
--- a/crog-ai-backend/README.md
+++ b/crog-ai-backend/README.md
@@ -108,6 +108,8 @@ uv run python scripts/compare_signal_candidate_lanes.py --limit-tickers 500 --to
 uv run python scripts/review_signal_candidate_promotion.py --lane-limit 50 --chart-ticker-limit 24
 uv run python scripts/research_range_trigger_guardrails.py --output docs/reports/dochia-v0-3-atr-cooldown-research-2026-05-03.md
 uv run python scripts/review_signal_outcomes.py --output docs/reports/dochia-v0-3-return-outcome-review-2026-05-03.md
+uv run python scripts/review_ticker_cluster_candidates.py --include-exclude --output docs/reports/dochia-v0-3-ticker-cluster-review-2026-05-03.md
+uv run python scripts/review_ticker_cluster_candidates.py --include-exclude --cluster-until 2025-09-24 --since 2025-09-25 --output docs/reports/dochia-v0-3-ticker-cluster-holdout-2026-05-03.md
 ```
 
 Best 2026-05-02 research candidate: 3-session intraday range trigger. It
@@ -160,6 +162,16 @@ forward returns are flat for both production close and v0.2 raw range: v0.2
 v0.2 whipsaw clusters are ticker-specific, led by MOD, ISRG, MRVL, DLR, and HD.
 Future candidates must preserve alert quality, reduce whipsaw clusters, and
 avoid degrading forward directional returns.
+
+Ticker-cluster reports:
+`docs/reports/dochia-v0-3-ticker-cluster-review-2026-05-03.md` and
+`docs/reports/dochia-v0-3-ticker-cluster-holdout-2026-05-03.md`. Full-period
+top-15 exclusion cuts 5.11% of events while keeping F1 at 74.98% and improving
+5-session average directional return to +0.05%. Chronological holdout, with
+clusters learned before 2025-09-25 and evaluated after, does not clear the
+default gate: top-15 exclusion cuts 4.74% of events, keeps F1 at 78.16%, and
+leaves 5-session average directional return flat at -0.04%. Keep v0.2
+candidate-only; do not persist the cluster candidate yet.
 
 ## Relationship to Fortress-Prime
 

--- a/crog-ai-backend/app/signals/outcome_review.py
+++ b/crog-ai-backend/app/signals/outcome_review.py
@@ -7,8 +7,9 @@ from collections import defaultdict
 from dataclasses import asdict, dataclass
 from statistics import median
 
+from app.signals.calibration import CalibrationObservation, normalize_triangle_color
 from app.signals.calibration_sweep import DailyEventHistory
-from app.signals.trade_triangles import EodBar
+from app.signals.trade_triangles import EodBar, TriangleState
 
 
 @dataclass(frozen=True, slots=True)
@@ -48,6 +49,64 @@ class TickerWhipsawOutcome:
         return asdict(self)
 
 
+@dataclass(frozen=True, slots=True)
+class AlertMatchSummary:
+    total_observations: int
+    covered_observations: int
+    generated_events: int
+    carried_state_matches: int
+    exact_event_matches: int
+    window_event_matches: int
+    opposite_event_observations: int
+    no_event_observations: int
+    carried_state_accuracy: float | None
+    exact_event_recall: float | None
+    exact_event_precision: float | None
+    exact_event_f1: float | None
+    window_event_recall: float | None
+
+    def as_json_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class TickerClusterCandidate:
+    cluster_size: int
+    mode: str
+    cooldown_sessions: int = 0
+
+    @property
+    def name(self) -> str:
+        if self.mode == "exclude":
+            return f"top_{self.cluster_size}_exclude"
+        return f"top_{self.cluster_size}_cooldown_{self.cooldown_sessions}"
+
+    def as_json_dict(self) -> dict[str, object]:
+        return asdict(self) | {"name": self.name}
+
+
+@dataclass(frozen=True, slots=True)
+class TickerClusterReview:
+    candidate: TickerClusterCandidate
+    cluster_tickers: list[str]
+    alert_match: AlertMatchSummary
+    generated_event_reduction: float | None
+    outcome_5_session: ReturnOutcomeSummary
+    top_whipsaw_count: int
+    top_whipsaw_tickers: list[str]
+
+    def as_json_dict(self) -> dict[str, object]:
+        return {
+            "candidate": self.candidate.as_json_dict(),
+            "cluster_tickers": self.cluster_tickers,
+            "alert_match": self.alert_match.as_json_dict(),
+            "generated_event_reduction": self.generated_event_reduction,
+            "outcome_5_session": self.outcome_5_session.as_json_dict(),
+            "top_whipsaw_count": self.top_whipsaw_count,
+            "top_whipsaw_tickers": self.top_whipsaw_tickers,
+        }
+
+
 def _ordered_bars(bars: list[EodBar]) -> list[EodBar]:
     return sorted(bars, key=lambda bar: (bar.ticker, bar.bar_date))
 
@@ -64,6 +123,12 @@ def _percentile(values: list[float], percentile: float) -> float | None:
     ordered = sorted(values)
     index = round((len(ordered) - 1) * percentile)
     return ordered[index]
+
+
+def _f1(precision: float | None, recall: float | None) -> float | None:
+    if precision is None or recall is None or precision + recall == 0:
+        return None
+    return 2 * precision * recall / (precision + recall)
 
 
 def events_from_histories(
@@ -94,6 +159,155 @@ def events_from_histories(
                 )
             )
     return sorted(events, key=lambda event: (event.ticker, event.index))
+
+
+def _rebuild_history_from_events(
+    history: DailyEventHistory,
+    *,
+    kept_events: dict[dt.date, int],
+) -> DailyEventHistory:
+    current_state = TriangleState.NEUTRAL.numeric
+    state_by_date: dict[dt.date, int] = {}
+    event_dates_by_state: dict[int, list[dt.date]] = defaultdict(list)
+
+    for trading_day in history.dates:
+        event_state = kept_events.get(trading_day)
+        if event_state is not None:
+            current_state = event_state
+            event_dates_by_state[event_state].append(trading_day)
+        state_by_date[trading_day] = current_state
+
+    return DailyEventHistory(
+        ticker=history.ticker,
+        dates=history.dates,
+        state_by_date=state_by_date,
+        event_by_date=kept_events,
+        event_dates_by_state={
+            state: tuple(sorted(event_dates)) for state, event_dates in event_dates_by_state.items()
+        },
+    )
+
+
+def apply_ticker_cluster_candidate(
+    histories: dict[str, DailyEventHistory],
+    bars_by_ticker: dict[str, list[EodBar]],
+    *,
+    cluster_tickers: set[str],
+    candidate: TickerClusterCandidate,
+) -> dict[str, DailyEventHistory]:
+    if candidate.mode not in {"cooldown", "exclude"}:
+        raise ValueError("candidate mode must be cooldown or exclude")
+    if candidate.cluster_size < 1:
+        raise ValueError("cluster_size must be at least 1")
+    if candidate.cooldown_sessions < 0:
+        raise ValueError("cooldown_sessions must be non-negative")
+
+    adjusted: dict[str, DailyEventHistory] = {}
+    for ticker, history in histories.items():
+        if ticker not in cluster_tickers:
+            adjusted[ticker] = history
+            continue
+
+        if candidate.mode == "exclude":
+            adjusted[ticker] = _rebuild_history_from_events(history, kept_events={})
+            continue
+
+        bars = _ordered_bars(bars_by_ticker.get(ticker, []))
+        index_by_date = {bar.bar_date: index for index, bar in enumerate(bars)}
+        kept_events: dict[dt.date, int] = {}
+        last_kept_index: int | None = None
+        for event_date, event_state in sorted(history.event_by_date.items()):
+            event_index = index_by_date.get(event_date)
+            if event_index is None:
+                continue
+            within_cooldown = (
+                last_kept_index is not None
+                and event_index - last_kept_index <= candidate.cooldown_sessions
+            )
+            if within_cooldown:
+                continue
+            kept_events[event_date] = event_state
+            last_kept_index = event_index
+        adjusted[ticker] = _rebuild_history_from_events(history, kept_events=kept_events)
+    return adjusted
+
+
+def evaluate_event_histories(
+    observations: list[CalibrationObservation],
+    histories: dict[str, DailyEventHistory],
+    *,
+    event_window_days: int = 3,
+) -> AlertMatchSummary:
+    if observations:
+        since = min(observation.trading_day for observation in observations)
+        until = max(observation.trading_day for observation in observations)
+    else:
+        since = until = None
+
+    generated_events = 0
+    for history in histories.values():
+        for event_date in history.event_by_date:
+            if since is not None and event_date < since:
+                continue
+            if until is not None and event_date > until:
+                continue
+            generated_events += 1
+
+    covered = 0
+    state_matches = 0
+    exact_matches = 0
+    window_matches = 0
+    opposite_events = 0
+    no_events = 0
+    matched_generated_events: set[tuple[str, dt.date]] = set()
+
+    for observation in observations:
+        actual = normalize_triangle_color(observation.triangle_color)
+        actual_state = TriangleState.GREEN.numeric if actual == "green" else TriangleState.RED.numeric
+        history = histories.get(observation.ticker)
+        if history is None:
+            continue
+
+        state = history.state_as_of(observation.trading_day)
+        if state is None:
+            continue
+        covered += 1
+        if state == actual_state:
+            state_matches += 1
+
+        event = history.event_on(observation.trading_day)
+        if event is None:
+            no_events += 1
+        elif event == actual_state:
+            exact_matches += 1
+            matched_generated_events.add((observation.ticker, observation.trading_day))
+        else:
+            opposite_events += 1
+
+        if history.has_event_within(
+            trading_day=observation.trading_day,
+            state=actual_state,
+            window_days=event_window_days,
+        ):
+            window_matches += 1
+
+    recall = _safe_rate(exact_matches, covered)
+    precision = _safe_rate(len(matched_generated_events), generated_events)
+    return AlertMatchSummary(
+        total_observations=len(observations),
+        covered_observations=covered,
+        generated_events=generated_events,
+        carried_state_matches=state_matches,
+        exact_event_matches=exact_matches,
+        window_event_matches=window_matches,
+        opposite_event_observations=opposite_events,
+        no_event_observations=no_events,
+        carried_state_accuracy=_safe_rate(state_matches, covered),
+        exact_event_recall=recall,
+        exact_event_precision=precision,
+        exact_event_f1=_f1(precision, recall),
+        window_event_recall=_safe_rate(window_matches, covered),
+    )
 
 
 def _directional_return(
@@ -150,6 +364,19 @@ def summarize_forward_returns(
             )
         )
     return summaries
+
+
+def _first_outcome(
+    events: list[SignalEvent],
+    bars_by_ticker: dict[str, list[EodBar]],
+    *,
+    horizon_sessions: int,
+) -> ReturnOutcomeSummary:
+    return summarize_forward_returns(
+        events,
+        bars_by_ticker,
+        horizons=[horizon_sessions],
+    )[0]
 
 
 def build_ticker_whipsaw_outcomes(
@@ -212,3 +439,56 @@ def build_ticker_whipsaw_outcomes(
         reverse=True,
     )
     return outcomes[:top]
+
+
+def review_ticker_cluster_candidate(
+    observations: list[CalibrationObservation],
+    raw_histories: dict[str, DailyEventHistory],
+    bars_by_ticker: dict[str, list[EodBar]],
+    *,
+    cluster_tickers: list[str],
+    candidate: TickerClusterCandidate,
+    raw_generated_events: int,
+    event_window_days: int,
+    whipsaw_window_sessions: int,
+    outcome_horizon_sessions: int,
+    top_whipsaws: int,
+    since: dt.date | None = None,
+    until: dt.date | None = None,
+) -> TickerClusterReview:
+    selected_tickers = set(cluster_tickers[: candidate.cluster_size])
+    adjusted_histories = apply_ticker_cluster_candidate(
+        raw_histories,
+        bars_by_ticker,
+        cluster_tickers=selected_tickers,
+        candidate=candidate,
+    )
+    alert_match = evaluate_event_histories(
+        observations,
+        adjusted_histories,
+        event_window_days=event_window_days,
+    )
+    events = events_from_histories(adjusted_histories, bars_by_ticker, since=since, until=until)
+    whipsaws = build_ticker_whipsaw_outcomes(
+        events,
+        bars_by_ticker,
+        whipsaw_window_sessions=whipsaw_window_sessions,
+        outcome_horizon_sessions=outcome_horizon_sessions,
+        top=top_whipsaws,
+    )
+    return TickerClusterReview(
+        candidate=candidate,
+        cluster_tickers=cluster_tickers[: candidate.cluster_size],
+        alert_match=alert_match,
+        generated_event_reduction=_safe_rate(
+            raw_generated_events - alert_match.generated_events,
+            raw_generated_events,
+        ),
+        outcome_5_session=_first_outcome(
+            events,
+            bars_by_ticker,
+            horizon_sessions=outcome_horizon_sessions,
+        ),
+        top_whipsaw_count=sum(row.whipsaw_count for row in whipsaws),
+        top_whipsaw_tickers=[row.ticker for row in whipsaws],
+    )

--- a/crog-ai-backend/docs/MARKETCLUB-DOCHIA-BUILD-PLAN.md
+++ b/crog-ai-backend/docs/MARKETCLUB-DOCHIA-BUILD-PLAN.md
@@ -210,6 +210,15 @@ Useful query params:
   range: v0.2 5-session win rate is 50.33% with +0.01% average directional
   return. The worst v0.2 whipsaw clusters are concentrated in MOD, ISRG, MRVL,
   DLR, and HD.
+- Added ticker-cluster cooldown/exclusion research with a chronological
+  holdout. Reports are tracked at
+  `docs/reports/dochia-v0-3-ticker-cluster-review-2026-05-03.md` and
+  `docs/reports/dochia-v0-3-ticker-cluster-holdout-2026-05-03.md`. Full-period
+  top-15 exclusion is promising: 5.11% fewer events, 74.98% F1, and +0.05%
+  average 5-session directional return. The holdout learns clusters before
+  2025-09-25 and evaluates after; it does not clear the default gate, with
+  4.74% event reduction, 78.16% F1, and -0.04% average 5-session directional
+  return. Do not persist this candidate yet.
 - Added and enabled `crog-ai-backend.service` on spark-node-2.
 - Promoted the Command Center production build and restarted
   `crog-ai-frontend.service`; `/financial/hedge-fund` is live through
@@ -219,6 +228,6 @@ Useful query params:
   status, and live backend/BFF reads for both production and v0.2 candidate
   selectors. `/financial/hedge-fund` returns 200 after frontend restart.
 
-Next clean build step: design a ticker-cluster exclusion/cooldown candidate
-that targets the worst whipsaw names without degrading forward directional
-returns on the broader universe.
+Next clean build step: build a rolling, date-safe whipsaw-risk score that can
+cool down names as they become noisy without relying on a fixed historical
+blocklist.

--- a/crog-ai-backend/docs/reports/dochia-v0-3-ticker-cluster-holdout-2026-05-03.md
+++ b/crog-ai-backend/docs/reports/dochia-v0-3-ticker-cluster-holdout-2026-05-03.md
@@ -1,0 +1,51 @@
+# Dochia v0.3 Ticker-Cluster Candidate Review
+
+Generated: 2026-05-03T12:50:23.573566+00:00
+Scope: ticker=all since=2025-09-25 until=latest
+Cluster source: top 30 v0.2 whipsaw tickers over 5 sessions; since=beginning until=2025-09-24
+
+## Raw v0.2 Baseline
+
+| Events | F1 | Precision | Recall | ±3d recall | 5d win | Avg 5d | Top whipsaw count |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 8613 | 79.93% | 71.37% | 90.82% | 94.68% | 50.15% | -0.04% | 759 |
+
+Top cluster tickers: MOD, CME, MRVL, WMB, RIO, ISRG, VICI, DT, DLR, VRT, FLNC, HD, GFS, KHC, ROL
+
+## Quality-Preserving Candidates
+
+| Rank | Candidate | Events | Event reduction | F1 | Precision | Recall | ±3d recall | 5d win | Avg 5d | Top whipsaws | Top whipsaw tickers |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| 1 | top 15 exclude | 8205 | 4.74% | 78.16% | 71.31% | 86.47% | 90.17% | 50.12% | -0.04% | 756 | GCT, SMCI, DBC, DIVO, PSTG |
+| 2 | top 15 cooldown 20 | 8292 | 3.73% | 78.60% | 71.37% | 87.46% | 91.23% | 50.15% | -0.03% | 756 | GCT, SMCI, DBC, DIVO, PSTG |
+| 3 | top 10 exclude | 8339 | 3.18% | 78.79% | 71.36% | 87.94% | 91.72% | 50.13% | -0.03% | 756 | GCT, SMCI, DBC, DIVO, PSTG |
+| 4 | top 15 cooldown 10 | 8351 | 3.04% | 78.77% | 71.30% | 87.99% | 91.80% | 50.11% | -0.04% | 756 | GCT, SMCI, DBC, DIVO, PSTG |
+| 5 | top 10 cooldown 20 | 8397 | 2.51% | 79.07% | 71.39% | 88.59% | 92.41% | 50.15% | -0.04% | 756 | GCT, SMCI, DBC, DIVO, PSTG |
+| 6 | top 15 cooldown 5 | 8425 | 2.18% | 79.12% | 71.34% | 88.81% | 92.69% | 50.17% | -0.05% | 756 | GCT, SMCI, DBC, DIVO, PSTG |
+| 7 | top 10 cooldown 10 | 8435 | 2.07% | 79.18% | 71.36% | 88.94% | 92.79% | 50.09% | -0.05% | 756 | GCT, SMCI, DBC, DIVO, PSTG |
+| 8 | top 5 exclude | 8484 | 1.50% | 79.52% | 71.48% | 89.60% | 93.39% | 50.14% | -0.03% | 759 | GCT, SMCI, DBC, DIVO, PSTG |
+| 9 | top 10 cooldown 5 | 8484 | 1.50% | 79.41% | 71.38% | 89.48% | 93.36% | 50.10% | -0.05% | 756 | GCT, SMCI, DBC, DIVO, PSTG |
+| 10 | top 5 cooldown 20 | 8512 | 1.17% | 79.61% | 71.45% | 89.87% | 93.70% | 50.16% | -0.03% | 759 | GCT, SMCI, DBC, DIVO, PSTG |
+| 11 | top 5 cooldown 10 | 8531 | 0.95% | 79.65% | 71.42% | 90.03% | 93.88% | 50.12% | -0.04% | 759 | GCT, SMCI, DBC, DIVO, PSTG |
+| 12 | top 5 cooldown 5 | 8554 | 0.69% | 79.73% | 71.41% | 90.25% | 94.11% | 50.08% | -0.05% | 759 | GCT, SMCI, DBC, DIVO, PSTG |
+
+## Best Event-Reduction Candidates
+
+| Rank | Candidate | Events | Event reduction | F1 | Precision | Recall | ±3d recall | 5d win | Avg 5d | Top whipsaws | Top whipsaw tickers |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| R1 | top 15 exclude | 8205 | 4.74% | 78.16% | 71.31% | 86.47% | 90.17% | 50.12% | -0.04% | 756 | GCT, SMCI, DBC, DIVO, PSTG |
+| R2 | top 15 cooldown 20 | 8292 | 3.73% | 78.60% | 71.37% | 87.46% | 91.23% | 50.15% | -0.03% | 756 | GCT, SMCI, DBC, DIVO, PSTG |
+| R3 | top 10 exclude | 8339 | 3.18% | 78.79% | 71.36% | 87.94% | 91.72% | 50.13% | -0.03% | 756 | GCT, SMCI, DBC, DIVO, PSTG |
+| R4 | top 15 cooldown 10 | 8351 | 3.04% | 78.77% | 71.30% | 87.99% | 91.80% | 50.11% | -0.04% | 756 | GCT, SMCI, DBC, DIVO, PSTG |
+| R5 | top 10 cooldown 20 | 8397 | 2.51% | 79.07% | 71.39% | 88.59% | 92.41% | 50.15% | -0.04% | 756 | GCT, SMCI, DBC, DIVO, PSTG |
+| R6 | top 15 cooldown 5 | 8425 | 2.18% | 79.12% | 71.34% | 88.81% | 92.69% | 50.17% | -0.05% | 756 | GCT, SMCI, DBC, DIVO, PSTG |
+| R7 | top 10 cooldown 10 | 8435 | 2.07% | 79.18% | 71.36% | 88.94% | 92.79% | 50.09% | -0.05% | 756 | GCT, SMCI, DBC, DIVO, PSTG |
+| R8 | top 5 exclude | 8484 | 1.50% | 79.52% | 71.48% | 89.60% | 93.39% | 50.14% | -0.03% | 759 | GCT, SMCI, DBC, DIVO, PSTG |
+| R9 | top 10 cooldown 5 | 8484 | 1.50% | 79.41% | 71.38% | 89.48% | 93.36% | 50.10% | -0.05% | 756 | GCT, SMCI, DBC, DIVO, PSTG |
+| R10 | top 5 cooldown 20 | 8512 | 1.17% | 79.61% | 71.45% | 89.87% | 93.70% | 50.16% | -0.03% | 759 | GCT, SMCI, DBC, DIVO, PSTG |
+| R11 | top 5 cooldown 10 | 8531 | 0.95% | 79.65% | 71.42% | 90.03% | 93.88% | 50.12% | -0.04% | 759 | GCT, SMCI, DBC, DIVO, PSTG |
+| R12 | top 5 cooldown 5 | 8554 | 0.69% | 79.73% | 71.41% | 90.25% | 94.11% | 50.08% | -0.05% | 759 | GCT, SMCI, DBC, DIVO, PSTG |
+
+## Recommendation
+
+No ticker-cluster candidate cleared the default gate: at least 95% of raw-range F1, at least 5% event reduction, fewer top whipsaws, and no worse 5-session average directional return. Keep v0.2 candidate-only.

--- a/crog-ai-backend/docs/reports/dochia-v0-3-ticker-cluster-review-2026-05-03.md
+++ b/crog-ai-backend/docs/reports/dochia-v0-3-ticker-cluster-review-2026-05-03.md
@@ -1,0 +1,55 @@
+# Dochia v0.3 Ticker-Cluster Candidate Review
+
+Generated: 2026-05-03T12:50:39.698708+00:00
+Scope: ticker=all since=beginning until=latest
+Cluster source: top 30 v0.2 whipsaw tickers over 5 sessions; since=beginning until=latest
+
+## Raw v0.2 Baseline
+
+| Events | F1 | Precision | Recall | ±3d recall | 5d win | Avg 5d | Top whipsaw count |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 30806 | 76.64% | 65.71% | 91.93% | 95.21% | 50.33% | +0.01% | 2164 |
+
+Top cluster tickers: MOD, ISRG, MRVL, DLR, HD, VRT, GFS, APG, RUN, WMB, DT, SIG, DBC, AVGO, CME
+
+## Quality-Preserving Candidates
+
+| Rank | Candidate | Events | Event reduction | F1 | Precision | Recall | ±3d recall | 5d win | Avg 5d | Top whipsaws | Top whipsaw tickers |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| 1 | top 15 exclude | 29232 | 5.11% | 74.98% | 65.73% | 87.28% | 90.44% | 50.58% | +0.05% | 2036 | BNDX, MO, RUM, PINS, KC |
+| 2 | top 15 cooldown 20 | 29544 | 4.10% | 75.31% | 65.72% | 88.19% | 91.43% | 50.54% | +0.04% | 2036 | BNDX, MO, RUM, PINS, KC |
+| 3 | top 10 exclude | 29750 | 3.43% | 75.46% | 65.65% | 88.72% | 91.90% | 50.53% | +0.04% | 2067 | DT, SIG, DBC, AVGO, CME |
+| 4 | top 15 cooldown 10 | 29755 | 3.41% | 75.54% | 65.72% | 88.82% | 92.10% | 50.48% | +0.03% | 2036 | BNDX, MO, RUM, PINS, KC |
+| 5 | top 10 cooldown 20 | 29959 | 2.75% | 75.69% | 65.66% | 89.35% | 92.59% | 50.51% | +0.04% | 2067 | DT, SIG, DBC, AVGO, CME |
+| 6 | top 15 cooldown 5 | 30053 | 2.44% | 75.86% | 65.71% | 89.70% | 93.04% | 50.47% | +0.03% | 2036 | BNDX, MO, RUM, PINS, KC |
+| 7 | top 10 cooldown 10 | 30098 | 2.30% | 75.86% | 65.68% | 89.78% | 93.05% | 50.45% | +0.03% | 2067 | DT, SIG, DBC, AVGO, CME |
+| 8 | top 5 exclude | 30268 | 1.75% | 75.92% | 65.57% | 90.15% | 93.38% | 50.46% | +0.03% | 2104 | VRT, GFS, APG, RUN, WMB |
+| 9 | top 10 cooldown 5 | 30299 | 1.65% | 76.07% | 65.67% | 90.37% | 93.69% | 50.46% | +0.03% | 2067 | DT, SIG, DBC, AVGO, CME |
+| 10 | top 5 cooldown 20 | 30373 | 1.41% | 76.06% | 65.60% | 90.49% | 93.76% | 50.44% | +0.03% | 2104 | VRT, GFS, APG, RUN, WMB |
+| 11 | top 5 cooldown 10 | 30441 | 1.18% | 76.16% | 65.63% | 90.73% | 93.99% | 50.41% | +0.02% | 2104 | VRT, GFS, APG, RUN, WMB |
+| 12 | top 5 cooldown 5 | 30541 | 0.86% | 76.28% | 65.64% | 91.04% | 94.34% | 50.38% | +0.02% | 2104 | VRT, GFS, APG, RUN, WMB |
+
+## Best Event-Reduction Candidates
+
+| Rank | Candidate | Events | Event reduction | F1 | Precision | Recall | ±3d recall | 5d win | Avg 5d | Top whipsaws | Top whipsaw tickers |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| R1 | top 15 exclude | 29232 | 5.11% | 74.98% | 65.73% | 87.28% | 90.44% | 50.58% | +0.05% | 2036 | BNDX, MO, RUM, PINS, KC |
+| R2 | top 15 cooldown 20 | 29544 | 4.10% | 75.31% | 65.72% | 88.19% | 91.43% | 50.54% | +0.04% | 2036 | BNDX, MO, RUM, PINS, KC |
+| R3 | top 10 exclude | 29750 | 3.43% | 75.46% | 65.65% | 88.72% | 91.90% | 50.53% | +0.04% | 2067 | DT, SIG, DBC, AVGO, CME |
+| R4 | top 15 cooldown 10 | 29755 | 3.41% | 75.54% | 65.72% | 88.82% | 92.10% | 50.48% | +0.03% | 2036 | BNDX, MO, RUM, PINS, KC |
+| R5 | top 10 cooldown 20 | 29959 | 2.75% | 75.69% | 65.66% | 89.35% | 92.59% | 50.51% | +0.04% | 2067 | DT, SIG, DBC, AVGO, CME |
+| R6 | top 15 cooldown 5 | 30053 | 2.44% | 75.86% | 65.71% | 89.70% | 93.04% | 50.47% | +0.03% | 2036 | BNDX, MO, RUM, PINS, KC |
+| R7 | top 10 cooldown 10 | 30098 | 2.30% | 75.86% | 65.68% | 89.78% | 93.05% | 50.45% | +0.03% | 2067 | DT, SIG, DBC, AVGO, CME |
+| R8 | top 5 exclude | 30268 | 1.75% | 75.92% | 65.57% | 90.15% | 93.38% | 50.46% | +0.03% | 2104 | VRT, GFS, APG, RUN, WMB |
+| R9 | top 10 cooldown 5 | 30299 | 1.65% | 76.07% | 65.67% | 90.37% | 93.69% | 50.46% | +0.03% | 2067 | DT, SIG, DBC, AVGO, CME |
+| R10 | top 5 cooldown 20 | 30373 | 1.41% | 76.06% | 65.60% | 90.49% | 93.76% | 50.44% | +0.03% | 2104 | VRT, GFS, APG, RUN, WMB |
+| R11 | top 5 cooldown 10 | 30441 | 1.18% | 76.16% | 65.63% | 90.73% | 93.99% | 50.41% | +0.02% | 2104 | VRT, GFS, APG, RUN, WMB |
+| R12 | top 5 cooldown 5 | 30541 | 0.86% | 76.28% | 65.64% | 91.04% | 94.34% | 50.38% | +0.02% | 2104 | VRT, GFS, APG, RUN, WMB |
+
+## Recommendation
+
+Use this as the next non-production v0.3 candidate only after a chronological holdout check:
+
+| Rank | Candidate | Events | Event reduction | F1 | Precision | Recall | ±3d recall | 5d win | Avg 5d | Top whipsaws | Top whipsaw tickers |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| 1 | top 15 exclude | 29232 | 5.11% | 74.98% | 65.73% | 87.28% | 90.44% | 50.58% | +0.05% | 2036 | BNDX, MO, RUM, PINS, KC |

--- a/crog-ai-backend/scripts/review_ticker_cluster_candidates.py
+++ b/crog-ai-backend/scripts/review_ticker_cluster_candidates.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Research ticker-cluster cooldown/exclusion candidates for v0.2 whipsaws."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import psycopg
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from app.signals.calibration_repository import fetch_daily_sweep_inputs  # noqa: E402
+from app.signals.guardrail_sweep import (  # noqa: E402
+    GuardedRangeCandidate,
+    generated_guarded_range_event_history,
+)
+from app.signals.outcome_review import (  # noqa: E402
+    TickerClusterCandidate,
+    build_ticker_whipsaw_outcomes,
+    evaluate_event_histories,
+    events_from_histories,
+    review_ticker_cluster_candidate,
+    summarize_forward_returns,
+)
+from scripts.sweep_daily_signal_parameters import _database_url  # noqa: E402
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Review ticker-cluster cooldown/exclusion candidates for v0.2 whipsaws."
+    )
+    parser.add_argument("--since", type=dt.date.fromisoformat, default=None)
+    parser.add_argument("--until", type=dt.date.fromisoformat, default=None)
+    parser.add_argument("--cluster-since", type=dt.date.fromisoformat, default=None)
+    parser.add_argument("--cluster-until", type=dt.date.fromisoformat, default=None)
+    parser.add_argument("--ticker", default=None)
+    parser.add_argument("--cluster-size", action="append", type=int, default=None)
+    parser.add_argument("--cooldown-sessions", action="append", type=int, default=None)
+    parser.add_argument("--include-exclude", action="store_true")
+    parser.add_argument("--event-window-days", type=int, default=3)
+    parser.add_argument("--outcome-horizon", type=int, default=5)
+    parser.add_argument("--whipsaw-window-sessions", type=int, default=5)
+    parser.add_argument("--top-whipsaws", type=int, default=30)
+    parser.add_argument("--top", type=int, default=12)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--output", type=Path, default=None)
+    return parser.parse_args()
+
+
+def _pct(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value * 100:.2f}%"
+
+
+def _signed_pct(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value * 100:+.2f}%"
+
+
+def _table_row(values: list[object]) -> str:
+    return "| " + " | ".join(str(value) for value in values) + " |"
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if args.since is not None and args.until is not None and args.since > args.until:
+        raise SystemExit("since cannot be after until")
+    if (
+        args.cluster_since is not None
+        and args.cluster_until is not None
+        and args.cluster_since > args.cluster_until
+    ):
+        raise SystemExit("cluster-since cannot be after cluster-until")
+    for cluster_size in args.cluster_size or [5, 10, 15]:
+        if cluster_size < 1:
+            raise SystemExit("cluster-size must be at least 1")
+    for cooldown in args.cooldown_sessions or [5, 10, 20]:
+        if cooldown < 1:
+            raise SystemExit("cooldown-sessions must be at least 1")
+    if args.event_window_days < 0:
+        raise SystemExit("event-window-days must be non-negative")
+    if args.outcome_horizon < 1:
+        raise SystemExit("outcome-horizon must be at least 1")
+    if args.whipsaw_window_sessions < 1:
+        raise SystemExit("whipsaw-window-sessions must be at least 1")
+    if args.top_whipsaws < 1:
+        raise SystemExit("top-whipsaws must be at least 1")
+    if args.top < 1:
+        raise SystemExit("top must be at least 1")
+
+
+def _raw_range_histories(bars_by_ticker: dict[str, list[Any]]) -> dict[str, Any]:
+    histories: dict[str, Any] = {}
+    for ticker, bars in bars_by_ticker.items():
+        history = generated_guarded_range_event_history(
+            bars,
+            candidate=GuardedRangeCandidate(lookback_sessions=3),
+        )
+        if history is not None:
+            histories[ticker] = history
+    return histories
+
+
+def _candidate_grid(args: argparse.Namespace) -> list[TickerClusterCandidate]:
+    cluster_sizes = args.cluster_size or [5, 10, 15]
+    cooldowns = args.cooldown_sessions or [5, 10, 20]
+    candidates = [
+        TickerClusterCandidate(
+            cluster_size=cluster_size,
+            mode="cooldown",
+            cooldown_sessions=cooldown,
+        )
+        for cluster_size in cluster_sizes
+        for cooldown in cooldowns
+    ]
+    if args.include_exclude:
+        candidates.extend(
+            TickerClusterCandidate(cluster_size=cluster_size, mode="exclude")
+            for cluster_size in cluster_sizes
+        )
+    return candidates
+
+
+def _candidate_label(row: dict[str, Any]) -> str:
+    candidate = row["candidate"]
+    if candidate["mode"] == "exclude":
+        return f"top {candidate['cluster_size']} exclude"
+    return f"top {candidate['cluster_size']} cooldown {candidate['cooldown_sessions']}"
+
+
+def _render_candidate_row(row: dict[str, Any], rank: int | str) -> str:
+    alert = row["alert_match"]
+    outcome = row["outcome_5_session"]
+    return _table_row(
+        [
+            rank,
+            _candidate_label(row),
+            alert["generated_events"],
+            _pct(row["generated_event_reduction"]),
+            _pct(alert["exact_event_f1"]),
+            _pct(alert["exact_event_precision"]),
+            _pct(alert["exact_event_recall"]),
+            _pct(alert["window_event_recall"]),
+            _pct(outcome["win_rate"]),
+            _signed_pct(outcome["average_directional_return"]),
+            row["top_whipsaw_count"],
+            ", ".join(row["top_whipsaw_tickers"][:5]),
+        ]
+    )
+
+
+def _append_candidate_table(lines: list[str], rows: list[dict[str, Any]], *, prefix: str = "") -> None:
+    lines.extend(
+        [
+            _table_row(
+                [
+                    "Rank",
+                    "Candidate",
+                    "Events",
+                    "Event reduction",
+                    "F1",
+                    "Precision",
+                    "Recall",
+                    "±3d recall",
+                    "5d win",
+                    "Avg 5d",
+                    "Top whipsaws",
+                    "Top whipsaw tickers",
+                ]
+            ),
+            _table_row(
+                [
+                    "---:",
+                    "---",
+                    "---:",
+                    "---:",
+                    "---:",
+                    "---:",
+                    "---:",
+                    "---:",
+                    "---:",
+                    "---:",
+                    "---:",
+                    "---",
+                ]
+            ),
+        ]
+    )
+    for rank, row in enumerate(rows, start=1):
+        lines.append(_render_candidate_row(row, f"{prefix}{rank}"))
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    raw_alert = payload["raw_range_baseline"]["alert_match"]
+    raw_outcome = payload["raw_range_baseline"]["outcome_5_session"]
+    recommendation = payload["recommendation"]
+    lines = [
+        "# Dochia v0.3 Ticker-Cluster Candidate Review",
+        "",
+        f"Generated: {payload['generated_at']}",
+        f"Scope: ticker={payload['ticker'] or 'all'} since={payload['since'] or 'beginning'} until={payload['until'] or 'latest'}",
+        f"Cluster source: top {payload['top_whipsaws']} v0.2 whipsaw tickers over {payload['whipsaw_window_sessions']} sessions; since={payload['cluster_since'] or 'beginning'} until={payload['cluster_until'] or 'latest'}",
+        "",
+        "## Raw v0.2 Baseline",
+        "",
+        _table_row(
+            [
+                "Events",
+                "F1",
+                "Precision",
+                "Recall",
+                "±3d recall",
+                "5d win",
+                "Avg 5d",
+                "Top whipsaw count",
+            ]
+        ),
+        _table_row(["---:", "---:", "---:", "---:", "---:", "---:", "---:", "---:"]),
+        _table_row(
+            [
+                raw_alert["generated_events"],
+                _pct(raw_alert["exact_event_f1"]),
+                _pct(raw_alert["exact_event_precision"]),
+                _pct(raw_alert["exact_event_recall"]),
+                _pct(raw_alert["window_event_recall"]),
+                _pct(raw_outcome["win_rate"]),
+                _signed_pct(raw_outcome["average_directional_return"]),
+                payload["raw_range_baseline"]["top_whipsaw_count"],
+            ]
+        ),
+        "",
+        "Top cluster tickers: " + ", ".join(payload["cluster_tickers"][:15]),
+        "",
+        "## Quality-Preserving Candidates",
+        "",
+    ]
+    if payload["quality_preserving_results"]:
+        _append_candidate_table(lines, payload["quality_preserving_results"])
+    else:
+        lines.append("_No candidates preserved at least 95% of raw-range F1._")
+
+    lines.extend(["", "## Best Event-Reduction Candidates", ""])
+    _append_candidate_table(lines, payload["best_reduction_results"], prefix="R")
+
+    lines.extend(["", "## Recommendation", ""])
+    if recommendation is None:
+        lines.append(
+            "No ticker-cluster candidate cleared the default gate: at least 95% of raw-range F1, at least 5% event reduction, fewer top whipsaws, and no worse 5-session average directional return. Keep v0.2 candidate-only."
+        )
+    else:
+        lines.extend(
+            [
+                "Use this as the next non-production v0.3 candidate only after a chronological holdout check:",
+                "",
+            ]
+        )
+        _append_candidate_table(lines, [recommendation])
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _review_sort_key(row: dict[str, Any]) -> tuple[float, float, float]:
+    return (
+        row["generated_event_reduction"] or 0,
+        row["alert_match"]["exact_event_f1"] or 0,
+        row["outcome_5_session"]["average_directional_return"] or 0,
+    )
+
+
+def _pick_recommendation(
+    rows: list[dict[str, Any]],
+    *,
+    raw_f1: float,
+    raw_avg_return: float,
+    raw_whipsaw_count: int,
+) -> dict[str, Any] | None:
+    eligible = [
+        row
+        for row in rows
+        if (row["alert_match"]["exact_event_f1"] or 0) >= raw_f1 * 0.95
+        and (row["generated_event_reduction"] or 0) >= 0.05
+        and row["top_whipsaw_count"] < raw_whipsaw_count
+        and (row["outcome_5_session"]["average_directional_return"] or 0) >= raw_avg_return
+    ]
+    if not eligible:
+        return None
+    eligible.sort(key=_review_sort_key, reverse=True)
+    return eligible[0]
+
+
+def build_payload(args: argparse.Namespace) -> dict[str, Any]:
+    _validate_args(args)
+    with psycopg.connect(_database_url()) as conn:
+        conn.execute("SET default_transaction_read_only = on")
+        observations, bars_by_ticker = fetch_daily_sweep_inputs(
+            conn,
+            since=None,
+            until=args.until,
+            ticker=args.ticker,
+        )
+
+    eval_observations = [
+        observation
+        for observation in observations
+        if (args.since is None or observation.trading_day >= args.since)
+        and (args.until is None or observation.trading_day <= args.until)
+    ]
+    raw_histories = _raw_range_histories(bars_by_ticker)
+    raw_alert = evaluate_event_histories(
+        eval_observations,
+        raw_histories,
+        event_window_days=args.event_window_days,
+    )
+    raw_events = events_from_histories(raw_histories, bars_by_ticker, since=args.since, until=args.until)
+    raw_outcome = summarize_forward_returns(
+        raw_events,
+        bars_by_ticker,
+        horizons=[args.outcome_horizon],
+    )[0]
+    eval_whipsaws = build_ticker_whipsaw_outcomes(
+        raw_events,
+        bars_by_ticker,
+        whipsaw_window_sessions=args.whipsaw_window_sessions,
+        outcome_horizon_sessions=args.outcome_horizon,
+        top=args.top_whipsaws,
+    )
+    cluster_events = events_from_histories(
+        raw_histories,
+        bars_by_ticker,
+        since=args.cluster_since,
+        until=args.cluster_until,
+    )
+    cluster_whipsaws = build_ticker_whipsaw_outcomes(
+        cluster_events,
+        bars_by_ticker,
+        whipsaw_window_sessions=args.whipsaw_window_sessions,
+        outcome_horizon_sessions=args.outcome_horizon,
+        top=args.top_whipsaws,
+    )
+    cluster_tickers = [row.ticker for row in cluster_whipsaws]
+    candidate_rows = [
+        review_ticker_cluster_candidate(
+            eval_observations,
+            raw_histories,
+            bars_by_ticker,
+            cluster_tickers=cluster_tickers,
+            candidate=candidate,
+            raw_generated_events=raw_alert.generated_events,
+            event_window_days=args.event_window_days,
+            whipsaw_window_sessions=args.whipsaw_window_sessions,
+            outcome_horizon_sessions=args.outcome_horizon,
+            top_whipsaws=args.top_whipsaws,
+            since=args.since,
+            until=args.until,
+        ).as_json_dict()
+        for candidate in _candidate_grid(args)
+    ]
+    raw_f1 = raw_alert.exact_event_f1 or 0
+    raw_avg_return = raw_outcome.average_directional_return or 0
+    raw_whipsaw_count = sum(row.whipsaw_count for row in eval_whipsaws)
+    quality_preserving = [
+        row
+        for row in candidate_rows
+        if (row["alert_match"]["exact_event_f1"] or 0) >= raw_f1 * 0.95
+    ]
+    quality_preserving.sort(key=_review_sort_key, reverse=True)
+    best_reduction = sorted(candidate_rows, key=_review_sort_key, reverse=True)
+    return {
+        "generated_at": dt.datetime.now(dt.UTC).isoformat(),
+        "since": args.since.isoformat() if args.since else None,
+        "until": args.until.isoformat() if args.until else None,
+        "cluster_since": args.cluster_since.isoformat() if args.cluster_since else None,
+        "cluster_until": args.cluster_until.isoformat() if args.cluster_until else None,
+        "ticker": args.ticker.upper() if args.ticker else None,
+        "top_whipsaws": args.top_whipsaws,
+        "whipsaw_window_sessions": args.whipsaw_window_sessions,
+        "cluster_tickers": cluster_tickers,
+        "raw_range_baseline": {
+            "alert_match": raw_alert.as_json_dict(),
+            "outcome_5_session": raw_outcome.as_json_dict(),
+            "top_whipsaw_count": raw_whipsaw_count,
+        },
+        "quality_preserving_results": quality_preserving[: args.top],
+        "best_reduction_results": best_reduction[: args.top],
+        "recommendation": _pick_recommendation(
+            candidate_rows,
+            raw_f1=raw_f1,
+            raw_avg_return=raw_avg_return,
+            raw_whipsaw_count=raw_whipsaw_count,
+        ),
+    }
+
+
+def main() -> None:
+    args = parse_args()
+    payload = build_payload(args)
+    text = (
+        json.dumps(payload, indent=2, sort_keys=True)
+        if args.json
+        else _render_markdown(payload)
+    )
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text)
+    else:
+        print(text, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/crog-ai-backend/tests/test_outcome_review.py
+++ b/crog-ai-backend/tests/test_outcome_review.py
@@ -1,12 +1,16 @@
 import datetime as dt
 from decimal import Decimal
 
+from app.signals.calibration import CalibrationObservation
 from app.signals.guardrail_sweep import (
     GuardedRangeCandidate,
     generated_guarded_range_event_history,
 )
 from app.signals.outcome_review import (
+    TickerClusterCandidate,
+    apply_ticker_cluster_candidate,
     build_ticker_whipsaw_outcomes,
+    evaluate_event_histories,
     events_from_histories,
     summarize_forward_returns,
 )
@@ -76,3 +80,86 @@ def test_build_ticker_whipsaw_outcomes_counts_fast_reversals() -> None:
     assert clusters[0].event_count == 3
     assert clusters[0].whipsaw_count == 2
     assert clusters[0].whipsaw_rate == 1
+
+
+def test_apply_ticker_cluster_cooldown_suppresses_selected_ticker_only() -> None:
+    aa_bars = [
+        _bar(0, open_="10", high="10", low="9", close="10"),
+        _bar(1, open_="11", high="11", low="10", close="11"),
+        _bar(2, open_="12", high="12", low="10", close="12"),
+        _bar(3, open_="9", high="10", low="8", close="8"),
+        _bar(4, open_="13", high="13", low="9", close="12"),
+    ]
+    bb_bars = [
+        EodBar(
+            ticker="BB",
+            bar_date=bar.bar_date,
+            open=bar.open,
+            high=bar.high,
+            low=bar.low,
+            close=bar.close,
+            volume=bar.volume,
+        )
+        for bar in aa_bars
+    ]
+    aa_history = generated_guarded_range_event_history(
+        aa_bars,
+        candidate=GuardedRangeCandidate(lookback_sessions=2),
+    )
+    bb_history = generated_guarded_range_event_history(
+        bb_bars,
+        candidate=GuardedRangeCandidate(lookback_sessions=2),
+    )
+    assert aa_history is not None
+    assert bb_history is not None
+
+    adjusted = apply_ticker_cluster_candidate(
+        {"AA": aa_history, "BB": bb_history},
+        {"AA": aa_bars, "BB": bb_bars},
+        cluster_tickers={"AA"},
+        candidate=TickerClusterCandidate(
+            cluster_size=1,
+            mode="cooldown",
+            cooldown_sessions=2,
+        ),
+    )
+
+    assert len(aa_history.event_by_date) == 3
+    assert len(adjusted["AA"].event_by_date) == 1
+    assert adjusted["BB"].event_by_date == bb_history.event_by_date
+
+
+def test_evaluate_event_histories_scores_exact_and_precision() -> None:
+    bars = [
+        _bar(0, open_="10", high="10", low="9", close="10"),
+        _bar(1, open_="11", high="11", low="10", close="11"),
+        _bar(2, open_="12", high="12", low="10", close="12"),
+        _bar(3, open_="9", high="10", low="8", close="8"),
+    ]
+    history = generated_guarded_range_event_history(
+        bars,
+        candidate=GuardedRangeCandidate(lookback_sessions=2),
+    )
+    assert history is not None
+
+    summary = evaluate_event_histories(
+        [
+            CalibrationObservation(
+                ticker="AA",
+                trading_day=dt.date(2026, 1, 3),
+                triangle_color="green",
+                score=15,
+            ),
+            CalibrationObservation(
+                ticker="AA",
+                trading_day=dt.date(2026, 1, 4),
+                triangle_color="red",
+                score=-15,
+            ),
+        ],
+        {"AA": history},
+    )
+
+    assert summary.generated_events == 2
+    assert summary.exact_event_matches == 2
+    assert summary.exact_event_f1 == 1

--- a/docs/operational/MASTER-PLAN.md
+++ b/docs/operational/MASTER-PLAN.md
@@ -259,7 +259,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 | Legacy watchlist context | `watchlist` has 431 rows; `market_signals` has 1,105 rows through 2026-02-12; read-only grant applied for app overlays |
 | Calibration baseline | 24,204 daily observations; 91.44% coverage; 62.05% carried daily color accuracy; 40.67% exact alert match; 52.54% ±3-day alert match; score MAE 43.94 |
 | Calibration sweep | Best validated candidate: 3-session intraday range trigger; exact alert F1 76.64% vs 44.59% baseline, exact recall 91.93% vs 40.67%, precision 65.71%, ±3-day recall 95.21%; holdout after 2025-09-25 scores 83.18% F1 vs 46.26% baseline |
-| v0.3 guardrail research | Return-outcome report complete: v0.2 raw range has flat 5-session forward directional return (+0.01%, 50.33% win rate); worst whipsaw clusters are ticker-specific (MOD, ISRG, MRVL, DLR, HD); next research targets ticker-cluster exclusion/cooldown without degrading broader returns |
+| v0.3 guardrail research | Ticker-cluster holdout complete: full-period top-15 exclusion is promising (5.11% event cut, 74.98% F1), but chronological holdout misses the gate (4.74% event cut, 78.16% F1, -0.04% avg 5d return); next research targets rolling date-safe whipsaw-risk scoring |
 | Candidate persisted state | v0.2 candidate has 328 `signal_scores` rows and 1,624 `signal_transitions` rows under non-production parameter set; internal API/BFF selector live for scanner, transitions, symbol detail, Portfolio Lens, and chart overlays |
 | Candidate lane comparison | v0.2 bullish lane unchanged at 129, risk unchanged at 47, re-entry 164→145, mixed 202→203, 61 daily states/scores change |
 | Promotion contract | Fresh Dochia scores still staged; legacy `market_signals` remains contextual until calibration/promotion |
@@ -292,7 +292,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 - Do not call generated weekly/monthly states "MarketClub truth"; they are Dochia-derived.
 - Avoid gamified trading prompts; build an evidence cockpit.
 
-**Immediate next step:** Design a ticker-cluster exclusion/cooldown candidate that targets the worst whipsaw names without degrading forward directional returns on the broader universe.
+**Immediate next step:** Build a rolling, date-safe whipsaw-risk score that can cool down names as they become noisy without relying on a fixed historical blocklist.
 
 ### 6.6 Architectural follow-ups
 
@@ -352,7 +352,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 - Added v0.2 chart-overlay parity: the symbol chart now follows the active Production/v0.2 Range mode, using close-break daily events for production and range-trigger daily events for the v0.2 candidate.
 - Added read-only v0.2 promotion-review harness covering top-lane churn, recent whipsaw/transition pressure, and chart-level candidate event deltas.
 - Ran first v0.2 promotion-review report. Decision: do not promote range trigger yet. Risk lane is stable, but re-entry lane churn is 66.7%, mixed-timeframe churn is 52.9%, top whipsaw tickers show 8-9 candidate transitions in the 30-day window, and reviewed chart overlays add up to 29 candidate-only daily events on some symbols.
-- Added and ran read-only v0.3 range-trigger guardrail research for break buffers, same-direction close confirmation, ATR-normalized buffers, trailing per-symbol adaptive cooldowns, return-conditioned outcomes, and ticker whipsaw clusters. Decision: no tested v0.3 guardrail clears the quality/reduction bar; next research targets ticker-cluster exclusion/cooldown without degrading broader returns.
+- Added and ran read-only v0.3 range-trigger guardrail research for break buffers, same-direction close confirmation, ATR-normalized buffers, trailing per-symbol adaptive cooldowns, return-conditioned outcomes, ticker whipsaw clusters, and chronological ticker-cluster holdout. Decision: do not persist the fixed cluster candidate; next research targets rolling date-safe whipsaw-risk scoring.
 - Added internal Production/v0.2 Range toggle to the Command Center Hedge Fund page and promoted the production frontend build.
 - Added chart-data endpoint and chart overlay with close, daily/weekly channel bands, and generated triangle event markers.
 - Refined calibration metrics to separate carried-state agreement from exact new-alert agreement: 40.67% same-day alert match and 52.54% ±3-day alert match.


### PR DESCRIPTION
## Summary
- adds ticker-cluster cooldown/exclusion candidate review for v0.2 whipsaw names
- adds chronological holdout support so clusters can be learned before a split and evaluated after it
- tracks full-period and holdout reports and updates MarketClub plans

## Result
- full-period top-15 exclusion: 5.11% event reduction, 74.98% F1, +0.05% avg 5-session directional return
- chronological holdout learns clusters before 2025-09-25 and evaluates after
- holdout top-15 exclusion: 4.74% event reduction, 78.16% F1, -0.04% avg 5-session directional return
- decision: do not persist fixed cluster candidate yet; next research should be rolling date-safe whipsaw-risk scoring

## Verification
- PYTHONPATH=. /home/admin/.local/bin/uv run pytest tests/test_trade_triangles.py tests/test_calibration.py tests/test_calibration_sweep.py tests/test_guardrail_sweep.py tests/test_outcome_review.py tests/test_promotion_review.py
- /home/admin/.local/bin/uv run ruff check app/signals/outcome_review.py scripts/review_ticker_cluster_candidates.py tests/test_outcome_review.py
- PYTHONPATH=. /home/admin/.local/bin/uv run python scripts/review_ticker_cluster_candidates.py --include-exclude --output docs/reports/dochia-v0-3-ticker-cluster-review-2026-05-03.md
- PYTHONPATH=. /home/admin/.local/bin/uv run python scripts/review_ticker_cluster_candidates.py --include-exclude --cluster-until 2025-09-24 --since 2025-09-25 --output docs/reports/dochia-v0-3-ticker-cluster-holdout-2026-05-03.md