### PR TITLE
Fix database foundation contract

### DIFF
--- a/docs/architecture/004-postgres-contract.md
+++ b/docs/architecture/004-postgres-contract.md
@@ -63,6 +63,21 @@ Required URI rules:
 - Admin role must authenticate as `fortress_admin`
 - Runtime role must authenticate as `fortress_api`
 
+
+## Runtime SQLAlchemy Contract
+
+`fortress-guest-platform/backend/core/database.py` is the single FastAPI runtime database/session contract.
+
+- Importing `backend.core.database` or `Base` must not create a runtime engine or open a database connection. Alembic imports metadata from this module, so module import has to stay side-effect light.
+- `get_async_engine()` lazily creates the shared `AsyncEngine` from `POSTGRES_API_URI` and normalizes local PostgreSQL URIs to the `postgresql+asyncpg` driver.
+- `get_session_factory()` lazily creates the shared `async_sessionmaker` with `autoflush=False` and `expire_on_commit=False`.
+- `AsyncSessionLocal`, `async_session_factory`, and `async_session_maker` are compatibility names for the same callable session factory contract. Do not let these aliases drift apart.
+- `get_db()` is the FastAPI request dependency. It yields one async session, rolls back on exception, and closes the session after use.
+- `init_db()` may verify runtime connectivity only. Runtime startup must not create, alter, or repair tables.
+- `close_db()` disposes the shared engine and resets cached runtime state so tests and shutdown hooks can start cleanly.
+- Callers that need the engine must call `get_async_engine()` instead of importing `async_engine` directly; direct imports can capture stale state under the lazy/reset contract.
+- Schema ownership stays in the Alembic lane through `POSTGRES_ADMIN_URI`; runtime code uses `POSTGRES_API_URI` only.
+
 ## Workload Intent
 
 This contract is designed to support two concurrent pressure profiles on the same sovereign database stack:

--- a/fortress-guest-platform/backend/core/database.py
+++ b/fortress-guest-platform/backend/core/database.py
@@ -9,19 +9,27 @@ from typing import Any, AsyncIterator
 import structlog
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy.orm import declarative_base
 
 from backend.core.config import settings
 
 logger = structlog.get_logger()
 
 
-class Base(DeclarativeBase):
-    """Shared declarative base for Fortress Prime models."""
+Base = declarative_base()
 
 
 async_engine: AsyncEngine | None = None
 _session_factory: async_sessionmaker[AsyncSession] | None = None
+
+
+def _async_url(url: str) -> str:
+    """Ensure runtime database URLs use the asyncpg driver."""
+    if url.startswith("postgresql://"):
+        return url.replace("postgresql://", "postgresql+asyncpg://", 1)
+    if url.startswith("postgres://"):
+        return url.replace("postgres://", "postgresql+asyncpg://", 1)
+    return url
 
 
 def get_async_engine() -> AsyncEngine:
@@ -30,7 +38,7 @@ def get_async_engine() -> AsyncEngine:
 
     if async_engine is None:
         async_engine = create_async_engine(
-            settings.database_url,
+            _async_url(settings.database_url),
             echo=False,
             pool_pre_ping=True,
             pool_size=20,
@@ -118,73 +126,3 @@ async def close_db() -> None:
         async_engine = None
         _session_factory = None
         logger.info("database_connections_closed")
-"""
-Async database engine, session factory, and FastAPI dependency.
-"""
-from sqlalchemy import text
-import structlog
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
-from sqlalchemy.orm import declarative_base
-
-from backend.core.config import settings
-
-logger = structlog.get_logger()
-
-Base = declarative_base()
-
-def _async_url(url: str) -> str:
-    """Ensure the database URL uses the asyncpg driver."""
-    if url.startswith("postgresql://"):
-        return url.replace("postgresql://", "postgresql+asyncpg://", 1)
-    if url.startswith("postgres://"):
-        return url.replace("postgres://", "postgresql+asyncpg://", 1)
-    return url
-
-async_engine = create_async_engine(
-    _async_url(settings.database_url),
-    echo=False,
-    pool_size=20,
-    max_overflow=10,
-    pool_pre_ping=True,
-)
-
-AsyncSessionLocal = async_sessionmaker(
-    async_engine,
-    class_=AsyncSession,
-    expire_on_commit=False,
-)
-
-# Backward-compatible alias for legacy service imports.
-async_session_maker = AsyncSessionLocal
-
-
-def get_session_factory():
-    """Backward-compatible accessor for legacy async session callers."""
-    return AsyncSessionLocal
-
-
-async def get_db():
-    """FastAPI dependency that yields an async DB session."""
-    async with AsyncSessionLocal() as session:
-        try:
-            yield session
-        except Exception:
-            await session.rollback()
-            raise
-
-
-async def init_db():
-    """Validate connectivity and optionally create tables in opt-in dev mode."""
-    async with async_engine.begin() as conn:
-        await conn.execute(text("SELECT 1"))
-        if settings.db_auto_create_tables:
-            await conn.run_sync(Base.metadata.create_all)
-            logger.info("database_tables_ensured")
-        else:
-            logger.info("database_connection_verified", auto_create_tables=False)
-
-
-async def close_db():
-    """Dispose of the engine connection pool."""
-    await async_engine.dispose()
-    logger.info("database_connections_closed")

--- a/fortress-guest-platform/backend/main.py
+++ b/fortress-guest-platform/backend/main.py
@@ -23,7 +23,7 @@ from fastapi.responses import FileResponse, JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from backend.core.config import settings
-from backend.core.database import init_db, close_db, get_db, async_engine
+from backend.core.database import init_db, close_db, get_db
 from backend.core.public_api_paths import is_public_api_path
 from backend.core.queue import create_arq_pool
 from backend.api import guests, messages, reservations, properties, workorders, analytics, webhooks, webhooks_channex, guestbook

--- a/fortress-guest-platform/backend/tests/test_database_contract.py
+++ b/fortress-guest-platform/backend/tests/test_database_contract.py
@@ -1,0 +1,35 @@
+"""Database module contract tests."""
+from __future__ import annotations
+
+import pytest
+
+import backend.core.database as database
+
+
+def test_database_import_does_not_create_runtime_engine() -> None:
+    assert database.async_engine is None
+
+
+def test_backward_compatible_session_aliases_share_factory() -> None:
+    assert database.async_session_factory is database.AsyncSessionLocal
+    assert database.async_session_maker is database.AsyncSessionLocal
+
+
+@pytest.mark.asyncio
+async def test_close_db_disposes_and_resets_cached_runtime_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeEngine:
+        def __init__(self) -> None:
+            self.disposed = False
+
+        async def dispose(self) -> None:
+            self.disposed = True
+
+    fake_engine = FakeEngine()
+    monkeypatch.setattr(database, "async_engine", fake_engine)
+    monkeypatch.setattr(database, "_session_factory", object())
+
+    await database.close_db()
+
+    assert fake_engine.disposed is True
+    assert database.async_engine is None
+    assert database._session_factory is None


### PR DESCRIPTION
## What this PR does

Collapses `fortress-guest-platform/backend/core/database.py` from two competing DB implementations into one runtime contract.

- Removes the later eager engine/session block that overrode the first implementation.
- Keeps the public DB import surface intact: `Base`, `AsyncSessionLocal`, `async_session_factory`, `async_session_maker`, `get_async_engine`, `get_session_factory`, `get_db`, `init_db`, and `close_db`.
- Preserves lazy runtime engine creation so importing `backend.core.database` and Alembic metadata does not create the app engine.
- Removes the unused direct `async_engine` import from `backend/main.py`.
- Adds focused database contract tests to prevent reintroducing eager import-time engine creation or alias drift.
- Documents the runtime SQLAlchemy contract in `docs/architecture/004-postgres-contract.md`.

## Verification

Passed on `spark-2` using the existing project virtualenv:

```bash
python -m py_compile backend/core/database.py backend/main.py backend/alembic/env.py backend/tests/test_database_contract.py
python -c "import backend.core.database as db; print(db.async_engine is None)"
pytest backend/tests/test_database_contract.py -q
pytest backend/tests/test_database_contract.py backend/tests/test_scout_action_router_db_integration.py -q
alembic -c backend/alembic.ini heads
alembic -c backend/alembic.ini current
```

Results:

- Database contract tests: 3 passed.
- Database contract + scout DB integration tests with `TEST_DATABASE_URL`: 5 passed.
- Alembic heads/current passed with local DB env loaded from the moved, out-of-repo secrets location.

## Known upstream note

`backend/tests/test_ci_schema_bootstrap.py` is already red on current `origin/main` because the test expects old Alembic heads (`c255801e28a0`, `i23a1_add_payment_credit_codes`) while current `schema.meta.json` lists `u7a8b9c0d1e2`. This PR does not touch CI schema snapshots because the database foundation fix is intentionally narrow.

## Out of scope

- No Fortress Legal feature work.
- No schema migration changes.
- No evidence intake changes.
- No secret or `.gitignore` changes.
