### PR TITLE
Docs: canonical Fortress Legal runtime map

### DIFF
--- a/docs/architecture/runtime-map.md
+++ b/docs/architecture/runtime-map.md
@@ -1,0 +1,386 @@
+# Fortress Legal Runtime Map
+
+Last updated: 2026-05-03
+Status: canonical runtime map, documentation-only foundation pass
+Scope: Fortress Legal runtime surfaces inside Fortress Prime
+
+This map records what the repository currently says about Fortress Legal runtime shape. It does not create features, change services, or decide open conflicts by assumption.
+
+## Reading Rules
+
+- **Authoritative** means the repo has a current code path, migration, or locked architecture document that callers already depend on.
+- **Target** means a documented destination state that is not proven as the current runtime.
+- **Legacy** means a prior or fallback path that still exists in code/docs and may still be reachable.
+- **CONFLICT** marks facts that disagree. The conflict is preserved until an operator or follow-up PR resolves it.
+
+Primary evidence reviewed:
+
+- `CLAUDE.md`
+- `docs/architecture/FORTRESS-LEGAL-CONSTITUTION.md`
+- `docs/architecture/shared/infrastructure.md`
+- `docs/architecture/shared/postgres-schemas.md`
+- `docs/architecture/shared/qdrant-collections.md`
+- `docs/architecture/cross-division/ADR-003-inference-cluster-topology.md`
+- `docs/operational/spark-1-legal-migration-runbook.md`
+- `docs/operational/spark1-current-state-2026-04-29.md`
+- `docs/operational/qdrant-legal-audit-2026-04-29.md`
+- `docs/operational/track-a-v3-case-i-vs-v2-regression-2026-05-02.md`
+- `deploy/systemd/*`, `deploy/litellm_config.yaml`, `deploy/fortress-prime-compose.yaml`
+- `fortress-guest-platform/backend/core/config.py`
+- `fortress-guest-platform/backend/core/qdrant.py`
+- `fortress-guest-platform/backend/core/vector_db.py`
+- `fortress-guest-platform/backend/main.py`
+- `fortress-guest-platform/backend/api/legal_*.py`
+- `fortress-guest-platform/backend/services/legal_*.py`
+- `fortress-guest-platform/backend/services/ediscovery_agent.py`
+- `fortress-guest-platform/backend/services/ingest_run_tracker.py`
+- `fortress-guest-platform/backend/services/qdrant_dual_writer.py`
+- `fortress-guest-platform/backend/scripts/vault_ingest_legal_case.py`
+- `fortress-guest-platform/backend/scripts/email_backfill_legal.py`
+
+## 1. Spark Host Roles
+
+| Host | Current / documented role | Fortress Legal runtime meaning | Conflicts and notes |
+|---|---|---|---|
+| `spark-1` | Target single-tenant Fortress Legal app host. Spark-1 current-state doc says Postgres, Redis, OCR, Python deps, and schema-only DBs exist. | **Target authority** for eventual legal isolation. | **CONFLICT:** migration docs say Legal belongs on Spark-1, but current-state capture says no service consumes Spark-1 Postgres yet and app wiring is incomplete. Treat as target, not proven current runtime. |
+| `spark-2` | Current app/control-plane host. Tailscale access host for operator sessions. Docs place FastAPI, Postgres, Qdrant legal, Redis, ARQ, LiteLLM, command/control services here. | **Current practical runtime** for Fortress Prime and Legal until Spark-1 migration is completed and verified. | **CONFLICT:** shared infrastructure says Legal target is Spark-1, but operational runbook says the stack still runs on Spark-2 today. |
+| `spark-3` | Mixed current/planned inference host. Some docs say planned Ray worker; deploy files include `fortress-nim-embed.service`. | Embedding/inference support host for legal retrieval in newer docs. | **CONFLICT:** host is described both as planned worker and active embed service (`:8102`) participant. Verify live systemd before treating it as mandatory. |
+| `spark-4` | Planned inference worker and/or VRS Qdrant host. Deploy includes `fortress-qdrant-vrs.service`. | Secondary Qdrant for VRS dual-write, not primary legal store. | **CONFLICT:** docs describe Spark-4 as planned wipe/worker and also as active `192.168.0.106:6333` VRS Qdrant target. |
+| `spark-5` | Active BRAIN/frontier inference in several current docs; newer Phase 9 docs also describe legal aliases routed through a Spark-3+4 TP=2 endpoint. | Legal reasoning/drafting may route through LiteLLM aliases backed by Spark-5 or Spark-3+4 depending on cutover status. | **CONFLICT:** older docs place 49B BRAIN on Spark-5; Phase 9 docs say BRAIN-49B retired and legal aliases route to Spark-3+4. Runtime must be checked against live LiteLLM config before legal run. |
+| `spark-6` | Staged inference worker; cable pending in shared docs. | No authoritative Legal runtime dependency. | Treat as future capacity until live service evidence exists. |
+
+Canonical conclusion: Fortress Legal's **target** isolation host is Spark-1, but the **current operational control plane** remains Spark-2 unless a later cutover document proves otherwise.
+
+## 2. Database Names And Purposes
+
+| Database | Purpose | Main callers | Authority / risk |
+|---|---|---|---|
+| `fortress_db` | Operational legal database for runtime legal services, e-discovery, mail/event ledger, `LegacySession`, and `legal.ingest_runs`. | `backend/services/ediscovery_agent.py`, `legal_mail_ingester.py`, `legal_dispatcher.py`, `ingest_run_tracker.py`, legal APIs. | **Authoritative for many Legal runtime writes today.** |
+| `fortress_prod` | Canonical/mirror target for legal case metadata and production mirror rows. `vault_ingest_legal_case.py` treats `legal.cases.nas_layout` here as source of truth for batch ingest layout. | legal ingestion scripts, mirror writers, `hold_service.py`, Spark-1 mirror paths. | **Authoritative for case layout during batch ingest.** Mirror drift must be visible. |
+| `fortress_shadow` | Runtime VRS/booking/control-plane DB for `AsyncSessionLocal` under current config. | General backend API/session contract, VRS, booking, owner/guest surfaces. | **Not the main legal operational DB.** It remains important because shared backend sessions default here in parts of the app. |
+| `fortress_shadow_test` | Isolated test DB. | Test fixtures through `TEST_DATABASE_URL`. | Required for safe CI/test writes. |
+| `fortress_pr366_schema_tmp` | Temporary schema snapshot DB used during PR #366 CI refresh. | CI/schema-dump only. | Not runtime. |
+| `fortress_guest` | Legacy/dev compose DB name. | `deploy/fortress-prime-compose.yaml` and older scripts/docs. | **Legacy/conflicting.** Not canonical production. |
+
+Current DB contract from `backend/core/config.py`:
+
+- `POSTGRES_API_URI` is the runtime API DSN and should use role `fortress_api`.
+- `POSTGRES_ADMIN_URI` is the admin/Alembic/script DSN and should use role `fortress_admin`.
+- `TEST_DATABASE_URL` should point to `fortress_shadow_test` for tests.
+- Allowed DB names are `fortress_prod`, `fortress_shadow`, `fortress_db`, and `fortress_shadow_test`.
+- Allowed Postgres port is `5432`.
+
+CONFLICT: `deploy/fortress-prime-compose.yaml` still defines `DATABASE_URL` against `fortress_guest` with an old role. Treat that compose file as a legacy/dev baseline unless it is brought forward to the current contract.
+
+CONFLICT: Spark-1 current-state docs show `fortress_db`, `fortress_prod`, and `fortress_shadow_test` created on Spark-1, but `fortress_shadow` absent and no service wired to those DBs yet.
+
+## 3. Qdrant Collections And Aliases
+
+Primary Qdrant URL in code defaults to `http://localhost:6333`. Docs identify this as Spark-2 legal Qdrant. VRS secondary defaults to `http://192.168.0.106:6333`.
+
+| Collection / alias | Vector size | Purpose | Current authority / conflict |
+|---|---:|---|---|
+| `legal_ediscovery` | 768 in legacy code/audit | Work-product and nonprivileged legal vault chunks. Hardcoded in `legal_ediscovery.py` and `vault_ingest_legal_case.py`. | **Legacy code authority.** Operational audit reported 738,918 points on 2026-04-29. |
+| `legal_ediscovery_v2` | 2048 | Reindexed legal e-discovery collection using `legal-embed`. | **New retrieval authority per 2026-05-02 regression doc only when callers use alias.** |
+| `legal_ediscovery_active` | alias | Qdrant alias documented as swapped to `legal_ediscovery_v2`. | **CONFLICT:** regression docs call alias swap canonical; ingest code still hardcodes `legal_ediscovery`. Verify all retrieval callers before treating v2 as universal runtime. |
+| `legal_privileged_communications` | 768 | Physically separate privileged communications collection. | Hardcoded privileged path in `legal_ediscovery.py`. Audit reported 241,167 points. |
+| `legal_privileged_communications_v2` | 2048 | Reindexed privileged collection. | Reindex complete but quality report says cutover deferred. Legacy collection remains active. |
+| `legal_caselaw` | 768 | Georgia/state caselaw. | Audit reported 2,711 points. Some docs later accept `legal_caselaw_v2` for caller cutover. |
+| `legal_caselaw_v2` | 2048 | Reindexed caselaw. | Accepted by quality report for cutover, but confirm caller code before relying on it. |
+| `legal_caselaw_federal` | unknown/absent | Federal/11th Circuit caselaw target. | **CONFLICT:** older docs say empty/awaiting ingest; Qdrant audit says collection does not exist. |
+| `legal_caselaw_federal_v2` | 2048 | Schema-only future federal collection. | Documented empty; no authoritative callers. |
+| `legal_library` | 768 | Legacy legal-library corpus. | Audit reported only 3 points; older docs report larger/stale counts. |
+| `legal_library_v2` | 2048 | Reindexed legal library. | Accepted for caller cutover in quality report. |
+| `legal_headhunter_memory` | unknown | Counsel/recruiting memory. | Audit reported 0 points. |
+| `legal_headhunter_memory_v2` | 2048 | Future/reindexed schema-only collection. | No content. |
+| `legal_hive_mind_memory` | unknown | Hive-mind/drafting memory. | Audit reported 4 points. |
+| `fgp_knowledge` | 768 | General Fortress knowledge collection from `QDRANT_COLLECTION_NAME` default. | Shared non-legal app knowledge. |
+| `fgp_vrs_knowledge` | 768 | VRS secondary dual-write collection on Spark-4 Qdrant. | Controlled by `ENABLE_QDRANT_VRS_DUAL_WRITE` and `READ_FROM_VRS_STORE`. |
+| `email_embeddings`, `fgp_sent_mail`, `fortress_knowledge` | varied | Email/general knowledge collections in older docs. | Not the canonical legal vault path. |
+
+Model/service aliases used by Legal:
+
+- `legal-embed` is the sovereign embedding alias in newer docs; retrieval-side calls need `input_type=query`, ingest-side calls need `input_type=passage`.
+- `legal-reasoning`, `legal-drafting`, `legal-summarization`, `legal-classification`, and `legal-brain` are LiteLLM/legal inference aliases documented for Council/drafting routes.
+- CONFLICT: older docs place legal frontier on Spark-5 BRAIN; Phase 9 docs place aliases on Spark-3+4 TP=2. Check live `deploy/litellm_config.yaml` and running gateway before major legal generation.
+
+## 4. NAS Roots And Legal Source Drops
+
+Authoritative locked NAS layout from the Fortress Legal Constitution:
+
+| Root | Purpose | Authority |
+|---|---|---|
+| `/mnt/fortress_nas/legal_vault/<case_slug>/` | Stored NFS vault copies after ingest. | Used by `process_vault_upload()` through `NAS_VAULT_ROOT`. |
+| `/mnt/fortress_nas/Corporate_Legal/Business_Legal/<case_slug>/` | Curated case source folders and generated briefing output. | Locked in Constitution and populated in `legal.cases.nas_layout` for Case I/II. |
+| `/mnt/fortress_nas/intel/judges/<court>/<judge-slug>.md` | Judge intelligence. | Locked intel layout. |
+| `/mnt/fortress_nas/intel/firms/<firm-slug>.md` | Firm intelligence. | Locked intel layout. |
+| `/mnt/fortress_nas/intel/attorneys/<attorney-slug>.md` | Attorney intelligence. | Locked intel layout. |
+| `/mnt/fortress_nas/audits/` | Script manifests and audit output. | Used by legal ingest scripts. |
+| `/mnt/fortress_nas/models/` and `/mnt/fortress_nas/nim-cache/` | Model storage/cache. | Infrastructure/model layer. |
+| `/mnt/fortress_nas/legal-corpus/` and `/mnt/fortress_nas/datasets/legal-corpus/` | Courtlistener/rules/static legal corpora. | Corpus source, not case evidence source by default. |
+
+Case source-drop authority for Wave 7 / Case I and II:
+
+| Case slug | Source root | Include subdirs | Exclude rule |
+|---|---|---|---|
+| `7il-v-knight-ndga-i` | `/mnt/fortress_nas/Corporate_Legal/Business_Legal/7il-v-knight-ndga-i` | `curated`, `case-i-context` | Do not use legacy mixed dump. |
+| `7il-v-knight-ndga-ii` | `/mnt/fortress_nas/Corporate_Legal/Business_Legal/7il-v-knight-ndga-ii` | `curated` | Do not use legacy mixed dump. |
+| `vanderburge-v-knight-fannin` | case-specific configured row | not locked in this map | Keep untouched until scoped. |
+| `fish-trap-suv2026000013` | case-specific configured row | not locked in this map | Keep untouched until scoped. |
+
+Authoritative scoping rule: Case I and Case II ingest should walk the curated `Corporate_Legal/Business_Legal/<slug>` paths only. The legacy mixed dump `/mnt/fortress_nas/legal_vault/7il-v-knight-ndga/` must not be used as a source for rebuilding Case II.
+
+CONFLICT: `backend/api/legal_cases.py` still has fallback/older layout logic rooted at `/mnt/fortress_nas/sectors/legal/<slug>` and expects `nas_layout` shaped as `{root, subdirs, recursive}`. `vault_ingest_legal_case.py` supports both the old shape and the newer `{primary_root, include_subdirs, exclude_subdirs}` shape. The UI/API file-browser path may not match the batch-ingest source-of-truth shape until reconciled.
+
+CONFLICT: `legal_ediscovery.py` stores uploaded vault copies under `/mnt/fortress_nas/legal_vault`, while `LEGAL_VAULT_ROOT` in config defaults to `/mnt/fortress_nas/sectors/legal`. Treat `/mnt/fortress_nas/legal_vault` as the active process-vault-upload storage path, and treat `sectors/legal` as legacy/API fallback unless resolved.
+
+## 5. Backend Services
+
+Primary backend entry point:
+
+- `fortress-guest-platform/backend/main.py` builds the FastAPI app.
+- Internal Legal API prefix is `/api/internal/legal`.
+- Systemd service `deploy/systemd/fortress-backend.service` starts the backend through `run-fortress-backend.sh` with env files from the app directory and `/etc/fortress/secrets` overlays.
+
+Legal routers included by the backend include:
+
+- `backend/api/legal_cases.py`
+- `backend/api/ediscovery.py`
+- `backend/api/legal_graph.py`
+- `backend/api/legal_discovery.py`
+- `backend/api/legal_council.py`
+- `backend/api/legal_docgen.py`
+- `backend/api/legal_strategy.py`
+- `backend/api/legal_counsel_dispatch.py`
+- `backend/api/legal_hold.py`
+- `backend/api/legal_tactical.py`
+- `backend/api/legal_sanctions.py`
+- `backend/api/legal_deposition.py`
+- `backend/api/legal_agent.py`
+- `backend/api/legal_email_intake_api.py`
+
+Important legal services and scripts:
+
+| Service/script | Purpose | Runtime dependency |
+|---|---|---|
+| `backend/services/legal_ediscovery.py` | Canonical single-file vault upload, privilege classification, text extraction, chunking, embedding, Qdrant upsert. | `fortress_db` session through caller, NAS vault root, Qdrant, embedding endpoint, Ollama/SWARM classifier. |
+| `backend/scripts/vault_ingest_legal_case.py` | Case-scoped batch ingest from `legal.cases.nas_layout`. | `POSTGRES_ADMIN_URI`, `fortress_prod`, `fortress_db`, Qdrant, NAS source roots, audit manifest path. |
+| `backend/services/ingest_run_tracker.py` | Writes `legal.ingest_runs` lifecycle records. | Defaults to `fortress_db`; `INGEST_RUN_DB` can override. |
+| `backend/services/ediscovery_agent.py` | Legal/e-discovery read surface using `LegacySession`. | Targets `fortress_db`. |
+| `backend/services/legal_council.py` | Council deliberation, legal retrieval, drafting/reasoning seats. | LiteLLM aliases, Qdrant legal collections, case context. |
+| `backend/services/legal_mail_ingester.py` | Multi-mailbox legal mail ingestion and bilateral mirror. | `fortress_db`, `fortress_prod`, mail credentials, legal event log. |
+| `backend/services/legal_email_intake.py` | Dedicated legal email intake service. | `fortress_db` via `LegacySession`, MailPlus settings. |
+| `backend/services/legal_dispatcher.py` | FLOS/legal event dispatcher. | `fortress_db` primary, `fortress_prod` mirror, optional Spark-1 mirror. |
+| `backend/scripts/email_backfill_legal.py` | Email/document backfill into legal vault paths. | `POSTGRES_ADMIN_URI`, both legal DBs, process-vault-upload. |
+| `backend/scripts/ocr_legal_case.py` | OCR support for legal case documents. | NAS source, OCR runtime, legal DB/Qdrant as scripted. |
+| `backend/scripts/track_a_case_i_runner.py` and `case_briefing_cli.py` | Legal brief/regression generation. | Legal Qdrant alias, LiteLLM/frontier, NAS output root. |
+
+Systemd/deploy services with runtime relevance:
+
+- `fortress-backend.service` - FastAPI backend.
+- `fortress-arq-worker.service` - async worker.
+- `fortress-deadline-sweeper.service` / timer - legal deadline sweep.
+- `fortress-dashboard.service` - internal dashboard/command-center surface.
+- `fortress-qdrant-vrs.service` - VRS secondary Qdrant host.
+- `fortress-nim-brain.service`, `fortress-nim-embed.service`, `fortress-vllm-adapter.service` - inference/embedding support.
+
+## 6. Frontend Surfaces
+
+Constitution and `CLAUDE.md` both require strict zone separation:
+
+| Zone | Domain/app | Purpose | Legal rule |
+|---|---|---|---|
+| Zone A public | `cabin-rentals-of-georgia.com`, `apps/storefront` | Public lodging/storefront and guest booking. | Must not expose privileged legal command surfaces. |
+| Zone B internal | `crog-ai.com`, `apps/command-center` | Staff, command center, AI/legal operators. | Fortress Legal should live here. |
+
+Current Legal command-center surfaces found in `apps/command-center` include:
+
+- `/legal`
+- `/legal/cases/[slug]`
+- `/legal/council`
+- `/legal/email-intake`
+- `/legal/war-room`
+- `/legal/deposition/[targetId]/print`
+- Legal components such as e-discovery dropzone, document viewer, counsel matrix, deposition war-room, discovery draft panel, graph snapshot, sanctions tripwire, hive-mind editor, inference radar, jurisprudence radar, and agent terminal.
+
+CONFLICT / risk: `apps/storefront` contains shared legal hooks/types/tests in some places, and older `frontend-next` / legacy dashboard files contain legal discovery/damage-claim UI remnants. Treat command-center as authoritative for privileged Legal UI; audit any storefront legal imports before exposing or deploying.
+
+## 7. Legal Ingest Flow
+
+Canonical batch flow for a case-scoped vault ingest:
+
+1. Operator runs `backend/scripts/vault_ingest_legal_case.py` with a `--case-slug`.
+2. Script loads environment from `fortress-guest-platform/.env` if needed.
+3. Script checks the case slug exists in both `fortress_prod.legal.cases` and `fortress_db.legal.cases`.
+4. Script treats `fortress_prod.legal.cases.nas_layout` as the source-of-truth source layout.
+5. Script verifies source directories exist and `legal.ingest_runs` is writable.
+6. Script checks Qdrant collection reachability and expected vector size.
+7. Script walks only the configured NAS subdirs, deduping by resolved physical path and skipping system/dot paths.
+8. Script hashes each file and skips terminal statuses already in `legal.vault_documents`.
+9. For each file, script calls `process_vault_upload()`.
+10. `process_vault_upload()` stores/copies the file under `/mnt/fortress_nas/legal_vault/<case_slug>/` or local fallback.
+11. `process_vault_upload()` inserts/updates `legal.vault_documents`.
+12. Privilege classification runs before general vectorization.
+13. Privileged material is logged to `legal.privilege_log`, marked `locked_privileged`, and upserted to `legal_privileged_communications`.
+14. Nonprivileged material is extracted, chunked, embedded, and upserted to `legal_ediscovery` in the legacy code path.
+15. Qdrant failures mark rows `qdrant_upsert_failed` instead of silently succeeding.
+16. Batch script mirrors written vault rows from `fortress_db` to `fortress_prod`.
+17. `IngestRunTracker` writes one `legal.ingest_runs` lifecycle record.
+18. Script writes a JSON manifest under `/mnt/fortress_nas/audits/`.
+
+Rollback behavior: `vault_ingest_legal_case.py --rollback` deletes case `legal.vault_documents` rows in both `fortress_db` and `fortress_prod`, and deletes Qdrant points whose payload `case_slug` matches. It requires explicit confirmation unless forced.
+
+CONFLICT: the script usage example still shows legacy slug `7il-v-knight-ndga`; canonical Case I/II slugs are `7il-v-knight-ndga-i` and `7il-v-knight-ndga-ii`.
+
+CONFLICT: v2 retrieval docs say `legal_ediscovery_active` points at `legal_ediscovery_v2`, but the single-file ingest service still writes to hardcoded `legal_ediscovery`. That may be correct during a staged v1/v2 transition, but it is an open runtime contract until documented in code.
+
+## 8. Required Environment Variables
+
+Do not store real secrets in repo files. The names below are runtime contract names, not values.
+
+### Database
+
+- `POSTGRES_API_URI`
+- `POSTGRES_ADMIN_URI`
+- `TEST_DATABASE_URL`
+- `INGEST_RUN_DB` optional override
+- `SPARK1_DATABASE_URL` optional Spark-1 mirror target
+- `LEGAL_M3_SPARK1_MIRROR_ENABLED`
+- `DELIBERATION_LEDGER_DATABASE_URL` or `FORTRESS_DELIBERATION_DSN` for legal deliberation ledger overrides
+
+### Qdrant And Embeddings
+
+- `QDRANT_URL`
+- `QDRANT_API_KEY`
+- `QDRANT_COLLECTION_NAME`
+- `QDRANT_VRS_URL`
+- `ENABLE_QDRANT_VRS_DUAL_WRITE`
+- `READ_FROM_VRS_STORE`
+- `EMBED_BASE_URL`
+- `EMBED_MODEL`
+- `EMBED_DIM`
+- `RECURSIVE_EMBED_URL`
+
+### Inference / Gateway
+
+- `LITELLM_BASE_URL`
+- `LITELLM_MASTER_KEY`
+- `INTERNAL_API_BASE_URL`
+- `INTERNAL_API_TOKEN`
+- `SWARM_API_KEY`
+- `OLLAMA_BASE_URL`
+- `OLLAMA_FAST_MODEL`
+- `OLLAMA_DEEP_MODEL`
+- `BRAIN_BASE_URL`
+- `DGX_INFERENCE_URL`
+- `DGX_INFERENCE_MODEL`
+- `DGX_INFERENCE_API_KEY`
+- `LEGAL_DISCOVERY_CHAT_URL`
+- `LEGAL_DISCOVERY_CHAT_MODEL`
+- `LEGAL_DISCOVERY_API_KEY`
+
+### Legal/NAS
+
+- `LEGAL_VAULT_ROOT`
+- `CASE_BRIEFING_OUTPUT_ROOT`
+- `LEGAL_PERSONAS_DIR`
+- `CONCIERGE_PERSONAS_DIR`
+- `LEGAL_DISCOVERY_MAX_ITEMS`
+- `LEGAL_GRAPH_MAX_NODES`
+- `LEGAL_DISCOVERY_FOIA_ENABLED`
+- `LEGAL_PROPORTIONALITY_MODE`
+- `LEGAL_TRIPWIRE_*`
+- `LEGAL_DEPOSITION_*`
+
+### Email Intake
+
+- `LEGAL_EMAIL_INTAKE_ENABLED`
+- `LEGAL_MAILPLUS_HOST`
+- `LEGAL_MAILPLUS_PORT`
+- `LEGAL_MAILPLUS_USER`
+- `LEGAL_MAILPLUS_PASSWORD`
+- `LEGAL_MAILPLUS_FOLDER`
+- `LEGAL_EMAIL_POLL_INTERVAL`
+- `LEGACY_LEGAL_INTAKE_ENABLED`
+- `LEGAL_MAIL_INGESTER_ENABLED`
+- `LEGAL_DISPATCHER_ENABLED`
+- `MAILBOXES_CONFIG`
+- `GMAIL_CLIENT_ID`
+- `GMAIL_CLIENT_SECRET`
+- `GMAIL_REFRESH_TOKEN`
+- `IMAP_HOST`
+- `IMAP_USER`
+- `IMAP_APP_PASSWORD`
+- `MAILPLUS_IMAP_HOST`
+- `MAILPLUS_IMAP_PORT`
+- `MAILPLUS_IMAP_PASSWORD`
+
+### Auth / Security / Audit
+
+- `JWT_RSA_PRIVATE_KEY`
+- `JWT_RSA_PUBLIC_KEY`
+- `JWT_SECRET_KEY` legacy fallback only
+- `AUDIT_LOG_SIGNING_KEY`
+- `S3_ENDPOINT_URL`
+- `S3_BUCKET_NAME`
+- `S3_ACCESS_KEY`
+- `S3_SECRET_KEY`
+- `S3_PUBLIC_BASE_URL`
+
+## 9. Known Open Questions
+
+1. Has Fortress Legal actually cut over from Spark-2 to Spark-1, or is Spark-1 still a staged target with schema-only DBs?
+2. Which live LiteLLM alias map is authoritative now: Spark-5 BRAIN-era or Spark-3+4 TP=2 Phase 9?
+3. Should legal ingest write directly to `legal_ediscovery_v2` / `legal_ediscovery_active`, or is legacy `legal_ediscovery` intentionally retained as ingest source with separate reindex?
+4. Are Qdrant aliases managed in code/config, or only by operator/manual Qdrant API calls?
+5. Should `legal_cases.py` support the new `nas_layout` shape (`primary_root`, `include_subdirs`, `exclude_subdirs`) used by the migration and batch ingest script?
+6. Should `/mnt/fortress_nas/sectors/legal` remain an active legal file root or be marked legacy-only?
+7. Which DB is the legal case metadata source of truth after Spark-1 migration: `fortress_prod`, `fortress_db`, or Spark-1 `fortress_prod` mirror?
+8. What is the exact production Qdrant storage path and snapshot/backup policy for privileged collections?
+9. Should storefront legal hooks/types be removed, isolated, or explicitly documented as shared nonprivileged client code?
+10. Are `legal_caselaw_v2` and `legal_library_v2` already cut over in all caller code, or only accepted for future caller cutover?
+11. What is the retention and access-control policy for `legal_privileged_communications_v2`, given cutover was deferred but the collection exists?
+12. Does `vault_ingest_legal_case.py` pass current syntax/tests after the schema reconciliation work, and are its docstring examples updated to Case I/II slugs?
+13. Should `deploy/fortress-prime-compose.yaml` be updated to the current Postgres contract or explicitly moved to legacy/dev docs?
+
+## 10. Authoritative Versus Legacy
+
+### Authoritative Now
+
+- Fortress Legal Constitution: `docs/architecture/FORTRESS-LEGAL-CONSTITUTION.md`.
+- Internal legal UI belongs to `apps/command-center`, not public storefront.
+- Current DB config contract: `POSTGRES_API_URI`, `POSTGRES_ADMIN_URI`, `TEST_DATABASE_URL`, roles `fortress_api` / `fortress_admin`.
+- Allowed DB names from config: `fortress_prod`, `fortress_shadow`, `fortress_db`, `fortress_shadow_test`.
+- `legal.cases` keyed by `case_slug` with `related_matters`, `privileged_counsel_domains`, and `nas_layout`.
+- `legal.ingest_runs` for ingest lifecycle tracking.
+- `process_vault_upload()` as the canonical single-file vault ingestion function.
+- `vault_ingest_legal_case.py` as the case-scoped batch ingest wrapper.
+- Curated Case I/II source drops under `/mnt/fortress_nas/Corporate_Legal/Business_Legal/<slug>/`.
+- Privileged communications must stay physically separated from ordinary e-discovery search.
+- Spark-2 is the current practical operator/control-plane host until Spark-1 cutover is proven.
+
+### Authoritative Target, Not Proven Current
+
+- Spark-1 as single-tenant Fortress Legal app host.
+- Spark-1 Postgres as legal runtime DB host.
+- `legal_ediscovery_active -> legal_ediscovery_v2` as universal retrieval target for every caller.
+- Spark-3+4 TP=2 as the only legal frontier endpoint.
+
+### Legacy / Risky Until Reconciled
+
+- `deploy/fortress-prime-compose.yaml` with `fortress_guest`, `DATABASE_URL`, and old roles.
+- `/mnt/fortress_nas/sectors/legal` legal file root defaults.
+- Storefront or legacy frontend legal UI fragments that could blur public/internal zones.
+- Hardcoded `legal_ediscovery` writes if the retrieval world has fully moved to v2 alias.
+- Older Qdrant point counts and collection-existence claims in docs predating the 2026-04-29 audit.
+- Older BRAIN/Spark role docs that place services on different hosts than newer migration/Phase 9 docs.
+
+## Operating Rule For Next Work
+
+Before new Fortress Legal features, resolve foundation ambiguity in this order:
+
+1. Prove live host ownership: Spark-2 current vs Spark-1 cutover state.
+2. Prove DB source-of-truth contract for Legal after PR #366/#405 era changes.
+3. Prove Qdrant alias/read/write contract for `legal_ediscovery_active` and v2.
+4. Reconcile `nas_layout` shape across migration, batch ingest, and legal case API.
+5. Re-audit frontend zone separation so privileged Legal never leaks into public storefront surfaces.

--- a/docs/architecture/runtime-map.md
+++ b/docs/architecture/runtime-map.md
@@ -25,6 +25,7 @@ Primary evidence reviewed:
 - `docs/operational/spark1-current-state-2026-04-29.md`
 - `docs/operational/qdrant-legal-audit-2026-04-29.md`
 - `docs/operational/track-a-v3-case-i-vs-v2-regression-2026-05-02.md`
+- `docs/operational/fortress-legal-runtime-ownership-audit-2026-05-03.md`
 - `deploy/systemd/*`, `deploy/litellm_config.yaml`, `deploy/fortress-prime-compose.yaml`
 - `fortress-guest-platform/backend/core/config.py`
 - `fortress-guest-platform/backend/core/qdrant.py`
@@ -50,6 +51,8 @@ Primary evidence reviewed:
 | `spark-6` | Staged inference worker; cable pending in shared docs. | No authoritative Legal runtime dependency. | Treat as future capacity until live service evidence exists. |
 
 Canonical conclusion: Fortress Legal's **target** isolation host is Spark-1, but the **current operational control plane** remains Spark-2 unless a later cutover document proves otherwise.
+
+Live audit note: `docs/operational/fortress-legal-runtime-ownership-audit-2026-05-03.md` verified this current-state call on 2026-05-03. Spark-2 showed active backend, ARQ, command-center, Postgres, Redis, Qdrant, LiteLLM, Ollama, Ray head, and sync/indexing services. Spark-1 was reachable and running Postgres/Redis/NIM/Ollama/Ray worker, but no Legal backend, ARQ, command-center, Qdrant, or LiteLLM runtime was observed.
 
 ## 2. Database Names And Purposes
 

--- a/docs/architecture/runtime-map.md
+++ b/docs/architecture/runtime-map.md
@@ -135,7 +135,7 @@ Case source-drop authority for Wave 7 / Case I and II:
 
 Authoritative scoping rule: Case I and Case II ingest should walk the curated `Corporate_Legal/Business_Legal/<slug>` paths only. The legacy mixed dump `/mnt/fortress_nas/legal_vault/7il-v-knight-ndga/` must not be used as a source for rebuilding Case II.
 
-CONFLICT: `backend/api/legal_cases.py` still has fallback/older layout logic rooted at `/mnt/fortress_nas/sectors/legal/<slug>` and expects `nas_layout` shaped as `{root, subdirs, recursive}`. `vault_ingest_legal_case.py` supports both the old shape and the newer `{primary_root, include_subdirs, exclude_subdirs}` shape. The 2026-05-03 NAS layout audit confirmed live Case I/II DB rows use the newer shape, Case II `curated/` exists, Case I declared include folders are missing, and the legacy `/sectors/legal/<slug>` fallback is absent for both 7IL slugs.
+RESOLVED AFTER AUDIT: PR #410 added `backend/services/legal/nas_layout.py` and wired both `backend/api/legal_cases.py` and `backend/scripts/vault_ingest_legal_case.py` to the same normalizer. Both callers now support the legacy `{root, subdirs, recursive}` shape and the Wave 7 `{primary_root, include_subdirs, exclude_subdirs}` shape. The 2026-05-03 NAS layout audit still stands on live data: Case I/II DB rows use the newer shape, Case II `curated/` exists, Case I declared include folders are missing, and the legacy `/sectors/legal/<slug>` fallback is absent for both 7IL slugs.
 
 CONFLICT: `legal_ediscovery.py` stores uploaded vault copies under `/mnt/fortress_nas/legal_vault`, while `LEGAL_VAULT_ROOT` in config defaults to `/mnt/fortress_nas/sectors/legal`. Treat `/mnt/fortress_nas/legal_vault` as the active process-vault-upload storage path, and treat `sectors/legal` as legacy/API fallback unless resolved.
 
@@ -338,7 +338,7 @@ Do not store real secrets in repo files. The names below are runtime contract na
 2. Which live LiteLLM alias map is authoritative now: Spark-5 BRAIN-era or Spark-3+4 TP=2 Phase 9?
 3. Should legal ingest write directly to `legal_ediscovery_v2` / `legal_ediscovery_active`, or is legacy `legal_ediscovery` intentionally retained as ingest source with separate reindex?
 4. Are Qdrant aliases managed in code/config, or only by operator/manual Qdrant API calls?
-5. Should `legal_cases.py` support the new `nas_layout` shape (`primary_root`, `include_subdirs`, `exclude_subdirs`) used by the migration and batch ingest script?
+5. Should recursive Legal Command Center downloads include a nested relative path or stable document id instead of filename-only lookup?
 6. Should `/mnt/fortress_nas/sectors/legal` remain an active legal file root or be marked legacy-only?
 7. Which DB is the legal case metadata source of truth after Spark-1 migration: `fortress_prod`, `fortress_db`, or Spark-1 `fortress_prod` mirror?
 8. What is the exact production Qdrant storage path and snapshot/backup policy for privileged collections?
@@ -360,6 +360,7 @@ Do not store real secrets in repo files. The names below are runtime contract na
 - `legal.ingest_runs` for ingest lifecycle tracking.
 - `process_vault_upload()` as the canonical single-file vault ingestion function.
 - `vault_ingest_legal_case.py` as the case-scoped batch ingest wrapper.
+- `backend/services/legal/nas_layout.py` as the shared NAS layout normalizer for Legal API file browsing and case-scoped ingest.
 - Curated Case I/II source drops under `/mnt/fortress_nas/Corporate_Legal/Business_Legal/<slug>/`.
 - Privileged communications must stay physically separated from ordinary e-discovery search.
 - Spark-2 is the current practical operator/control-plane host until Spark-1 cutover is proven.
@@ -387,5 +388,5 @@ Before new Fortress Legal features, resolve foundation ambiguity in this order:
 1. Prove live host ownership: Spark-2 current vs Spark-1 cutover state.
 2. Prove DB source-of-truth contract for Legal after PR #366/#405 era changes.
 3. Prove Qdrant alias/read/write contract for `legal_ediscovery_active` and v2.
-4. Reconcile `nas_layout` shape across migration, batch ingest, and legal case API; the next implementation PR should add a shared layout normalizer and teach the Legal case API the new `{primary_root, include_subdirs, exclude_subdirs}` shape without changing DB/NAS data.
+4. Reconcile download addressing for recursive Legal Command Center file browsing so duplicate filenames cannot resolve ambiguously.
 5. Re-audit frontend zone separation so privileged Legal never leaks into public storefront surfaces.

--- a/docs/architecture/runtime-map.md
+++ b/docs/architecture/runtime-map.md
@@ -27,6 +27,7 @@ Primary evidence reviewed:
 - `docs/operational/track-a-v3-case-i-vs-v2-regression-2026-05-02.md`
 - `docs/operational/fortress-legal-runtime-ownership-audit-2026-05-03.md`
 - `docs/operational/fortress-legal-qdrant-contract-audit-2026-05-03.md`
+- `docs/operational/fortress-legal-nas-layout-contract-audit-2026-05-03.md`
 - `deploy/systemd/*`, `deploy/litellm_config.yaml`, `deploy/fortress-prime-compose.yaml`
 - `fortress-guest-platform/backend/core/config.py`
 - `fortress-guest-platform/backend/core/qdrant.py`
@@ -134,7 +135,7 @@ Case source-drop authority for Wave 7 / Case I and II:
 
 Authoritative scoping rule: Case I and Case II ingest should walk the curated `Corporate_Legal/Business_Legal/<slug>` paths only. The legacy mixed dump `/mnt/fortress_nas/legal_vault/7il-v-knight-ndga/` must not be used as a source for rebuilding Case II.
 
-CONFLICT: `backend/api/legal_cases.py` still has fallback/older layout logic rooted at `/mnt/fortress_nas/sectors/legal/<slug>` and expects `nas_layout` shaped as `{root, subdirs, recursive}`. `vault_ingest_legal_case.py` supports both the old shape and the newer `{primary_root, include_subdirs, exclude_subdirs}` shape. The UI/API file-browser path may not match the batch-ingest source-of-truth shape until reconciled.
+CONFLICT: `backend/api/legal_cases.py` still has fallback/older layout logic rooted at `/mnt/fortress_nas/sectors/legal/<slug>` and expects `nas_layout` shaped as `{root, subdirs, recursive}`. `vault_ingest_legal_case.py` supports both the old shape and the newer `{primary_root, include_subdirs, exclude_subdirs}` shape. The 2026-05-03 NAS layout audit confirmed live Case I/II DB rows use the newer shape, Case II `curated/` exists, Case I declared include folders are missing, and the legacy `/sectors/legal/<slug>` fallback is absent for both 7IL slugs.
 
 CONFLICT: `legal_ediscovery.py` stores uploaded vault copies under `/mnt/fortress_nas/legal_vault`, while `LEGAL_VAULT_ROOT` in config defaults to `/mnt/fortress_nas/sectors/legal`. Treat `/mnt/fortress_nas/legal_vault` as the active process-vault-upload storage path, and treat `sectors/legal` as legacy/API fallback unless resolved.
 
@@ -386,5 +387,5 @@ Before new Fortress Legal features, resolve foundation ambiguity in this order:
 1. Prove live host ownership: Spark-2 current vs Spark-1 cutover state.
 2. Prove DB source-of-truth contract for Legal after PR #366/#405 era changes.
 3. Prove Qdrant alias/read/write contract for `legal_ediscovery_active` and v2.
-4. Reconcile `nas_layout` shape across migration, batch ingest, and legal case API.
+4. Reconcile `nas_layout` shape across migration, batch ingest, and legal case API; the next implementation PR should add a shared layout normalizer and teach the Legal case API the new `{primary_root, include_subdirs, exclude_subdirs}` shape without changing DB/NAS data.
 5. Re-audit frontend zone separation so privileged Legal never leaks into public storefront surfaces.

--- a/docs/architecture/runtime-map.md
+++ b/docs/architecture/runtime-map.md
@@ -26,6 +26,7 @@ Primary evidence reviewed:
 - `docs/operational/qdrant-legal-audit-2026-04-29.md`
 - `docs/operational/track-a-v3-case-i-vs-v2-regression-2026-05-02.md`
 - `docs/operational/fortress-legal-runtime-ownership-audit-2026-05-03.md`
+- `docs/operational/fortress-legal-qdrant-contract-audit-2026-05-03.md`
 - `deploy/systemd/*`, `deploy/litellm_config.yaml`, `deploy/fortress-prime-compose.yaml`
 - `fortress-guest-platform/backend/core/config.py`
 - `fortress-guest-platform/backend/core/qdrant.py`
@@ -85,7 +86,7 @@ Primary Qdrant URL in code defaults to `http://localhost:6333`. Docs identify th
 |---|---:|---|---|
 | `legal_ediscovery` | 768 in legacy code/audit | Work-product and nonprivileged legal vault chunks. Hardcoded in `legal_ediscovery.py` and `vault_ingest_legal_case.py`. | **Legacy code authority.** Operational audit reported 738,918 points on 2026-04-29. |
 | `legal_ediscovery_v2` | 2048 | Reindexed legal e-discovery collection using `legal-embed`. | **New retrieval authority per 2026-05-02 regression doc only when callers use alias.** |
-| `legal_ediscovery_active` | alias | Qdrant alias documented as swapped to `legal_ediscovery_v2`. | **CONFLICT:** regression docs call alias swap canonical; ingest code still hardcodes `legal_ediscovery`. Verify all retrieval callers before treating v2 as universal runtime. |
+| `legal_ediscovery_active` | alias | Live alias points to `legal_ediscovery_v2`. | **CONFLICT:** 2026-05-03 live audit found Case I/II `case_slug` counts are zero in the alias target while backend callers still use legacy `legal_ediscovery`. Do not treat this alias as a safe 7IL evidence source yet. |
 | `legal_privileged_communications` | 768 | Physically separate privileged communications collection. | Hardcoded privileged path in `legal_ediscovery.py`. Audit reported 241,167 points. |
 | `legal_privileged_communications_v2` | 2048 | Reindexed privileged collection. | Reindex complete but quality report says cutover deferred. Legacy collection remains active. |
 | `legal_caselaw` | 768 | Georgia/state caselaw. | Audit reported 2,711 points. Some docs later accept `legal_caselaw_v2` for caller cutover. |
@@ -235,7 +236,7 @@ Rollback behavior: `vault_ingest_legal_case.py --rollback` deletes case `legal.v
 
 CONFLICT: the script usage example still shows legacy slug `7il-v-knight-ndga`; canonical Case I/II slugs are `7il-v-knight-ndga-i` and `7il-v-knight-ndga-ii`.
 
-CONFLICT: v2 retrieval docs say `legal_ediscovery_active` points at `legal_ediscovery_v2`, but the single-file ingest service still writes to hardcoded `legal_ediscovery`. That may be correct during a staged v1/v2 transition, but it is an open runtime contract until documented in code.
+CONFLICT: v2 retrieval docs say `legal_ediscovery_active` points at `legal_ediscovery_v2`, but the single-file ingest service still writes to hardcoded `legal_ediscovery`. The 2026-05-03 Qdrant audit makes this operational: Case I and Case II have points in legacy `legal_ediscovery` and zero `case_slug`-filtered points in the active v2 alias target. Current safe 7IL retrieval remains legacy until a separate v2 migration/reindex proves coverage.
 
 ## 8. Required Environment Variables
 

--- a/docs/operational/fortress-legal-nas-layout-contract-audit-2026-05-03.md
+++ b/docs/operational/fortress-legal-nas-layout-contract-audit-2026-05-03.md
@@ -1,25 +1,25 @@
 # Fortress Legal NAS Layout Contract Audit - 2026-05-03
 
-Status: read-only live audit
+Status: read-only live audit; amended after PR #410 code reconciliation
 Scope: `legal.cases.nas_layout`, Legal case API file browsing, and case-scoped ingest source layout
 Related map: `docs/architecture/runtime-map.md`
 
-No database rows, NAS files, services, application code, or migrations were changed during this audit.
+No database rows, NAS files, services, application code, or migrations were changed during this audit. Post-audit application code reconciliation landed separately in PR #410.
 
 ## Summary
 
-There are two competing `nas_layout` shapes in the repo:
+At audit time, there were two competing `nas_layout` shapes in the repo:
 
 1. **Legacy/API shape:** `{root, subdirs, recursive}`
 2. **Wave 7 ingest shape:** `{primary_root, include_subdirs, exclude_subdirs}`
 
-Live `fortress_prod` and `fortress_db` currently use the Wave 7 ingest shape for Case I and Case II. The batch ingest script understands that shape. The Legal case API file resolver does **not** understand it yet.
+Live `fortress_prod` and `fortress_db` currently use the Wave 7 ingest shape for Case I and Case II. The batch ingest script already understood that shape at audit time. The Legal case API file resolver did not understand it yet.
 
-Therefore:
+Post-audit update:
 
-- Case-scoped batch ingest can interpret the new Case I/II layout shape.
-- Legal Command Center file browsing/downloading through `backend/api/legal_cases.py` will not correctly list files for Case I/II from the new layout shape.
-- The old `/mnt/fortress_nas/sectors/legal/<slug>` fallback does not exist for Case I/II, so fallback behavior does not rescue those matters.
+- PR #410 added `backend/services/legal/nas_layout.py` as the shared normalizer.
+- Case-scoped batch ingest and Legal Command Center file browsing now interpret both supported shapes.
+- The old `/mnt/fortress_nas/sectors/legal/<slug>` fallback still does not exist for Case I/II, so those matters must continue to use the curated `Corporate_Legal/Business_Legal/<slug>` layout rows.
 
 ## Live DB State
 
@@ -104,20 +104,20 @@ For Case I, the current layout would fail path preflight because declared includ
 
 ## Code Contract: Legal Case API
 
-`fortress-guest-platform/backend/api/legal_cases.py` currently resolves files as follows:
+Post-audit, PR #410 changed `fortress-guest-platform/backend/api/legal_cases.py` to use the shared normalizer in `backend/services/legal/nas_layout.py`.
 
-| Input | API behavior |
+| Input | API behavior after PR #410 |
 |---|---|
 | `nas_layout` null or `{}` | Falls back to `/mnt/fortress_nas/sectors/legal/<slug>` and the six-subdir legacy tree. |
 | `{root, subdirs, recursive}` | Uses configured `root`, configured `subdirs`, and optional `recursive`. |
-| `{primary_root, include_subdirs, exclude_subdirs}` | Not supported. `root` becomes empty, `subdirs` becomes empty, so listing returns no files. |
+| `{primary_root, include_subdirs, exclude_subdirs}` | Uses `primary_root`, maps each included subdir to itself, defaults recursive to true when omitted, and honors excludes. |
 
-Affected API endpoints:
+Affected API endpoints now share the reconciled layout interpretation:
 
 - `GET /api/internal/legal/cases/{slug}/files`
 - `GET /api/internal/legal/cases/{slug}/download/{filename}`
 
-Because Case I/II live DB rows use the new shape and `/mnt/fortress_nas/sectors/legal/<slug>` is absent for both slugs, the Legal Command Center file browser/download surface is expected to be wrong or empty for Case I/II until the API resolver is updated.
+The remaining API concern is download addressing: recursive layouts still download by filename, so duplicate filenames in different nested folders can be ambiguous.
 
 ## Migration History
 
@@ -130,38 +130,30 @@ The newer migration reflects the curated Case I/II source-scoping decision, but 
 
 ## Current Contract Decision
 
-Until a code PR reconciles the resolver, treat this as the current safe contract:
+After PR #410, treat this as the current safe contract:
 
 | Surface | Authoritative layout contract today | Notes |
 |---|---|---|
 | Case II batch ingest | `{primary_root, include_subdirs, exclude_subdirs}` | Use `Corporate_Legal/Business_Legal/7il-v-knight-ndga-ii/curated`. |
 | Case I batch ingest | Declared new shape, but current NAS paths are missing | Do not run Case I batch ingest without fixing or updating includes. |
-| Legal Command Center file browsing | Legacy `{root, subdirs, recursive}` only | Does not yet support Case I/II live layout. |
+| Legal Command Center file browsing | Shared normalizer accepts both legacy and Wave 7 shapes | Case I/II no longer depend on the absent `/sectors/legal/<slug>` fallback. |
 | Non-7IL batch ingest | Not explicitly scoped | `{}` rows will fail batch-ingest preflight. |
 | Non-7IL API file browsing | Legacy fallback | Uses `/mnt/fortress_nas/sectors/legal/<slug>` if present. |
 
 ## Open Risks
 
-1. Case II source-of-truth layout is correct for ingest but not for UI/API file browsing.
-2. Case I source-of-truth layout points to missing `curated` and `case-i-context` folders.
-3. `{}` means different things in different callers: batch ingest treats it as invalid; API treats it as fallback.
-4. The newer `exclude_subdirs` field is honored by batch ingest but ignored by the API resolver.
-5. The newer `include_subdirs` field defaults to recursive true in batch ingest; the old API shape defaults recursive false unless explicitly set.
-6. Download-by-filename may be ambiguous in recursive layouts because nested relative paths are not part of the download route.
-7. The old `/mnt/fortress_nas/sectors/legal` fallback is still in code but is not valid for Case I/II.
+1. Case I source-of-truth layout points to missing `curated` and `case-i-context` folders.
+2. `{}` intentionally means different things in different callers: batch ingest treats it as invalid; API treats it as fallback.
+3. Download-by-filename may be ambiguous in recursive layouts because nested relative paths are not part of the download route.
+4. The old `/mnt/fortress_nas/sectors/legal` fallback is still in code but is not valid for Case I/II.
 
 ## Recommended Next Move
 
 Do **not** change NAS files, DB rows, or runtime services in this docs PR.
 
-The next implementation PR should be a narrow resolver reconciliation:
+The narrow resolver reconciliation recommended by this audit landed in PR #410. The next clean moves are:
 
-1. Add a shared layout normalization helper that accepts both shapes and returns one normalized form: `{root, subdirs, recursive, exclude_subdirs}`.
-2. Use that helper in both `vault_ingest_legal_case.py` and `backend/api/legal_cases.py`.
-3. Preserve legacy `{root, subdirs, recursive}` behavior for non-7IL cases.
-4. Preserve `{}` API fallback behavior only where intended.
-5. Add tests proving Case II new-shape layout lists files from `curated/` recursively.
-6. Add tests proving batch ingest still rejects `{}` for case-scoped ingest.
-7. Decide separately whether to create Case I `curated` / `case-i-context` folders or update its DB layout to current real paths.
-
-Given active Case II priority, the lowest-risk implementation target is to make the API resolver support the new shape without changing DB values or NAS structure.
+1. Keep Case II on the curated `Corporate_Legal/Business_Legal/7il-v-knight-ndga-ii/curated` source path.
+2. Decide separately whether to create Case I `curated` / `case-i-context` folders or update its DB layout to current real paths.
+3. Add stable download addressing for recursive layouts so duplicate filenames cannot resolve ambiguously.
+4. Leave non-7IL `{}` batch-ingest rows untouched until each matter receives explicit scoping.

--- a/docs/operational/fortress-legal-nas-layout-contract-audit-2026-05-03.md
+++ b/docs/operational/fortress-legal-nas-layout-contract-audit-2026-05-03.md
@@ -1,0 +1,167 @@
+# Fortress Legal NAS Layout Contract Audit - 2026-05-03
+
+Status: read-only live audit
+Scope: `legal.cases.nas_layout`, Legal case API file browsing, and case-scoped ingest source layout
+Related map: `docs/architecture/runtime-map.md`
+
+No database rows, NAS files, services, application code, or migrations were changed during this audit.
+
+## Summary
+
+There are two competing `nas_layout` shapes in the repo:
+
+1. **Legacy/API shape:** `{root, subdirs, recursive}`
+2. **Wave 7 ingest shape:** `{primary_root, include_subdirs, exclude_subdirs}`
+
+Live `fortress_prod` and `fortress_db` currently use the Wave 7 ingest shape for Case I and Case II. The batch ingest script understands that shape. The Legal case API file resolver does **not** understand it yet.
+
+Therefore:
+
+- Case-scoped batch ingest can interpret the new Case I/II layout shape.
+- Legal Command Center file browsing/downloading through `backend/api/legal_cases.py` will not correctly list files for Case I/II from the new layout shape.
+- The old `/mnt/fortress_nas/sectors/legal/<slug>` fallback does not exist for Case I/II, so fallback behavior does not rescue those matters.
+
+## Live DB State
+
+Read-only query against both `fortress_prod.legal.cases` and `fortress_db.legal.cases` returned matching layout rows for the known matters.
+
+| Case slug | Live `nas_layout` shape | DBs observed | Meaning |
+|---|---|---|---|
+| `7il-v-knight-ndga-i` | `{primary_root, include_subdirs, exclude_subdirs}` | `fortress_prod`, `fortress_db` | New Wave 7 ingest shape. |
+| `7il-v-knight-ndga-ii` | `{primary_root, include_subdirs, exclude_subdirs}` | `fortress_prod`, `fortress_db` | New Wave 7 ingest shape. |
+| `vanderburge-v-knight-fannin` | `{}` | `fortress_prod`, `fortress_db` | No explicit ingest layout yet. |
+| `fish-trap-suv2026000013` | `{}` | `fortress_prod`, `fortress_db` | No explicit ingest layout yet. |
+| `prime-trust-23-11161` | `{}` | `fortress_prod`, `fortress_db` | No explicit ingest layout yet. |
+
+Live Case I layout:
+
+```json
+{
+  "primary_root": "/mnt/fortress_nas/Corporate_Legal/Business_Legal/7il-v-knight-ndga-i",
+  "include_subdirs": ["curated", "case-i-context"],
+  "exclude_subdirs": []
+}
+```
+
+Live Case II layout:
+
+```json
+{
+  "primary_root": "/mnt/fortress_nas/Corporate_Legal/Business_Legal/7il-v-knight-ndga-ii",
+  "include_subdirs": ["curated"],
+  "exclude_subdirs": []
+}
+```
+
+## Live NAS Path State
+
+Read-only path existence checks found:
+
+| Path | Status | Meaning |
+|---|---|---|
+| `/mnt/fortress_nas/Corporate_Legal/Business_Legal/7il-v-knight-ndga-i` | exists | Case I root exists. |
+| `/mnt/fortress_nas/Corporate_Legal/Business_Legal/7il-v-knight-ndga-i/curated` | missing | Case I declared ingest include is currently absent. |
+| `/mnt/fortress_nas/Corporate_Legal/Business_Legal/7il-v-knight-ndga-i/case-i-context` | missing | Case I declared related/context include is currently absent. |
+| `/mnt/fortress_nas/Corporate_Legal/Business_Legal/7il-v-knight-ndga-ii` | exists | Case II root exists. |
+| `/mnt/fortress_nas/Corporate_Legal/Business_Legal/7il-v-knight-ndga-ii/curated` | exists | Case II declared ingest include exists. |
+| `/mnt/fortress_nas/sectors/legal/7il-v-knight-ndga-i` | missing | Legacy API fallback path absent for Case I. |
+| `/mnt/fortress_nas/sectors/legal/7il-v-knight-ndga-ii` | missing | Legacy API fallback path absent for Case II. |
+
+Observed Case I root subdirs:
+
+- `filings/`
+- `filings/outgoing/`
+
+Observed Case II root subdirs include:
+
+- `curated/`
+- `curated/documents/`
+- `curated/emails/`
+- `filings/outgoing/`
+- `incoming/`
+- `incoming/dot-gnrr-records-request-20260502/`
+- `incoming/wilson-pruitt-email-intake-20260503/`
+- `incoming/wilson-pruitt-email-pull-20260502/`
+- `operator-memos/`
+- `work-product/`
+- `work-product/privileged/`
+
+## Code Contract: Batch Ingest
+
+`fortress-guest-platform/backend/scripts/vault_ingest_legal_case.py` treats `fortress_prod.legal.cases.nas_layout` as the source of truth.
+
+It accepts both shapes:
+
+| Shape | Handling |
+|---|---|
+| `{primary_root, include_subdirs, exclude_subdirs}` | New shape. Converts includes to a logical subdir map, defaults `recursive` to true when omitted, honors excludes. |
+| `{root, subdirs, recursive}` | Legacy shape. Uses explicit logical-to-physical subdir map. |
+| `{}` / null | Batch ingest preflight fails. Empty layout is not accepted for case-scoped ingest. |
+
+For Case II, the current layout should walk `/mnt/fortress_nas/Corporate_Legal/Business_Legal/7il-v-knight-ndga-ii/curated` recursively.
+
+For Case I, the current layout would fail path preflight because declared includes `curated` and `case-i-context` are absent.
+
+## Code Contract: Legal Case API
+
+`fortress-guest-platform/backend/api/legal_cases.py` currently resolves files as follows:
+
+| Input | API behavior |
+|---|---|
+| `nas_layout` null or `{}` | Falls back to `/mnt/fortress_nas/sectors/legal/<slug>` and the six-subdir legacy tree. |
+| `{root, subdirs, recursive}` | Uses configured `root`, configured `subdirs`, and optional `recursive`. |
+| `{primary_root, include_subdirs, exclude_subdirs}` | Not supported. `root` becomes empty, `subdirs` becomes empty, so listing returns no files. |
+
+Affected API endpoints:
+
+- `GET /api/internal/legal/cases/{slug}/files`
+- `GET /api/internal/legal/cases/{slug}/download/{filename}`
+
+Because Case I/II live DB rows use the new shape and `/mnt/fortress_nas/sectors/legal/<slug>` is absent for both slugs, the Legal Command Center file browser/download surface is expected to be wrong or empty for Case I/II until the API resolver is updated.
+
+## Migration History
+
+| Migration | Layout contract |
+|---|---|
+| `e7f9a3c2d8b1_add_legal_cases_nas_layout.py` | Introduced old/API shape: `{root, subdirs, recursive}` with `/mnt/fortress_nas/sectors/legal/<slug>` fallback. |
+| `u7a8b9c0d1e2_reconcile_legal_cases_ingest_runs.py` | Seeded Case I/II with new Wave 7 ingest shape: `{primary_root, include_subdirs, exclude_subdirs}`. |
+
+The newer migration reflects the curated Case I/II source-scoping decision, but one API resolver still reflects the older migration comment/shape.
+
+## Current Contract Decision
+
+Until a code PR reconciles the resolver, treat this as the current safe contract:
+
+| Surface | Authoritative layout contract today | Notes |
+|---|---|---|
+| Case II batch ingest | `{primary_root, include_subdirs, exclude_subdirs}` | Use `Corporate_Legal/Business_Legal/7il-v-knight-ndga-ii/curated`. |
+| Case I batch ingest | Declared new shape, but current NAS paths are missing | Do not run Case I batch ingest without fixing or updating includes. |
+| Legal Command Center file browsing | Legacy `{root, subdirs, recursive}` only | Does not yet support Case I/II live layout. |
+| Non-7IL batch ingest | Not explicitly scoped | `{}` rows will fail batch-ingest preflight. |
+| Non-7IL API file browsing | Legacy fallback | Uses `/mnt/fortress_nas/sectors/legal/<slug>` if present. |
+
+## Open Risks
+
+1. Case II source-of-truth layout is correct for ingest but not for UI/API file browsing.
+2. Case I source-of-truth layout points to missing `curated` and `case-i-context` folders.
+3. `{}` means different things in different callers: batch ingest treats it as invalid; API treats it as fallback.
+4. The newer `exclude_subdirs` field is honored by batch ingest but ignored by the API resolver.
+5. The newer `include_subdirs` field defaults to recursive true in batch ingest; the old API shape defaults recursive false unless explicitly set.
+6. Download-by-filename may be ambiguous in recursive layouts because nested relative paths are not part of the download route.
+7. The old `/mnt/fortress_nas/sectors/legal` fallback is still in code but is not valid for Case I/II.
+
+## Recommended Next Move
+
+Do **not** change NAS files, DB rows, or runtime services in this docs PR.
+
+The next implementation PR should be a narrow resolver reconciliation:
+
+1. Add a shared layout normalization helper that accepts both shapes and returns one normalized form: `{root, subdirs, recursive, exclude_subdirs}`.
+2. Use that helper in both `vault_ingest_legal_case.py` and `backend/api/legal_cases.py`.
+3. Preserve legacy `{root, subdirs, recursive}` behavior for non-7IL cases.
+4. Preserve `{}` API fallback behavior only where intended.
+5. Add tests proving Case II new-shape layout lists files from `curated/` recursively.
+6. Add tests proving batch ingest still rejects `{}` for case-scoped ingest.
+7. Decide separately whether to create Case I `curated` / `case-i-context` folders or update its DB layout to current real paths.
+
+Given active Case II priority, the lowest-risk implementation target is to make the API resolver support the new shape without changing DB values or NAS structure.

--- a/docs/operational/fortress-legal-qdrant-contract-audit-2026-05-03.md
+++ b/docs/operational/fortress-legal-qdrant-contract-audit-2026-05-03.md
@@ -1,0 +1,159 @@
+# Fortress Legal Qdrant Contract Audit - 2026-05-03
+
+Status: read-only live audit
+Scope: Spark-2 Qdrant legal collections, aliases, and backend/script caller contract
+Related map: `docs/architecture/runtime-map.md`
+
+No Qdrant aliases, collections, payloads, points, services, or application code were changed during this audit.
+
+## Summary
+
+Live Spark-2 Qdrant has the alias `legal_ediscovery_active -> legal_ediscovery_v2`, but the backend Legal runtime does **not** currently use that alias for e-discovery retrieval or ingest.
+
+The important operational finding is sharper:
+
+- `legal_ediscovery` legacy 768-dim contains 7IL Case I and Case II points.
+- `legal_ediscovery_v2` / `legal_ediscovery_active` 2048-dim contains **zero** points for `7il-v-knight-ndga-i` and `7il-v-knight-ndga-ii` when filtered by `case_slug`.
+- `legal_privileged_communications` legacy 768-dim contains Case II privileged points.
+- `legal_privileged_communications_v2` 2048-dim contains **zero** Case II privileged points when filtered by `case_slug`.
+
+Therefore, for current Fortress Legal 7IL work, the safe contract is:
+
+1. Use legacy `legal_ediscovery` for 7IL work-product evidence retrieval.
+2. Use legacy `legal_privileged_communications` for 7IL privileged retrieval.
+3. Do not route 7IL e-discovery retrieval through `legal_ediscovery_active` until Case I/II are reindexed into the active target and verified.
+4. Keep `legal_caselaw_v2` and `legal_library_v2` as separate accepted 2048-dim legal-reference surfaces.
+
+## Live Qdrant State
+
+Endpoint audited:
+
+- `http://127.0.0.1:6333` on Spark-2
+- Qdrant version: `1.13.2`
+
+Live aliases:
+
+| Alias | Target collection |
+|---|---|
+| `legal_ediscovery_active` | `legal_ediscovery_v2` |
+
+Legal collection metadata snapshot:
+
+| Collection | Dim | Points | Indexed vectors | Status | Runtime meaning |
+|---|---:|---:|---:|---|---|
+| `legal_ediscovery` | 768 | 823,479 | 830,498 | green | Legacy work-product e-discovery collection; active backend ingest/write target. |
+| `legal_ediscovery_v2` | 2048 | 587,604 | 587,604 | green | Alias target for `legal_ediscovery_active`; not populated for 7IL Case I/II by `case_slug`. |
+| `legal_privileged_communications` | 768 | 253,157 | 268,928 | green | Legacy privileged communications collection; active backend privileged target. |
+| `legal_privileged_communications_v2` | 2048 | 241,167 | 240,192 | green | Reindexed privileged collection; not populated for 7IL Case II by `case_slug`. |
+| `legal_caselaw` | 768 | 2,711 | 0 | green | Legacy caselaw collection. |
+| `legal_caselaw_v2` | 2048 | 2,711 | 0 | green | Current Council caselaw collection in backend code. |
+| `legal_caselaw_federal_v2` | 2048 | 0 | 0 | green | Empty federal caselaw v2 target. |
+| `legal_library` | 768 | 3 | 0 | green | Legacy legal library. |
+| `legal_library_v2` | 2048 | 3 | 0 | green | Current legal-library/statutory collection in backend code. |
+| `legal_headhunter_memory` | 768 | 0 | 0 | green | Counsel/recruiting memory, empty. |
+| `legal_headhunter_memory_v2` | 2048 | 0 | 0 | green | Counsel/recruiting v2 target, empty. |
+| `legal_hive_mind_memory` | 768 | 4 | 0 | green | Small hive-mind/drafting memory surface. |
+
+Counts are point-count snapshots, not legal completeness findings.
+
+## Case-Scoped Counts
+
+Read-only counts used exact Qdrant `points/count` queries with a payload filter on `case_slug`.
+
+### Work-Product E-Discovery
+
+| Case slug | `legal_ediscovery` | `legal_ediscovery_v2` | `legal_ediscovery_active` |
+|---|---:|---:|---:|
+| `7il-v-knight-ndga-i` | 91,245 | 0 | 0 |
+| `7il-v-knight-ndga-ii` | 214,612 | 0 | 0 |
+| `7il-v-knight-ndga` | 0 | 0 | 0 |
+| `vanderburge-v-knight-fannin` | 516,756 | 586,739 | 586,739 |
+| `fish-trap-suv2026000013` | 859 | 858 | 858 |
+| `prime-trust-23-11161` | 0 | 0 | 0 |
+
+### Privileged Communications
+
+| Case slug | `legal_privileged_communications` | `legal_privileged_communications_v2` |
+|---|---:|---:|
+| `7il-v-knight-ndga-i` | 0 | 0 |
+| `7il-v-knight-ndga-ii` | 81,188 | 0 |
+| `7il-v-knight-ndga` | 0 | 0 |
+| `vanderburge-v-knight-fannin` | 171,969 | 241,167 |
+| `fish-trap-suv2026000013` | 0 | 0 |
+| `prime-trust-23-11161` | 0 | 0 |
+
+Payload sampling confirmed `legal_ediscovery_v2` points can carry `case_slug`, `chunk_index`, `document_id`, `file_name`, and `text`. The zero 7IL counts therefore appear to be content/reindex coverage, not merely a missing `case_slug` field.
+
+## Repo Caller Contract
+
+### E-Discovery Ingest / Write Paths
+
+| File | Collection contract | Meaning |
+|---|---|---|
+| `fortress-guest-platform/backend/services/legal_ediscovery.py` | `QDRANT_COLLECTION = "legal_ediscovery"`; `QDRANT_PRIVILEGED_COLLECTION = "legal_privileged_communications"` | Canonical single-file vault upload writes legacy 768-dim work-product and privileged collections. |
+| `fortress-guest-platform/backend/scripts/vault_ingest_legal_case.py` | `QDRANT_COLLECTION = "legal_ediscovery"`; `EXPECTED_VECTOR_SIZE = 768` | Batch ingest preflight requires legacy 768-dim work-product collection. |
+| `fortress-guest-platform/backend/scripts/email_backfill_legal.py` | `legal_ediscovery` and `legal_privileged_communications`; expected vector size 768 | Email backfill follows the same legacy ingest contract. |
+| `fortress-guest-platform/backend/scripts/backfill_vector_ids.py` | `legal_ediscovery` and `legal_privileged_communications` | Backfill/support tooling targets legacy collections. |
+
+### Legal Retrieval Paths
+
+| File | Collection contract | Meaning |
+|---|---|---|
+| `fortress-guest-platform/backend/services/legal_council.py` | `LEGAL_COLLECTION = "legal_ediscovery"` | Council e-discovery context freezing still retrieves from legacy 768-dim `legal_ediscovery`. |
+| `fortress-guest-platform/backend/services/legal_council.py` | `PRIVILEGED_COLLECTION = "legal_privileged_communications"` | Council privileged retrieval still retrieves from legacy 768-dim privileged collection. |
+| `fortress-guest-platform/backend/services/legal_council.py` | `CASELAW_COLLECTION = "legal_caselaw_v2"` | Council precedent retrieval uses 2048-dim v2 caselaw. |
+| `fortress-guest-platform/backend/services/knowledge_retriever.py` | `LEGAL_COLLECTION = "legal_library_v2"` | Legal-library retrieval uses 2048-dim v2 legal library. |
+| `fortress-guest-platform/backend/services/legal_auditor.py` | `STATUTORY_COLLECTION = "legal_library_v2"` | Statutory/legal-auditor retrieval uses 2048-dim v2 legal library. |
+
+### Alias Usage
+
+`legal_ediscovery_active` appears in operational docs and the Constitution, but no backend caller found in this audit uses it directly. That means the alias exists in Qdrant but is not yet the backend runtime e-discovery contract.
+
+## Current Contract Decision
+
+Until a separate caller-migration/reindex PR changes the code and proves coverage, treat this as the current contract:
+
+| Surface | Current safe collection | Reason |
+|---|---|---|
+| 7IL Case I/II e-discovery retrieval | `legal_ediscovery` | Contains 7IL Case I/II points; backend uses it. |
+| 7IL Case II privileged retrieval | `legal_privileged_communications` | Contains Case II privileged points; backend uses it. |
+| Legal caselaw retrieval | `legal_caselaw_v2` | Backend code already targets v2. |
+| Legal library/statutory retrieval | `legal_library_v2` | Backend code already targets v2. |
+| `legal_ediscovery_active` | Not safe for 7IL yet | Alias points to v2, but Case I/II `case_slug` counts are zero. |
+| `legal_privileged_communications_v2` | Not safe for 7IL yet | Case II privileged `case_slug` count is zero. |
+
+## Why Direct Write To V2 Is Not A Small Fix
+
+Directly changing ingest from `legal_ediscovery` to `legal_ediscovery_v2` is not a safe one-line change:
+
+- Current ingest uses `nomic-embed-text` / 768-dim embeddings.
+- `legal_ediscovery_v2` is 2048-dim and expects `legal-embed` passage embeddings.
+- The current `process_vault_upload()` path also writes deterministic UUID5 IDs keyed to the legacy collection contract.
+- A direct cutover must update embedding, collection target, validation, tests, rollback, and probably reindex/backfill semantics together.
+
+Safer options are:
+
+1. Keep ingest on legacy 768 and run a controlled reindex into v2 after ingest batches.
+2. Build an explicit dual-embed write path that writes both legacy 768 and v2 2048, with separate verification and rollback.
+3. Migrate readers to `legal_ediscovery_active` only after v2 Case I/II coverage is proven and regression-tested.
+
+## Open Risks
+
+1. `legal_ediscovery_active` is live but misleading for 7IL work because it points to a v2 collection with zero Case I/II `case_slug` points.
+2. Documentation claims that production retrieval uses `legal_ediscovery_active`, but backend code still uses `legal_ediscovery`.
+3. The 2048-dim v2 collection appears mostly populated for `vanderburge-v-knight-fannin` and `fish-trap-suv2026000013`, not 7IL.
+4. `legal_privileged_communications_v2` is populated for `vanderburge-v-knight-fannin`, but not for 7IL Case II.
+5. If an operator or script manually queries `legal_ediscovery_active` for 7IL, retrieval will silently miss known legacy evidence.
+6. The reindex tool found in `src/reindex_legal_qdrant_to_legal_embed.py` covers `legal_caselaw`, `legal_library`, and `legal_privileged_communications`; it does not list `legal_ediscovery` in its `TEXT_FIELD` map in the audited branch.
+
+## Recommended Next Move
+
+Do **not** change runtime Qdrant aliases or backend callers in this docs PR.
+
+Next foundation PR should be a targeted design/implementation PR that chooses one of these paths:
+
+1. **Legacy-stable path:** explicitly document and enforce that 7IL runtime retrieval remains on `legal_ediscovery` / `legal_privileged_communications` until Wave 7 reindex completes.
+2. **V2 migration path:** reindex 7IL Case I/II work-product and privileged points into v2, verify case counts and retrieval quality, then migrate code callers to `legal_ediscovery_active` with matching 2048-dim query embeddings.
+3. **Dual-write path:** preserve legacy reads while adding a tested 2048-dim v2 write/update path for new ingest.
+
+Given the current 7IL priority, the least-risk near-term choice is the legacy-stable path: leave code on legacy collections, prevent any 7IL process from relying on `legal_ediscovery_active`, and schedule v2 migration separately after Case II ingest scope is stable.

--- a/docs/operational/fortress-legal-runtime-ownership-audit-2026-05-03.md
+++ b/docs/operational/fortress-legal-runtime-ownership-audit-2026-05-03.md
@@ -157,4 +157,4 @@ For Fortress Legal planning and feature-free foundation hardening, the current l
 2. Add an explicit Spark-1 cutover gate before any doc claims Spark-1 is the active Legal host.
 3. Verify live LiteLLM alias ownership and reconcile Spark-5 vs Spark-3+4 vs Spark-1 inference docs.
 4. Verify Qdrant alias/read/write contract for `legal_ediscovery_active` and v2.
-5. Reconcile `nas_layout` shape across migration, batch ingest, and legal case API.
+5. COMPLETED after this audit in PR #410: reconcile `nas_layout` shape across migration, batch ingest, and legal case API. Remaining follow-up is stable download addressing for recursive layouts.

--- a/docs/operational/fortress-legal-runtime-ownership-audit-2026-05-03.md
+++ b/docs/operational/fortress-legal-runtime-ownership-audit-2026-05-03.md
@@ -1,0 +1,149 @@
+# Fortress Legal Runtime Ownership Audit - 2026-05-03
+
+Status: read-only live audit
+Scope: Spark-2 vs Spark-1 runtime ownership for Fortress Legal foundation hardening
+Related map: `docs/architecture/runtime-map.md`
+
+No services were started, stopped, restarted, reloaded, migrated, or modified during this audit.
+
+## Summary
+
+The live runtime evidence supports the runtime map's current-state conclusion:
+
+- **Spark-2 is the active Fortress Legal / Fortress Prime app-control-plane host today.**
+- **Spark-1 is reachable and running useful platform pieces, but it is not yet serving the Fortress Legal backend, ARQ worker, command-center, Qdrant, or LiteLLM gateway.**
+- Spark-1 should remain documented as the Legal target/staging host until an explicit cutover proves otherwise.
+
+## Spark-2 Live Evidence
+
+Spark-2 hostname evidence:
+
+- Hostname: `spark-node-2`
+- Operator access path: `ssh admin@spark-2`
+
+Running service evidence included:
+
+| Runtime surface | Live Spark-2 evidence |
+|---|---|
+| Backend | `fortress-backend.service` active/running, `ExecStart=/usr/local/bin/run-fortress-backend.sh` |
+| Worker | `fortress-arq-worker.service` active/running |
+| Command center / console | `crog-ai-frontend.service`, `fortress-console.service`, and Next.js processes active |
+| Postgres | `postgresql@16-main.service` active/running, listening on `5432` |
+| Redis | `redis-server.service` active/running, listening on `127.0.0.1:6379` |
+| Qdrant | Docker container `fortress-qdrant` running `qdrant/qdrant:v1.13.2`, ports `6333-6334` |
+| LiteLLM | `litellm-gateway.service` active/running on `127.0.0.1:8002` using `/home/admin/Fortress-Prime/litellm_config.yaml` |
+| Ollama | `ollama.service` active/running, port `11434` |
+| Ray | `fortress-ray-head.service` active/running, head at `192.168.0.100` |
+| Sync/indexing | `fortress-sync-worker.service`, `fortress-sentinel.service`, `fortress-watcher.service`, `fortress-telemetry.service` active/running |
+
+Observed listening ports relevant to the map:
+
+| Port | Interpretation |
+|---:|---|
+| `5432` | Postgres 16 on Spark-2 |
+| `6333`, `6334` | Qdrant on Spark-2 |
+| `6379` | Redis on Spark-2 loopback |
+| `8000` | Backend or internal app surface on Spark-2 |
+| `8002` | LiteLLM gateway on Spark-2 loopback |
+| `3000`, `3005` | Next.js / command-center frontend surfaces |
+| `9800` | Fortress console |
+| `11434` | Ollama |
+| `6390`, `8265` | Ray head / dashboard |
+
+Observed active Postgres connections on Spark-2:
+
+| Database | Role(s) observed | Meaning |
+|---|---|---|
+| `fortress_shadow` | `fortress_api` | Active runtime/control-plane sessions |
+| `fortress_db` | `fortress_api`, `miner_bot` | Active legal/legacy DB usage still present |
+| `fortress_prod` | `fortress_api` | Active production/mirror DB usage still present |
+| `fortress_guest` | `fgp_app` | Legacy/dev surface still connected somewhere |
+| `paperclip_db` | `paperclip_admin` | Paperclip control-plane usage |
+
+## Spark-1 Live Evidence
+
+Spark-1 reachability evidence:
+
+- `spark-1` resolves to Tailscale `100.127.241.36`.
+- `spark-node-1` resolves to `10.10.10.1`.
+- Spark-1 responded to ping from Spark-2.
+- Hostname: `spark-node-1`.
+- Observed addresses include `192.168.0.104`, `10.10.10.1`, and `100.127.241.36`.
+
+Running service evidence included:
+
+| Runtime surface | Live Spark-1 evidence |
+|---|---|
+| Postgres | `postgresql@16-main.service` active/running |
+| Redis | `redis-server.service` active/running on loopback |
+| NIM sovereign | `fortress-nim-sovereign.service` active/running, Docker container on port `8000` |
+| Ray | `fortress-ray-worker.service` active/running as worker against Spark-2 Ray head |
+| Ollama | `ollama.service` active/running |
+| Brain UI | `fortress-brain.service` active/running on loopback `8501` |
+
+Spark-1 unit-file evidence did **not** show these app-control-plane units installed/enabled:
+
+- `fortress-backend.service`
+- `fortress-arq-worker.service`
+- `fortress-console.service`
+- `litellm-gateway.service`
+- `fortress-qdrant.service` or equivalent Qdrant unit
+
+Spark-1 Docker evidence:
+
+| Container | Image | Runtime meaning |
+|---|---|---|
+| `fortress-nim-sovereign` | `nvcr.io/nim/meta/llama-3.1-8b-instruct-dgx-spark:latest` | Sovereign inference endpoint on Spark-1 |
+| Portainer agent | `portainer/agent:lts` | Cluster/container management agent |
+
+Observed active Postgres connections on Spark-1:
+
+| Database | Role(s) observed | Meaning |
+|---|---|---|
+| `postgres` | `postgres` | Only local audit/admin query observed |
+
+No active application sessions into Spark-1 legal/runtime DBs were observed during this audit.
+
+## Security Finding
+
+### High: Spark-1 NGC key exposed in process arguments
+
+The Spark-1 NIM container command exposes an `NGC_API_KEY` value in process arguments. The value is intentionally **not** copied into this document.
+
+Why this matters:
+
+- Process arguments can be visible to local users and captured in process listings, telemetry, debug logs, shell history, or incident artifacts.
+- Because the key appeared in live process arguments, assume the credential is exposed.
+
+Recommended remediation:
+
+1. Rotate the affected NGC credential.
+2. Move the key out of command-line arguments.
+3. Prefer a root-owned environment file, systemd credential, or Docker secret-style injection.
+4. Restart only the affected NIM service after the replacement secret path is in place.
+5. Re-run a redacted process-argument check after restart to prove the key no longer appears in `ps` output.
+
+Do not commit the key, print it, or paste it into issue/PR text.
+
+## Conclusion
+
+For Fortress Legal planning and feature-free foundation hardening, the current live ownership should be treated as:
+
+| Layer | Current live owner | Target / notes |
+|---|---|---|
+| Backend API | Spark-2 | Spark-1 target only after explicit cutover |
+| ARQ / workers | Spark-2 | Spark-1 not active for these units |
+| Command center / Legal UI | Spark-2 | Spark-1 not active for these units |
+| Postgres runtime sessions | Spark-2 | Spark-1 DB exists but no app sessions observed |
+| Qdrant legal | Spark-2 | Spark-1 has no observed Qdrant runtime |
+| LiteLLM gateway | Spark-2 | Spark-1 has no observed LiteLLM runtime |
+| Redis | Spark-2 active; Spark-1 also running local Redis | Legal app consumers observed on Spark-2 |
+| Inference | Spark-1 and Spark-2 both participate | Spark-1 runs NIM sovereign and Ray worker; Spark-2 runs Ollama/LiteLLM/Ray head |
+
+## Next Foundation Moves
+
+1. Remediate and rotate the exposed Spark-1 NGC credential.
+2. Add an explicit Spark-1 cutover gate before any doc claims Spark-1 is the active Legal host.
+3. Verify live LiteLLM alias ownership and reconcile Spark-5 vs Spark-3+4 vs Spark-1 inference docs.
+4. Verify Qdrant alias/read/write contract for `legal_ediscovery_active` and v2.
+5. Reconcile `nas_layout` shape across migration, batch ingest, and legal case API.

--- a/docs/operational/fortress-legal-runtime-ownership-audit-2026-05-03.md
+++ b/docs/operational/fortress-legal-runtime-ownership-audit-2026-05-03.md
@@ -115,13 +115,24 @@ Why this matters:
 - Process arguments can be visible to local users and captured in process listings, telemetry, debug logs, shell history, or incident artifacts.
 - Because the key appeared in live process arguments, assume the credential is exposed.
 
-Recommended remediation:
+Remediation performed on 2026-05-03:
 
-1. Rotate the affected NGC credential.
-2. Move the key out of command-line arguments.
-3. Prefer a root-owned environment file, systemd credential, or Docker secret-style injection.
-4. Restart only the affected NIM service after the replacement secret path is in place.
-5. Re-run a redacted process-argument check after restart to prove the key no longer appears in `ps` output.
+1. Kept the existing root-owned env file at `/etc/fortress/nim.env` (`root:root`, `600`).
+2. Patched `/etc/systemd/system/fortress-nim-sovereign.service` so Docker receives `-e NGC_API_KEY` from the environment instead of `-e NGC_API_KEY=<value>`.
+3. Created timestamped systemd-unit backups under `/etc/systemd/system/`.
+4. Ran `systemctl daemon-reload`.
+5. Restarted only `fortress-nim-sovereign.service`.
+6. Verified the service is active.
+7. Verified `/v1/models` returned HTTP 200.
+8. Verified the service MainPID process args no longer contain `NGC_API_KEY=<value>` or an `nvapi-` token pattern.
+9. Verified the unit file no longer contains an inline `NGC_API_KEY=<value>` assignment.
+
+Remaining remediation:
+
+1. Rotate the affected NGC credential from NVIDIA/NGC because it was already exposed before this cleanup.
+2. Replace `/etc/fortress/nim.env` with the newly rotated key.
+3. Restart only `fortress-nim-sovereign.service`.
+4. Re-run the same redacted process-argument and `/v1/models` checks.
 
 Do not commit the key, print it, or paste it into issue/PR text.
 


### PR DESCRIPTION
## What this PR does

Adds docs/architecture/runtime-map.md as the canonical Fortress Legal runtime map for the foundation-hardening pause.

## Scope

Documentation only. No services, migrations, ingest code, frontend code, deploy files, or runtime behavior changed.

## Covered

- Spark host roles and current/target conflicts
- DB names and purposes
- Qdrant collections, aliases, and v1/v2 conflicts
- NAS roots and legal source-drop paths
- Backend legal services and scripts
- Frontend legal surfaces and public/internal separation
- Legal ingest flow
- Required environment variables
- Known open questions
- Authoritative vs legacy surfaces

## Review notes

Where repo evidence conflicts, this document marks CONFLICT: rather than guessing. The biggest unresolved areas are Spark-1 vs Spark-2 runtime ownership, legal Qdrant v2 alias/read-write contract, and nas_layout shape mismatch across ingest/API paths.