### PR TITLE
feat(financial): add Dochia rolling whipsaw review

### DIFF
--- a/crog-ai-backend/README.md
+++ b/crog-ai-backend/README.md
@@ -110,6 +110,8 @@ uv run python scripts/research_range_trigger_guardrails.py --output docs/reports
 uv run python scripts/review_signal_outcomes.py --output docs/reports/dochia-v0-3-return-outcome-review-2026-05-03.md
 uv run python scripts/review_ticker_cluster_candidates.py --include-exclude --output docs/reports/dochia-v0-3-ticker-cluster-review-2026-05-03.md
 uv run python scripts/review_ticker_cluster_candidates.py --include-exclude --cluster-until 2025-09-24 --since 2025-09-25 --output docs/reports/dochia-v0-3-ticker-cluster-holdout-2026-05-03.md
+uv run python scripts/review_rolling_whipsaw_candidates.py --output docs/reports/dochia-v0-3-rolling-whipsaw-review-2026-05-03.md
+uv run python scripts/review_rolling_whipsaw_candidates.py --since 2025-09-25 --output docs/reports/dochia-v0-3-rolling-whipsaw-holdout-2026-05-03.md
 ```
 
 Best 2026-05-02 research candidate: 3-session intraday range trigger. It
@@ -172,6 +174,16 @@ clusters learned before 2025-09-25 and evaluated after, does not clear the
 default gate: top-15 exclusion cuts 4.74% of events, keeps F1 at 78.16%, and
 leaves 5-session average directional return flat at -0.04%. Keep v0.2
 candidate-only; do not persist the cluster candidate yet.
+
+Rolling whipsaw-risk reports:
+`docs/reports/dochia-v0-3-rolling-whipsaw-review-2026-05-03.md` and
+`docs/reports/dochia-v0-3-rolling-whipsaw-holdout-2026-05-03.md`. The rolling,
+date-safe suppressor uses only prior raw whipsaws before cooling down a ticker.
+It is not viable as a production filter: no candidate preserves at least 95% of
+raw v0.2 F1. Full-period best reductions cut 90%+ of events but collapse exact
+F1 into the 6.57%-14.07% range. Holdout behaves the same way, with the strongest
+reducers cutting 95%+ of events while exact F1 stays below 7.41%. Keep v0.2
+candidate-only; expose whipsaw risk as evidence instead of suppressing signals.
 
 ## Relationship to Fortress-Prime
 

--- a/crog-ai-backend/app/signals/outcome_review.py
+++ b/crog-ai-backend/app/signals/outcome_review.py
@@ -107,6 +107,44 @@ class TickerClusterReview:
         }
 
 
+@dataclass(frozen=True, slots=True)
+class RollingWhipsawCandidate:
+    risk_lookback_sessions: int
+    min_whipsaws: int
+    cooldown_sessions: int
+    whipsaw_window_sessions: int = 5
+
+    @property
+    def name(self) -> str:
+        return (
+            f"rolling_{self.risk_lookback_sessions}_"
+            f"{self.min_whipsaws}_cooldown_{self.cooldown_sessions}"
+        )
+
+    def as_json_dict(self) -> dict[str, object]:
+        return asdict(self) | {"name": self.name}
+
+
+@dataclass(frozen=True, slots=True)
+class RollingWhipsawReview:
+    candidate: RollingWhipsawCandidate
+    alert_match: AlertMatchSummary
+    generated_event_reduction: float | None
+    outcome_5_session: ReturnOutcomeSummary
+    top_whipsaw_count: int
+    top_whipsaw_tickers: list[str]
+
+    def as_json_dict(self) -> dict[str, object]:
+        return {
+            "candidate": self.candidate.as_json_dict(),
+            "alert_match": self.alert_match.as_json_dict(),
+            "generated_event_reduction": self.generated_event_reduction,
+            "outcome_5_session": self.outcome_5_session.as_json_dict(),
+            "top_whipsaw_count": self.top_whipsaw_count,
+            "top_whipsaw_tickers": self.top_whipsaw_tickers,
+        }
+
+
 def _ordered_bars(bars: list[EodBar]) -> list[EodBar]:
     return sorted(bars, key=lambda bar: (bar.ticker, bar.bar_date))
 
@@ -228,6 +266,69 @@ def apply_ticker_cluster_candidate(
                 continue
             kept_events[event_date] = event_state
             last_kept_index = event_index
+        adjusted[ticker] = _rebuild_history_from_events(history, kept_events=kept_events)
+    return adjusted
+
+
+def apply_rolling_whipsaw_candidate(
+    histories: dict[str, DailyEventHistory],
+    bars_by_ticker: dict[str, list[EodBar]],
+    *,
+    candidate: RollingWhipsawCandidate,
+) -> dict[str, DailyEventHistory]:
+    if candidate.risk_lookback_sessions < 1:
+        raise ValueError("risk_lookback_sessions must be at least 1")
+    if candidate.min_whipsaws < 1:
+        raise ValueError("min_whipsaws must be at least 1")
+    if candidate.cooldown_sessions < 1:
+        raise ValueError("cooldown_sessions must be at least 1")
+    if candidate.whipsaw_window_sessions < 1:
+        raise ValueError("whipsaw_window_sessions must be at least 1")
+
+    adjusted: dict[str, DailyEventHistory] = {}
+    for ticker, history in histories.items():
+        bars = _ordered_bars(bars_by_ticker.get(ticker, []))
+        index_by_date = {bar.bar_date: index for index, bar in enumerate(bars)}
+        raw_events = [
+            SignalEvent(
+                ticker=ticker,
+                event_date=event_date,
+                index=index_by_date[event_date],
+                state=event_state,
+            )
+            for event_date, event_state in sorted(history.event_by_date.items())
+            if event_date in index_by_date
+        ]
+
+        kept_events: dict[dt.date, int] = {}
+        whipsaw_indices: list[int] = []
+        cooldown_until_index: int | None = None
+        previous_raw_event: SignalEvent | None = None
+        for event in raw_events:
+            recent_whipsaws = [
+                whipsaw_index
+                for whipsaw_index in whipsaw_indices
+                if event.index - whipsaw_index <= candidate.risk_lookback_sessions
+            ]
+            whipsaw_indices = recent_whipsaws
+            in_cooldown = cooldown_until_index is not None and event.index <= cooldown_until_index
+            risk_active = len(recent_whipsaws) >= candidate.min_whipsaws or in_cooldown
+            if risk_active:
+                cooldown_until_index = max(
+                    cooldown_until_index or event.index,
+                    event.index + candidate.cooldown_sessions,
+                )
+            else:
+                kept_events[event.event_date] = event.state
+
+            if (
+                previous_raw_event is not None
+                and event.state != previous_raw_event.state
+                and event.index - previous_raw_event.index <= candidate.whipsaw_window_sessions
+            ):
+                whipsaw_indices.append(event.index)
+            previous_raw_event = event
+
         adjusted[ticker] = _rebuild_history_from_events(history, kept_events=kept_events)
     return adjusted
 
@@ -479,6 +580,54 @@ def review_ticker_cluster_candidate(
     return TickerClusterReview(
         candidate=candidate,
         cluster_tickers=cluster_tickers[: candidate.cluster_size],
+        alert_match=alert_match,
+        generated_event_reduction=_safe_rate(
+            raw_generated_events - alert_match.generated_events,
+            raw_generated_events,
+        ),
+        outcome_5_session=_first_outcome(
+            events,
+            bars_by_ticker,
+            horizon_sessions=outcome_horizon_sessions,
+        ),
+        top_whipsaw_count=sum(row.whipsaw_count for row in whipsaws),
+        top_whipsaw_tickers=[row.ticker for row in whipsaws],
+    )
+
+
+def review_rolling_whipsaw_candidate(
+    observations: list[CalibrationObservation],
+    raw_histories: dict[str, DailyEventHistory],
+    bars_by_ticker: dict[str, list[EodBar]],
+    *,
+    candidate: RollingWhipsawCandidate,
+    raw_generated_events: int,
+    event_window_days: int,
+    outcome_horizon_sessions: int,
+    top_whipsaws: int,
+    since: dt.date | None = None,
+    until: dt.date | None = None,
+) -> RollingWhipsawReview:
+    adjusted_histories = apply_rolling_whipsaw_candidate(
+        raw_histories,
+        bars_by_ticker,
+        candidate=candidate,
+    )
+    alert_match = evaluate_event_histories(
+        observations,
+        adjusted_histories,
+        event_window_days=event_window_days,
+    )
+    events = events_from_histories(adjusted_histories, bars_by_ticker, since=since, until=until)
+    whipsaws = build_ticker_whipsaw_outcomes(
+        events,
+        bars_by_ticker,
+        whipsaw_window_sessions=candidate.whipsaw_window_sessions,
+        outcome_horizon_sessions=outcome_horizon_sessions,
+        top=top_whipsaws,
+    )
+    return RollingWhipsawReview(
+        candidate=candidate,
         alert_match=alert_match,
         generated_event_reduction=_safe_rate(
             raw_generated_events - alert_match.generated_events,

--- a/crog-ai-backend/docs/MARKETCLUB-DOCHIA-BUILD-PLAN.md
+++ b/crog-ai-backend/docs/MARKETCLUB-DOCHIA-BUILD-PLAN.md
@@ -219,6 +219,15 @@ Useful query params:
   2025-09-25 and evaluates after; it does not clear the default gate, with
   4.74% event reduction, 78.16% F1, and -0.04% average 5-session directional
   return. Do not persist this candidate yet.
+- Added a rolling, date-safe whipsaw-risk suppressor and review script. Reports
+  are tracked at
+  `docs/reports/dochia-v0-3-rolling-whipsaw-review-2026-05-03.md` and
+  `docs/reports/dochia-v0-3-rolling-whipsaw-holdout-2026-05-03.md`. The
+  suppressor only uses prior raw whipsaws before cooling down a ticker, but no
+  candidate preserves at least 95% of raw v0.2 F1. Full-period high-reduction
+  rows collapse exact F1 into the 6.57%-14.07% range, and holdout rows with
+  95%+ event reduction stay below 7.41% F1. Do not persist this as a filter;
+  surface whipsaw risk as evidence in the app.
 - Added and enabled `crog-ai-backend.service` on spark-node-2.
 - Promoted the Command Center production build and restarted
   `crog-ai-frontend.service`; `/financial/hedge-fund` is live through
@@ -228,6 +237,6 @@ Useful query params:
   status, and live backend/BFF reads for both production and v0.2 candidate
   selectors. `/financial/hedge-fund` returns 200 after frontend restart.
 
-Next clean build step: build a rolling, date-safe whipsaw-risk score that can
-cool down names as they become noisy without relying on a fixed historical
-blocklist.
+Next clean build step: add a user-facing Whipsaw Risk / Backtest panel to the
+Hedge Fund cockpit so noisy names are explainable without suppressing validated
+daily range signals.

--- a/crog-ai-backend/docs/reports/dochia-v0-3-rolling-whipsaw-holdout-2026-05-03.md
+++ b/crog-ai-backend/docs/reports/dochia-v0-3-rolling-whipsaw-holdout-2026-05-03.md
@@ -1,0 +1,36 @@
+# Dochia v0.3 Rolling Whipsaw-Risk Review
+
+Generated: 2026-05-03T13:17:50.004419+00:00
+Scope: ticker=all since=2025-09-25 until=latest
+Whipsaw window: 5 sessions
+
+## Raw v0.2 Baseline
+
+| Events | F1 | Precision | Recall | ±3d recall | 5d win | Avg 5d | Top whipsaw count |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 8613 | 79.93% | 71.37% | 90.82% | 94.68% | 50.15% | -0.04% | 759 |
+
+## Quality-Preserving Candidates
+
+_No candidates preserved at least 95% of raw-range F1._
+
+## Best Event-Reduction Candidates
+
+| Rank | Candidate | Events | Event reduction | F1 | Precision | Recall | ±3d recall | 5d win | Avg 5d | Top whipsaws | Top whipsaw tickers |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| R1 | 2 whipsaws/60 sessions -> 20 cooldown | 16 | 99.81% | 0.41% | 87.50% | 0.21% | 0.22% | 43.75% | -0.06% | 9 | SPXC, MGA, HPQ, UVXY, PR |
+| R2 | 3 whipsaws/60 sessions -> 20 cooldown | 53 | 99.38% | 0.99% | 64.15% | 0.50% | 0.53% | 52.83% | +0.06% | 28 | SPXC, MGA, NOW, TRMD, PR |
+| R3 | 2 whipsaws/60 sessions -> 10 cooldown | 57 | 99.34% | 1.31% | 78.95% | 0.66% | 0.70% | 36.36% | -1.19% | 28 | SPXC, MGA, HPQ, ORN, ALGM |
+| R4 | 2 whipsaws/45 sessions -> 20 cooldown | 81 | 99.06% | 1.77% | 75.31% | 0.90% | 0.93% | 48.15% | +0.34% | 40 | SPXC, MGA, MDT, MAS, LPX |
+| R5 | 2 whipsaws/60 sessions -> 5 cooldown | 126 | 98.54% | 2.71% | 74.60% | 1.38% | 1.47% | 45.16% | -0.79% | 44 | SPXC, MGNX, MGA, HPQ, TREX |
+| R6 | 4 whipsaws/60 sessions -> 20 cooldown | 128 | 98.51% | 2.22% | 60.16% | 1.13% | 1.20% | 48.44% | -0.20% | 67 | SPXC, MGA, NOW, HQH, FEIM |
+| R7 | 3 whipsaws/45 sessions -> 20 cooldown | 179 | 97.92% | 3.63% | 70.95% | 1.87% | 2.03% | 46.93% | -0.11% | 87 | SPXC, MGA, MDT, MAS, LPX |
+| R8 | 3 whipsaws/60 sessions -> 10 cooldown | 219 | 97.46% | 4.33% | 69.41% | 2.23% | 2.34% | 49.77% | -0.45% | 77 | NVAX, ZBRA, NTAP, NOW, MGA |
+| R9 | 2 whipsaws/30 sessions -> 20 cooldown | 263 | 96.95% | 5.01% | 67.30% | 2.60% | 2.82% | 47.13% | +0.23% | 69 | TFC, ACLX, DCI, RDVT, PR |
+| R10 | 2 whipsaws/45 sessions -> 10 cooldown | 282 | 96.73% | 6.01% | 75.53% | 3.13% | 3.26% | 49.28% | -0.21% | 65 | MAS, LPX, BLDR, ALGM, VKTX |
+| R11 | 4 whipsaws/45 sessions -> 20 cooldown | 345 | 95.99% | 6.49% | 67.25% | 3.41% | 3.64% | 46.49% | -0.21% | 124 | FMB, OCUL, PR, SPXC, MGA |
+| R12 | 3 whipsaws/60 sessions -> 5 cooldown | 370 | 95.70% | 7.41% | 71.89% | 3.91% | 4.13% | 47.54% | -0.38% | 89 | IOVA, OPEN, NVAX, ZBRA, TREX |
+
+## Recommendation
+
+No rolling whipsaw-risk candidate cleared the default gate: at least 95% of raw-range F1, at least 5% event reduction, fewer top whipsaws, and no worse 5-session average directional return. Keep v0.2 candidate-only.

--- a/crog-ai-backend/docs/reports/dochia-v0-3-rolling-whipsaw-review-2026-05-03.md
+++ b/crog-ai-backend/docs/reports/dochia-v0-3-rolling-whipsaw-review-2026-05-03.md
@@ -1,0 +1,36 @@
+# Dochia v0.3 Rolling Whipsaw-Risk Review
+
+Generated: 2026-05-03T13:18:02.480010+00:00
+Scope: ticker=all since=beginning until=latest
+Whipsaw window: 5 sessions
+
+## Raw v0.2 Baseline
+
+| Events | F1 | Precision | Recall | ±3d recall | 5d win | Avg 5d | Top whipsaw count |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 30806 | 76.64% | 65.71% | 91.93% | 95.21% | 50.33% | +0.01% | 2164 |
+
+## Quality-Preserving Candidates
+
+_No candidates preserved at least 95% of raw-range F1._
+
+## Best Event-Reduction Candidates
+
+| Rank | Candidate | Events | Event reduction | F1 | Precision | Recall | ±3d recall | 5d win | Avg 5d | Top whipsaws | Top whipsaw tickers |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| R1 | 2 whipsaws/60 sessions -> 20 cooldown | 1548 | 94.98% | 6.57% | 50.00% | 3.52% | 4.12% | 49.90% | -0.25% | 79 | CRM, HPQ, MGA, SPXC, MOS |
+| R2 | 2 whipsaws/45 sessions -> 20 cooldown | 1688 | 94.52% | 7.35% | 51.66% | 3.96% | 4.58% | 49.61% | -0.21% | 123 | VZ, MOS, REGN, MSTR, HE |
+| R3 | 2 whipsaws/60 sessions -> 10 cooldown | 1755 | 94.30% | 7.63% | 51.68% | 4.12% | 4.74% | 49.43% | -0.20% | 127 | SPXC, ORN, MGA, XLE, HQH |
+| R4 | 2 whipsaws/60 sessions -> 5 cooldown | 1940 | 93.70% | 8.65% | 53.45% | 4.70% | 5.36% | 49.15% | -0.25% | 135 | SPXC, ORN, MOS, HQH, ANY |
+| R5 | 2 whipsaws/30 sessions -> 20 cooldown | 2149 | 93.02% | 9.51% | 53.56% | 5.22% | 5.91% | 49.91% | -0.21% | 171 | BLDR, OXLC, MIGI, SPXC, TFC |
+| R6 | 3 whipsaws/60 sessions -> 20 cooldown | 2236 | 92.74% | 9.64% | 52.33% | 5.31% | 5.95% | 49.91% | -0.20% | 156 | MOS, HE, CRM, MGA, DIS |
+| R7 | 2 whipsaws/45 sessions -> 10 cooldown | 2414 | 92.16% | 11.07% | 55.92% | 6.15% | 6.85% | 49.31% | -0.23% | 184 | THQ, COP, MAS, ORN, MOS |
+| R8 | 3 whipsaws/45 sessions -> 20 cooldown | 2597 | 91.57% | 11.45% | 54.33% | 6.40% | 7.13% | 49.94% | -0.23% | 201 | BLDR, AVAV, ADBE, MSTR, SPXC |
+| R9 | 2 whipsaws/20 sessions -> 20 cooldown | 2694 | 91.25% | 12.14% | 55.79% | 6.81% | 7.59% | 50.45% | -0.16% | 229 | AVAV, OXLC, HE, ADBE, MIGI |
+| R10 | 3 whipsaws/60 sessions -> 10 cooldown | 2875 | 90.67% | 12.71% | 55.13% | 7.18% | 7.90% | 49.74% | -0.20% | 219 | XLB, ORN, XLE, RVT, SPXC |
+| R11 | 4 whipsaws/60 sessions -> 20 cooldown | 3021 | 90.19% | 13.18% | 54.68% | 7.49% | 8.24% | 49.29% | -0.18% | 236 | VZ, MOS, CMBT, MGA, HE |
+| R12 | 2 whipsaws/45 sessions -> 5 cooldown | 3028 | 90.17% | 14.07% | 58.16% | 8.00% | 8.80% | 48.99% | -0.21% | 215 | OC, COP, MTRX, DIS, NBR |
+
+## Recommendation
+
+No rolling whipsaw-risk candidate cleared the default gate: at least 95% of raw-range F1, at least 5% event reduction, fewer top whipsaws, and no worse 5-session average directional return. Keep v0.2 candidate-only.

--- a/crog-ai-backend/scripts/review_rolling_whipsaw_candidates.py
+++ b/crog-ai-backend/scripts/review_rolling_whipsaw_candidates.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""Research date-safe rolling whipsaw-risk candidates for v0.2."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import psycopg
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from app.signals.calibration_repository import fetch_daily_sweep_inputs  # noqa: E402
+from app.signals.guardrail_sweep import (  # noqa: E402
+    GuardedRangeCandidate,
+    generated_guarded_range_event_history,
+)
+from app.signals.outcome_review import (  # noqa: E402
+    RollingWhipsawCandidate,
+    build_ticker_whipsaw_outcomes,
+    evaluate_event_histories,
+    events_from_histories,
+    review_rolling_whipsaw_candidate,
+    summarize_forward_returns,
+)
+from scripts.sweep_daily_signal_parameters import _database_url  # noqa: E402
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Review rolling, date-safe whipsaw-risk candidates for v0.2 range signals."
+    )
+    parser.add_argument("--since", type=dt.date.fromisoformat, default=None)
+    parser.add_argument("--until", type=dt.date.fromisoformat, default=None)
+    parser.add_argument("--ticker", default=None)
+    parser.add_argument("--risk-lookback", action="append", type=int, default=None)
+    parser.add_argument("--min-whipsaws", action="append", type=int, default=None)
+    parser.add_argument("--cooldown-sessions", action="append", type=int, default=None)
+    parser.add_argument("--whipsaw-window-sessions", type=int, default=5)
+    parser.add_argument("--event-window-days", type=int, default=3)
+    parser.add_argument("--outcome-horizon", type=int, default=5)
+    parser.add_argument("--top-whipsaws", type=int, default=30)
+    parser.add_argument("--top", type=int, default=12)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--output", type=Path, default=None)
+    return parser.parse_args()
+
+
+def _pct(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value * 100:.2f}%"
+
+
+def _signed_pct(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value * 100:+.2f}%"
+
+
+def _table_row(values: list[object]) -> str:
+    return "| " + " | ".join(str(value) for value in values) + " |"
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if args.since is not None and args.until is not None and args.since > args.until:
+        raise SystemExit("since cannot be after until")
+    for risk_lookback in args.risk_lookback or [20, 30, 45, 60]:
+        if risk_lookback < 1:
+            raise SystemExit("risk-lookback must be at least 1")
+    for min_whipsaws in args.min_whipsaws or [2, 3, 4]:
+        if min_whipsaws < 1:
+            raise SystemExit("min-whipsaws must be at least 1")
+    for cooldown in args.cooldown_sessions or [5, 10, 20]:
+        if cooldown < 1:
+            raise SystemExit("cooldown-sessions must be at least 1")
+    if args.whipsaw_window_sessions < 1:
+        raise SystemExit("whipsaw-window-sessions must be at least 1")
+    if args.event_window_days < 0:
+        raise SystemExit("event-window-days must be non-negative")
+    if args.outcome_horizon < 1:
+        raise SystemExit("outcome-horizon must be at least 1")
+    if args.top_whipsaws < 1:
+        raise SystemExit("top-whipsaws must be at least 1")
+    if args.top < 1:
+        raise SystemExit("top must be at least 1")
+
+
+def _raw_range_histories(bars_by_ticker: dict[str, list[Any]]) -> dict[str, Any]:
+    histories: dict[str, Any] = {}
+    for ticker, bars in bars_by_ticker.items():
+        history = generated_guarded_range_event_history(
+            bars,
+            candidate=GuardedRangeCandidate(lookback_sessions=3),
+        )
+        if history is not None:
+            histories[ticker] = history
+    return histories
+
+
+def _candidate_grid(args: argparse.Namespace) -> list[RollingWhipsawCandidate]:
+    return [
+        RollingWhipsawCandidate(
+            risk_lookback_sessions=risk_lookback,
+            min_whipsaws=min_whipsaws,
+            cooldown_sessions=cooldown,
+            whipsaw_window_sessions=args.whipsaw_window_sessions,
+        )
+        for risk_lookback in (args.risk_lookback or [20, 30, 45, 60])
+        for min_whipsaws in (args.min_whipsaws or [2, 3, 4])
+        for cooldown in (args.cooldown_sessions or [5, 10, 20])
+    ]
+
+
+def _candidate_label(row: dict[str, Any]) -> str:
+    candidate = row["candidate"]
+    return (
+        f"{candidate['min_whipsaws']} whipsaws/"
+        f"{candidate['risk_lookback_sessions']} sessions -> "
+        f"{candidate['cooldown_sessions']} cooldown"
+    )
+
+
+def _render_candidate_row(row: dict[str, Any], rank: int | str) -> str:
+    alert = row["alert_match"]
+    outcome = row["outcome_5_session"]
+    return _table_row(
+        [
+            rank,
+            _candidate_label(row),
+            alert["generated_events"],
+            _pct(row["generated_event_reduction"]),
+            _pct(alert["exact_event_f1"]),
+            _pct(alert["exact_event_precision"]),
+            _pct(alert["exact_event_recall"]),
+            _pct(alert["window_event_recall"]),
+            _pct(outcome["win_rate"]),
+            _signed_pct(outcome["average_directional_return"]),
+            row["top_whipsaw_count"],
+            ", ".join(row["top_whipsaw_tickers"][:5]),
+        ]
+    )
+
+
+def _append_candidate_table(lines: list[str], rows: list[dict[str, Any]], *, prefix: str = "") -> None:
+    lines.extend(
+        [
+            _table_row(
+                [
+                    "Rank",
+                    "Candidate",
+                    "Events",
+                    "Event reduction",
+                    "F1",
+                    "Precision",
+                    "Recall",
+                    "±3d recall",
+                    "5d win",
+                    "Avg 5d",
+                    "Top whipsaws",
+                    "Top whipsaw tickers",
+                ]
+            ),
+            _table_row(
+                [
+                    "---:",
+                    "---",
+                    "---:",
+                    "---:",
+                    "---:",
+                    "---:",
+                    "---:",
+                    "---:",
+                    "---:",
+                    "---:",
+                    "---:",
+                    "---",
+                ]
+            ),
+        ]
+    )
+    for rank, row in enumerate(rows, start=1):
+        lines.append(_render_candidate_row(row, f"{prefix}{rank}"))
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    raw_alert = payload["raw_range_baseline"]["alert_match"]
+    raw_outcome = payload["raw_range_baseline"]["outcome_5_session"]
+    recommendation = payload["recommendation"]
+    lines = [
+        "# Dochia v0.3 Rolling Whipsaw-Risk Review",
+        "",
+        f"Generated: {payload['generated_at']}",
+        f"Scope: ticker={payload['ticker'] or 'all'} since={payload['since'] or 'beginning'} until={payload['until'] or 'latest'}",
+        f"Whipsaw window: {payload['whipsaw_window_sessions']} sessions",
+        "",
+        "## Raw v0.2 Baseline",
+        "",
+        _table_row(
+            [
+                "Events",
+                "F1",
+                "Precision",
+                "Recall",
+                "±3d recall",
+                "5d win",
+                "Avg 5d",
+                "Top whipsaw count",
+            ]
+        ),
+        _table_row(["---:", "---:", "---:", "---:", "---:", "---:", "---:", "---:"]),
+        _table_row(
+            [
+                raw_alert["generated_events"],
+                _pct(raw_alert["exact_event_f1"]),
+                _pct(raw_alert["exact_event_precision"]),
+                _pct(raw_alert["exact_event_recall"]),
+                _pct(raw_alert["window_event_recall"]),
+                _pct(raw_outcome["win_rate"]),
+                _signed_pct(raw_outcome["average_directional_return"]),
+                payload["raw_range_baseline"]["top_whipsaw_count"],
+            ]
+        ),
+        "",
+        "## Quality-Preserving Candidates",
+        "",
+    ]
+    if payload["quality_preserving_results"]:
+        _append_candidate_table(lines, payload["quality_preserving_results"])
+    else:
+        lines.append("_No candidates preserved at least 95% of raw-range F1._")
+
+    lines.extend(["", "## Best Event-Reduction Candidates", ""])
+    _append_candidate_table(lines, payload["best_reduction_results"], prefix="R")
+
+    lines.extend(["", "## Recommendation", ""])
+    if recommendation is None:
+        lines.append(
+            "No rolling whipsaw-risk candidate cleared the default gate: at least 95% of raw-range F1, at least 5% event reduction, fewer top whipsaws, and no worse 5-session average directional return. Keep v0.2 candidate-only."
+        )
+    else:
+        lines.extend(
+            [
+                "Use this as the next non-production v0.3 candidate only after promotion-review lane and chart checks:",
+                "",
+            ]
+        )
+        _append_candidate_table(lines, [recommendation])
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _review_sort_key(row: dict[str, Any]) -> tuple[float, float, float]:
+    return (
+        row["generated_event_reduction"] or 0,
+        row["alert_match"]["exact_event_f1"] or 0,
+        row["outcome_5_session"]["average_directional_return"] or 0,
+    )
+
+
+def _pick_recommendation(
+    rows: list[dict[str, Any]],
+    *,
+    raw_f1: float,
+    raw_avg_return: float,
+    raw_whipsaw_count: int,
+) -> dict[str, Any] | None:
+    eligible = [
+        row
+        for row in rows
+        if (row["alert_match"]["exact_event_f1"] or 0) >= raw_f1 * 0.95
+        and (row["generated_event_reduction"] or 0) >= 0.05
+        and row["top_whipsaw_count"] < raw_whipsaw_count
+        and (row["outcome_5_session"]["average_directional_return"] or 0) >= raw_avg_return
+    ]
+    if not eligible:
+        return None
+    eligible.sort(key=_review_sort_key, reverse=True)
+    return eligible[0]
+
+
+def build_payload(args: argparse.Namespace) -> dict[str, Any]:
+    _validate_args(args)
+    with psycopg.connect(_database_url()) as conn:
+        conn.execute("SET default_transaction_read_only = on")
+        observations, bars_by_ticker = fetch_daily_sweep_inputs(
+            conn,
+            since=None,
+            until=args.until,
+            ticker=args.ticker,
+        )
+
+    eval_observations = [
+        observation
+        for observation in observations
+        if (args.since is None or observation.trading_day >= args.since)
+        and (args.until is None or observation.trading_day <= args.until)
+    ]
+    raw_histories = _raw_range_histories(bars_by_ticker)
+    raw_alert = evaluate_event_histories(
+        eval_observations,
+        raw_histories,
+        event_window_days=args.event_window_days,
+    )
+    raw_events = events_from_histories(raw_histories, bars_by_ticker, since=args.since, until=args.until)
+    raw_outcome = summarize_forward_returns(
+        raw_events,
+        bars_by_ticker,
+        horizons=[args.outcome_horizon],
+    )[0]
+    raw_whipsaws = build_ticker_whipsaw_outcomes(
+        raw_events,
+        bars_by_ticker,
+        whipsaw_window_sessions=args.whipsaw_window_sessions,
+        outcome_horizon_sessions=args.outcome_horizon,
+        top=args.top_whipsaws,
+    )
+    candidate_rows = [
+        review_rolling_whipsaw_candidate(
+            eval_observations,
+            raw_histories,
+            bars_by_ticker,
+            candidate=candidate,
+            raw_generated_events=raw_alert.generated_events,
+            event_window_days=args.event_window_days,
+            outcome_horizon_sessions=args.outcome_horizon,
+            top_whipsaws=args.top_whipsaws,
+            since=args.since,
+            until=args.until,
+        ).as_json_dict()
+        for candidate in _candidate_grid(args)
+    ]
+    raw_f1 = raw_alert.exact_event_f1 or 0
+    raw_avg_return = raw_outcome.average_directional_return or 0
+    raw_whipsaw_count = sum(row.whipsaw_count for row in raw_whipsaws)
+    quality_preserving = [
+        row
+        for row in candidate_rows
+        if (row["alert_match"]["exact_event_f1"] or 0) >= raw_f1 * 0.95
+    ]
+    quality_preserving.sort(key=_review_sort_key, reverse=True)
+    best_reduction = sorted(candidate_rows, key=_review_sort_key, reverse=True)
+    return {
+        "generated_at": dt.datetime.now(dt.UTC).isoformat(),
+        "since": args.since.isoformat() if args.since else None,
+        "until": args.until.isoformat() if args.until else None,
+        "ticker": args.ticker.upper() if args.ticker else None,
+        "whipsaw_window_sessions": args.whipsaw_window_sessions,
+        "raw_range_baseline": {
+            "alert_match": raw_alert.as_json_dict(),
+            "outcome_5_session": raw_outcome.as_json_dict(),
+            "top_whipsaw_count": raw_whipsaw_count,
+        },
+        "quality_preserving_results": quality_preserving[: args.top],
+        "best_reduction_results": best_reduction[: args.top],
+        "recommendation": _pick_recommendation(
+            candidate_rows,
+            raw_f1=raw_f1,
+            raw_avg_return=raw_avg_return,
+            raw_whipsaw_count=raw_whipsaw_count,
+        ),
+    }
+
+
+def main() -> None:
+    args = parse_args()
+    payload = build_payload(args)
+    text = (
+        json.dumps(payload, indent=2, sort_keys=True)
+        if args.json
+        else _render_markdown(payload)
+    )
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text)
+    else:
+        print(text, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/crog-ai-backend/tests/test_outcome_review.py
+++ b/crog-ai-backend/tests/test_outcome_review.py
@@ -7,7 +7,9 @@ from app.signals.guardrail_sweep import (
     generated_guarded_range_event_history,
 )
 from app.signals.outcome_review import (
+    RollingWhipsawCandidate,
     TickerClusterCandidate,
+    apply_rolling_whipsaw_candidate,
     apply_ticker_cluster_candidate,
     build_ticker_whipsaw_outcomes,
     evaluate_event_histories,
@@ -163,3 +165,40 @@ def test_evaluate_event_histories_scores_exact_and_precision() -> None:
     assert summary.generated_events == 2
     assert summary.exact_event_matches == 2
     assert summary.exact_event_f1 == 1
+
+
+def test_apply_rolling_whipsaw_candidate_uses_only_prior_churn() -> None:
+    bars = [
+        _bar(0, open_="10", high="10", low="9", close="10"),
+        _bar(1, open_="11", high="11", low="10", close="11"),
+        _bar(2, open_="12", high="12", low="10", close="12"),
+        _bar(3, open_="9", high="10", low="8", close="8"),
+        _bar(4, open_="13", high="13", low="9", close="12"),
+        _bar(5, open_="8", high="9", low="7", close="8"),
+        _bar(6, open_="14", high="14", low="8", close="13"),
+    ]
+    history = generated_guarded_range_event_history(
+        bars,
+        candidate=GuardedRangeCandidate(lookback_sessions=2),
+    )
+    assert history is not None
+
+    adjusted = apply_rolling_whipsaw_candidate(
+        {"AA": history},
+        {"AA": bars},
+        candidate=RollingWhipsawCandidate(
+            risk_lookback_sessions=4,
+            min_whipsaws=2,
+            cooldown_sessions=2,
+            whipsaw_window_sessions=2,
+        ),
+    )
+
+    event_dates = list(adjusted["AA"].event_by_date)
+    assert event_dates == [
+        dt.date(2026, 1, 3),
+        dt.date(2026, 1, 4),
+        dt.date(2026, 1, 5),
+    ]
+    assert dt.date(2026, 1, 6) not in adjusted["AA"].event_by_date
+    assert dt.date(2026, 1, 7) not in adjusted["AA"].event_by_date

--- a/docs/operational/MASTER-PLAN.md
+++ b/docs/operational/MASTER-PLAN.md
@@ -2,7 +2,7 @@
 
 **Operator:** Gary Knight
 **Established:** 2026-04-29
-**Updated:** 2026-05-02 (v1.8 — MarketClub/Dochia Financial build activation)
+**Updated:** 2026-05-03 (v1.9 — Dochia v0.3 whipsaw research closed)
 **Cadence:** Updated on change
 
 ---
@@ -43,8 +43,8 @@ Both advance toward: white-shoe-grade output produced by single operator on his 
 | Plaintiff | 7 IL Properties, LLC (Colorado LLC, federal diversity) |
 | Phase | counsel_search |
 | Target counsel-hire | **2026-06-15** |
-| Today | 2026-05-02 |
-| **Days remaining** | **~44** |
+| Today | 2026-05-03 |
+| **Days remaining** | **~43** |
 
 **Counsel-hire deliverable:** Phase B v0.1 dry-run on Case I produces v3 brief exceeding v2. Validation passes → Phase B runs on Case II.
 
@@ -259,7 +259,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 | Legacy watchlist context | `watchlist` has 431 rows; `market_signals` has 1,105 rows through 2026-02-12; read-only grant applied for app overlays |
 | Calibration baseline | 24,204 daily observations; 91.44% coverage; 62.05% carried daily color accuracy; 40.67% exact alert match; 52.54% ±3-day alert match; score MAE 43.94 |
 | Calibration sweep | Best validated candidate: 3-session intraday range trigger; exact alert F1 76.64% vs 44.59% baseline, exact recall 91.93% vs 40.67%, precision 65.71%, ±3-day recall 95.21%; holdout after 2025-09-25 scores 83.18% F1 vs 46.26% baseline |
-| v0.3 guardrail research | Ticker-cluster holdout complete: full-period top-15 exclusion is promising (5.11% event cut, 74.98% F1), but chronological holdout misses the gate (4.74% event cut, 78.16% F1, -0.04% avg 5d return); next research targets rolling date-safe whipsaw-risk scoring |
+| v0.3 guardrail research | Closed as research-only: simple guardrails, ATR/cooldowns, ticker clusters, and rolling whipsaw suppressors all miss the promotion gate. Rolling date-safe holdout confirms suppression destroys recall: no candidate keeps at least 95% of raw v0.2 F1; strongest reducers cut 95%+ of events but stay below 7.41% F1 |
 | Candidate persisted state | v0.2 candidate has 328 `signal_scores` rows and 1,624 `signal_transitions` rows under non-production parameter set; internal API/BFF selector live for scanner, transitions, symbol detail, Portfolio Lens, and chart overlays |
 | Candidate lane comparison | v0.2 bullish lane unchanged at 129, risk unchanged at 47, re-entry 164→145, mixed 202→203, 61 daily states/scores change |
 | Promotion contract | Fresh Dochia scores still staged; legacy `market_signals` remains contextual until calibration/promotion |
@@ -292,7 +292,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 - Do not call generated weekly/monthly states "MarketClub truth"; they are Dochia-derived.
 - Avoid gamified trading prompts; build an evidence cockpit.
 
-**Immediate next step:** Build a rolling, date-safe whipsaw-risk score that can cool down names as they become noisy without relying on a fixed historical blocklist.
+**Immediate next step:** Build a user-facing Whipsaw Risk / Backtest panel in the Hedge Fund cockpit so noisy names are visible and explainable without suppressing the validated v0.2 daily range signal.
 
 ### 6.6 Architectural follow-ups
 
@@ -321,7 +321,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 
 ---
 
-## 7. Today's snapshot (2026-05-02 — MarketClub/Dochia activation)
+## 7. Today's snapshot (2026-05-03 — MarketClub/Dochia activation)
 
 **New Financial Division build track activated.**
 
@@ -352,7 +352,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 - Added v0.2 chart-overlay parity: the symbol chart now follows the active Production/v0.2 Range mode, using close-break daily events for production and range-trigger daily events for the v0.2 candidate.
 - Added read-only v0.2 promotion-review harness covering top-lane churn, recent whipsaw/transition pressure, and chart-level candidate event deltas.
 - Ran first v0.2 promotion-review report. Decision: do not promote range trigger yet. Risk lane is stable, but re-entry lane churn is 66.7%, mixed-timeframe churn is 52.9%, top whipsaw tickers show 8-9 candidate transitions in the 30-day window, and reviewed chart overlays add up to 29 candidate-only daily events on some symbols.
-- Added and ran read-only v0.3 range-trigger guardrail research for break buffers, same-direction close confirmation, ATR-normalized buffers, trailing per-symbol adaptive cooldowns, return-conditioned outcomes, ticker whipsaw clusters, and chronological ticker-cluster holdout. Decision: do not persist the fixed cluster candidate; next research targets rolling date-safe whipsaw-risk scoring.
+- Added and ran read-only v0.3 range-trigger guardrail research for break buffers, same-direction close confirmation, ATR-normalized buffers, trailing per-symbol adaptive cooldowns, return-conditioned outcomes, ticker whipsaw clusters, chronological ticker-cluster holdout, and rolling date-safe whipsaw suppressors. Decision: do not persist any v0.3 suppression filter; expose whipsaw risk and backtest evidence in the app instead.
 - Added internal Production/v0.2 Range toggle to the Command Center Hedge Fund page and promoted the production frontend build.
 - Added chart-data endpoint and chart overlay with close, daily/weekly channel bands, and generated triangle event markers.
 - Refined calibration metrics to separate carried-state agreement from exact new-alert agreement: 40.67% same-day alert match and 52.54% ±3-day alert match.


### PR DESCRIPTION
Adds rolling date-safe whipsaw candidate review helpers, CLI report, full/holdout reports, and plan updates. Full-period: no candidate preserves at least 95% of raw v0.2 F1; strongest reducers cut 90%+ of events but collapse F1 to 6.57%-14.07%. Holdout since 2025-09-25: strongest reducers cut 95%+ of events while staying below 7.41% F1. Decision: do not persist v0.3 suppression filters; build whipsaw risk and backtest evidence into the app. Verification: focused outcome tests, 24 backend signal tests, ruff, and holdout JSON smoke passed.