### PR TITLE
feat(financial): add whipsaw risk panel

### DIFF
--- a/crog-ai-backend/README.md
+++ b/crog-ai-backend/README.md
@@ -55,6 +55,7 @@ Current Financial / Hedge Fund endpoints:
 | `GET /api/financial/signals/watchlist-candidates` | portfolio-lens lanes with legacy watchlist context |
 | `GET /api/financial/signals/calibration/daily` | daily MarketClub truth calibration metrics |
 | `GET /api/financial/signals/{ticker}/chart` | EOD bars, rolling channels, and parameter-set aware triangle overlay events |
+| `GET /api/financial/signals/{ticker}/whipsaw-risk` | symbol whipsaw count/rate and forward-return backtest evidence |
 | `GET /api/financial/signals/{ticker}` | symbol-level latest score plus recent transitions |
 
 Internal candidate reads can pass `parameter_set=dochia_v0_2_range_daily` to
@@ -184,6 +185,12 @@ raw v0.2 F1. Full-period best reductions cut 90%+ of events but collapse exact
 F1 into the 6.57%-14.07% range. Holdout behaves the same way, with the strongest
 reducers cutting 95%+ of events while exact F1 stays below 7.41%. Keep v0.2
 candidate-only; expose whipsaw risk as evidence instead of suppressing signals.
+
+Whipsaw Risk / Backtest app surface: the symbol-level API now exposes daily
+whipsaw count/rate, risk level, 5-session forward-return outcome, and recent
+daily events through `/api/financial/signals/{ticker}/whipsaw-risk`. The Command
+Center Hedge Fund cockpit renders that evidence beside the selected ticker
+chart for both production and v0.2 Range modes.
 
 ## Relationship to Fortress-Prime
 

--- a/crog-ai-backend/app/api/signals.py
+++ b/crog-ai-backend/app/api/signals.py
@@ -204,6 +204,43 @@ class SymbolSignalChart(BaseModel):
     events: list[SymbolChartEvent]
 
 
+class SignalReturnOutcome(BaseModel):
+    horizon_sessions: int
+    evaluated_events: int
+    win_count: int
+    win_rate: float | None
+    average_directional_return: float | None
+    median_directional_return: float | None
+    p25_directional_return: float | None
+    p75_directional_return: float | None
+
+
+class SymbolWhipsawEvent(BaseModel):
+    event_date: dt.date
+    state: str
+    sessions_since_previous: int | None
+    is_whipsaw: bool
+    directional_return: float | None
+
+
+class SymbolWhipsawRisk(BaseModel):
+    ticker: str
+    parameter_set_name: str
+    daily_trigger_mode: str
+    sessions: int
+    as_of: dt.date | None
+    whipsaw_window_sessions: int
+    outcome_horizon_sessions: int
+    event_count: int
+    whipsaw_count: int
+    whipsaw_rate: float | None
+    latest_whipsaw_date: dt.date | None
+    risk_score: int
+    risk_level: str
+    outcome: SignalReturnOutcome
+    recent_events: list[SymbolWhipsawEvent]
+
+
 def _state_label(value: int) -> str:
     if value > 0:
         return "green"
@@ -332,6 +369,29 @@ def symbol_signal_chart(
     if not chart["bars"]:
         raise HTTPException(status_code=404, detail=f"chart data not found for {ticker.upper()}")
     return chart
+
+
+@router.get("/{ticker}/whipsaw-risk", response_model=SymbolWhipsawRisk)
+def symbol_whipsaw_risk(
+    ticker: Annotated[str, Path(min_length=1, max_length=20)],
+    store: Annotated[SignalDataStore, Depends(get_signal_store)],
+    sessions: Annotated[int, Query(ge=30, le=500)] = 260,
+    as_of: dt.date | None = None,
+    parameter_set: Annotated[str | None, Query(min_length=1, max_length=100)] = None,
+    whipsaw_window_sessions: Annotated[int, Query(ge=1, le=30)] = 5,
+    outcome_horizon_sessions: Annotated[int, Query(ge=1, le=60)] = 5,
+) -> dict[str, object]:
+    risk = store.symbol_whipsaw_risk(
+        ticker=ticker.upper(),
+        sessions=sessions,
+        as_of=as_of,
+        parameter_set=parameter_set,
+        whipsaw_window_sessions=whipsaw_window_sessions,
+        outcome_horizon_sessions=outcome_horizon_sessions,
+    )
+    if risk["sessions"] == 0:
+        raise HTTPException(status_code=404, detail=f"whipsaw data not found for {ticker.upper()}")
+    return risk
 
 
 @router.get("/{ticker}", response_model=SymbolSignalDetail)

--- a/crog-ai-backend/app/signals/repository.py
+++ b/crog-ai-backend/app/signals/repository.py
@@ -11,6 +11,7 @@ from psycopg.rows import dict_row
 from app.database import connect
 from app.signals.calibration_repository import fetch_daily_calibration
 from app.signals.chart_repository import fetch_symbol_chart
+from app.signals.whipsaw_risk import fetch_symbol_whipsaw_risk
 
 
 class SignalDataStore(Protocol):
@@ -60,6 +61,17 @@ class SignalDataStore(Protocol):
         sessions: int,
         as_of: dt.date | None = None,
         parameter_set: str | None = None,
+    ) -> dict[str, Any]: ...
+
+    def symbol_whipsaw_risk(
+        self,
+        *,
+        ticker: str,
+        sessions: int,
+        as_of: dt.date | None = None,
+        parameter_set: str | None = None,
+        whipsaw_window_sessions: int = 5,
+        outcome_horizon_sessions: int = 5,
     ) -> dict[str, Any]: ...
 
 
@@ -447,4 +459,26 @@ class PostgresSignalDataStore:
                 sessions=sessions,
                 as_of=as_of,
                 parameter_set=parameter_set,
+            )
+
+    def symbol_whipsaw_risk(
+        self,
+        *,
+        ticker: str,
+        sessions: int,
+        as_of: dt.date | None = None,
+        parameter_set: str | None = None,
+        whipsaw_window_sessions: int = 5,
+        outcome_horizon_sessions: int = 5,
+    ) -> dict[str, Any]:
+        with connect() as conn:
+            conn.execute("SET default_transaction_read_only = on")
+            return fetch_symbol_whipsaw_risk(
+                conn,
+                ticker=ticker,
+                sessions=sessions,
+                as_of=as_of,
+                parameter_set=parameter_set,
+                whipsaw_window_sessions=whipsaw_window_sessions,
+                outcome_horizon_sessions=outcome_horizon_sessions,
             )

--- a/crog-ai-backend/app/signals/whipsaw_risk.py
+++ b/crog-ai-backend/app/signals/whipsaw_risk.py
@@ -1,0 +1,254 @@
+"""Whipsaw and forward-return read model for app-facing signal review."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+import psycopg
+from psycopg.rows import dict_row
+
+from app.signals.chart_repository import (
+    PRODUCTION_PARAMETER_SET,
+    daily_trigger_mode_for_parameter_set,
+)
+from app.signals.db_preview import eod_row_to_bar
+from app.signals.outcome_review import SignalEvent, summarize_forward_returns
+from app.signals.trade_triangles import (
+    EodBar,
+    TriangleTimeframe,
+    detect_triangle_events,
+)
+
+DAILY_LOOKBACK_BUFFER = 3
+
+
+def _safe_rate(numerator: int, denominator: int) -> float | None:
+    if denominator == 0:
+        return None
+    return numerator / denominator
+
+
+def _state_label(value: int) -> str:
+    if value > 0:
+        return "green"
+    if value < 0:
+        return "red"
+    return "neutral"
+
+
+def _directional_return(
+    event: SignalEvent,
+    bars_by_ticker: dict[str, list[EodBar]],
+    *,
+    horizon_sessions: int,
+) -> float | None:
+    bars = sorted(bars_by_ticker.get(event.ticker, []), key=lambda bar: bar.bar_date)
+    future_index = event.index + horizon_sessions
+    if future_index >= len(bars):
+        return None
+    entry_close = bars[event.index].close
+    future_close = bars[future_index].close
+    if entry_close == 0:
+        return None
+    return float((future_close - entry_close) / entry_close) * event.state
+
+
+def _risk_score(
+    *,
+    whipsaw_count: int,
+    whipsaw_rate: float | None,
+    average_directional_return: float | None,
+) -> int:
+    rate_score = int(round((whipsaw_rate or 0) * 100))
+    count_score = min(100, whipsaw_count * 20)
+    return_drag = 15 if average_directional_return is not None and average_directional_return < 0 else 0
+    return min(100, max(rate_score, count_score) + return_drag)
+
+
+def _risk_level(
+    *,
+    event_count: int,
+    whipsaw_count: int,
+    whipsaw_rate: float | None,
+    risk_score: int,
+) -> str:
+    if event_count < 2:
+        return "quiet"
+    if whipsaw_count >= 3 and (whipsaw_rate or 0) >= 0.35:
+        return "high"
+    if whipsaw_count >= 2 and (whipsaw_rate or 0) >= 0.75:
+        return "high"
+    if risk_score >= 45 or whipsaw_count >= 2 or (whipsaw_rate or 0) >= 0.25:
+        return "elevated"
+    return "quiet"
+
+
+def _signal_events_from_bars(
+    bars: list[EodBar],
+    *,
+    parameter_set: str | None,
+    first_visible_date: dt.date,
+) -> list[SignalEvent]:
+    ordered = sorted(bars, key=lambda bar: bar.bar_date)
+    index_by_date = {bar.bar_date: index for index, bar in enumerate(ordered)}
+    daily_trigger_mode = daily_trigger_mode_for_parameter_set(parameter_set)
+    events = detect_triangle_events(
+        ordered,
+        TriangleTimeframe.DAILY,
+        trigger_mode=daily_trigger_mode,
+    )
+    return [
+        SignalEvent(
+            ticker=event.ticker,
+            event_date=event.bar_date,
+            index=index_by_date[event.bar_date],
+            state=event.state.numeric,
+        )
+        for event in events
+        if event.bar_date >= first_visible_date
+    ]
+
+
+def build_symbol_whipsaw_risk(
+    *,
+    ticker: str,
+    bars: list[EodBar],
+    sessions: int,
+    parameter_set: str | None = None,
+    whipsaw_window_sessions: int = 5,
+    outcome_horizon_sessions: int = 5,
+) -> dict[str, Any]:
+    ordered = sorted(bars, key=lambda bar: bar.bar_date)
+    parameter_set_name = parameter_set or PRODUCTION_PARAMETER_SET
+    daily_trigger_mode = daily_trigger_mode_for_parameter_set(parameter_set)
+    visible_bars = ordered[-sessions:]
+    if not visible_bars:
+        return {
+            "ticker": ticker.upper(),
+            "parameter_set_name": parameter_set_name,
+            "daily_trigger_mode": daily_trigger_mode.value,
+            "sessions": sessions,
+            "as_of": None,
+            "whipsaw_window_sessions": whipsaw_window_sessions,
+            "outcome_horizon_sessions": outcome_horizon_sessions,
+            "event_count": 0,
+            "whipsaw_count": 0,
+            "whipsaw_rate": None,
+            "latest_whipsaw_date": None,
+            "risk_score": 0,
+            "risk_level": "quiet",
+            "outcome": summarize_forward_returns([], {}, horizons=[outcome_horizon_sessions])[
+                0
+            ].as_json_dict(),
+            "recent_events": [],
+        }
+
+    bars_by_ticker = {ticker.upper(): ordered}
+    events = _signal_events_from_bars(
+        ordered,
+        parameter_set=parameter_set,
+        first_visible_date=visible_bars[0].bar_date,
+    )
+
+    whipsaw_dates: list[dt.date] = []
+    recent_events: list[dict[str, Any]] = []
+    previous: SignalEvent | None = None
+    for event in events:
+        sessions_since_previous = event.index - previous.index if previous else None
+        is_whipsaw = (
+            previous is not None
+            and event.state != previous.state
+            and sessions_since_previous is not None
+            and sessions_since_previous <= whipsaw_window_sessions
+        )
+        if is_whipsaw:
+            whipsaw_dates.append(event.event_date)
+        recent_events.append(
+            {
+                "event_date": event.event_date,
+                "state": _state_label(event.state),
+                "sessions_since_previous": sessions_since_previous,
+                "is_whipsaw": is_whipsaw,
+                "directional_return": _directional_return(
+                    event,
+                    bars_by_ticker,
+                    horizon_sessions=outcome_horizon_sessions,
+                ),
+            }
+        )
+        previous = event
+
+    outcome = summarize_forward_returns(
+        events,
+        bars_by_ticker,
+        horizons=[outcome_horizon_sessions],
+    )[0]
+    whipsaw_count = len(whipsaw_dates)
+    whipsaw_rate = _safe_rate(whipsaw_count, max(len(events) - 1, 0))
+    risk_score = _risk_score(
+        whipsaw_count=whipsaw_count,
+        whipsaw_rate=whipsaw_rate,
+        average_directional_return=outcome.average_directional_return,
+    )
+    return {
+        "ticker": ticker.upper(),
+        "parameter_set_name": parameter_set_name,
+        "daily_trigger_mode": daily_trigger_mode.value,
+        "sessions": len(visible_bars),
+        "as_of": visible_bars[-1].bar_date,
+        "whipsaw_window_sessions": whipsaw_window_sessions,
+        "outcome_horizon_sessions": outcome_horizon_sessions,
+        "event_count": len(events),
+        "whipsaw_count": whipsaw_count,
+        "whipsaw_rate": whipsaw_rate,
+        "latest_whipsaw_date": max(whipsaw_dates) if whipsaw_dates else None,
+        "risk_score": risk_score,
+        "risk_level": _risk_level(
+            event_count=len(events),
+            whipsaw_count=whipsaw_count,
+            whipsaw_rate=whipsaw_rate,
+            risk_score=risk_score,
+        ),
+        "outcome": outcome.as_json_dict(),
+        "recent_events": list(reversed(recent_events[-8:])),
+    }
+
+
+def fetch_symbol_whipsaw_risk(
+    conn: psycopg.Connection,
+    *,
+    ticker: str,
+    sessions: int,
+    as_of: dt.date | None = None,
+    parameter_set: str | None = None,
+    whipsaw_window_sessions: int = 5,
+    outcome_horizon_sessions: int = 5,
+) -> dict[str, Any]:
+    normalized = ticker.upper()
+    fetch_limit = sessions + DAILY_LOOKBACK_BUFFER
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            """
+            SELECT ticker, bar_date, open, high, low, close, volume
+            FROM (
+                SELECT ticker, bar_date, open, high, low, close, volume
+                FROM hedge_fund.eod_bars
+                WHERE ticker = %(ticker)s
+                  AND (%(as_of)s::date IS NULL OR bar_date <= %(as_of)s::date)
+                ORDER BY bar_date DESC
+                LIMIT %(limit)s
+            ) latest
+            ORDER BY bar_date
+            """,
+            {"ticker": normalized, "as_of": as_of, "limit": fetch_limit},
+        )
+        bars = [eod_row_to_bar(dict(row)) for row in cur.fetchall()]
+    return build_symbol_whipsaw_risk(
+        ticker=normalized,
+        bars=bars,
+        sessions=sessions,
+        parameter_set=parameter_set,
+        whipsaw_window_sessions=whipsaw_window_sessions,
+        outcome_horizon_sessions=outcome_horizon_sessions,
+    )

--- a/crog-ai-backend/docs/MARKETCLUB-DOCHIA-BUILD-PLAN.md
+++ b/crog-ai-backend/docs/MARKETCLUB-DOCHIA-BUILD-PLAN.md
@@ -90,6 +90,7 @@ Base app entrypoint: `app.main:app`
 | `GET /api/financial/signals/watchlist-candidates` | portfolio-lens lanes with legacy watchlist context |
 | `GET /api/financial/signals/calibration/daily` | daily MarketClub truth calibration metrics |
 | `GET /api/financial/signals/{ticker}/chart` | EOD bars, rolling channels, and triangle overlay events |
+| `GET /api/financial/signals/{ticker}/whipsaw-risk` | symbol whipsaw count/rate and forward-return evidence |
 | `GET /api/financial/signals/{ticker}` | symbol-level latest score plus recent transitions |
 
 Useful query params:
@@ -101,6 +102,8 @@ Useful query params:
 - `watchlist-candidates`: `limit`, optional `parameter_set`
 - `calibration/daily`: `since`, `until`, `ticker`, `parameter_set`, `top_tickers`
 - `{ticker}/chart`: `sessions`, `as_of`
+- `{ticker}/whipsaw-risk`: `sessions`, `as_of`, optional `parameter_set`,
+  `whipsaw_window_sessions`, `outcome_horizon_sessions`
 - `{ticker}`: `transition_limit`, `lookback_days`, optional `parameter_set`
 
 ## Operations
@@ -228,6 +231,11 @@ Useful query params:
   rows collapse exact F1 into the 6.57%-14.07% range, and holdout rows with
   95%+ event reduction stay below 7.41% F1. Do not persist this as a filter;
   surface whipsaw risk as evidence in the app.
+- Added the Whipsaw Risk / Backtest app surface. Backend endpoint
+  `/api/financial/signals/{ticker}/whipsaw-risk` returns selected-symbol daily
+  whipsaw count/rate, risk level, 5-session forward-return outcome, and recent
+  daily events for either production or v0.2 Range mode. The Command Center
+  Hedge Fund cockpit now renders that evidence beside the selected ticker chart.
 - Added and enabled `crog-ai-backend.service` on spark-node-2.
 - Promoted the Command Center production build and restarted
   `crog-ai-frontend.service`; `/financial/hedge-fund` is live through
@@ -237,6 +245,6 @@ Useful query params:
   status, and live backend/BFF reads for both production and v0.2 candidate
   selectors. `/financial/hedge-fund` returns 200 after frontend restart.
 
-Next clean build step: add a user-facing Whipsaw Risk / Backtest panel to the
-Hedge Fund cockpit so noisy names are explainable without suppressing validated
-daily range signals.
+Next clean build step: use the Whipsaw Risk / Backtest evidence to add a compact
+promotion-gate panel that compares production and v0.2 Range side by side before
+any `market_signals` promotion.

--- a/crog-ai-backend/tests/test_api_signals.py
+++ b/crog-ai-backend/tests/test_api_signals.py
@@ -232,6 +232,51 @@ class FakeSignalStore:
             ],
         }
 
+    def symbol_whipsaw_risk(
+        self,
+        *,
+        ticker: str,
+        sessions: int,
+        as_of: dt.date | None = None,
+        parameter_set: str | None = None,
+        whipsaw_window_sessions: int = 5,
+        outcome_horizon_sessions: int = 5,
+    ) -> dict[str, Any]:
+        return {
+            "ticker": ticker,
+            "parameter_set_name": parameter_set or "dochia_v0_estimated",
+            "daily_trigger_mode": "range" if parameter_set else "close",
+            "sessions": sessions,
+            "as_of": as_of or dt.date(2026, 4, 24),
+            "whipsaw_window_sessions": whipsaw_window_sessions,
+            "outcome_horizon_sessions": outcome_horizon_sessions,
+            "event_count": 4,
+            "whipsaw_count": 2,
+            "whipsaw_rate": 2 / 3,
+            "latest_whipsaw_date": dt.date(2026, 4, 22),
+            "risk_score": 67,
+            "risk_level": "elevated",
+            "outcome": {
+                "horizon_sessions": outcome_horizon_sessions,
+                "evaluated_events": 3,
+                "win_count": 2,
+                "win_rate": 2 / 3,
+                "average_directional_return": 0.0123,
+                "median_directional_return": 0.01,
+                "p25_directional_return": -0.005,
+                "p75_directional_return": 0.02,
+            },
+            "recent_events": [
+                {
+                    "event_date": dt.date(2026, 4, 22),
+                    "state": "green",
+                    "sessions_since_previous": 2,
+                    "is_whipsaw": True,
+                    "directional_return": 0.018,
+                }
+            ],
+        }
+
 
 def test_latest_scores_endpoint_returns_scanner_rows() -> None:
     app = create_app()
@@ -394,6 +439,27 @@ def test_symbol_chart_endpoint_accepts_parameter_set_selector() -> None:
     payload = response.json()
     assert payload["parameter_set_name"] == "dochia_v0_2_range_daily"
     assert payload["daily_trigger_mode"] == "range"
+
+
+def test_symbol_whipsaw_risk_endpoint_returns_backtest_context() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/financial/signals/aa/whipsaw-risk"
+        "?sessions=60&parameter_set=dochia_v0_2_range_daily"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ticker"] == "AA"
+    assert payload["parameter_set_name"] == "dochia_v0_2_range_daily"
+    assert payload["daily_trigger_mode"] == "range"
+    assert payload["whipsaw_count"] == 2
+    assert payload["risk_level"] == "elevated"
+    assert payload["outcome"]["horizon_sessions"] == 5
+    assert payload["recent_events"][0]["is_whipsaw"] is True
 
 
 def test_symbol_signal_detail_404_when_no_latest_score() -> None:

--- a/crog-ai-backend/tests/test_whipsaw_risk.py
+++ b/crog-ai-backend/tests/test_whipsaw_risk.py
@@ -1,0 +1,46 @@
+import datetime as dt
+from decimal import Decimal
+
+from app.signals.trade_triangles import EodBar
+from app.signals.whipsaw_risk import build_symbol_whipsaw_risk
+
+
+def _bar(day: int, *, high: str, low: str, close: str) -> EodBar:
+    close_decimal = Decimal(close)
+    return EodBar(
+        ticker="AA",
+        bar_date=dt.date(2026, 1, day),
+        open=close_decimal,
+        high=Decimal(high),
+        low=Decimal(low),
+        close=close_decimal,
+        volume=1000,
+    )
+
+
+def test_build_symbol_whipsaw_risk_flags_fast_reversals_and_outcomes() -> None:
+    bars = [
+        _bar(1, high="11", low="9", close="10"),
+        _bar(2, high="12", low="10", close="11"),
+        _bar(3, high="12", low="10", close="11"),
+        _bar(4, high="14", low="12", close="13"),
+        _bar(5, high="9", low="7", close="8"),
+        _bar(6, high="16", low="14", close="15"),
+        _bar(7, high="17", low="15", close="16"),
+    ]
+
+    payload = build_symbol_whipsaw_risk(
+        ticker="AA",
+        bars=bars,
+        sessions=7,
+        whipsaw_window_sessions=2,
+        outcome_horizon_sessions=1,
+    )
+
+    assert payload["event_count"] == 3
+    assert payload["whipsaw_count"] == 2
+    assert payload["whipsaw_rate"] == 1
+    assert payload["risk_level"] == "high"
+    assert payload["outcome"]["evaluated_events"] == 3
+    assert payload["recent_events"][0]["event_date"] == dt.date(2026, 1, 6)
+    assert payload["recent_events"][0]["is_whipsaw"] is True

--- a/docs/operational/MASTER-PLAN.md
+++ b/docs/operational/MASTER-PLAN.md
@@ -263,7 +263,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 | Candidate persisted state | v0.2 candidate has 328 `signal_scores` rows and 1,624 `signal_transitions` rows under non-production parameter set; internal API/BFF selector live for scanner, transitions, symbol detail, Portfolio Lens, and chart overlays |
 | Candidate lane comparison | v0.2 bullish lane unchanged at 129, risk unchanged at 47, re-entry 164→145, mixed 202→203, 61 daily states/scores change |
 | Promotion contract | Fresh Dochia scores still staged; legacy `market_signals` remains contextual until calibration/promotion |
-| UI state | Hedge Fund route live in production at `https://crog-ai.com/financial/hedge-fund` with scanner, synced chart overlays, alert feed, symbol panel, Portfolio Lens, Calibration Baseline, and internal Production/v0.2 Range toggle |
+| UI state | Hedge Fund route live in production at `https://crog-ai.com/financial/hedge-fund` with scanner, synced chart overlays, Whipsaw Risk / Backtest evidence, alert feed, symbol panel, Portfolio Lens, Calibration Baseline, and internal Production/v0.2 Range toggle |
 
 **Signal doctrine:**
 
@@ -280,8 +280,8 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 2. Database scorer: populate `hedge_fund.signal_scores` and `signal_transitions` idempotently. Complete initial fresh batch.
 3. Calibration harness: compare generated daily state/score against 24,204 MarketClub observations. Baseline complete; refinement remains.
 4. Production contract: promote approved signals to `hedge_fund.market_signals`.
-5. API surface: scanner, symbol detail, portfolio board, alert inbox, backtest lab, model health. Scanner, symbol detail, chart data, alert feed, watchlist-candidate lanes, and daily calibration endpoint complete.
-6. Command Center UI: Financial / Hedge Fund route with sober cockpit UX, not gamified retail nudges. First route, chart overlays, Portfolio Lens, and Calibration Baseline complete at `/financial/hedge-fund`.
+5. API surface: scanner, symbol detail, portfolio board, alert inbox, backtest lab, model health. Scanner, symbol detail, chart data, whipsaw/backtest evidence, alert feed, watchlist-candidate lanes, and daily calibration endpoint complete.
+6. Command Center UI: Financial / Hedge Fund route with sober cockpit UX, not gamified retail nudges. First route, chart overlays, Whipsaw Risk / Backtest, Portfolio Lens, and Calibration Baseline complete at `/financial/hedge-fund`.
 
 **Product principles:**
 
@@ -292,7 +292,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 - Do not call generated weekly/monthly states "MarketClub truth"; they are Dochia-derived.
 - Avoid gamified trading prompts; build an evidence cockpit.
 
-**Immediate next step:** Build a user-facing Whipsaw Risk / Backtest panel in the Hedge Fund cockpit so noisy names are visible and explainable without suppressing the validated v0.2 daily range signal.
+**Immediate next step:** Add a compact promotion-gate panel that compares production and v0.2 Range side by side before any `market_signals` promotion.
 
 ### 6.6 Architectural follow-ups
 
@@ -353,6 +353,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 - Added read-only v0.2 promotion-review harness covering top-lane churn, recent whipsaw/transition pressure, and chart-level candidate event deltas.
 - Ran first v0.2 promotion-review report. Decision: do not promote range trigger yet. Risk lane is stable, but re-entry lane churn is 66.7%, mixed-timeframe churn is 52.9%, top whipsaw tickers show 8-9 candidate transitions in the 30-day window, and reviewed chart overlays add up to 29 candidate-only daily events on some symbols.
 - Added and ran read-only v0.3 range-trigger guardrail research for break buffers, same-direction close confirmation, ATR-normalized buffers, trailing per-symbol adaptive cooldowns, return-conditioned outcomes, ticker whipsaw clusters, chronological ticker-cluster holdout, and rolling date-safe whipsaw suppressors. Decision: do not persist any v0.3 suppression filter; expose whipsaw risk and backtest evidence in the app instead.
+- Added the Whipsaw Risk / Backtest backend endpoint and cockpit panel. Selected tickers now show daily whipsaw count/rate, risk level, 5-session forward-return outcome, and recent daily event context for both production and v0.2 Range modes.
 - Added internal Production/v0.2 Range toggle to the Command Center Hedge Fund page and promoted the production frontend build.
 - Added chart-data endpoint and chart overlay with close, daily/weekly channel bands, and generated triangle event markers.
 - Refined calibration metrics to separate carried-state agreement from exact new-alert agreement: 40.67% same-day alert match and 52.54% ±3-day alert match.

--- a/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
+++ b/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
@@ -126,6 +126,41 @@ const chartData = {
   ],
 };
 
+const whipsawRisk = {
+  ticker: "AA",
+  parameter_set_name: "dochia_v0_estimated",
+  daily_trigger_mode: "close",
+  sessions: 260,
+  as_of: "2026-04-24",
+  whipsaw_window_sessions: 5,
+  outcome_horizon_sessions: 5,
+  event_count: 6,
+  whipsaw_count: 2,
+  whipsaw_rate: 0.4,
+  latest_whipsaw_date: "2026-04-22",
+  risk_score: 45,
+  risk_level: "elevated",
+  outcome: {
+    horizon_sessions: 5,
+    evaluated_events: 5,
+    win_count: 3,
+    win_rate: 0.6,
+    average_directional_return: 0.0123,
+    median_directional_return: 0.01,
+    p25_directional_return: -0.004,
+    p75_directional_return: 0.026,
+  },
+  recent_events: [
+    {
+      event_date: "2026-04-22",
+      state: "green",
+      sessions_since_previous: 2,
+      is_whipsaw: true,
+      directional_return: 0.018,
+    },
+  ],
+};
+
 vi.mock("recharts", () => ({
   CartesianGrid: () => null,
   Line: () => null,
@@ -262,6 +297,13 @@ vi.mock("@/lib/hooks", () => ({
     isLoading: false,
     refetch: vi.fn(),
   }),
+  useFinancialWhipsawRisk: () => ({
+    data: whipsawRisk,
+    isError: false,
+    isFetching: false,
+    isLoading: false,
+    refetch: vi.fn(),
+  }),
   useFinancialWatchlistCandidates: () => ({
     data: watchlistCandidates,
     isError: false,
@@ -294,6 +336,9 @@ describe("HedgeFundSignalsShell", () => {
     expect(screen.getByText("62.1%")).toBeInTheDocument();
     expect(screen.getByText("Chart Overlay")).toBeInTheDocument();
     expect(screen.getByText("1 triangle events")).toBeInTheDocument();
+    expect(screen.getByText("Whipsaw Risk / Backtest")).toBeInTheDocument();
+    expect(screen.getByText("Elevated")).toBeInTheDocument();
+    expect(screen.getByText("60.0%")).toBeInTheDocument();
     expect(screen.getAllByText("dochia_v0_estimated").length).toBeGreaterThan(0);
   });
 

--- a/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
+++ b/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
@@ -43,6 +43,7 @@ import {
   useFinancialSignalChart,
   useFinancialSignalTransitions,
   useFinancialWatchlistCandidates,
+  useFinancialWhipsawRisk,
 } from "@/lib/hooks";
 import type {
   FinancialDailyCalibrationResponse,
@@ -52,6 +53,8 @@ import type {
   FinancialTransitionType,
   FinancialWatchlistCandidate,
   FinancialWatchlistCandidateLane,
+  FinancialWhipsawRiskLevel,
+  FinancialWhipsawRiskResponse,
 } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
@@ -119,6 +122,12 @@ function formatPercent(value: number | null | undefined): string {
   return `${(value * 100).toFixed(1)}%`;
 }
 
+function formatSignedPercent(value: number | null | undefined): string {
+  if (value === null || value === undefined) return "—";
+  const sign = value > 0 ? "+" : "";
+  return `${sign}${(value * 100).toFixed(1)}%`;
+}
+
 function formatMetricNumber(value: number | null | undefined): string {
   if (value === null || value === undefined) return "—";
   return value.toFixed(1);
@@ -153,6 +162,18 @@ function transitionClasses(type: FinancialTransitionType): string {
     return "border-red-500/40 bg-red-500/10 text-red-600";
   }
   return "border-amber-500/40 bg-amber-500/10 text-amber-600";
+}
+
+function whipsawRiskClasses(level: FinancialWhipsawRiskLevel): string {
+  if (level === "high") return "border-red-500/40 bg-red-500/10 text-red-600";
+  if (level === "elevated") return "border-amber-500/40 bg-amber-500/10 text-amber-600";
+  return "border-emerald-500/40 bg-emerald-500/10 text-emerald-600";
+}
+
+function whipsawRiskLabel(level: FinancialWhipsawRiskLevel): string {
+  if (level === "high") return "High";
+  if (level === "elevated") return "Elevated";
+  return "Quiet";
 }
 
 function StatePill({ label, value }: { label: string; value: number }) {
@@ -737,6 +758,153 @@ function SignalChart({
   );
 }
 
+function WhipsawRiskPanel({
+  risk,
+  loading,
+  error,
+}: {
+  risk: FinancialWhipsawRiskResponse | null;
+  loading: boolean;
+  error: boolean;
+}) {
+  if (error) {
+    return (
+      <div className="flex items-center gap-2 border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+        <AlertTriangle className="h-4 w-4" />
+        Whipsaw risk unavailable.
+      </div>
+    );
+  }
+
+  if (loading && !risk) {
+    return <div className="py-8 text-sm text-muted-foreground">Loading whipsaw risk…</div>;
+  }
+
+  if (!risk) {
+    return (
+      <div className="border border-dashed border-border p-5 text-sm text-muted-foreground">
+        No whipsaw risk data.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-4">
+        <div className="border border-border p-3">
+          <p className="text-xs text-muted-foreground">Risk</p>
+          <div className="mt-2 flex items-center gap-2">
+            <Badge variant="outline" className={cn("font-medium", whipsawRiskClasses(risk.risk_level))}>
+              {whipsawRiskLabel(risk.risk_level)}
+            </Badge>
+            <span className="font-mono text-sm font-semibold">{risk.risk_score}</span>
+          </div>
+        </div>
+        <div className="border border-border p-3">
+          <p className="text-xs text-muted-foreground">Whipsaws</p>
+          <p className="mt-1 font-mono text-xl font-bold">
+            {risk.whipsaw_count}
+            <span className="text-xs font-normal text-muted-foreground"> / {risk.event_count}</span>
+          </p>
+        </div>
+        <div className="border border-border p-3">
+          <p className="text-xs text-muted-foreground">
+            {risk.outcome_horizon_sessions}d Win
+          </p>
+          <p className="mt-1 font-mono text-xl font-bold">
+            {formatPercent(risk.outcome.win_rate)}
+          </p>
+        </div>
+        <div className="border border-border p-3">
+          <p className="text-xs text-muted-foreground">
+            Avg {risk.outcome_horizon_sessions}d
+          </p>
+          <p
+            className={cn(
+              "mt-1 font-mono text-xl font-bold",
+              (risk.outcome.average_directional_return ?? 0) >= 0
+                ? "text-emerald-500"
+                : "text-red-500",
+            )}
+          >
+            {formatSignedPercent(risk.outcome.average_directional_return)}
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,0.75fr)_minmax(0,1fr)]">
+        <div className="border border-border p-3">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-sm font-semibold">Backtest</h2>
+            <span className="text-xs text-muted-foreground">
+              {risk.outcome.evaluated_events} events
+            </span>
+          </div>
+          <div className="mt-3 grid grid-cols-2 gap-2 text-xs">
+            <div className="bg-muted/40 p-2">
+              <span className="text-muted-foreground">Median</span>
+              <p className="mt-1 font-mono font-semibold">
+                {formatSignedPercent(risk.outcome.median_directional_return)}
+              </p>
+            </div>
+            <div className="bg-muted/40 p-2">
+              <span className="text-muted-foreground">Whipsaw Rate</span>
+              <p className="mt-1 font-mono font-semibold">{formatPercent(risk.whipsaw_rate)}</p>
+            </div>
+            <div className="bg-muted/40 p-2">
+              <span className="text-muted-foreground">P25</span>
+              <p className="mt-1 font-mono font-semibold">
+                {formatSignedPercent(risk.outcome.p25_directional_return)}
+              </p>
+            </div>
+            <div className="bg-muted/40 p-2">
+              <span className="text-muted-foreground">P75</span>
+              <p className="mt-1 font-mono font-semibold">
+                {formatSignedPercent(risk.outcome.p75_directional_return)}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="border border-border p-3">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-sm font-semibold">Recent Daily Events</h2>
+            <span className="text-xs text-muted-foreground">
+              {risk.daily_trigger_mode} · {risk.sessions} sessions
+            </span>
+          </div>
+          <div className="mt-3 space-y-2">
+            {risk.recent_events.length ? (
+              risk.recent_events.slice(0, 5).map((event) => (
+                <div
+                  key={`${event.event_date}-${event.state}`}
+                  className="grid grid-cols-[82px_72px_minmax(0,1fr)_68px] items-center gap-2 text-xs"
+                >
+                  <span className="font-mono text-muted-foreground">{formatDate(event.event_date)}</span>
+                  <Badge variant="outline" className={cn("justify-center", stateClasses(event.state === "green" ? 1 : -1))}>
+                    {event.state}
+                  </Badge>
+                  <span className="truncate text-muted-foreground">
+                    {event.is_whipsaw ? "Flip" : "Trend"} ·{" "}
+                    {event.sessions_since_previous ?? "—"} sessions
+                  </span>
+                  <span className="text-right font-mono font-semibold">
+                    {formatSignedPercent(event.directional_return)}
+                  </span>
+                </div>
+              ))
+            ) : (
+              <div className="border border-dashed border-border p-3 text-xs text-muted-foreground">
+                No recent daily events.
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function SymbolPanel({
   signal,
   transitions,
@@ -744,6 +912,9 @@ function SymbolPanel({
   chart,
   chartLoading,
   chartError,
+  whipsawRisk,
+  whipsawLoading,
+  whipsawError,
 }: {
   signal: FinancialLatestSignal | null;
   transitions: FinancialSignalTransition[];
@@ -751,6 +922,9 @@ function SymbolPanel({
   chart: FinancialSignalChartResponse | null;
   chartLoading: boolean;
   chartError: boolean;
+  whipsawRisk: FinancialWhipsawRiskResponse | null;
+  whipsawLoading: boolean;
+  whipsawError: boolean;
 }) {
   if (loading && !signal) {
     return (
@@ -822,6 +996,20 @@ function SymbolPanel({
 
         <div className="space-y-3">
           <div className="flex items-center justify-between gap-3">
+            <h2 className="text-sm font-semibold">Whipsaw Risk / Backtest</h2>
+            <span className="text-xs text-muted-foreground">
+              {formatDate(whipsawRisk?.as_of)}
+            </span>
+          </div>
+          <WhipsawRiskPanel
+            risk={whipsawRisk}
+            loading={whipsawLoading}
+            error={whipsawError}
+          />
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between gap-3">
             <h2 className="text-sm font-semibold">Recent Transitions</h2>
             <span className="text-xs text-muted-foreground">{formatDate(signal.bar_date)}</span>
           </div>
@@ -878,6 +1066,12 @@ export function HedgeFundSignalsShell() {
     sessions: 180,
     parameter_set: activeParameterSet,
   });
+  const whipsawRisk = useFinancialWhipsawRisk(activeTicker, {
+    sessions: 260,
+    parameter_set: activeParameterSet,
+    whipsaw_window_sessions: 5,
+    outcome_horizon_sessions: 5,
+  });
 
   const selectedSignal =
     detail.data?.latest ?? signals.find((signal) => signal.ticker === activeTicker) ?? null;
@@ -898,6 +1092,7 @@ export function HedgeFundSignalsShell() {
     transitions.isFetching ||
     detail.isFetching ||
     chart.isFetching ||
+    whipsawRisk.isFetching ||
     watchlistCandidates.isFetching ||
     dailyCalibration.isFetching;
 
@@ -945,6 +1140,7 @@ export function HedgeFundSignalsShell() {
               void transitions.refetch();
               void detail.refetch();
               void chart.refetch();
+              void whipsawRisk.refetch();
               void watchlistCandidates.refetch();
               void dailyCalibration.refetch();
             }}
@@ -1104,6 +1300,9 @@ export function HedgeFundSignalsShell() {
             chart={chart.data ?? null}
             chartLoading={chart.isLoading}
             chartError={chart.isError}
+            whipsawRisk={whipsawRisk.data ?? null}
+            whipsawLoading={whipsawRisk.isLoading}
+            whipsawError={whipsawRisk.isError}
           />
 
           <Card>

--- a/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
@@ -18,6 +18,7 @@ import type {
   FinancialSymbolSignalDetail,
   FinancialTransitionType,
   FinancialWatchlistCandidatesResponse,
+  FinancialWhipsawRiskResponse,
   ReviewQueueItem,
   ConversationThread,
   MessageTemplate,
@@ -140,6 +141,27 @@ export function useFinancialSignalChart(
   return useQuery<FinancialSignalChartResponse>({
     queryKey: ["financial", "signals", "chart", normalized, params],
     queryFn: () => api.get(`/api/financial/signals/${encodeURIComponent(normalized)}/chart`, params),
+    enabled: Boolean(normalized),
+    refetchInterval: 60_000,
+    staleTime: 15_000,
+  });
+}
+
+export function useFinancialWhipsawRisk(
+  ticker: string | null,
+  params?: {
+    sessions?: number;
+    as_of?: string;
+    parameter_set?: string;
+    whipsaw_window_sessions?: number;
+    outcome_horizon_sessions?: number;
+  },
+) {
+  const normalized = ticker?.trim().toUpperCase() ?? "";
+  return useQuery<FinancialWhipsawRiskResponse>({
+    queryKey: ["financial", "signals", "whipsaw-risk", normalized, params],
+    queryFn: () =>
+      api.get(`/api/financial/signals/${encodeURIComponent(normalized)}/whipsaw-risk`, params),
     enabled: Boolean(normalized),
     refetchInterval: 60_000,
     staleTime: 15_000,

--- a/fortress-guest-platform/apps/command-center/src/lib/types.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/types.ts
@@ -230,6 +230,45 @@ export interface FinancialSignalChartResponse {
   events: FinancialSignalChartEvent[];
 }
 
+export type FinancialWhipsawRiskLevel = "quiet" | "elevated" | "high";
+
+export interface FinancialWhipsawOutcome {
+  horizon_sessions: number;
+  evaluated_events: number;
+  win_count: number;
+  win_rate: number | null;
+  average_directional_return: number | null;
+  median_directional_return: number | null;
+  p25_directional_return: number | null;
+  p75_directional_return: number | null;
+}
+
+export interface FinancialWhipsawEvent {
+  event_date: string;
+  state: "green" | "red" | "neutral";
+  sessions_since_previous: number | null;
+  is_whipsaw: boolean;
+  directional_return: number | null;
+}
+
+export interface FinancialWhipsawRiskResponse {
+  ticker: string;
+  parameter_set_name: string;
+  daily_trigger_mode: "close" | "range";
+  sessions: number;
+  as_of: string | null;
+  whipsaw_window_sessions: number;
+  outcome_horizon_sessions: number;
+  event_count: number;
+  whipsaw_count: number;
+  whipsaw_rate: number | null;
+  latest_whipsaw_date: string | null;
+  risk_score: number;
+  risk_level: FinancialWhipsawRiskLevel;
+  outcome: FinancialWhipsawOutcome;
+  recent_events: FinancialWhipsawEvent[];
+}
+
 export interface FinancialWatchlistCandidate {
   ticker: string;
   bar_date: string;


### PR DESCRIPTION
Adds a selected-symbol Whipsaw Risk / Backtest surface for the Dochia Hedge Fund cockpit. Backend: new read-only /api/financial/signals/{ticker}/whipsaw-risk endpoint with daily whipsaw count/rate, risk score/level, 5-session forward-return outcome, and recent event evidence. Frontend: Hedge Fund symbol panel now fetches and renders that evidence for production and v0.2 Range modes. Docs/master plan updated: next clean step is the promotion-gate comparison panel. Verification: 40 backend signal/API tests, ruff, live DB smoke (AA v0.2 range: high, 57 events, 38 whipsaws), focused Hedge Fund UI test, focused frontend lint, TypeScript, and production Command Center build passed.