### PR TITLE
feat(financial): add promotion gate panel

### DIFF
--- a/crog-ai-backend/app/api/signals.py
+++ b/crog-ai-backend/app/api/signals.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import datetime as dt
 from decimal import Decimal
 from enum import StrEnum
-from typing import Annotated
+from typing import Annotated, Literal
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
@@ -165,6 +165,69 @@ class DailyCalibrationResponse(BaseModel):
     confusion: dict[str, dict[str, int]]
     event_confusion: dict[str, dict[str, int]]
     top_tickers: list[TickerCalibrationStats]
+
+
+class PromotionGateCalibrationSummary(BaseModel):
+    total_observations: int
+    covered_observations: int
+    accuracy: float | None
+    exact_event_accuracy: float | None
+    window_event_accuracy: float | None
+    coverage_rate: float | None
+    exact_coverage_rate: float | None
+    score_mae: float | None
+    score_rmse: float | None
+
+
+class PromotionGateModelSummary(BaseModel):
+    id: Literal["production", "candidate"]
+    label: str
+    parameter_set_name: str
+    daily_trigger_mode: str
+    latest_bar_date: dt.date | None
+    signal_count: int
+    bullish_count: int
+    risk_count: int
+    neutral_count: int
+    reentry_count: int
+    average_score: float | None
+    calibration: PromotionGateCalibrationSummary
+
+
+class PromotionGateDeltas(BaseModel):
+    window_event_accuracy: float | None
+    exact_event_accuracy: float | None
+    coverage_rate: float | None
+    score_mae: float | None
+    signal_count: int
+    reentry_count: int
+
+
+class PromotionGateGuardrail(BaseModel):
+    id: str
+    label: str
+    status: Literal["pass", "watch", "fail"]
+    detail: str
+
+
+class PromotionGateRecommendation(BaseModel):
+    status: Literal["hold", "review", "ready_for_shadow"]
+    label: str
+    rationale: str
+
+
+class PromotionGateResponse(BaseModel):
+    generated_at: dt.datetime
+    candidate_parameter_set: str
+    baseline_parameter_set: str
+    since: dt.date | None
+    until: dt.date | None
+    event_window_days: int
+    production: PromotionGateModelSummary
+    candidate: PromotionGateModelSummary
+    deltas: PromotionGateDeltas
+    guardrails: list[PromotionGateGuardrail]
+    recommendation: PromotionGateRecommendation
 
 
 class SymbolChartBar(BaseModel):
@@ -347,6 +410,28 @@ def daily_calibration(
         until=until,
         ticker=ticker,
         parameter_set=parameter_set,
+        top_tickers=top_tickers,
+        event_window_days=event_window_days,
+    )
+
+
+@router.get("/promotion-gate/daily", response_model=PromotionGateResponse)
+def promotion_gate_daily(
+    store: Annotated[SignalDataStore, Depends(get_signal_store)],
+    candidate_parameter_set: Annotated[
+        str, Query(min_length=1, max_length=100)
+    ] = "dochia_v0_2_range_daily",
+    since: dt.date | None = None,
+    until: dt.date | None = None,
+    top_tickers: Annotated[int, Query(ge=1, le=100)] = 20,
+    event_window_days: Annotated[int, Query(ge=0, le=10)] = 3,
+) -> dict[str, object]:
+    if since is not None and until is not None and since > until:
+        raise HTTPException(status_code=400, detail="since cannot be after until")
+    return store.promotion_gate(
+        candidate_parameter_set=candidate_parameter_set,
+        since=since,
+        until=until,
         top_tickers=top_tickers,
         event_window_days=event_window_days,
     )

--- a/crog-ai-backend/app/signals/repository.py
+++ b/crog-ai-backend/app/signals/repository.py
@@ -10,7 +10,11 @@ from psycopg.rows import dict_row
 
 from app.database import connect
 from app.signals.calibration_repository import fetch_daily_calibration
-from app.signals.chart_repository import fetch_symbol_chart
+from app.signals.chart_repository import (
+    PRODUCTION_PARAMETER_SET,
+    daily_trigger_mode_for_parameter_set,
+    fetch_symbol_chart,
+)
 from app.signals.whipsaw_risk import fetch_symbol_whipsaw_risk
 
 
@@ -50,6 +54,16 @@ class SignalDataStore(Protocol):
         until: dt.date | None = None,
         ticker: str | None = None,
         parameter_set: str | None = None,
+        top_tickers: int = 20,
+        event_window_days: int = 3,
+    ) -> dict[str, Any]: ...
+
+    def promotion_gate(
+        self,
+        *,
+        candidate_parameter_set: str,
+        since: dt.date | None = None,
+        until: dt.date | None = None,
         top_tickers: int = 20,
         event_window_days: int = 3,
     ) -> dict[str, Any]: ...
@@ -229,6 +243,271 @@ def fetch_recent_transitions(
     with conn.cursor(row_factory=dict_row) as cur:
         cur.execute(sql, params)
         return [dict(row) for row in cur.fetchall()]
+
+
+def _safe_average_score(rows: list[dict[str, Any]]) -> float | None:
+    if not rows:
+        return None
+    return sum(int(row["composite_score"]) for row in rows) / len(rows)
+
+
+def _calibration_metric(calibration: dict[str, Any], key: str) -> float | None:
+    value = calibration.get(key)
+    if value is None:
+        return None
+    return float(value)
+
+
+def _metric_delta(
+    *,
+    candidate: dict[str, Any],
+    production: dict[str, Any],
+    key: str,
+) -> float | None:
+    candidate_value = _calibration_metric(candidate, key)
+    production_value = _calibration_metric(production, key)
+    if candidate_value is None or production_value is None:
+        return None
+    return candidate_value - production_value
+
+
+def _promotion_model_summary(
+    *,
+    id: str,
+    label: str,
+    parameter_set: str | None,
+    latest_rows: list[dict[str, Any]],
+    transition_rows: list[dict[str, Any]],
+    calibration: dict[str, Any],
+) -> dict[str, Any]:
+    latest_dates = [row["bar_date"] for row in latest_rows if row.get("bar_date") is not None]
+    signal_count = len(latest_rows)
+    bullish_count = sum(1 for row in latest_rows if int(row["composite_score"]) >= 50)
+    risk_count = sum(1 for row in latest_rows if int(row["composite_score"]) <= -50)
+    neutral_count = sum(1 for row in latest_rows if -30 <= int(row["composite_score"]) <= 30)
+    reentry_count = sum(
+        1 for row in transition_rows if str(row["transition_type"]) == "exit_to_reentry"
+    )
+    return {
+        "id": id,
+        "label": label,
+        "parameter_set_name": str(calibration["parameter_set_name"]),
+        "daily_trigger_mode": daily_trigger_mode_for_parameter_set(parameter_set).value,
+        "latest_bar_date": max(latest_dates) if latest_dates else None,
+        "signal_count": signal_count,
+        "bullish_count": bullish_count,
+        "risk_count": risk_count,
+        "neutral_count": neutral_count,
+        "reentry_count": reentry_count,
+        "average_score": _safe_average_score(latest_rows),
+        "calibration": {
+            "total_observations": int(calibration["total_observations"]),
+            "covered_observations": int(calibration["covered_observations"]),
+            "accuracy": calibration["accuracy"],
+            "exact_event_accuracy": calibration["exact_event_accuracy"],
+            "window_event_accuracy": calibration["window_event_accuracy"],
+            "coverage_rate": calibration["coverage_rate"],
+            "exact_coverage_rate": calibration["exact_coverage_rate"],
+            "score_mae": calibration["score_mae"],
+            "score_rmse": calibration["score_rmse"],
+        },
+    }
+
+
+def _promotion_guardrails(
+    *,
+    production: dict[str, Any],
+    candidate: dict[str, Any],
+) -> list[dict[str, str]]:
+    production_calibration = production["calibration"]
+    candidate_calibration = candidate["calibration"]
+    window_delta = _metric_delta(
+        candidate=candidate_calibration,
+        production=production_calibration,
+        key="window_event_accuracy",
+    )
+    coverage_delta = _metric_delta(
+        candidate=candidate_calibration,
+        production=production_calibration,
+        key="coverage_rate",
+    )
+    score_mae_delta = _metric_delta(
+        candidate=candidate_calibration,
+        production=production_calibration,
+        key="score_mae",
+    )
+    production_signal_count = max(int(production["signal_count"]), 1)
+    signal_count_delta_rate = (
+        int(candidate["signal_count"]) - int(production["signal_count"])
+    ) / production_signal_count
+
+    window_status = "pass"
+    if window_delta is None or window_delta < -0.03:
+        window_status = "fail"
+    elif window_delta < 0:
+        window_status = "watch"
+
+    coverage_status = "pass"
+    candidate_coverage = _calibration_metric(candidate_calibration, "coverage_rate")
+    if candidate_coverage is None or (
+        candidate_coverage < 0.75 or (coverage_delta is not None and coverage_delta < -0.05)
+    ):
+        coverage_status = "fail"
+    elif coverage_delta is not None and coverage_delta < -0.02:
+        coverage_status = "watch"
+
+    score_mae_status = "pass"
+    if score_mae_delta is None or score_mae_delta > 8:
+        score_mae_status = "fail"
+    elif score_mae_delta > 3:
+        score_mae_status = "watch"
+
+    scanner_status = "pass"
+    if candidate["signal_count"] == 0:
+        scanner_status = "fail"
+    elif abs(signal_count_delta_rate) > 0.35:
+        scanner_status = "watch"
+
+    return [
+        {
+            "id": "window_event_accuracy",
+            "label": "Window alert match",
+            "status": window_status,
+            "detail": "Candidate should not materially trail production on ± window alert matches.",
+        },
+        {
+            "id": "coverage_rate",
+            "label": "Observation coverage",
+            "status": coverage_status,
+            "detail": "Candidate needs broad MarketClub observation coverage before promotion.",
+        },
+        {
+            "id": "score_mae",
+            "label": "Score error",
+            "status": score_mae_status,
+            "detail": "Candidate score error should stay close to production.",
+        },
+        {
+            "id": "scanner_count",
+            "label": "Scanner posture",
+            "status": scanner_status,
+            "detail": "Candidate should not radically collapse or inflate the visible signal book.",
+        },
+    ]
+
+
+def _promotion_recommendation(guardrails: list[dict[str, str]]) -> dict[str, str]:
+    statuses = {guardrail["status"] for guardrail in guardrails}
+    if "fail" in statuses:
+        return {
+            "status": "hold",
+            "label": "Hold promotion",
+            "rationale": "One or more guardrails are below the promotion threshold.",
+        }
+    if "watch" in statuses:
+        return {
+            "status": "review",
+            "label": "Review before promotion",
+            "rationale": "No hard failure, but at least one metric needs human review.",
+        }
+    return {
+        "status": "ready_for_shadow",
+        "label": "Ready for shadow",
+        "rationale": "Candidate clears the compact promotion gate for supervised shadow review.",
+    }
+
+
+def fetch_promotion_gate(
+    conn: psycopg.Connection,
+    *,
+    candidate_parameter_set: str,
+    since: dt.date | None = None,
+    until: dt.date | None = None,
+    top_tickers: int = 20,
+    event_window_days: int = 3,
+) -> dict[str, Any]:
+    production_latest = fetch_latest_scores(conn, limit=500)
+    candidate_latest = fetch_latest_scores(
+        conn,
+        limit=500,
+        parameter_set=candidate_parameter_set,
+    )
+    production_transitions = fetch_recent_transitions(conn, limit=500, lookback_days=30)
+    candidate_transitions = fetch_recent_transitions(
+        conn,
+        limit=500,
+        lookback_days=30,
+        parameter_set=candidate_parameter_set,
+    )
+    production_calibration = fetch_daily_calibration(
+        conn,
+        since=since,
+        until=until,
+        top_tickers=top_tickers,
+        event_window_days=event_window_days,
+    ).as_json_dict()
+    candidate_calibration = fetch_daily_calibration(
+        conn,
+        since=since,
+        until=until,
+        parameter_set=candidate_parameter_set,
+        top_tickers=top_tickers,
+        event_window_days=event_window_days,
+    ).as_json_dict()
+    production = _promotion_model_summary(
+        id="production",
+        label="Production",
+        parameter_set=None,
+        latest_rows=production_latest,
+        transition_rows=production_transitions,
+        calibration=production_calibration,
+    )
+    candidate = _promotion_model_summary(
+        id="candidate",
+        label="v0.2 Range",
+        parameter_set=candidate_parameter_set,
+        latest_rows=candidate_latest,
+        transition_rows=candidate_transitions,
+        calibration=candidate_calibration,
+    )
+    deltas = {
+        "window_event_accuracy": _metric_delta(
+            candidate=candidate["calibration"],
+            production=production["calibration"],
+            key="window_event_accuracy",
+        ),
+        "exact_event_accuracy": _metric_delta(
+            candidate=candidate["calibration"],
+            production=production["calibration"],
+            key="exact_event_accuracy",
+        ),
+        "coverage_rate": _metric_delta(
+            candidate=candidate["calibration"],
+            production=production["calibration"],
+            key="coverage_rate",
+        ),
+        "score_mae": _metric_delta(
+            candidate=candidate["calibration"],
+            production=production["calibration"],
+            key="score_mae",
+        ),
+        "signal_count": int(candidate["signal_count"]) - int(production["signal_count"]),
+        "reentry_count": int(candidate["reentry_count"]) - int(production["reentry_count"]),
+    }
+    guardrails = _promotion_guardrails(production=production, candidate=candidate)
+    return {
+        "generated_at": dt.datetime.now(dt.UTC),
+        "candidate_parameter_set": candidate_parameter_set,
+        "baseline_parameter_set": PRODUCTION_PARAMETER_SET,
+        "since": since,
+        "until": until,
+        "event_window_days": event_window_days,
+        "production": production,
+        "candidate": candidate,
+        "deltas": deltas,
+        "guardrails": guardrails,
+        "recommendation": _promotion_recommendation(guardrails),
+    }
 
 
 WATCHLIST_CANDIDATE_BASE_SQL = """
@@ -442,6 +721,26 @@ class PostgresSignalDataStore:
                 top_tickers=top_tickers,
                 event_window_days=event_window_days,
             ).as_json_dict()
+
+    def promotion_gate(
+        self,
+        *,
+        candidate_parameter_set: str,
+        since: dt.date | None = None,
+        until: dt.date | None = None,
+        top_tickers: int = 20,
+        event_window_days: int = 3,
+    ) -> dict[str, Any]:
+        with connect() as conn:
+            conn.execute("SET default_transaction_read_only = on")
+            return fetch_promotion_gate(
+                conn,
+                candidate_parameter_set=candidate_parameter_set,
+                since=since,
+                until=until,
+                top_tickers=top_tickers,
+                event_window_days=event_window_days,
+            )
 
     def symbol_chart(
         self,

--- a/crog-ai-backend/tests/test_api_signals.py
+++ b/crog-ai-backend/tests/test_api_signals.py
@@ -172,6 +172,111 @@ class FakeSignalStore:
             ][:top_tickers],
         }
 
+    def promotion_gate(
+        self,
+        *,
+        candidate_parameter_set: str,
+        since: dt.date | None = None,
+        until: dt.date | None = None,
+        top_tickers: int = 20,
+        event_window_days: int = 3,
+    ) -> dict[str, Any]:
+        production_calibration = self.daily_calibration(
+            since=since,
+            until=until,
+            top_tickers=top_tickers,
+            event_window_days=event_window_days,
+        )
+        candidate_calibration = {
+            **self.daily_calibration(
+                since=since,
+                until=until,
+                parameter_set=candidate_parameter_set,
+                top_tickers=top_tickers,
+                event_window_days=event_window_days,
+            ),
+            "window_event_accuracy": 0.46,
+            "exact_event_accuracy": 0.3,
+            "score_mae": 42.0,
+        }
+        return {
+            "generated_at": dt.datetime(2026, 5, 2, 22, 0, tzinfo=dt.UTC),
+            "candidate_parameter_set": candidate_parameter_set,
+            "baseline_parameter_set": "dochia_v0_estimated",
+            "since": since,
+            "until": until,
+            "event_window_days": event_window_days,
+            "production": {
+                "id": "production",
+                "label": "Production",
+                "parameter_set_name": production_calibration["parameter_set_name"],
+                "daily_trigger_mode": "close",
+                "latest_bar_date": dt.date(2026, 4, 24),
+                "signal_count": 120,
+                "bullish_count": 40,
+                "risk_count": 20,
+                "neutral_count": 18,
+                "reentry_count": 7,
+                "average_score": 12.5,
+                "calibration": {
+                    "total_observations": production_calibration["total_observations"],
+                    "covered_observations": production_calibration["covered_observations"],
+                    "accuracy": production_calibration["accuracy"],
+                    "exact_event_accuracy": production_calibration["exact_event_accuracy"],
+                    "window_event_accuracy": production_calibration["window_event_accuracy"],
+                    "coverage_rate": production_calibration["coverage_rate"],
+                    "exact_coverage_rate": production_calibration["exact_coverage_rate"],
+                    "score_mae": production_calibration["score_mae"],
+                    "score_rmse": production_calibration["score_rmse"],
+                },
+            },
+            "candidate": {
+                "id": "candidate",
+                "label": "v0.2 Range",
+                "parameter_set_name": candidate_parameter_set,
+                "daily_trigger_mode": "range",
+                "latest_bar_date": dt.date(2026, 4, 24),
+                "signal_count": 118,
+                "bullish_count": 43,
+                "risk_count": 21,
+                "neutral_count": 15,
+                "reentry_count": 9,
+                "average_score": 14.0,
+                "calibration": {
+                    "total_observations": candidate_calibration["total_observations"],
+                    "covered_observations": candidate_calibration["covered_observations"],
+                    "accuracy": candidate_calibration["accuracy"],
+                    "exact_event_accuracy": candidate_calibration["exact_event_accuracy"],
+                    "window_event_accuracy": candidate_calibration["window_event_accuracy"],
+                    "coverage_rate": candidate_calibration["coverage_rate"],
+                    "exact_coverage_rate": candidate_calibration["exact_coverage_rate"],
+                    "score_mae": candidate_calibration["score_mae"],
+                    "score_rmse": candidate_calibration["score_rmse"],
+                },
+            },
+            "deltas": {
+                "window_event_accuracy": 0.0319,
+                "exact_event_accuracy": 0.0229,
+                "coverage_rate": 0.0,
+                "score_mae": -1.94,
+                "signal_count": -2,
+                "reentry_count": 2,
+            },
+            "guardrails": [
+                {
+                    "id": "window_event_accuracy",
+                    "label": "Window alert match",
+                    "status": "pass",
+                    "detail": "Candidate should not materially trail production.",
+                }
+            ],
+            "recommendation": {
+                "status": "ready_for_shadow",
+                "label": "Ready for shadow",
+                "rationale": "Candidate clears the compact promotion gate.",
+            },
+        }
+
     def symbol_chart(
         self,
         *,
@@ -408,6 +513,26 @@ def test_daily_calibration_endpoint_returns_model_health_metrics() -> None:
     assert payload["confusion"]["green"]["missing"] == 1
     assert payload["event_confusion"]["red"]["none"] == 1
     assert payload["top_tickers"][0]["ticker"] == "aa"
+
+
+def test_promotion_gate_endpoint_compares_candidate_to_production() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/financial/signals/promotion-gate/daily"
+        "?candidate_parameter_set=dochia_v0_2_range_daily&top_tickers=3"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["candidate_parameter_set"] == "dochia_v0_2_range_daily"
+    assert payload["production"]["daily_trigger_mode"] == "close"
+    assert payload["candidate"]["daily_trigger_mode"] == "range"
+    assert payload["deltas"]["signal_count"] == -2
+    assert payload["guardrails"][0]["status"] == "pass"
+    assert payload["recommendation"]["status"] == "ready_for_shadow"
 
 
 def test_symbol_chart_endpoint_returns_overlay_data() -> None:

--- a/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
+++ b/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
@@ -265,6 +265,90 @@ const dailyCalibration = {
   ],
 };
 
+const promotionGate = {
+  generated_at: "2026-05-02T22:00:00Z",
+  candidate_parameter_set: "dochia_v0_2_range_daily",
+  baseline_parameter_set: "dochia_v0_estimated",
+  since: null,
+  until: null,
+  event_window_days: 3,
+  production: {
+    id: "production",
+    label: "Production",
+    parameter_set_name: "dochia_v0_estimated",
+    daily_trigger_mode: "close",
+    latest_bar_date: "2026-04-24",
+    signal_count: 120,
+    bullish_count: 40,
+    risk_count: 20,
+    neutral_count: 18,
+    reentry_count: 7,
+    average_score: 12.5,
+    calibration: {
+      total_observations: 24204,
+      covered_observations: 22131,
+      accuracy: 0.6205,
+      exact_event_accuracy: 0.2771,
+      window_event_accuracy: 0.4281,
+      coverage_rate: 0.9144,
+      exact_coverage_rate: 0.9142,
+      score_mae: 43.94,
+      score_rmse: 55.74,
+    },
+  },
+  candidate: {
+    id: "candidate",
+    label: "v0.2 Range",
+    parameter_set_name: "dochia_v0_2_range_daily",
+    daily_trigger_mode: "range",
+    latest_bar_date: "2026-04-24",
+    signal_count: 118,
+    bullish_count: 43,
+    risk_count: 21,
+    neutral_count: 15,
+    reentry_count: 9,
+    average_score: 14,
+    calibration: {
+      total_observations: 24204,
+      covered_observations: 22131,
+      accuracy: 0.6205,
+      exact_event_accuracy: 0.3,
+      window_event_accuracy: 0.46,
+      coverage_rate: 0.9144,
+      exact_coverage_rate: 0.9142,
+      score_mae: 42,
+      score_rmse: 54,
+    },
+  },
+  deltas: {
+    window_event_accuracy: 0.0319,
+    exact_event_accuracy: 0.0229,
+    coverage_rate: 0,
+    score_mae: -1.94,
+    signal_count: -2,
+    reentry_count: 2,
+  },
+  guardrails: [
+    {
+      id: "window_event_accuracy",
+      label: "Window alert match",
+      status: "pass",
+      detail: "Candidate should not materially trail production.",
+    },
+    {
+      id: "score_mae",
+      label: "Score error",
+      status: "pass",
+      detail: "Candidate score error should stay close to production.",
+    },
+  ],
+  recommendation: {
+    status: "ready_for_shadow",
+    label: "Ready for shadow",
+    rationale: "Candidate clears the compact promotion gate.",
+  },
+};
+
 vi.mock("@/lib/hooks", () => ({
   useFinancialLatestSignals: () => ({
     data: latestSignals,
@@ -318,6 +402,13 @@ vi.mock("@/lib/hooks", () => ({
     isLoading: false,
     refetch: vi.fn(),
   }),
+  useFinancialPromotionGate: () => ({
+    data: promotionGate,
+    isError: false,
+    isFetching: false,
+    isLoading: false,
+    refetch: vi.fn(),
+  }),
 }));
 
 describe("HedgeFundSignalsShell", () => {
@@ -334,6 +425,9 @@ describe("HedgeFundSignalsShell", () => {
     expect(screen.getByText("BUY")).toBeInTheDocument();
     expect(screen.getByText("Calibration Baseline")).toBeInTheDocument();
     expect(screen.getByText("62.1%")).toBeInTheDocument();
+    expect(screen.getByText("Promotion Gate")).toBeInTheDocument();
+    expect(screen.getByText("Ready for shadow")).toBeInTheDocument();
+    expect(screen.getByText("Production vs v0.2 Range")).toBeInTheDocument();
     expect(screen.getByText("Chart Overlay")).toBeInTheDocument();
     expect(screen.getByText("1 triangle events")).toBeInTheDocument();
     expect(screen.getByText("Whipsaw Risk / Backtest")).toBeInTheDocument();

--- a/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
+++ b/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
@@ -39,6 +39,7 @@ import {
 import {
   useFinancialLatestSignals,
   useFinancialDailyCalibration,
+  useFinancialPromotionGate,
   useFinancialSignalDetail,
   useFinancialSignalChart,
   useFinancialSignalTransitions,
@@ -48,6 +49,9 @@ import {
 import type {
   FinancialDailyCalibrationResponse,
   FinancialLatestSignal,
+  FinancialPromotionGateGuardrailStatus,
+  FinancialPromotionGateRecommendationStatus,
+  FinancialPromotionGateResponse,
   FinancialSignalChartResponse,
   FinancialSignalTransition,
   FinancialTransitionType,
@@ -174,6 +178,24 @@ function whipsawRiskLabel(level: FinancialWhipsawRiskLevel): string {
   if (level === "high") return "High";
   if (level === "elevated") return "Elevated";
   return "Quiet";
+}
+
+function promotionRecommendationClasses(status: FinancialPromotionGateRecommendationStatus): string {
+  if (status === "hold") return "border-red-500/40 bg-red-500/10 text-red-600";
+  if (status === "review") return "border-amber-500/40 bg-amber-500/10 text-amber-600";
+  return "border-emerald-500/40 bg-emerald-500/10 text-emerald-600";
+}
+
+function promotionGuardrailClasses(status: FinancialPromotionGateGuardrailStatus): string {
+  if (status === "fail") return "border-red-500/40 bg-red-500/10 text-red-600";
+  if (status === "watch") return "border-amber-500/40 bg-amber-500/10 text-amber-600";
+  return "border-emerald-500/40 bg-emerald-500/10 text-emerald-600";
+}
+
+function formatSignedNumber(value: number | null | undefined, digits = 0): string {
+  if (value === null || value === undefined) return "—";
+  const sign = value > 0 ? "+" : "";
+  return `${sign}${value.toFixed(digits)}`;
 }
 
 function StatePill({ label, value }: { label: string; value: number }) {
@@ -905,6 +927,139 @@ function WhipsawRiskPanel({
   );
 }
 
+function PromotionGatePanel({
+  gate,
+  loading,
+  error,
+}: {
+  gate: FinancialPromotionGateResponse | null;
+  loading: boolean;
+  error: boolean;
+}) {
+  if (error) {
+    return (
+      <div className="flex items-center gap-2 border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+        <AlertTriangle className="h-4 w-4" />
+        Promotion gate unavailable.
+      </div>
+    );
+  }
+
+  if (loading && !gate) {
+    return <div className="py-8 text-sm text-muted-foreground">Loading promotion gate…</div>;
+  }
+
+  if (!gate) {
+    return (
+      <div className="border border-dashed border-border p-5 text-sm text-muted-foreground">
+        No promotion-gate data.
+      </div>
+    );
+  }
+
+  const metricRows = [
+    {
+      label: "± Window Match",
+      production: formatPercent(gate.production.calibration.window_event_accuracy),
+      candidate: formatPercent(gate.candidate.calibration.window_event_accuracy),
+      delta: formatSignedPercent(gate.deltas.window_event_accuracy),
+    },
+    {
+      label: "Exact Alert Match",
+      production: formatPercent(gate.production.calibration.exact_event_accuracy),
+      candidate: formatPercent(gate.candidate.calibration.exact_event_accuracy),
+      delta: formatSignedPercent(gate.deltas.exact_event_accuracy),
+    },
+    {
+      label: "Coverage",
+      production: formatPercent(gate.production.calibration.coverage_rate),
+      candidate: formatPercent(gate.candidate.calibration.coverage_rate),
+      delta: formatSignedPercent(gate.deltas.coverage_rate),
+    },
+    {
+      label: "Score MAE",
+      production: formatMetricNumber(gate.production.calibration.score_mae),
+      candidate: formatMetricNumber(gate.candidate.calibration.score_mae),
+      delta: formatSignedNumber(gate.deltas.score_mae, 1),
+    },
+    {
+      label: "Signals",
+      production: gate.production.signal_count.toLocaleString(),
+      candidate: gate.candidate.signal_count.toLocaleString(),
+      delta: formatSignedNumber(gate.deltas.signal_count),
+    },
+    {
+      label: "Re-entry",
+      production: gate.production.reentry_count.toLocaleString(),
+      candidate: gate.candidate.reentry_count.toLocaleString(),
+      delta: formatSignedNumber(gate.deltas.reentry_count),
+    },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold">Production vs v0.2 Range</p>
+          <p className="text-xs text-muted-foreground">
+            {gate.baseline_parameter_set} → {gate.candidate_parameter_set}
+          </p>
+        </div>
+        <Badge
+          variant="outline"
+          className={cn("font-medium", promotionRecommendationClasses(gate.recommendation.status))}
+        >
+          {gate.recommendation.label}
+        </Badge>
+      </div>
+
+      <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_220px]">
+        <div className="overflow-hidden border border-border">
+          <div className="grid grid-cols-[minmax(120px,1fr)_repeat(3,minmax(92px,0.7fr))] border-b border-border bg-muted/40 px-3 py-2 text-xs font-medium text-muted-foreground">
+            <span>Metric</span>
+            <span className="text-right">{gate.production.label}</span>
+            <span className="text-right">{gate.candidate.label}</span>
+            <span className="text-right">Delta</span>
+          </div>
+          {metricRows.map((row) => (
+            <div
+              key={row.label}
+              className="grid grid-cols-[minmax(120px,1fr)_repeat(3,minmax(92px,0.7fr))] border-b border-border px-3 py-2 text-xs last:border-b-0"
+            >
+              <span className="font-medium">{row.label}</span>
+              <span className="text-right font-mono text-muted-foreground">{row.production}</span>
+              <span className="text-right font-mono font-semibold">{row.candidate}</span>
+              <span className="text-right font-mono text-muted-foreground">{row.delta}</span>
+            </div>
+          ))}
+        </div>
+
+        <div className="border border-border p-3">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-sm font-semibold">Guardrails</h2>
+            <span className="text-xs text-muted-foreground">{formatDate(gate.generated_at)}</span>
+          </div>
+          <div className="mt-3 space-y-2">
+            {gate.guardrails.map((guardrail) => (
+              <div key={guardrail.id} className="flex items-center justify-between gap-2 text-xs">
+                <span className="min-w-0 truncate">{guardrail.label}</span>
+                <Badge
+                  variant="outline"
+                  className={cn("shrink-0 font-medium", promotionGuardrailClasses(guardrail.status))}
+                >
+                  {guardrail.status}
+                </Badge>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <p className="text-xs text-muted-foreground">{gate.recommendation.rationale}</p>
+    </div>
+  );
+}
+
 function SymbolPanel({
   signal,
   transitions,
@@ -1053,6 +1208,10 @@ export function HedgeFundSignalsShell() {
     parameter_set: activeParameterSet,
   });
   const dailyCalibration = useFinancialDailyCalibration({ top_tickers: 8 });
+  const promotionGate = useFinancialPromotionGate({
+    candidate_parameter_set: "dochia_v0_2_range_daily",
+    top_tickers: 8,
+  });
   const signals = latest.data ?? EMPTY_SIGNALS;
   const alertRows = transitions.data ?? EMPTY_TRANSITIONS;
   const watchlistLanes = watchlistCandidates.data?.lanes ?? EMPTY_LANES;
@@ -1094,7 +1253,8 @@ export function HedgeFundSignalsShell() {
     chart.isFetching ||
     whipsawRisk.isFetching ||
     watchlistCandidates.isFetching ||
-    dailyCalibration.isFetching;
+    dailyCalibration.isFetching ||
+    promotionGate.isFetching;
 
   return (
     <div className="space-y-6">
@@ -1143,6 +1303,7 @@ export function HedgeFundSignalsShell() {
               void whipsawRisk.refetch();
               void watchlistCandidates.refetch();
               void dailyCalibration.refetch();
+              void promotionGate.refetch();
             }}
             disabled={isRefreshing}
             aria-label="Refresh hedge fund signals"
@@ -1217,6 +1378,25 @@ export function HedgeFundSignalsShell() {
             calibration={dailyCalibration.data ?? null}
             loading={dailyCalibration.isLoading}
             error={dailyCalibration.isError}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <ShieldAlert className="h-5 w-5 text-primary" />
+            <CardTitle>Promotion Gate</CardTitle>
+          </div>
+          <Badge variant="outline">
+            {promotionGate.data ? formatDate(promotionGate.data.generated_at) : "—"}
+          </Badge>
+        </CardHeader>
+        <CardContent>
+          <PromotionGatePanel
+            gate={promotionGate.data ?? null}
+            loading={promotionGate.isLoading}
+            error={promotionGate.isError}
           />
         </CardContent>
       </Card>

--- a/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
@@ -13,6 +13,7 @@ import type {
   DashboardStats,
   FinancialLatestSignal,
   FinancialDailyCalibrationResponse,
+  FinancialPromotionGateResponse,
   FinancialSignalTransition,
   FinancialSignalChartResponse,
   FinancialSymbolSignalDetail,
@@ -189,6 +190,20 @@ export function useFinancialDailyCalibration(params?: {
     queryKey: ["financial", "signals", "calibration", "daily", params],
     queryFn: () => api.get("/api/financial/signals/calibration/daily", params),
     staleTime: 10 * 60_000,
+  });
+}
+
+export function useFinancialPromotionGate(params?: {
+  candidate_parameter_set?: string;
+  since?: string;
+  until?: string;
+  top_tickers?: number;
+  event_window_days?: number;
+}) {
+  return useQuery<FinancialPromotionGateResponse>({
+    queryKey: ["financial", "signals", "promotion-gate", "daily", params],
+    queryFn: () => api.get("/api/financial/signals/promotion-gate/daily", params),
+    staleTime: 5 * 60_000,
   });
 }
 

--- a/fortress-guest-platform/apps/command-center/src/lib/types.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/types.ts
@@ -269,6 +269,72 @@ export interface FinancialWhipsawRiskResponse {
   recent_events: FinancialWhipsawEvent[];
 }
 
+export interface FinancialPromotionGateCalibration {
+  total_observations: number;
+  covered_observations: number;
+  accuracy: number | null;
+  exact_event_accuracy: number | null;
+  window_event_accuracy: number | null;
+  coverage_rate: number | null;
+  exact_coverage_rate: number | null;
+  score_mae: number | null;
+  score_rmse: number | null;
+}
+
+export interface FinancialPromotionGateModel {
+  id: "production" | "candidate";
+  label: string;
+  parameter_set_name: string;
+  daily_trigger_mode: "close" | "range";
+  latest_bar_date: string | null;
+  signal_count: number;
+  bullish_count: number;
+  risk_count: number;
+  neutral_count: number;
+  reentry_count: number;
+  average_score: number | null;
+  calibration: FinancialPromotionGateCalibration;
+}
+
+export interface FinancialPromotionGateDeltas {
+  window_event_accuracy: number | null;
+  exact_event_accuracy: number | null;
+  coverage_rate: number | null;
+  score_mae: number | null;
+  signal_count: number;
+  reentry_count: number;
+}
+
+export type FinancialPromotionGateGuardrailStatus = "pass" | "watch" | "fail";
+export type FinancialPromotionGateRecommendationStatus = "hold" | "review" | "ready_for_shadow";
+
+export interface FinancialPromotionGateGuardrail {
+  id: string;
+  label: string;
+  status: FinancialPromotionGateGuardrailStatus;
+  detail: string;
+}
+
+export interface FinancialPromotionGateRecommendation {
+  status: FinancialPromotionGateRecommendationStatus;
+  label: string;
+  rationale: string;
+}
+
+export interface FinancialPromotionGateResponse {
+  generated_at: string;
+  candidate_parameter_set: string;
+  baseline_parameter_set: string;
+  since: string | null;
+  until: string | null;
+  event_window_days: number;
+  production: FinancialPromotionGateModel;
+  candidate: FinancialPromotionGateModel;
+  deltas: FinancialPromotionGateDeltas;
+  guardrails: FinancialPromotionGateGuardrail[];
+  recommendation: FinancialPromotionGateRecommendation;
+}
+
 export interface FinancialWatchlistCandidate {
   ticker: string;
   bar_date: string;


### PR DESCRIPTION
## Summary
- add a daily promotion-gate API comparing production Dochia signals with the v0.2 Range candidate
- surface the comparison in the Hedge Fund dashboard with calibration, scanner, re-entry, and guardrail status
- cover the new API route and UI panel in focused tests

## Verification
- PYTHONPATH=. /home/admin/.local/bin/uv run pytest tests/test_api_signals.py tests/test_whipsaw_risk.py
- /home/admin/.local/bin/uv run ruff check app/api/signals.py app/signals/repository.py tests/test_api_signals.py
- PYTHONPATH=. /home/admin/.local/bin/uv run pytest tests/test_trade_triangles.py tests/test_calibration.py tests/test_calibration_sweep.py tests/test_guardrail_sweep.py tests/test_outcome_review.py tests/test_promotion_review.py tests/test_chart_repository.py tests/test_api_signals.py tests/test_whipsaw_risk.py
- npm test -- financial-hedge-fund-shell.test.tsx
- npm run lint -- focused Hedge Fund files
- npx tsc --noEmit
- npm run build
- live DB smoke: promotion gate returned ready_for_shadow 328 328 0.0