### PR TITLE
Foundation: normalize Fortress Legal NAS layout contract

### DIFF
--- a/fortress-guest-platform/backend/api/legal_cases.py
+++ b/fortress-guest-platform/backend/api/legal_cases.py
@@ -40,6 +40,11 @@ from backend.core.queue import get_arq_pool
 from backend.core.security import require_manager_or_admin
 from backend.services.ediscovery_agent import LegacySession
 from backend.services.legal_extractor import extract_entities
+from backend.services.legal.nas_layout import (
+    DEFAULT_CASE_SUBDIR_MAP,
+    NormalizedCaseLayout,
+    normalize_case_layout,
+)
 from backend.services.legal_case_graph import HiveMindFeedback, get_case_graph_snapshot
 from backend.services.legal_discovery_engine import validate_discovery_pack
 from backend.services.legal_deposition_engine import (
@@ -519,50 +524,51 @@ async def get_correspondence_content(corr_id: int):
 # pre-existing behaviour so canonical cases (Generali, Prime Trust, MVP)
 # keep working unchanged. Logical names (returned to the UI) match the
 # physical paths under /mnt/fortress_nas/sectors/legal/{slug}/.
-_CASE_SUBDIRS = ("certified_mail", "correspondence", "evidence", "receipts",
-                 "filings/incoming", "filings/outgoing")
-_DEFAULT_SUBDIR_MAP: dict[str, str] = {
-    "certified_mail":   "certified_mail",
-    "correspondence":   "correspondence",
-    "evidence":         "evidence",
-    "receipts":         "receipts",
-    "filings_incoming": "filings/incoming",
-    "filings_outgoing": "filings/outgoing",
-}
+_DEFAULT_SUBDIR_MAP: dict[str, str] = dict(DEFAULT_CASE_SUBDIR_MAP)
+
+
+def _resolve_case_layout_details(
+    slug: str, nas_layout: dict | str | None,
+) -> NormalizedCaseLayout:
+    return normalize_case_layout(
+        slug,
+        nas_layout,
+        default_root=NAS_LEGAL_ROOT,
+        require_layout=False,
+    )
 
 
 def _resolve_case_layout(
-    slug: str, nas_layout: dict | None,
+    slug: str, nas_layout: dict | str | None,
 ) -> tuple[Path, dict[str, str], bool]:
-    """
-    Return (case_root, logical→physical subdir map, recursive_flag).
-
-    NULL nas_layout → canonical {NAS_LEGAL_ROOT}/{slug} + _DEFAULT_SUBDIR_MAP,
-    recursive=False. Populated nas_layout → use the configured `root`
-    + `subdirs` map; missing keys are skipped silently. `recursive`
-    defaults to False when omitted.
-    """
-    if not nas_layout:
-        return Path(NAS_LEGAL_ROOT) / slug, dict(_DEFAULT_SUBDIR_MAP), False
-
-    root = Path(str(nas_layout.get("root") or "")).expanduser()
-    raw_subdirs = nas_layout.get("subdirs") or {}
-    if not isinstance(raw_subdirs, dict):
-        raw_subdirs = {}
-    subdir_map = {
-        str(k): str(v) for k, v in raw_subdirs.items()
-        if v is not None and v != ""
-    }
-    recursive = bool(nas_layout.get("recursive"))
-    return root, subdir_map, recursive
+    """Return (case_root, logical→physical subdir map, recursive_flag)."""
+    layout = _resolve_case_layout_details(slug, nas_layout)
+    return layout.root, dict(layout.subdirs), layout.recursive
 
 
-def _walk_case_subdir(base: Path, recursive: bool) -> list[Path]:
+def _layout_excludes(path: Path, case_root: Path, exclude_subdirs: set[str] | frozenset[str]) -> bool:
+    if not exclude_subdirs:
+        return False
+    try:
+        rel_name = str(path.relative_to(case_root)).strip("/")
+    except ValueError:
+        return False
+    return any(rel_name == ex or rel_name.startswith(f"{ex}/") for ex in exclude_subdirs)
+
+
+def _walk_case_subdir(
+    base: Path,
+    recursive: bool,
+    *,
+    case_root: Path | None = None,
+    exclude_subdirs: set[str] | frozenset[str] | None = None,
+) -> list[Path]:
     """
     Yield files under `base`, sorted. Skips:
       - dotfiles (anywhere in the path)
       - Synology @eaDir metadata folders
       - directories themselves
+      - paths excluded by nas_layout.exclude_subdirs when provided
     """
     if not base.is_dir():
         return []
@@ -572,6 +578,8 @@ def _walk_case_subdir(base: Path, recursive: bool) -> list[Path]:
         if not p.is_file():
             continue
         if any(part.startswith(".") or part == "@eaDir" for part in p.parts):
+            continue
+        if case_root is not None and _layout_excludes(p, case_root, exclude_subdirs or set()):
             continue
         out.append(p)
     out.sort()
@@ -603,7 +611,8 @@ async def download_case_file(slug: str, filename: str):
             raise HTTPException(status_code=404, detail=f"Case '{slug}' not found")
 
     nas_layout = getattr(row, "nas_layout", None)
-    case_root, subdir_map, recursive = _resolve_case_layout(slug, nas_layout)
+    layout = _resolve_case_layout_details(slug, nas_layout)
+    case_root, subdir_map, recursive = layout.root, layout.subdirs, layout.recursive
 
     for logical_name, relative_path in subdir_map.items():
         d = case_root / relative_path
@@ -617,6 +626,8 @@ async def download_case_file(slug: str, filename: str):
         for candidate in iterator:
             if not _is_under(candidate, case_root):
                 # Path-traversal guard: a symlink could escape case_root.
+                continue
+            if _layout_excludes(candidate, case_root, layout.exclude_subdirs):
                 continue
             ext = candidate.suffix.lower()
             media_type = MIME_MAP.get(ext, "application/octet-stream")
@@ -647,12 +658,18 @@ async def list_case_files(slug: str):
             raise HTTPException(status_code=404, detail=f"Case '{slug}' not found")
 
     nas_layout = getattr(row, "nas_layout", None)
-    case_root, subdir_map, recursive = _resolve_case_layout(slug, nas_layout)
+    layout = _resolve_case_layout_details(slug, nas_layout)
+    case_root, subdir_map, recursive = layout.root, layout.subdirs, layout.recursive
 
     files: list[dict[str, Any]] = []
     for logical_name, relative_path in subdir_map.items():
         d = case_root / relative_path
-        for f in _walk_case_subdir(d, recursive):
+        for f in _walk_case_subdir(
+            d,
+            recursive,
+            case_root=case_root,
+            exclude_subdirs=layout.exclude_subdirs,
+        ):
             if not _is_under(f, case_root):
                 continue
             files.append({

--- a/fortress-guest-platform/backend/scripts/vault_ingest_legal_case.py
+++ b/fortress-guest-platform/backend/scripts/vault_ingest_legal_case.py
@@ -56,6 +56,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from backend.services.legal.nas_layout import (
+    LayoutNormalizationError,
+    normalize_case_layout,
+)
+
 logger = logging.getLogger("vault_ingest_legal_case")
 
 # ─── config ────────────────────────────────────────────────────────────────
@@ -316,40 +321,11 @@ def run_preflight(case_slug: str) -> dict[str, Any]:
 
 
 def _normalize_layout(raw: Any) -> dict[str, Any]:
-    """nas_layout column may be dict, str, or None (caught above)."""
-    if isinstance(raw, str):
-        try:
-            raw = json.loads(raw)
-        except Exception:
-            raw = None
-    if not raw:
-        raise PreflightError("nas_layout is empty after normalize")
-    if raw.get("primary_root") or raw.get("include_subdirs"):
-        root = Path(str(raw.get("primary_root") or raw.get("root") or "")).expanduser()
-        includes = raw.get("include_subdirs") or []
-        if isinstance(includes, str):
-            includes = [includes]
-        subdirs = {str(v): str(v) for v in includes if v not in (None, "")}
-        recursive_raw = raw.get("recursive")
-        recursive = True if recursive_raw is None else bool(recursive_raw)
-    else:
-        root = Path(str(raw.get("root") or "")).expanduser()
-        subs = raw.get("subdirs") or {}
-        if not isinstance(subs, dict):
-            subs = {}
-        subdirs = {
-            str(k): str(v) for k, v in subs.items() if v not in (None, "")
-        }
-        recursive = bool(raw.get("recursive"))
-    excludes = raw.get("exclude_subdirs") or []
-    if isinstance(excludes, str):
-        excludes = [excludes]
-    return {
-        "root": root,
-        "subdirs": subdirs,
-        "recursive": recursive,
-        "exclude_subdirs": {str(v).strip("/") for v in excludes if v not in (None, "")},
-    }
+    """Normalize legal.cases.nas_layout for the vault ingest walker."""
+    try:
+        return normalize_case_layout("", raw, require_layout=True).as_ingest_dict()
+    except LayoutNormalizationError as exc:
+        raise PreflightError(str(exc)) from exc
 
 
 # ─── physical-path dedup walk ─────────────────────────────────────────────

--- a/fortress-guest-platform/backend/services/legal/nas_layout.py
+++ b/fortress-guest-platform/backend/services/legal/nas_layout.py
@@ -1,0 +1,135 @@
+"""Shared Fortress Legal NAS layout normalization.
+
+legal.cases.nas_layout exists in two supported shapes:
+
+* legacy/API shape: {"root": "...", "subdirs": {logical: relative}, "recursive": bool}
+* Wave 7 ingest shape: {"primary_root": "...", "include_subdirs": [...], "exclude_subdirs": [...]}
+
+This module keeps the interpretation in one place so the command-center API
+and vault ingest pipeline walk the same curated source paths.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_LEGAL_NAS_ROOT = "/mnt/fortress_nas/sectors/legal"
+
+DEFAULT_CASE_SUBDIR_MAP: dict[str, str] = {
+    "certified_mail": "certified_mail",
+    "correspondence": "correspondence",
+    "evidence": "evidence",
+    "receipts": "receipts",
+    "filings_incoming": "filings/incoming",
+    "filings_outgoing": "filings/outgoing",
+}
+
+
+class LayoutNormalizationError(ValueError):
+    """Raised when a required nas_layout value cannot be normalized."""
+
+
+@dataclass(frozen=True)
+class NormalizedCaseLayout:
+    root: Path
+    subdirs: dict[str, str]
+    recursive: bool
+    exclude_subdirs: frozenset[str]
+    custom_layout: bool
+
+    def as_ingest_dict(self) -> dict[str, Any]:
+        return {
+            "root": self.root,
+            "subdirs": dict(self.subdirs),
+            "recursive": self.recursive,
+            "exclude_subdirs": set(self.exclude_subdirs),
+        }
+
+
+def _coerce_layout(raw: Any) -> dict[str, Any] | None:
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except Exception as exc:  # pragma: no cover - message path is tested via caller
+            raise LayoutNormalizationError("nas_layout is not valid JSON") from exc
+    if not raw:
+        return None
+    if not isinstance(raw, dict):
+        raise LayoutNormalizationError("nas_layout must be a JSON object")
+    return raw
+
+
+def _as_string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, (list, tuple, set)):
+        return []
+    return [str(v) for v in value if v not in (None, "")]
+
+
+def _clean_excludes(value: Any) -> frozenset[str]:
+    excludes = []
+    for item in _as_string_list(value):
+        cleaned = item.strip().strip("/")
+        if cleaned:
+            excludes.append(cleaned)
+    return frozenset(excludes)
+
+
+def normalize_case_layout(
+    slug: str,
+    nas_layout: Any,
+    *,
+    default_root: str | Path = DEFAULT_LEGAL_NAS_ROOT,
+    require_layout: bool = False,
+) -> NormalizedCaseLayout:
+    """Return the canonical runtime interpretation of legal.cases.nas_layout.
+
+    When ``require_layout`` is false, empty layouts fall back to the legacy
+    canonical case directory under ``default_root``. Vault ingest passes
+    ``require_layout=True`` because non-canonical ingest must be explicitly
+    scoped to curated source paths.
+    """
+    raw = _coerce_layout(nas_layout)
+    if raw is None:
+        if require_layout:
+            raise LayoutNormalizationError("nas_layout is empty after normalize")
+        return NormalizedCaseLayout(
+            root=Path(default_root) / slug,
+            subdirs=dict(DEFAULT_CASE_SUBDIR_MAP),
+            recursive=False,
+            exclude_subdirs=frozenset(),
+            custom_layout=False,
+        )
+
+    if raw.get("primary_root") or raw.get("include_subdirs"):
+        root = Path(str(raw.get("primary_root") or raw.get("root") or "")).expanduser()
+        include_subdirs = _as_string_list(raw.get("include_subdirs") or [])
+        subdirs = {value: value for value in include_subdirs}
+        recursive_raw = raw.get("recursive")
+        recursive = True if recursive_raw is None else bool(recursive_raw)
+    else:
+        root = Path(str(raw.get("root") or "")).expanduser()
+        raw_subdirs = raw.get("subdirs") or {}
+        if not isinstance(raw_subdirs, dict):
+            raw_subdirs = {}
+        subdirs = {
+            str(key): str(value)
+            for key, value in raw_subdirs.items()
+            if value not in (None, "")
+        }
+        recursive = bool(raw.get("recursive"))
+
+    return NormalizedCaseLayout(
+        root=root,
+        subdirs=subdirs,
+        recursive=recursive,
+        exclude_subdirs=_clean_excludes(raw.get("exclude_subdirs") or []),
+        custom_layout=True,
+    )

--- a/fortress-guest-platform/backend/tests/test_legal_cases_files.py
+++ b/fortress-guest-platform/backend/tests/test_legal_cases_files.py
@@ -152,6 +152,38 @@ class TestListFilesCustomLayout:
         }
 
 
+class TestListFilesWave7Layout:
+    @pytest.mark.asyncio
+    async def test_list_files_wave7_layout_walks_curated_paths_only(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        root = tmp_path / "Business_Legal" / "7il-v-knight-ndga-ii"
+        (root / "curated" / "pleadings").mkdir(parents=True)
+        (root / "curated" / "pleadings" / "Complaint.pdf").write_bytes(b"x")
+        (root / "curated" / "emails").mkdir()
+        (root / "curated" / "emails" / "Argo.eml").write_bytes(b"x")
+        (root / "curated" / "private").mkdir()
+        (root / "curated" / "private" / "DoNotServe.pdf").write_bytes(b"x")
+        (root / "legacy_dump").mkdir()
+        (root / "legacy_dump" / "Poison.pdf").write_bytes(b"x")
+
+        layout = {
+            "primary_root": str(root),
+            "include_subdirs": ["curated"],
+            "exclude_subdirs": ["curated/private"],
+        }
+        _patch_legacy_session(monkeypatch, _row(nas_layout=layout))
+
+        result = await list_case_files("7il-v-knight-ndga-ii")
+
+        assert result["total"] == 2
+        names = {(f["subdir"], f["relative_path"], f["filename"]) for f in result["files"]}
+        assert names == {
+            ("curated", "emails/Argo.eml", "Argo.eml"),
+            ("curated", "pleadings/Complaint.pdf", "Complaint.pdf"),
+        }
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # 3. test_list_files_recursive_flag — nested folder structure
 # ─────────────────────────────────────────────────────────────────────────────
@@ -342,6 +374,16 @@ class TestHelpers:
         assert m == {"evidence": "ev"}
         assert rec is True
 
+    def test_resolve_layout_wave7_shape_defaults_recursive_true(self):
+        layout = {
+            "primary_root": "/mnt/business/7il-v-knight-ndga-i",
+            "include_subdirs": ["curated", "case-i-context"],
+        }
+        root, m, rec = _resolve_case_layout("any", layout)
+        assert root == Path("/mnt/business/7il-v-knight-ndga-i")
+        assert m == {"curated": "curated", "case-i-context": "case-i-context"}
+        assert rec is True
+
     def test_resolve_layout_skips_empty_subdir_values(self):
         layout = {"root": "/mnt/y", "subdirs": {"a": "x", "b": "", "c": None}}
         _, m, _ = _resolve_case_layout("any", layout)
@@ -362,6 +404,21 @@ class TestHelpers:
 
         rec = _walk_case_subdir(tmp_path, recursive=True)
         assert sorted(p.name for p in rec) == ["nested.pdf", "real.pdf"]
+
+    def test_walk_honors_layout_excludes(self, tmp_path: Path):
+        (tmp_path / "curated" / "public").mkdir(parents=True)
+        (tmp_path / "curated" / "public" / "ok.pdf").write_bytes(b"x")
+        (tmp_path / "curated" / "private").mkdir()
+        (tmp_path / "curated" / "private" / "skip.pdf").write_bytes(b"x")
+
+        rec = _walk_case_subdir(
+            tmp_path / "curated",
+            recursive=True,
+            case_root=tmp_path,
+            exclude_subdirs={"curated/private"},
+        )
+
+        assert [p.name for p in rec] == ["ok.pdf"]
 
     def test_is_under_rejects_paths_outside_parent(self, tmp_path: Path):
         parent = tmp_path / "case"

--- a/fortress-guest-platform/backend/tests/test_vault_ingest_legal_case.py
+++ b/fortress-guest-platform/backend/tests/test_vault_ingest_legal_case.py
@@ -109,6 +109,41 @@ def _layout_with_subdirs(root: Path, subdirs: dict[str, str], recursive: bool = 
     return {"root": root, "subdirs": subdirs, "recursive": recursive}
 
 
+
+
+# ─── nas_layout normalization ────────────────────────────────────────────
+
+
+def test_normalize_layout_accepts_wave7_shape(tmp_path):
+    raw = {
+        "primary_root": str(tmp_path),
+        "include_subdirs": ["curated", "case-i-context"],
+        "exclude_subdirs": ["curated/private"],
+    }
+
+    layout = vil._normalize_layout(raw)
+
+    assert layout["root"] == tmp_path
+    assert layout["subdirs"] == {"curated": "curated", "case-i-context": "case-i-context"}
+    assert layout["recursive"] is True
+    assert layout["exclude_subdirs"] == {"curated/private"}
+
+
+def test_normalize_layout_preserves_legacy_shape(tmp_path):
+    raw = {"root": str(tmp_path), "subdirs": {"evidence": "ev"}, "recursive": False}
+
+    layout = vil._normalize_layout(raw)
+
+    assert layout["root"] == tmp_path
+    assert layout["subdirs"] == {"evidence": "ev"}
+    assert layout["recursive"] is False
+    assert layout["exclude_subdirs"] == set()
+
+
+def test_normalize_layout_rejects_empty_layout():
+    with pytest.raises(vil.PreflightError, match="nas_layout is empty"):
+        vil._normalize_layout({})
+
 def _registry_full_preflight_pass(case_slug: str, layout: dict):
     """Builds a registry that lets every preflight gate pass and lets
     _check_existing_row return None (= no existing row)."""


### PR DESCRIPTION
Foundation PR for Fortress Legal NAS layout normalization. Adds a shared backend/services/legal/nas_layout.py contract for both legacy root/subdirs/recursive layouts and Wave 7 primary_root/include_subdirs/exclude_subdirs layouts. Wires the Legal Command Center file API and vault ingest preflight to the same resolver, including curated include paths and exclude_subdirs. No database or NAS data changes. Tests: POSTGRES_API_URI=postgresql://fortress_api:test@127.0.0.1:5432/fortress_shadow_test TEST_DATABASE_URL=postgresql://fortress_api:test@127.0.0.1:5432/fortress_shadow_test python3 -m pytest backend/tests/test_legal_cases_files.py backend/tests/test_vault_ingest_legal_case.py. Result: 40 passed, 1 reportlab deprecation warning.