### PR TITLE
Foundation: stable Legal NAS download addressing

### DIFF
--- a/docs/architecture/runtime-map.md
+++ b/docs/architecture/runtime-map.md
@@ -338,7 +338,7 @@ Do not store real secrets in repo files. The names below are runtime contract na
 2. Which live LiteLLM alias map is authoritative now: Spark-5 BRAIN-era or Spark-3+4 TP=2 Phase 9?
 3. Should legal ingest write directly to `legal_ediscovery_v2` / `legal_ediscovery_active`, or is legacy `legal_ediscovery` intentionally retained as ingest source with separate reindex?
 4. Are Qdrant aliases managed in code/config, or only by operator/manual Qdrant API calls?
-5. Should recursive Legal Command Center downloads include a nested relative path or stable document id instead of filename-only lookup?
+5. Should recursive Legal Command Center downloads later move from `subdir` + `relative_path` query parameters to stable document ids?
 6. Should `/mnt/fortress_nas/sectors/legal` remain an active legal file root or be marked legacy-only?
 7. Which DB is the legal case metadata source of truth after Spark-1 migration: `fortress_prod`, `fortress_db`, or Spark-1 `fortress_prod` mirror?
 8. What is the exact production Qdrant storage path and snapshot/backup policy for privileged collections?
@@ -388,5 +388,4 @@ Before new Fortress Legal features, resolve foundation ambiguity in this order:
 1. Prove live host ownership: Spark-2 current vs Spark-1 cutover state.
 2. Prove DB source-of-truth contract for Legal after PR #366/#405 era changes.
 3. Prove Qdrant alias/read/write contract for `legal_ediscovery_active` and v2.
-4. Reconcile download addressing for recursive Legal Command Center file browsing so duplicate filenames cannot resolve ambiguously.
-5. Re-audit frontend zone separation so privileged Legal never leaks into public storefront surfaces.
+4. Re-audit frontend zone separation so privileged Legal never leaks into public storefront surfaces.

--- a/docs/operational/fortress-legal-nas-layout-contract-audit-2026-05-03.md
+++ b/docs/operational/fortress-legal-nas-layout-contract-audit-2026-05-03.md
@@ -117,7 +117,7 @@ Affected API endpoints now share the reconciled layout interpretation:
 - `GET /api/internal/legal/cases/{slug}/files`
 - `GET /api/internal/legal/cases/{slug}/download/{filename}`
 
-The remaining API concern is download addressing: recursive layouts still download by filename, so duplicate filenames in different nested folders can be ambiguous.
+Post-audit update: download URLs now include `subdir` and `relative_path` query parameters for stable recursive addressing; filename-only downloads remain backward compatible for unique matches and fail with conflict when ambiguous.
 
 ## Migration History
 
@@ -144,7 +144,7 @@ After PR #410, treat this as the current safe contract:
 
 1. Case I source-of-truth layout points to missing `curated` and `case-i-context` folders.
 2. `{}` intentionally means different things in different callers: batch ingest treats it as invalid; API treats it as fallback.
-3. Download-by-filename may be ambiguous in recursive layouts because nested relative paths are not part of the download route.
+3. Filename-only manual downloads can still be ambiguous in recursive layouts, but now fail with conflict instead of choosing an arbitrary match.
 4. The old `/mnt/fortress_nas/sectors/legal` fallback is still in code but is not valid for Case I/II.
 
 ## Recommended Next Move
@@ -155,5 +155,5 @@ The narrow resolver reconciliation recommended by this audit landed in PR #410. 
 
 1. Keep Case II on the curated `Corporate_Legal/Business_Legal/7il-v-knight-ndga-ii/curated` source path.
 2. Decide separately whether to create Case I `curated` / `case-i-context` folders or update its DB layout to current real paths.
-3. Add stable download addressing for recursive layouts so duplicate filenames cannot resolve ambiguously.
+3. Consider a future document-id based download route if the UI needs immutable links independent of NAS path changes.
 4. Leave non-7IL `{}` batch-ingest rows untouched until each matter receives explicit scoping.

--- a/fortress-guest-platform/backend/api/legal_cases.py
+++ b/fortress-guest-platform/backend/api/legal_cases.py
@@ -29,6 +29,7 @@ import httpx
 from datetime import date, datetime
 from pathlib import Path
 from typing import Any, Optional
+from urllib.parse import quote, urlencode
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from fastapi.responses import FileResponse, StreamingResponse
@@ -595,10 +596,68 @@ def _is_under(child: Path, parent: Path) -> bool:
     return True
 
 
+def _validate_download_relative_path(relative_path: str) -> Path:
+    if "\\" in relative_path:
+        raise HTTPException(status_code=400, detail="Invalid relative_path")
+    rel_path = Path(relative_path)
+    if rel_path.is_absolute() or not rel_path.parts:
+        raise HTTPException(status_code=400, detail="Invalid relative_path")
+    if any(part in ("", ".", "..") for part in rel_path.parts):
+        raise HTTPException(status_code=400, detail="Invalid relative_path")
+    return rel_path
+
+
+def _case_file_download_url(
+    slug: str,
+    filename: str,
+    logical_name: str,
+    relative_path: str,
+) -> str:
+    query = urlencode({"subdir": logical_name, "relative_path": relative_path})
+    encoded_filename = quote(filename, safe="")
+    return f"{INTERNAL_LEGAL_API_PREFIX}/cases/{slug}/download/{encoded_filename}?{query}"
+
+
+def _case_file_response(
+    *,
+    candidate: Path,
+    slug: str,
+    filename: str,
+    logical_name: str,
+    nas_layout: Any,
+    relative_path: str | None = None,
+) -> FileResponse:
+    ext = candidate.suffix.lower()
+    media_type = MIME_MAP.get(ext, "application/octet-stream")
+    logger.info(
+        "legal_file_download",
+        slug=slug,
+        filename=filename,
+        subdir=logical_name,
+        relative_path=relative_path,
+        custom_layout=bool(nas_layout),
+    )
+    return FileResponse(
+        path=str(candidate.resolve()),
+        media_type=media_type,
+        filename=filename,
+    )
+
+
 @router.get("/cases/{slug}/download/{filename}", summary="Download a file from a case's NAS vault")
-async def download_case_file(slug: str, filename: str):
+async def download_case_file(
+    slug: str,
+    filename: str,
+    subdir: str | None = None,
+    relative_path: str | None = None,
+):
     if ".." in filename or "/" in filename or "\\" in filename:
         raise HTTPException(status_code=400, detail="Invalid filename")
+    if (subdir is None) != (relative_path is None):
+        raise HTTPException(
+            status_code=400,
+            detail="subdir and relative_path must be provided together",
+        )
 
     async with LegacySession() as session:
         slug = await _resolve_case_slug(session, slug)
@@ -614,33 +673,69 @@ async def download_case_file(slug: str, filename: str):
     layout = _resolve_case_layout_details(slug, nas_layout)
     case_root, subdir_map, recursive = layout.root, layout.subdirs, layout.recursive
 
+    if subdir is not None and relative_path is not None:
+        if subdir not in subdir_map:
+            raise HTTPException(status_code=404, detail=f"Subdir '{subdir}' not found in case vault")
+
+        rel_path = _validate_download_relative_path(relative_path)
+        if rel_path.name != filename:
+            raise HTTPException(status_code=400, detail="relative_path filename mismatch")
+
+        base = case_root / subdir_map[subdir]
+        candidate = base / rel_path
+        if (
+            not candidate.is_file()
+            or not _is_under(candidate, base)
+            or not _is_under(candidate, case_root)
+            or _layout_excludes(candidate, case_root, layout.exclude_subdirs)
+        ):
+            raise HTTPException(status_code=404, detail=f"File '{filename}' not found in case vault")
+
+        return _case_file_response(
+            candidate=candidate,
+            slug=slug,
+            filename=filename,
+            logical_name=subdir,
+            nas_layout=nas_layout,
+            relative_path=relative_path,
+        )
+
+    matches: list[tuple[str, str, Path]] = []
     for logical_name, relative_path in subdir_map.items():
         d = case_root / relative_path
-        if not d.is_dir():
-            continue
-        if recursive:
-            iterator = (p for p in d.rglob(filename) if p.is_file())
-        else:
-            cand = d / filename
-            iterator = iter([cand]) if cand.is_file() else iter(())
-        for candidate in iterator:
-            if not _is_under(candidate, case_root):
+        for candidate in _walk_case_subdir(
+            d,
+            recursive,
+            case_root=case_root,
+            exclude_subdirs=layout.exclude_subdirs,
+        ):
+            if candidate.name != filename:
+                continue
+            if not _is_under(candidate, d) or not _is_under(candidate, case_root):
                 # Path-traversal guard: a symlink could escape case_root.
                 continue
-            if _layout_excludes(candidate, case_root, layout.exclude_subdirs):
-                continue
-            ext = candidate.suffix.lower()
-            media_type = MIME_MAP.get(ext, "application/octet-stream")
-            logger.info(
-                "legal_file_download",
-                slug=slug, filename=filename, subdir=logical_name,
-                custom_layout=bool(nas_layout),
-            )
-            return FileResponse(
-                path=str(candidate.resolve()),
-                media_type=media_type,
-                filename=filename,
-            )
+            rel_name = str(candidate.relative_to(d))
+            matches.append((logical_name, rel_name, candidate))
+
+    if len(matches) == 1:
+        logical_name, rel_name, candidate = matches[0]
+        return _case_file_response(
+            candidate=candidate,
+            slug=slug,
+            filename=filename,
+            logical_name=logical_name,
+            nas_layout=nas_layout,
+            relative_path=rel_name,
+        )
+
+    if len(matches) > 1:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Multiple files named '{filename}' found in case vault; "
+                "use subdir and relative_path"
+            ),
+        )
 
     raise HTTPException(status_code=404, detail=f"File '{filename}' not found in case vault")
 
@@ -672,12 +767,18 @@ async def list_case_files(slug: str):
         ):
             if not _is_under(f, case_root):
                 continue
+            relative_file_path = str(f.relative_to(d))
             files.append({
                 "filename":     f.name,
                 "subdir":       logical_name,            # logical, not physical
-                "relative_path": str(f.relative_to(d)),  # for nested layouts
+                "relative_path": relative_file_path,      # for nested layouts
                 "size_bytes":   f.stat().st_size,
-                "download_url": f"{INTERNAL_LEGAL_API_PREFIX}/cases/{slug}/download/{f.name}",
+                "download_url": _case_file_download_url(
+                    slug,
+                    f.name,
+                    logical_name,
+                    relative_file_path,
+                ),
             })
     return {"case_slug": slug, "files": files, "total": len(files)}
 

--- a/fortress-guest-platform/backend/tests/test_legal_cases_files.py
+++ b/fortress-guest-platform/backend/tests/test_legal_cases_files.py
@@ -12,6 +12,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
+from urllib.parse import parse_qs, urlsplit
 
 import pytest
 
@@ -103,10 +104,14 @@ class TestListFilesDefaultLayout:
         subdirs = {f["subdir"] for f in result["files"]}
         assert subdirs <= set(_DEFAULT_SUBDIR_MAP.keys())
         # Each entry has a download_url referencing the slug
-        assert all(
-            f["download_url"] == f"/api/internal/legal/cases/{slug}/download/{f['filename']}"
-            for f in result["files"]
-        )
+        for f in result["files"]:
+            parsed = urlsplit(f["download_url"])
+            params = parse_qs(parsed.query)
+            assert parsed.path == f"/api/internal/legal/cases/{slug}/download/{f['filename']}"
+            assert params == {
+                "subdir": [f["subdir"]],
+                "relative_path": [f["relative_path"]],
+            }
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -181,6 +186,13 @@ class TestListFilesWave7Layout:
         assert names == {
             ("curated", "emails/Argo.eml", "Argo.eml"),
             ("curated", "pleadings/Complaint.pdf", "Complaint.pdf"),
+        }
+        argo = next(f for f in result["files"] if f["filename"] == "Argo.eml")
+        parsed = urlsplit(argo["download_url"])
+        assert parsed.path == "/api/internal/legal/cases/7il-v-knight-ndga-ii/download/Argo.eml"
+        assert parse_qs(parsed.query) == {
+            "subdir": ["curated"],
+            "relative_path": ["emails/Argo.eml"],
         }
 
 
@@ -297,6 +309,79 @@ class TestDownloadCustomLayout:
         resp = await download_case_file("7il", "#1 Complaint.pdf")
         assert isinstance(resp, FileResponse)
         assert Path(resp.path).resolve() == target.resolve()
+
+
+class TestDownloadStableAddressing:
+    @pytest.mark.asyncio
+    async def test_relative_path_selects_nested_duplicate_filename(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        case_root = tmp_path / "case"
+        email_target = case_root / "curated" / "emails" / "Report.pdf"
+        pleading_target = case_root / "curated" / "pleadings" / "Report.pdf"
+        email_target.parent.mkdir(parents=True)
+        pleading_target.parent.mkdir(parents=True)
+        email_target.write_bytes(b"email")
+        pleading_target.write_bytes(b"pleading")
+
+        layout = {
+            "primary_root": str(case_root),
+            "include_subdirs": ["curated"],
+        }
+        _patch_legacy_session(monkeypatch, _row(nas_layout=layout))
+
+        from fastapi.responses import FileResponse
+        resp = await download_case_file(
+            "case",
+            "Report.pdf",
+            subdir="curated",
+            relative_path="emails/Report.pdf",
+        )
+        assert isinstance(resp, FileResponse)
+        assert Path(resp.path).resolve() == email_target.resolve()
+
+    @pytest.mark.asyncio
+    async def test_filename_only_duplicate_download_returns_conflict(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        case_root = tmp_path / "case"
+        for folder in ("emails", "pleadings"):
+            target = case_root / "curated" / folder / "Report.pdf"
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(folder.encode())
+
+        layout = {
+            "primary_root": str(case_root),
+            "include_subdirs": ["curated"],
+        }
+        _patch_legacy_session(monkeypatch, _row(nas_layout=layout))
+
+        from fastapi import HTTPException
+        with pytest.raises(HTTPException) as exc_info:
+            await download_case_file("case", "Report.pdf")
+        assert exc_info.value.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_relative_path_traversal_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        case_root = tmp_path / "case"
+        (case_root / "curated").mkdir(parents=True)
+        layout = {
+            "primary_root": str(case_root),
+            "include_subdirs": ["curated"],
+        }
+        _patch_legacy_session(monkeypatch, _row(nas_layout=layout))
+
+        from fastapi import HTTPException
+        with pytest.raises(HTTPException) as exc_info:
+            await download_case_file(
+                "case",
+                "secret.pdf",
+                subdir="curated",
+                relative_path="../secret.pdf",
+            )
+        assert exc_info.value.status_code == 400
 
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What this PR does

Adds stable download addressing for Legal Command Center NAS file links.

- `/cases/{slug}/files` now emits download URLs with `subdir` and `relative_path` query parameters.
- `/cases/{slug}/download/{filename}` keeps filename-only backward compatibility for unique matches.
- Filename-only duplicate matches now return 409 instead of silently serving whichever file is found first.
- Relative-path downloads validate traversal, subdir scope, NAS layout excludes, and symlink escape guards.

## Why

After PR #410, recursive Wave 7 NAS layouts can expose multiple nested files with the same basename. The old download route only used `filename`, which could resolve ambiguously.

## Tests

```bash
cd fortress-guest-platform
POSTGRES_API_URI=postgresql://fortress_api:test@127.0.0.1:5432/fortress_shadow_test \
TEST_DATABASE_URL=postgresql://fortress_api:test@127.0.0.1:5432/fortress_shadow_test \
python3 -m pytest backend/tests/test_legal_cases_files.py
```

Result: 23 passed.

Also ran:

```bash
git diff --check
python3 -m py_compile backend/api/legal_cases.py
```

## Out of scope

- No DB changes.
- No NAS changes.
- No ingest behavior changes.
- Future document-id based download routes remain a separate decision.
