### PR TITLE
feat(financial): add shadow review panel

### DIFF
--- a/crog-ai-backend/app/api/signals.py
+++ b/crog-ai-backend/app/api/signals.py
@@ -230,6 +230,73 @@ class PromotionGateResponse(BaseModel):
     recommendation: PromotionGateRecommendation
 
 
+class ShadowReviewLaneChange(BaseModel):
+    lane_id: str
+    label: str
+    production_tickers: list[str]
+    candidate_tickers: list[str]
+    added_tickers: list[str]
+    removed_tickers: list[str]
+    unchanged_tickers: list[str]
+    churn_rate: float
+
+
+class ShadowReviewTransitionPressure(BaseModel):
+    ticker: str
+    production_transition_count: int
+    candidate_transition_count: int
+    delta: int
+    latest_candidate_transition_type: TransitionKind | None
+    latest_candidate_transition_date: dt.date | None
+
+
+class ShadowReviewWhipsawTicker(BaseModel):
+    ticker: str
+    risk_level: str
+    risk_score: int
+    event_count: int
+    whipsaw_count: int
+    whipsaw_rate: float | None
+    win_rate: float | None
+    average_directional_return: float | None
+    latest_whipsaw_date: dt.date | None
+
+
+class ShadowReviewChecklistItem(BaseModel):
+    id: str
+    label: str
+    status: Literal["pass", "review", "hold", "blocked"]
+    detail: str
+
+
+class ShadowReviewRecommendation(BaseModel):
+    status: Literal["ready_for_shadow_review", "needs_review", "hold"]
+    label: str
+    rationale: str
+
+
+class ShadowReviewDecisionRecordTemplate(BaseModel):
+    candidate_parameter_set: str
+    allowed_decisions: list[str]
+    required_approver: str
+    required_evidence: list[str]
+
+
+class ShadowReviewResponse(BaseModel):
+    generated_at: dt.datetime
+    candidate_parameter_set: str
+    baseline_parameter_set: str
+    lookback_days: int
+    review_limit: int
+    promotion_gate: PromotionGateResponse
+    lane_reviews: list[ShadowReviewLaneChange]
+    transition_pressure: list[ShadowReviewTransitionPressure]
+    whipsaw_reviews: list[ShadowReviewWhipsawTicker]
+    checklist: list[ShadowReviewChecklistItem]
+    recommendation: ShadowReviewRecommendation
+    decision_record_template: ShadowReviewDecisionRecordTemplate
+
+
 class SymbolChartBar(BaseModel):
     ticker: str
     bar_date: dt.date
@@ -434,6 +501,26 @@ def promotion_gate_daily(
         until=until,
         top_tickers=top_tickers,
         event_window_days=event_window_days,
+    )
+
+
+@router.get("/shadow-review/daily", response_model=ShadowReviewResponse)
+def shadow_review_daily(
+    store: Annotated[SignalDataStore, Depends(get_signal_store)],
+    candidate_parameter_set: Annotated[
+        str, Query(min_length=1, max_length=100)
+    ] = "dochia_v0_2_range_daily",
+    lookback_days: Annotated[int, Query(ge=1, le=365)] = 30,
+    review_limit: Annotated[int, Query(ge=1, le=20)] = 8,
+    whipsaw_window_sessions: Annotated[int, Query(ge=1, le=30)] = 5,
+    outcome_horizon_sessions: Annotated[int, Query(ge=1, le=60)] = 5,
+) -> dict[str, object]:
+    return store.shadow_review(
+        candidate_parameter_set=candidate_parameter_set,
+        lookback_days=lookback_days,
+        review_limit=review_limit,
+        whipsaw_window_sessions=whipsaw_window_sessions,
+        outcome_horizon_sessions=outcome_horizon_sessions,
     )
 
 

--- a/crog-ai-backend/app/signals/repository.py
+++ b/crog-ai-backend/app/signals/repository.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
+from collections import Counter
 from typing import Any, Protocol
 
 import psycopg
@@ -66,6 +67,16 @@ class SignalDataStore(Protocol):
         until: dt.date | None = None,
         top_tickers: int = 20,
         event_window_days: int = 3,
+    ) -> dict[str, Any]: ...
+
+    def shadow_review(
+        self,
+        *,
+        candidate_parameter_set: str,
+        lookback_days: int = 30,
+        review_limit: int = 8,
+        whipsaw_window_sessions: int = 5,
+        outcome_horizon_sessions: int = 5,
     ) -> dict[str, Any]: ...
 
     def symbol_chart(
@@ -510,6 +521,274 @@ def fetch_promotion_gate(
     }
 
 
+LANE_LABELS = {
+    "bullish_alignment": "Bullish Alignment",
+    "risk_alignment": "Risk Alignment",
+    "reentry": "Re-entry",
+    "mixed_timeframes": "Mixed Timeframes",
+}
+
+
+def _lane_change_review(
+    *,
+    production_lanes: dict[str, list[dict[str, Any]]],
+    candidate_lanes: dict[str, list[dict[str, Any]]],
+) -> list[dict[str, Any]]:
+    reviews: list[dict[str, Any]] = []
+    for lane_id, label in LANE_LABELS.items():
+        production_tickers = [str(row["ticker"]) for row in production_lanes.get(lane_id, [])]
+        candidate_tickers = [str(row["ticker"]) for row in candidate_lanes.get(lane_id, [])]
+        production_set = set(production_tickers)
+        candidate_set = set(candidate_tickers)
+        added = sorted(candidate_set - production_set)
+        removed = sorted(production_set - candidate_set)
+        unchanged = sorted(candidate_set & production_set)
+        universe = max(len(candidate_set | production_set), 1)
+        reviews.append(
+            {
+                "lane_id": lane_id,
+                "label": label,
+                "production_tickers": production_tickers,
+                "candidate_tickers": candidate_tickers,
+                "added_tickers": added,
+                "removed_tickers": removed,
+                "unchanged_tickers": unchanged,
+                "churn_rate": (len(added) + len(removed)) / universe,
+            }
+        )
+    return reviews
+
+
+def _transition_pressure_review(
+    *,
+    production_transitions: list[dict[str, Any]],
+    candidate_transitions: list[dict[str, Any]],
+    limit: int,
+) -> list[dict[str, Any]]:
+    production_counts = Counter(str(row["ticker"]) for row in production_transitions)
+    candidate_counts = Counter(str(row["ticker"]) for row in candidate_transitions)
+    latest_candidate: dict[str, dict[str, Any]] = {}
+    for row in candidate_transitions:
+        ticker = str(row["ticker"])
+        latest_candidate.setdefault(ticker, row)
+
+    ranked_tickers = sorted(
+        candidate_counts,
+        key=lambda ticker: (
+            candidate_counts[ticker],
+            candidate_counts[ticker] - production_counts.get(ticker, 0),
+            ticker,
+        ),
+        reverse=True,
+    )[:limit]
+    reviews: list[dict[str, Any]] = []
+    for ticker in ranked_tickers:
+        latest = latest_candidate.get(ticker, {})
+        reviews.append(
+            {
+                "ticker": ticker,
+                "production_transition_count": production_counts.get(ticker, 0),
+                "candidate_transition_count": candidate_counts[ticker],
+                "delta": candidate_counts[ticker] - production_counts.get(ticker, 0),
+                "latest_candidate_transition_type": latest.get("transition_type"),
+                "latest_candidate_transition_date": latest.get("to_bar_date"),
+            }
+        )
+    return reviews
+
+
+def _shadow_whipsaw_review(
+    conn: psycopg.Connection,
+    *,
+    tickers: list[str],
+    candidate_parameter_set: str,
+    whipsaw_window_sessions: int,
+    outcome_horizon_sessions: int,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for ticker in tickers:
+        risk = fetch_symbol_whipsaw_risk(
+            conn,
+            ticker=ticker,
+            sessions=260,
+            parameter_set=candidate_parameter_set,
+            whipsaw_window_sessions=whipsaw_window_sessions,
+            outcome_horizon_sessions=outcome_horizon_sessions,
+        )
+        rows.append(
+            {
+                "ticker": ticker,
+                "risk_level": risk["risk_level"],
+                "risk_score": risk["risk_score"],
+                "event_count": risk["event_count"],
+                "whipsaw_count": risk["whipsaw_count"],
+                "whipsaw_rate": risk["whipsaw_rate"],
+                "win_rate": risk["outcome"]["win_rate"],
+                "average_directional_return": risk["outcome"]["average_directional_return"],
+                "latest_whipsaw_date": risk["latest_whipsaw_date"],
+            }
+        )
+    return sorted(rows, key=lambda row: (row["risk_score"], row["whipsaw_count"]), reverse=True)
+
+
+def _shadow_review_checklist(
+    *,
+    gate: dict[str, Any],
+    lane_reviews: list[dict[str, Any]],
+    whipsaw_reviews: list[dict[str, Any]],
+) -> list[dict[str, str]]:
+    gate_status = gate["recommendation"]["status"]
+    lane_churn = max((float(row["churn_rate"]) for row in lane_reviews), default=0.0)
+    high_whipsaw_count = sum(1 for row in whipsaw_reviews if row["risk_level"] == "high")
+    gate_check_status = {"ready_for_shadow": "pass", "hold": "hold"}.get(
+        gate_status,
+        "review",
+    )
+
+    return [
+        {
+            "id": "promotion_gate",
+            "label": "Promotion Gate",
+            "status": gate_check_status,
+            "detail": gate["recommendation"]["rationale"],
+        },
+        {
+            "id": "lane_churn",
+            "label": "Lane Churn Review",
+            "status": "review" if lane_churn >= 0.35 else "pass",
+            "detail": f"Highest lane churn is {lane_churn:.0%}; review added and removed tickers before approval.",
+        },
+        {
+            "id": "whipsaw_review",
+            "label": "Whipsaw Review",
+            "status": "review" if high_whipsaw_count else "pass",
+            "detail": f"{high_whipsaw_count} reviewed ticker{'s' if high_whipsaw_count != 1 else ''} show high whipsaw risk.",
+        },
+        {
+            "id": "decision_record",
+            "label": "Human Decision Record",
+            "status": "blocked",
+            "detail": "A human promote/defer record is required before any market_signals write.",
+        },
+        {
+            "id": "market_signals_write",
+            "label": "market_signals Write",
+            "status": "blocked",
+            "detail": "This review is read-only; production signal promotion is intentionally disabled.",
+        },
+    ]
+
+
+def _shadow_recommendation(
+    *,
+    gate: dict[str, Any],
+    checklist: list[dict[str, str]],
+) -> dict[str, str]:
+    if gate["recommendation"]["status"] == "hold":
+        return {
+            "status": "hold",
+            "label": "Hold promotion",
+            "rationale": "Promotion Gate has a hard hold. Do not advance to market_signals.",
+        }
+    if any(item["status"] == "review" for item in checklist):
+        return {
+            "status": "needs_review",
+            "label": "Needs human review",
+            "rationale": "Evidence is ready, but lane churn or whipsaw pressure needs an explicit human decision.",
+        }
+    return {
+        "status": "ready_for_shadow_review",
+        "label": "Ready for shadow review",
+        "rationale": "Evidence packet is ready for a supervised promote/defer decision.",
+    }
+
+
+def fetch_shadow_review(
+    conn: psycopg.Connection,
+    *,
+    candidate_parameter_set: str,
+    lookback_days: int = 30,
+    review_limit: int = 8,
+    whipsaw_window_sessions: int = 5,
+    outcome_horizon_sessions: int = 5,
+) -> dict[str, Any]:
+    gate = fetch_promotion_gate(
+        conn,
+        candidate_parameter_set=candidate_parameter_set,
+        top_tickers=review_limit,
+    )
+    production_lanes = fetch_watchlist_candidates(conn, limit=review_limit)
+    candidate_lanes = fetch_watchlist_candidates(
+        conn,
+        limit=review_limit,
+        parameter_set=candidate_parameter_set,
+    )
+    lane_reviews = _lane_change_review(
+        production_lanes=production_lanes,
+        candidate_lanes=candidate_lanes,
+    )
+    production_transitions = fetch_recent_transitions(
+        conn,
+        limit=500,
+        lookback_days=lookback_days,
+    )
+    candidate_transitions = fetch_recent_transitions(
+        conn,
+        limit=500,
+        lookback_days=lookback_days,
+        parameter_set=candidate_parameter_set,
+    )
+    transition_pressure = _transition_pressure_review(
+        production_transitions=production_transitions,
+        candidate_transitions=candidate_transitions,
+        limit=review_limit,
+    )
+    pressure_tickers = [row["ticker"] for row in transition_pressure]
+    lane_tickers = [
+        ticker
+        for row in lane_reviews
+        for ticker in [*row["added_tickers"], *row["removed_tickers"]]
+    ]
+    review_tickers = list(dict.fromkeys([*pressure_tickers, *lane_tickers]))[:review_limit]
+    whipsaw_reviews = _shadow_whipsaw_review(
+        conn,
+        tickers=review_tickers,
+        candidate_parameter_set=candidate_parameter_set,
+        whipsaw_window_sessions=whipsaw_window_sessions,
+        outcome_horizon_sessions=outcome_horizon_sessions,
+    )
+    checklist = _shadow_review_checklist(
+        gate=gate,
+        lane_reviews=lane_reviews,
+        whipsaw_reviews=whipsaw_reviews,
+    )
+    return {
+        "generated_at": dt.datetime.now(dt.UTC),
+        "candidate_parameter_set": candidate_parameter_set,
+        "baseline_parameter_set": PRODUCTION_PARAMETER_SET,
+        "lookback_days": lookback_days,
+        "review_limit": review_limit,
+        "promotion_gate": gate,
+        "lane_reviews": lane_reviews,
+        "transition_pressure": transition_pressure,
+        "whipsaw_reviews": whipsaw_reviews,
+        "checklist": checklist,
+        "recommendation": _shadow_recommendation(gate=gate, checklist=checklist),
+        "decision_record_template": {
+            "candidate_parameter_set": candidate_parameter_set,
+            "allowed_decisions": ["defer", "continue_shadow", "promote_to_market_signals"],
+            "required_approver": "Financial operator",
+            "required_evidence": [
+                "Promotion Gate status",
+                "Lane churn review",
+                "Transition pressure review",
+                "Whipsaw/backtest review",
+                "Rollback criteria",
+            ],
+        },
+    }
+
+
 WATCHLIST_CANDIDATE_BASE_SQL = """
     WITH latest_scores AS (
         SELECT
@@ -740,6 +1019,26 @@ class PostgresSignalDataStore:
                 until=until,
                 top_tickers=top_tickers,
                 event_window_days=event_window_days,
+            )
+
+    def shadow_review(
+        self,
+        *,
+        candidate_parameter_set: str,
+        lookback_days: int = 30,
+        review_limit: int = 8,
+        whipsaw_window_sessions: int = 5,
+        outcome_horizon_sessions: int = 5,
+    ) -> dict[str, Any]:
+        with connect() as conn:
+            conn.execute("SET default_transaction_read_only = on")
+            return fetch_shadow_review(
+                conn,
+                candidate_parameter_set=candidate_parameter_set,
+                lookback_days=lookback_days,
+                review_limit=review_limit,
+                whipsaw_window_sessions=whipsaw_window_sessions,
+                outcome_horizon_sessions=outcome_horizon_sessions,
             )
 
     def symbol_chart(

--- a/crog-ai-backend/docs/MARKETCLUB-DOCHIA-BUILD-PLAN.md
+++ b/crog-ai-backend/docs/MARKETCLUB-DOCHIA-BUILD-PLAN.md
@@ -67,6 +67,8 @@ Dochia-derived until independent truth data exists.
 - Compact Promotion Gate is complete for production vs v0.2 Range review.
 - No `market_signals` promotion is approved yet; next phase is a supervised
   shadow review and explicit promote/defer runbook.
+- Supervised Shadow Review is complete: read-only decision packet, app panel,
+  and operator runbook. This still does not approve production writes.
 
 ### Phase 5 — App Surface
 
@@ -78,8 +80,8 @@ Dochia-derived until independent truth data exists.
   exposure remains.
 - Alert inbox: new signals, reversals, whipsaw warnings.
 - Backtest lab: symbol whipsaw risk and forward-return evidence complete.
-- Model health: daily calibration baseline and Promotion Gate complete;
-  freshness, failed-ticker, and drift views remain.
+- Model health: daily calibration baseline, Promotion Gate, and Shadow Review
+  complete; freshness, failed-ticker, and drift views remain.
 
 ## API Contract
 
@@ -93,6 +95,7 @@ Base app entrypoint: `app.main:app`
 | `GET /api/financial/signals/watchlist-candidates` | portfolio-lens lanes with legacy watchlist context |
 | `GET /api/financial/signals/calibration/daily` | daily MarketClub truth calibration metrics |
 | `GET /api/financial/signals/promotion-gate/daily` | production vs v0.2 Range promotion-gate comparison |
+| `GET /api/financial/signals/shadow-review/daily` | read-only promotion review packet with gate, lane churn, transition pressure, whipsaw evidence, and decision template |
 | `GET /api/financial/signals/{ticker}/chart` | EOD bars, rolling channels, and triangle overlay events |
 | `GET /api/financial/signals/{ticker}/whipsaw-risk` | symbol whipsaw count/rate and forward-return evidence |
 | `GET /api/financial/signals/{ticker}` | symbol-level latest score plus recent transitions |
@@ -107,6 +110,8 @@ Useful query params:
 - `calibration/daily`: `since`, `until`, `ticker`, `parameter_set`, `top_tickers`
 - `promotion-gate/daily`: `candidate_parameter_set`, `since`, `until`,
   `top_tickers`, `event_window_days`
+- `shadow-review/daily`: `candidate_parameter_set`, `lookback_days`,
+  `review_limit`, `whipsaw_window_sessions`, `outcome_horizon_sessions`
 - `{ticker}/chart`: `sessions`, `as_of`
 - `{ticker}/whipsaw-risk`: `sessions`, `as_of`, optional `parameter_set`,
   `whipsaw_window_sessions`, `outcome_horizon_sessions`
@@ -245,15 +250,25 @@ Useful query params:
   whipsaw count/rate, risk level, 5-session forward-return outcome, and recent
   daily events for either production or v0.2 Range mode. The Command Center
   Hedge Fund cockpit now renders that evidence beside the selected ticker chart.
+- Added the Promotion Gate app surface. Backend endpoint
+  `/api/financial/signals/promotion-gate/daily` compares production and v0.2
+  Range on calibration, coverage, score error, signal count, re-entry pressure,
+  and guardrail status before any `market_signals` promotion.
+- Added the supervised Shadow Review app surface and runbook. Backend endpoint
+  `/api/financial/signals/shadow-review/daily` combines Promotion Gate status,
+  lane churn, transition pressure, whipsaw/backtest tickers, checklist status,
+  and a human decision template. Live database smoke returned `needs_review`,
+  4 lane reviews, 8 transition-pressure tickers, and 8 whipsaw-review tickers.
+  Production `market_signals` writes remain blocked.
 - Added and enabled `crog-ai-backend.service` on spark-node-2.
 - Promoted the Command Center production build and restarted
   `crog-ai-frontend.service`; `/financial/hedge-fund` is live through
   `https://crog-ai.com/financial/hedge-fund`.
-- Latest verification passed: 28 backend tests, ruff, backend health, focused UI
+- Latest verification passed: 49 backend tests, ruff, backend health, focused UI
   tests, focused UI lint, TypeScript, production Command Center build, service
-  status, and live backend/BFF reads for both production and v0.2 candidate
-  selectors. `/financial/hedge-fund` returns 200 after frontend restart.
+  status, and live backend/BFF reads for production, v0.2 candidate, whipsaw,
+  Promotion Gate, and Shadow Review selectors.
 
-Next clean build step: use the Whipsaw Risk / Backtest evidence to add a compact
-promotion-gate panel that compares production and v0.2 Range side by side before
-any `market_signals` promotion.
+Next clean build step: capture the supervised Shadow Review human decision
+record. If the decision is `promote_to_market_signals`, build the promotion path
+as dry-run first before any guarded `market_signals` write.

--- a/crog-ai-backend/docs/MARKETCLUB-SHADOW-REVIEW-RUNBOOK.md
+++ b/crog-ai-backend/docs/MARKETCLUB-SHADOW-REVIEW-RUNBOOK.md
@@ -1,0 +1,60 @@
+# MarketClub / Dochia Shadow Review Runbook
+
+**Status:** Read-only promotion review
+**Date:** 2026-05-03
+
+## Purpose
+
+Use this runbook before any Dochia candidate writes to
+`hedge_fund.market_signals`. The shadow review is an evidence packet, not an
+approval mechanism.
+
+## Inputs
+
+- Candidate parameter set: `dochia_v0_2_range_daily`
+- Baseline parameter set: production `dochia_v0_estimated`
+- Live app panel: Command Center -> Financial -> Hedge Fund -> Shadow Review
+- API packet:
+  `GET /api/financial/signals/shadow-review/daily?candidate_parameter_set=dochia_v0_2_range_daily`
+
+## Review Gates
+
+1. Promotion Gate must not be `hold`.
+2. Lane churn must be reviewed for bullish alignment, risk alignment, re-entry,
+   and mixed timeframes.
+3. Transition-pressure tickers must be inspected on chart overlay.
+4. High whipsaw-risk tickers must be reviewed in the Whipsaw / Backtest panel.
+5. A human decision record must be captured before promotion.
+
+## Allowed Decisions
+
+- `defer`: do not promote; continue research.
+- `continue_shadow`: keep candidate visible in the app, no production write.
+- `promote_to_market_signals`: permit the next build step to create a controlled
+  dry-run and then a guarded write path.
+
+## Required Decision Record
+
+Capture:
+
+- Reviewer and timestamp.
+- Candidate parameter set.
+- Promotion Gate recommendation.
+- Lane churn summary.
+- Transition-pressure tickers reviewed.
+- Whipsaw/backtest tickers reviewed.
+- Decision: `defer`, `continue_shadow`, or `promote_to_market_signals`.
+- Rollback or depromotion criteria.
+
+## Hard Stops
+
+- Any Promotion Gate `hold`.
+- Missing live backend or frontend Promotion Gate data.
+- Unreviewed high whipsaw-risk ticker in the shadow packet.
+- No named human approver.
+
+## Next Build Step After Approval
+
+If the decision is `promote_to_market_signals`, build the promotion pipeline as
+dry-run first. It must preserve lineage fields: source pipeline, parameter set,
+model version, computed time, explanation payload, and rollback marker.

--- a/crog-ai-backend/tests/test_api_signals.py
+++ b/crog-ai-backend/tests/test_api_signals.py
@@ -277,6 +277,93 @@ class FakeSignalStore:
             },
         }
 
+    def shadow_review(
+        self,
+        *,
+        candidate_parameter_set: str,
+        lookback_days: int = 30,
+        review_limit: int = 8,
+        whipsaw_window_sessions: int = 5,
+        outcome_horizon_sessions: int = 5,
+    ) -> dict[str, Any]:
+        return {
+            "generated_at": dt.datetime(2026, 5, 3, 18, 30, tzinfo=dt.UTC),
+            "candidate_parameter_set": candidate_parameter_set,
+            "baseline_parameter_set": "dochia_v0_estimated",
+            "lookback_days": lookback_days,
+            "review_limit": review_limit,
+            "promotion_gate": self.promotion_gate(
+                candidate_parameter_set=candidate_parameter_set,
+                top_tickers=review_limit,
+            ),
+            "lane_reviews": [
+                {
+                    "lane_id": "reentry",
+                    "label": "Re-entry",
+                    "production_tickers": ["AA", "HUT"],
+                    "candidate_tickers": ["AA", "BTU"],
+                    "added_tickers": ["BTU"],
+                    "removed_tickers": ["HUT"],
+                    "unchanged_tickers": ["AA"],
+                    "churn_rate": 2 / 3,
+                }
+            ],
+            "transition_pressure": [
+                {
+                    "ticker": "AA",
+                    "production_transition_count": 3,
+                    "candidate_transition_count": 5,
+                    "delta": 2,
+                    "latest_candidate_transition_type": "exit_to_reentry",
+                    "latest_candidate_transition_date": dt.date(2026, 4, 22),
+                }
+            ],
+            "whipsaw_reviews": [
+                {
+                    "ticker": "AA",
+                    "risk_level": "high",
+                    "risk_score": 82,
+                    "event_count": 9,
+                    "whipsaw_count": 5,
+                    "whipsaw_rate": 0.625,
+                    "win_rate": 0.55,
+                    "average_directional_return": 0.01,
+                    "latest_whipsaw_date": dt.date(2026, 4, 23),
+                }
+            ],
+            "checklist": [
+                {
+                    "id": "promotion_gate",
+                    "label": "Promotion Gate",
+                    "status": "pass",
+                    "detail": "Candidate clears the compact promotion gate.",
+                },
+                {
+                    "id": "decision_record",
+                    "label": "Human Decision Record",
+                    "status": "blocked",
+                    "detail": "A human promote/defer record is required.",
+                },
+            ],
+            "recommendation": {
+                "status": "needs_review",
+                "label": "Needs human review",
+                "rationale": "Evidence is ready, but review pressure remains.",
+            },
+            "decision_record_template": {
+                "candidate_parameter_set": candidate_parameter_set,
+                "allowed_decisions": ["defer", "continue_shadow", "promote_to_market_signals"],
+                "required_approver": "Financial operator",
+                "required_evidence": [
+                    "Promotion Gate status",
+                    "Lane churn review",
+                    "Transition pressure review",
+                    "Whipsaw/backtest review",
+                    "Rollback criteria",
+                ],
+            },
+        }
+
     def symbol_chart(
         self,
         *,
@@ -533,6 +620,26 @@ def test_promotion_gate_endpoint_compares_candidate_to_production() -> None:
     assert payload["deltas"]["signal_count"] == -2
     assert payload["guardrails"][0]["status"] == "pass"
     assert payload["recommendation"]["status"] == "ready_for_shadow"
+
+
+def test_shadow_review_endpoint_returns_decision_packet() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/financial/signals/shadow-review/daily"
+        "?candidate_parameter_set=dochia_v0_2_range_daily&review_limit=3"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["candidate_parameter_set"] == "dochia_v0_2_range_daily"
+    assert payload["recommendation"]["status"] == "needs_review"
+    assert payload["lane_reviews"][0]["added_tickers"] == ["BTU"]
+    assert payload["transition_pressure"][0]["latest_candidate_transition_type"] == "exit_to_reentry"
+    assert payload["whipsaw_reviews"][0]["risk_level"] == "high"
+    assert payload["decision_record_template"]["allowed_decisions"][-1] == "promote_to_market_signals"
 
 
 def test_symbol_chart_endpoint_returns_overlay_data() -> None:

--- a/docs/operational/MASTER-PLAN.md
+++ b/docs/operational/MASTER-PLAN.md
@@ -2,7 +2,7 @@
 
 **Operator:** Gary Knight
 **Established:** 2026-04-29
-**Updated:** 2026-05-03 (v2.0 — Dochia promotion gate live)
+**Updated:** 2026-05-03 (v2.1 — Dochia shadow review ready)
 **Cadence:** Updated on change
 
 ---
@@ -262,8 +262,8 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 | v0.3 guardrail research | Closed as research-only: simple guardrails, ATR/cooldowns, ticker clusters, and rolling whipsaw suppressors all miss the promotion gate. Rolling date-safe holdout confirms suppression destroys recall: no candidate keeps at least 95% of raw v0.2 F1; strongest reducers cut 95%+ of events but stay below 7.41% F1 |
 | Candidate persisted state | v0.2 candidate has 328 `signal_scores` rows and 1,624 `signal_transitions` rows under non-production parameter set; internal API/BFF selector live for scanner, transitions, symbol detail, Portfolio Lens, and chart overlays |
 | Candidate lane comparison | v0.2 bullish lane unchanged at 129, risk unchanged at 47, re-entry 164→145, mixed 202→203, 61 daily states/scores change |
-| Promotion contract | Fresh Dochia scores still staged; legacy `market_signals` remains contextual until supervised promotion review |
-| UI state | Hedge Fund route live in production at `https://crog-ai.com/financial/hedge-fund` with scanner, synced chart overlays, Whipsaw Risk / Backtest evidence, alert feed, symbol panel, Portfolio Lens, Calibration Baseline, and internal Production/v0.2 Range toggle |
+| Promotion contract | Fresh Dochia scores still staged; legacy `market_signals` remains contextual until supervised Shadow Review and a named human promote/defer decision record |
+| UI state | Hedge Fund route live in production at `https://crog-ai.com/financial/hedge-fund` with scanner, synced chart overlays, Whipsaw Risk / Backtest evidence, alert feed, symbol panel, Portfolio Lens, Calibration Baseline, Promotion Gate, Shadow Review, and internal Production/v0.2 Range toggle |
 
 **Signal doctrine:**
 
@@ -280,8 +280,8 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 2. Database scorer: populate `hedge_fund.signal_scores` and `signal_transitions` idempotently. Complete initial fresh batch.
 3. Calibration harness: compare generated daily state/score against 24,204 MarketClub observations. Baseline complete; refinement remains.
 4. Production contract: promote approved signals to `hedge_fund.market_signals`.
-5. API surface: scanner, symbol detail, portfolio board, alert inbox, backtest lab, model health. Scanner, symbol detail, chart data, whipsaw/backtest evidence, alert feed, watchlist-candidate lanes, daily calibration, and promotion-gate comparison complete.
-6. Command Center UI: Financial / Hedge Fund route with sober cockpit UX, not gamified retail nudges. First route, chart overlays, Whipsaw Risk / Backtest, Portfolio Lens, and Calibration Baseline complete at `/financial/hedge-fund`.
+5. API surface: scanner, symbol detail, portfolio board, alert inbox, backtest lab, model health. Scanner, symbol detail, chart data, whipsaw/backtest evidence, alert feed, watchlist-candidate lanes, daily calibration, promotion-gate comparison, and Shadow Review packet complete.
+6. Command Center UI: Financial / Hedge Fund route with sober cockpit UX, not gamified retail nudges. First route, chart overlays, Whipsaw Risk / Backtest, Portfolio Lens, Calibration Baseline, Promotion Gate, and Shadow Review complete at `/financial/hedge-fund`.
 
 **Product principles:**
 
@@ -292,7 +292,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 - Do not call generated weekly/monthly states "MarketClub truth"; they are Dochia-derived.
 - Avoid gamified trading prompts; build an evidence cockpit.
 
-**Immediate next step:** Run supervised shadow review from the live Promotion Gate, then draft the explicit `market_signals` promotion/defer runbook. No production promotion happens without that human decision record.
+**Immediate next step:** Capture the supervised Shadow Review human decision record. If the decision is `promote_to_market_signals`, build the promotion path as dry-run first; no production promotion happens without that named approval and rollback criteria.
 
 ### 6.6 Architectural follow-ups
 
@@ -355,6 +355,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 - Added and ran read-only v0.3 range-trigger guardrail research for break buffers, same-direction close confirmation, ATR-normalized buffers, trailing per-symbol adaptive cooldowns, return-conditioned outcomes, ticker whipsaw clusters, chronological ticker-cluster holdout, and rolling date-safe whipsaw suppressors. Decision: do not persist any v0.3 suppression filter; expose whipsaw risk and backtest evidence in the app instead.
 - Added the Whipsaw Risk / Backtest backend endpoint and cockpit panel. Selected tickers now show daily whipsaw count/rate, risk level, 5-session forward-return outcome, and recent daily event context for both production and v0.2 Range modes.
 - Added the compact Promotion Gate backend endpoint and cockpit panel. Production and v0.2 Range now compare side by side on signal count, re-entry pressure, calibration match, coverage, score error, and guardrail status before any `market_signals` promotion.
+- Added the supervised Shadow Review backend endpoint, cockpit panel, and runbook. The read-only packet combines Promotion Gate status, lane churn, transition pressure, whipsaw/backtest tickers, a checklist, and an explicit human decision template. Live database smoke returned `needs_review`, 4 lane reviews, 8 transition-pressure tickers, and 8 whipsaw-review tickers. Production `market_signals` writes remain blocked.
 - Added internal Production/v0.2 Range toggle to the Command Center Hedge Fund page and promoted the production frontend build.
 - Added chart-data endpoint and chart overlay with close, daily/weekly channel bands, and generated triangle event markers.
 - Refined calibration metrics to separate carried-state agreement from exact new-alert agreement: 40.67% same-day alert match and 52.54% ±3-day alert match.
@@ -362,7 +363,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 - Applied read-only Hedge Fund legacy-table grants for the app role; grant SQL tracked in `deploy/sql/marketclub_legacy_read_grants.sql`.
 - Added and enabled `crog-ai-backend.service` on spark-node-2 for the Dochia signal API.
 - Promoted the Command Center production build and restarted `crog-ai-frontend.service`; `https://crog-ai.com/financial/hedge-fund` returns 200.
-- Verification passed: 41 backend signal tests, ruff, backend health, focused UI tests, focused UI lint, TypeScript, production Command Center build, service status, and live backend/BFF reads for production, v0.2 candidate, whipsaw, and Promotion Gate selectors.
+- Verification passed: 49 backend tests, ruff, backend health, focused UI tests, focused UI lint, TypeScript, production Command Center build, service status, and live backend/BFF reads for production, v0.2 candidate, whipsaw, Promotion Gate, and Shadow Review selectors.
 
 ### 7.1 Prior snapshot (2026-04-29 — embed deployment closing)
 

--- a/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
+++ b/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
@@ -349,6 +349,81 @@ const promotionGate = {
   },
 };
 
+const shadowReview = {
+  generated_at: "2026-05-03T18:30:00Z",
+  candidate_parameter_set: "dochia_v0_2_range_daily",
+  baseline_parameter_set: "dochia_v0_estimated",
+  lookback_days: 30,
+  review_limit: 8,
+  promotion_gate: promotionGate,
+  lane_reviews: [
+    {
+      lane_id: "reentry",
+      label: "Re-entry",
+      production_tickers: ["AA", "HUT"],
+      candidate_tickers: ["AA", "BTU"],
+      added_tickers: ["BTU"],
+      removed_tickers: ["HUT"],
+      unchanged_tickers: ["AA"],
+      churn_rate: 2 / 3,
+    },
+  ],
+  transition_pressure: [
+    {
+      ticker: "AA",
+      production_transition_count: 3,
+      candidate_transition_count: 5,
+      delta: 2,
+      latest_candidate_transition_type: "exit_to_reentry",
+      latest_candidate_transition_date: "2026-04-22",
+    },
+  ],
+  whipsaw_reviews: [
+    {
+      ticker: "AA",
+      risk_level: "high",
+      risk_score: 82,
+      event_count: 9,
+      whipsaw_count: 5,
+      whipsaw_rate: 0.625,
+      win_rate: 0.55,
+      average_directional_return: 0.01,
+      latest_whipsaw_date: "2026-04-23",
+    },
+  ],
+  checklist: [
+    {
+      id: "promotion_gate",
+      label: "Promotion Gate",
+      status: "pass",
+      detail: "Candidate clears the compact promotion gate.",
+    },
+    {
+      id: "decision_record",
+      label: "Human Decision Record",
+      status: "blocked",
+      detail: "A human promote/defer record is required.",
+    },
+  ],
+  recommendation: {
+    status: "needs_review",
+    label: "Needs human review",
+    rationale: "Evidence is ready, but review pressure remains.",
+  },
+  decision_record_template: {
+    candidate_parameter_set: "dochia_v0_2_range_daily",
+    allowed_decisions: ["defer", "continue_shadow", "promote_to_market_signals"],
+    required_approver: "Financial operator",
+    required_evidence: [
+      "Promotion Gate status",
+      "Lane churn review",
+      "Transition pressure review",
+      "Whipsaw/backtest review",
+      "Rollback criteria",
+    ],
+  },
+};
+
 vi.mock("@/lib/hooks", () => ({
   useFinancialLatestSignals: () => ({
     data: latestSignals,
@@ -409,6 +484,13 @@ vi.mock("@/lib/hooks", () => ({
     isLoading: false,
     refetch: vi.fn(),
   }),
+  useFinancialShadowReview: () => ({
+    data: shadowReview,
+    isError: false,
+    isFetching: false,
+    isLoading: false,
+    refetch: vi.fn(),
+  }),
 }));
 
 describe("HedgeFundSignalsShell", () => {
@@ -425,9 +507,13 @@ describe("HedgeFundSignalsShell", () => {
     expect(screen.getByText("BUY")).toBeInTheDocument();
     expect(screen.getByText("Calibration Baseline")).toBeInTheDocument();
     expect(screen.getByText("62.1%")).toBeInTheDocument();
-    expect(screen.getByText("Promotion Gate")).toBeInTheDocument();
+    expect(screen.getAllByText("Promotion Gate").length).toBeGreaterThan(0);
     expect(screen.getByText("Ready for shadow")).toBeInTheDocument();
     expect(screen.getByText("Production vs v0.2 Range")).toBeInTheDocument();
+    expect(screen.getByText("Shadow Review")).toBeInTheDocument();
+    expect(screen.getByText("Needs human review")).toBeInTheDocument();
+    expect(screen.getByText("Lane Churn")).toBeInTheDocument();
+    expect(screen.getByText("Human Decision Record")).toBeInTheDocument();
     expect(screen.getByText("Chart Overlay")).toBeInTheDocument();
     expect(screen.getByText("1 triangle events")).toBeInTheDocument();
     expect(screen.getByText("Whipsaw Risk / Backtest")).toBeInTheDocument();

--- a/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
+++ b/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
@@ -7,6 +7,7 @@ import {
   ArrowDownRight,
   ArrowUpRight,
   BriefcaseBusiness,
+  ClipboardCheck,
   Gauge,
   Info,
   RefreshCw,
@@ -40,6 +41,7 @@ import {
   useFinancialLatestSignals,
   useFinancialDailyCalibration,
   useFinancialPromotionGate,
+  useFinancialShadowReview,
   useFinancialSignalDetail,
   useFinancialSignalChart,
   useFinancialSignalTransitions,
@@ -52,6 +54,9 @@ import type {
   FinancialPromotionGateGuardrailStatus,
   FinancialPromotionGateRecommendationStatus,
   FinancialPromotionGateResponse,
+  FinancialShadowReviewChecklistStatus,
+  FinancialShadowReviewRecommendationStatus,
+  FinancialShadowReviewResponse,
   FinancialSignalChartResponse,
   FinancialSignalTransition,
   FinancialTransitionType,
@@ -189,6 +194,20 @@ function promotionRecommendationClasses(status: FinancialPromotionGateRecommenda
 function promotionGuardrailClasses(status: FinancialPromotionGateGuardrailStatus): string {
   if (status === "fail") return "border-red-500/40 bg-red-500/10 text-red-600";
   if (status === "watch") return "border-amber-500/40 bg-amber-500/10 text-amber-600";
+  return "border-emerald-500/40 bg-emerald-500/10 text-emerald-600";
+}
+
+function shadowReviewRecommendationClasses(status: FinancialShadowReviewRecommendationStatus): string {
+  if (status === "hold") return "border-red-500/40 bg-red-500/10 text-red-600";
+  if (status === "needs_review") return "border-amber-500/40 bg-amber-500/10 text-amber-600";
+  return "border-emerald-500/40 bg-emerald-500/10 text-emerald-600";
+}
+
+function shadowReviewChecklistClasses(status: FinancialShadowReviewChecklistStatus): string {
+  if (status === "hold" || status === "blocked") {
+    return "border-red-500/40 bg-red-500/10 text-red-600";
+  }
+  if (status === "review") return "border-amber-500/40 bg-amber-500/10 text-amber-600";
   return "border-emerald-500/40 bg-emerald-500/10 text-emerald-600";
 }
 
@@ -1060,6 +1079,151 @@ function PromotionGatePanel({
   );
 }
 
+function ShadowReviewPanel({
+  review,
+  loading,
+  error,
+}: {
+  review: FinancialShadowReviewResponse | null;
+  loading: boolean;
+  error: boolean;
+}) {
+  if (error) {
+    return (
+      <div className="flex items-center gap-2 border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+        <AlertTriangle className="h-4 w-4" />
+        Shadow review unavailable.
+      </div>
+    );
+  }
+
+  if (loading && !review) {
+    return <div className="py-8 text-sm text-muted-foreground">Loading shadow review…</div>;
+  }
+
+  if (!review) {
+    return (
+      <div className="border border-dashed border-border p-5 text-sm text-muted-foreground">
+        No shadow-review data.
+      </div>
+    );
+  }
+
+  const highestChurn = [...review.lane_reviews].sort((a, b) => b.churn_rate - a.churn_rate)[0];
+  const topPressure = review.transition_pressure.slice(0, 5);
+  const topWhipsaws = review.whipsaw_reviews.slice(0, 5);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold">Supervised Shadow Review</p>
+          <p className="text-xs text-muted-foreground">
+            {review.baseline_parameter_set} → {review.candidate_parameter_set}
+          </p>
+        </div>
+        <Badge
+          variant="outline"
+          className={cn("font-medium", shadowReviewRecommendationClasses(review.recommendation.status))}
+        >
+          {review.recommendation.label}
+        </Badge>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-5">
+        {review.checklist.map((item) => (
+          <div key={item.id} className="border border-border p-3">
+            <div className="flex items-center justify-between gap-2">
+              <p className="truncate text-xs font-medium">{item.label}</p>
+              <Badge
+                variant="outline"
+                className={cn("shrink-0 text-[10px]", shadowReviewChecklistClasses(item.status))}
+              >
+                {item.status}
+              </Badge>
+            </div>
+            <p className="mt-2 line-clamp-2 text-[11px] text-muted-foreground">{item.detail}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-3">
+        <div className="border border-border p-3">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-sm font-semibold">Lane Churn</h2>
+            <span className="font-mono text-xs text-muted-foreground">
+              {highestChurn ? formatPercent(highestChurn.churn_rate) : "—"}
+            </span>
+          </div>
+          <div className="mt-3 space-y-2">
+            {review.lane_reviews.map((lane) => (
+              <div key={lane.lane_id} className="grid grid-cols-[minmax(0,1fr)_56px_56px] gap-2 text-xs">
+                <span className="truncate font-medium">{lane.label}</span>
+                <span className="text-right font-mono text-emerald-600">+{lane.added_tickers.length}</span>
+                <span className="text-right font-mono text-red-600">-{lane.removed_tickers.length}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="border border-border p-3">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-sm font-semibold">Transition Pressure</h2>
+            <span className="text-xs text-muted-foreground">{review.lookback_days}d</span>
+          </div>
+          <div className="mt-3 space-y-2">
+            {topPressure.length ? (
+              topPressure.map((item) => (
+                <div key={item.ticker} className="grid grid-cols-[56px_minmax(0,1fr)_52px] items-center gap-2 text-xs">
+                  <span className="font-mono font-semibold">{item.ticker}</span>
+                  <span className="truncate text-muted-foreground">
+                    {item.latest_candidate_transition_type
+                      ? TRANSITION_LABELS[item.latest_candidate_transition_type]
+                      : "—"}
+                  </span>
+                  <span className="text-right font-mono">
+                    {item.candidate_transition_count}
+                    <span className="text-muted-foreground">({formatSignedNumber(item.delta)})</span>
+                  </span>
+                </div>
+              ))
+            ) : (
+              <p className="text-xs text-muted-foreground">No transition pressure.</p>
+            )}
+          </div>
+        </div>
+
+        <div className="border border-border p-3">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-sm font-semibold">Whipsaw Review</h2>
+            <span className="text-xs text-muted-foreground">{topWhipsaws.length} tickers</span>
+          </div>
+          <div className="mt-3 space-y-2">
+            {topWhipsaws.length ? (
+              topWhipsaws.map((item) => (
+                <div key={item.ticker} className="grid grid-cols-[56px_minmax(0,1fr)_52px] items-center gap-2 text-xs">
+                  <span className="font-mono font-semibold">{item.ticker}</span>
+                  <Badge
+                    variant="outline"
+                    className={cn("justify-center", whipsawRiskClasses(item.risk_level))}
+                  >
+                    {whipsawRiskLabel(item.risk_level)}
+                  </Badge>
+                  <span className="text-right font-mono">{item.risk_score}</span>
+                </div>
+              ))
+            ) : (
+              <p className="text-xs text-muted-foreground">No whipsaw pressure.</p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <p className="text-xs text-muted-foreground">{review.recommendation.rationale}</p>
+    </div>
+  );
+}
+
 function SymbolPanel({
   signal,
   transitions,
@@ -1212,6 +1376,13 @@ export function HedgeFundSignalsShell() {
     candidate_parameter_set: "dochia_v0_2_range_daily",
     top_tickers: 8,
   });
+  const shadowReview = useFinancialShadowReview({
+    candidate_parameter_set: "dochia_v0_2_range_daily",
+    lookback_days: 30,
+    review_limit: 8,
+    whipsaw_window_sessions: 5,
+    outcome_horizon_sessions: 5,
+  });
   const signals = latest.data ?? EMPTY_SIGNALS;
   const alertRows = transitions.data ?? EMPTY_TRANSITIONS;
   const watchlistLanes = watchlistCandidates.data?.lanes ?? EMPTY_LANES;
@@ -1254,7 +1425,8 @@ export function HedgeFundSignalsShell() {
     whipsawRisk.isFetching ||
     watchlistCandidates.isFetching ||
     dailyCalibration.isFetching ||
-    promotionGate.isFetching;
+    promotionGate.isFetching ||
+    shadowReview.isFetching;
 
   return (
     <div className="space-y-6">
@@ -1304,6 +1476,7 @@ export function HedgeFundSignalsShell() {
               void watchlistCandidates.refetch();
               void dailyCalibration.refetch();
               void promotionGate.refetch();
+              void shadowReview.refetch();
             }}
             disabled={isRefreshing}
             aria-label="Refresh hedge fund signals"
@@ -1397,6 +1570,25 @@ export function HedgeFundSignalsShell() {
             gate={promotionGate.data ?? null}
             loading={promotionGate.isLoading}
             error={promotionGate.isError}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <ClipboardCheck className="h-5 w-5 text-primary" />
+            <CardTitle>Shadow Review</CardTitle>
+          </div>
+          <Badge variant="outline">
+            {shadowReview.data ? formatDate(shadowReview.data.generated_at) : "—"}
+          </Badge>
+        </CardHeader>
+        <CardContent>
+          <ShadowReviewPanel
+            review={shadowReview.data ?? null}
+            loading={shadowReview.isLoading}
+            error={shadowReview.isError}
           />
         </CardContent>
       </Card>

--- a/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
@@ -14,6 +14,7 @@ import type {
   FinancialLatestSignal,
   FinancialDailyCalibrationResponse,
   FinancialPromotionGateResponse,
+  FinancialShadowReviewResponse,
   FinancialSignalTransition,
   FinancialSignalChartResponse,
   FinancialSymbolSignalDetail,
@@ -203,6 +204,20 @@ export function useFinancialPromotionGate(params?: {
   return useQuery<FinancialPromotionGateResponse>({
     queryKey: ["financial", "signals", "promotion-gate", "daily", params],
     queryFn: () => api.get("/api/financial/signals/promotion-gate/daily", params),
+    staleTime: 5 * 60_000,
+  });
+}
+
+export function useFinancialShadowReview(params?: {
+  candidate_parameter_set?: string;
+  lookback_days?: number;
+  review_limit?: number;
+  whipsaw_window_sessions?: number;
+  outcome_horizon_sessions?: number;
+}) {
+  return useQuery<FinancialShadowReviewResponse>({
+    queryKey: ["financial", "signals", "shadow-review", "daily", params],
+    queryFn: () => api.get("/api/financial/signals/shadow-review/daily", params),
     staleTime: 5 * 60_000,
   });
 }

--- a/fortress-guest-platform/apps/command-center/src/lib/types.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/types.ts
@@ -335,6 +335,79 @@ export interface FinancialPromotionGateResponse {
   recommendation: FinancialPromotionGateRecommendation;
 }
 
+export interface FinancialShadowReviewLaneChange {
+  lane_id: string;
+  label: string;
+  production_tickers: string[];
+  candidate_tickers: string[];
+  added_tickers: string[];
+  removed_tickers: string[];
+  unchanged_tickers: string[];
+  churn_rate: number;
+}
+
+export interface FinancialShadowReviewTransitionPressure {
+  ticker: string;
+  production_transition_count: number;
+  candidate_transition_count: number;
+  delta: number;
+  latest_candidate_transition_type: FinancialTransitionType | null;
+  latest_candidate_transition_date: string | null;
+}
+
+export interface FinancialShadowReviewWhipsawTicker {
+  ticker: string;
+  risk_level: FinancialWhipsawRiskLevel;
+  risk_score: number;
+  event_count: number;
+  whipsaw_count: number;
+  whipsaw_rate: number | null;
+  win_rate: number | null;
+  average_directional_return: number | null;
+  latest_whipsaw_date: string | null;
+}
+
+export type FinancialShadowReviewChecklistStatus = "pass" | "review" | "hold" | "blocked";
+export type FinancialShadowReviewRecommendationStatus =
+  | "ready_for_shadow_review"
+  | "needs_review"
+  | "hold";
+
+export interface FinancialShadowReviewChecklistItem {
+  id: string;
+  label: string;
+  status: FinancialShadowReviewChecklistStatus;
+  detail: string;
+}
+
+export interface FinancialShadowReviewRecommendation {
+  status: FinancialShadowReviewRecommendationStatus;
+  label: string;
+  rationale: string;
+}
+
+export interface FinancialShadowReviewDecisionRecordTemplate {
+  candidate_parameter_set: string;
+  allowed_decisions: string[];
+  required_approver: string;
+  required_evidence: string[];
+}
+
+export interface FinancialShadowReviewResponse {
+  generated_at: string;
+  candidate_parameter_set: string;
+  baseline_parameter_set: string;
+  lookback_days: number;
+  review_limit: number;
+  promotion_gate: FinancialPromotionGateResponse;
+  lane_reviews: FinancialShadowReviewLaneChange[];
+  transition_pressure: FinancialShadowReviewTransitionPressure[];
+  whipsaw_reviews: FinancialShadowReviewWhipsawTicker[];
+  checklist: FinancialShadowReviewChecklistItem[];
+  recommendation: FinancialShadowReviewRecommendation;
+  decision_record_template: FinancialShadowReviewDecisionRecordTemplate;
+}
+
 export interface FinancialWatchlistCandidate {
   ticker: string;
   bar_date: string;


### PR DESCRIPTION
## Summary

- add a read-only Shadow Review API packet for the v0.2 Range candidate
- surface Shadow Review on the Financial / Hedge Fund cockpit with checklist, lane churn, transition pressure, and whipsaw review
- add the Shadow Review runbook and update the MarketClub/Dochia master plan docs

## Verification

- `uv run pytest` in `crog-ai-backend` -> 49 passed
- focused backend ruff on changed Python files -> passed
- live database smoke for `PostgresSignalDataStore().shadow_review(...)` -> `needs_review 4 8 8`
- `npm test -- financial-hedge-fund-shell.test.tsx` -> 2 passed
- focused Command Center eslint on changed files -> passed
- Command Center `npx tsc --noEmit` -> passed
- Command Center `npm run build` -> passed

## Notes

- full backend ruff still reports existing unrelated issues in Alembic and `scripts/phase3_imap_harvester.py`
- full Command Center eslint still reports existing unrelated issues outside the Hedge Fund slice
- no production `hedge_fund.market_signals` write path is added
