### PR TITLE
feat(financial): add shadow decision records

### DIFF
--- a/crog-ai-backend/alembic/versions/0004_shadow_review_decisions.py
+++ b/crog-ai-backend/alembic/versions/0004_shadow_review_decisions.py
@@ -1,0 +1,78 @@
+"""add shadow review decision records
+
+Revision ID: 0004_shadow_review_decisions
+Revises: 0003_rehash_xsource_dedup
+Create Date: 2026-05-03
+
+Decision records are the supervised promotion/defer audit trail for Dochia
+candidate reviews. They do not promote rows into hedge_fund.market_signals.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0004_shadow_review_decisions"
+down_revision: str | None = "0003_rehash_xsource_dedup"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS hedge_fund.signal_shadow_review_decisions (
+            id                          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            candidate_parameter_set     TEXT NOT NULL,
+            baseline_parameter_set      TEXT NOT NULL,
+            decision                    TEXT NOT NULL,
+            reviewer                    TEXT NOT NULL,
+            rationale                   TEXT NOT NULL,
+            rollback_criteria           TEXT NOT NULL,
+            reviewed_tickers            TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+            notes                       TEXT,
+            shadow_review_generated_at  TIMESTAMPTZ NOT NULL,
+            promotion_gate_status       TEXT NOT NULL,
+            recommendation_status       TEXT NOT NULL,
+            evidence_payload            JSONB NOT NULL,
+            created_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            CHECK (decision IN (
+                'defer',
+                'continue_shadow',
+                'promote_to_market_signals'
+            )),
+            CHECK (promotion_gate_status IN ('hold', 'review', 'ready_for_shadow')),
+            CHECK (recommendation_status IN (
+                'ready_for_shadow_review',
+                'needs_review',
+                'hold'
+            ))
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_shadow_review_decisions_candidate_created
+        ON hedge_fund.signal_shadow_review_decisions (
+            candidate_parameter_set,
+            created_at DESC
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_shadow_review_decisions_decision_created
+        ON hedge_fund.signal_shadow_review_decisions (
+            decision,
+            created_at DESC
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS hedge_fund.ix_shadow_review_decisions_decision_created")
+    op.execute("DROP INDEX IF EXISTS hedge_fund.ix_shadow_review_decisions_candidate_created")
+    op.execute("DROP TABLE IF EXISTS hedge_fund.signal_shadow_review_decisions")

--- a/crog-ai-backend/app/api/signals.py
+++ b/crog-ai-backend/app/api/signals.py
@@ -9,7 +9,7 @@ from typing import Annotated, Literal
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
-from pydantic import BaseModel, ConfigDict, computed_field
+from pydantic import BaseModel, ConfigDict, Field, computed_field
 
 from app.signals.repository import PostgresSignalDataStore, SignalDataStore
 
@@ -297,6 +297,43 @@ class ShadowReviewResponse(BaseModel):
     decision_record_template: ShadowReviewDecisionRecordTemplate
 
 
+ShadowReviewDecision = Literal["defer", "continue_shadow", "promote_to_market_signals"]
+
+
+class ShadowReviewDecisionRecordCreate(BaseModel):
+    candidate_parameter_set: str = Field(
+        default="dochia_v0_2_range_daily",
+        min_length=1,
+        max_length=100,
+    )
+    decision: ShadowReviewDecision
+    reviewer: str = Field(min_length=2, max_length=120)
+    rationale: str = Field(min_length=12, max_length=2000)
+    rollback_criteria: str = Field(min_length=12, max_length=2000)
+    reviewed_tickers: list[str] = Field(default_factory=list, max_length=40)
+    notes: str | None = Field(default=None, max_length=2000)
+    lookback_days: int = Field(default=30, ge=1, le=365)
+    review_limit: int = Field(default=8, ge=1, le=20)
+    whipsaw_window_sessions: int = Field(default=5, ge=1, le=30)
+    outcome_horizon_sessions: int = Field(default=5, ge=1, le=60)
+
+
+class ShadowReviewDecisionRecord(BaseModel):
+    id: UUID
+    candidate_parameter_set: str
+    baseline_parameter_set: str
+    decision: ShadowReviewDecision
+    reviewer: str
+    rationale: str
+    rollback_criteria: str
+    reviewed_tickers: list[str]
+    notes: str | None
+    shadow_review_generated_at: dt.datetime
+    promotion_gate_status: Literal["hold", "review", "ready_for_shadow"]
+    recommendation_status: Literal["ready_for_shadow_review", "needs_review", "hold"]
+    created_at: dt.datetime
+
+
 class SymbolChartBar(BaseModel):
     ticker: str
     bar_date: dt.date
@@ -522,6 +559,53 @@ def shadow_review_daily(
         whipsaw_window_sessions=whipsaw_window_sessions,
         outcome_horizon_sessions=outcome_horizon_sessions,
     )
+
+
+@router.get(
+    "/shadow-review/decision-records",
+    response_model=list[ShadowReviewDecisionRecord],
+)
+def shadow_review_decision_records(
+    store: Annotated[SignalDataStore, Depends(get_signal_store)],
+    candidate_parameter_set: Annotated[str | None, Query(min_length=1, max_length=100)] = None,
+    limit: Annotated[int, Query(ge=1, le=50)] = 10,
+) -> list[dict[str, object]]:
+    return store.shadow_review_decision_records(
+        candidate_parameter_set=candidate_parameter_set,
+        limit=limit,
+    )
+
+
+@router.post(
+    "/shadow-review/decision-records",
+    response_model=ShadowReviewDecisionRecord,
+    status_code=201,
+)
+def create_shadow_review_decision_record_endpoint(
+    payload: ShadowReviewDecisionRecordCreate,
+    store: Annotated[SignalDataStore, Depends(get_signal_store)],
+) -> dict[str, object]:
+    reviewed_tickers = [
+        ticker.strip().upper()
+        for ticker in payload.reviewed_tickers
+        if ticker.strip()
+    ]
+    try:
+        return store.create_shadow_review_decision_record(
+            candidate_parameter_set=payload.candidate_parameter_set,
+            decision=payload.decision,
+            reviewer=payload.reviewer.strip(),
+            rationale=payload.rationale.strip(),
+            rollback_criteria=payload.rollback_criteria.strip(),
+            reviewed_tickers=list(dict.fromkeys(reviewed_tickers)),
+            notes=payload.notes.strip() if payload.notes else None,
+            lookback_days=payload.lookback_days,
+            review_limit=payload.review_limit,
+            whipsaw_window_sessions=payload.whipsaw_window_sessions,
+            outcome_horizon_sessions=payload.outcome_horizon_sessions,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.get("/{ticker}/chart", response_model=SymbolSignalChart)

--- a/crog-ai-backend/app/main.py
+++ b/crog-ai-backend/app/main.py
@@ -32,7 +32,7 @@ def create_app() -> FastAPI:
         CORSMiddleware,
         allow_origins=_cors_origins(),
         allow_credentials=True,
-        allow_methods=["GET", "OPTIONS"],
+        allow_methods=["GET", "POST", "OPTIONS"],
         allow_headers=["*"],
     )
     app.include_router(signals_router)

--- a/crog-ai-backend/app/signals/repository.py
+++ b/crog-ai-backend/app/signals/repository.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import datetime as dt
 from collections import Counter
+from decimal import Decimal
 from typing import Any, Protocol
 
 import psycopg
 from psycopg.rows import dict_row
+from psycopg.types.json import Jsonb
 
 from app.database import connect
 from app.signals.calibration_repository import fetch_daily_calibration
@@ -73,6 +75,29 @@ class SignalDataStore(Protocol):
         self,
         *,
         candidate_parameter_set: str,
+        lookback_days: int = 30,
+        review_limit: int = 8,
+        whipsaw_window_sessions: int = 5,
+        outcome_horizon_sessions: int = 5,
+    ) -> dict[str, Any]: ...
+
+    def shadow_review_decision_records(
+        self,
+        *,
+        candidate_parameter_set: str | None = None,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]: ...
+
+    def create_shadow_review_decision_record(
+        self,
+        *,
+        candidate_parameter_set: str,
+        decision: str,
+        reviewer: str,
+        rationale: str,
+        rollback_criteria: str,
+        reviewed_tickers: list[str],
+        notes: str | None = None,
         lookback_days: int = 30,
         review_limit: int = 8,
         whipsaw_window_sessions: int = 5,
@@ -789,6 +814,159 @@ def fetch_shadow_review(
     }
 
 
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, (dt.datetime, dt.date)):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(item) for item in value]
+    return value
+
+
+SHADOW_DECISION_RECORD_SELECT = """
+    SELECT
+        id,
+        candidate_parameter_set,
+        baseline_parameter_set,
+        decision,
+        reviewer,
+        rationale,
+        rollback_criteria,
+        reviewed_tickers,
+        notes,
+        shadow_review_generated_at,
+        promotion_gate_status,
+        recommendation_status,
+        created_at
+    FROM hedge_fund.signal_shadow_review_decisions
+"""
+
+
+def fetch_shadow_review_decision_records(
+    conn: psycopg.Connection,
+    *,
+    candidate_parameter_set: str | None = None,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    params: dict[str, Any] = {"limit": limit}
+    where = ""
+    if candidate_parameter_set:
+        where = "WHERE candidate_parameter_set = %(candidate_parameter_set)s"
+        params["candidate_parameter_set"] = candidate_parameter_set
+    sql = f"""
+        {SHADOW_DECISION_RECORD_SELECT}
+        {where}
+        ORDER BY created_at DESC
+        LIMIT %(limit)s
+    """
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(sql, params)
+        return [dict(row) for row in cur.fetchall()]
+
+
+def create_shadow_review_decision_record(
+    conn: psycopg.Connection,
+    *,
+    candidate_parameter_set: str,
+    decision: str,
+    reviewer: str,
+    rationale: str,
+    rollback_criteria: str,
+    reviewed_tickers: list[str],
+    notes: str | None = None,
+    lookback_days: int = 30,
+    review_limit: int = 8,
+    whipsaw_window_sessions: int = 5,
+    outcome_horizon_sessions: int = 5,
+) -> dict[str, Any]:
+    evidence = fetch_shadow_review(
+        conn,
+        candidate_parameter_set=candidate_parameter_set,
+        lookback_days=lookback_days,
+        review_limit=review_limit,
+        whipsaw_window_sessions=whipsaw_window_sessions,
+        outcome_horizon_sessions=outcome_horizon_sessions,
+    )
+    promotion_gate_status = evidence["promotion_gate"]["recommendation"]["status"]
+    recommendation_status = evidence["recommendation"]["status"]
+    if decision == "promote_to_market_signals" and recommendation_status == "hold":
+        raise ValueError("Cannot record a promote decision while Shadow Review is on hold.")
+    if decision == "promote_to_market_signals" and promotion_gate_status == "hold":
+        raise ValueError("Cannot record a promote decision while Promotion Gate is on hold.")
+
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            """
+            INSERT INTO hedge_fund.signal_shadow_review_decisions (
+                candidate_parameter_set,
+                baseline_parameter_set,
+                decision,
+                reviewer,
+                rationale,
+                rollback_criteria,
+                reviewed_tickers,
+                notes,
+                shadow_review_generated_at,
+                promotion_gate_status,
+                recommendation_status,
+                evidence_payload
+            ) VALUES (
+                %(candidate_parameter_set)s,
+                %(baseline_parameter_set)s,
+                %(decision)s,
+                %(reviewer)s,
+                %(rationale)s,
+                %(rollback_criteria)s,
+                %(reviewed_tickers)s,
+                %(notes)s,
+                %(shadow_review_generated_at)s,
+                %(promotion_gate_status)s,
+                %(recommendation_status)s,
+                %(evidence_payload)s
+            )
+            RETURNING *
+            """,
+            {
+                "candidate_parameter_set": candidate_parameter_set,
+                "baseline_parameter_set": evidence["baseline_parameter_set"],
+                "decision": decision,
+                "reviewer": reviewer,
+                "rationale": rationale,
+                "rollback_criteria": rollback_criteria,
+                "reviewed_tickers": reviewed_tickers,
+                "notes": notes,
+                "shadow_review_generated_at": evidence["generated_at"],
+                "promotion_gate_status": promotion_gate_status,
+                "recommendation_status": recommendation_status,
+                "evidence_payload": Jsonb(_json_safe(evidence)),
+            },
+        )
+        row = cur.fetchone()
+    if row is None:
+        raise RuntimeError("shadow review decision insert returned no row")
+    return {
+        key: row[key]
+        for key in [
+            "id",
+            "candidate_parameter_set",
+            "baseline_parameter_set",
+            "decision",
+            "reviewer",
+            "rationale",
+            "rollback_criteria",
+            "reviewed_tickers",
+            "notes",
+            "shadow_review_generated_at",
+            "promotion_gate_status",
+            "recommendation_status",
+            "created_at",
+        ]
+    }
+
+
 WATCHLIST_CANDIDATE_BASE_SQL = """
     WITH latest_scores AS (
         SELECT
@@ -1035,6 +1213,51 @@ class PostgresSignalDataStore:
             return fetch_shadow_review(
                 conn,
                 candidate_parameter_set=candidate_parameter_set,
+                lookback_days=lookback_days,
+                review_limit=review_limit,
+                whipsaw_window_sessions=whipsaw_window_sessions,
+                outcome_horizon_sessions=outcome_horizon_sessions,
+            )
+
+    def shadow_review_decision_records(
+        self,
+        *,
+        candidate_parameter_set: str | None = None,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        with connect() as conn:
+            conn.execute("SET default_transaction_read_only = on")
+            return fetch_shadow_review_decision_records(
+                conn,
+                candidate_parameter_set=candidate_parameter_set,
+                limit=limit,
+            )
+
+    def create_shadow_review_decision_record(
+        self,
+        *,
+        candidate_parameter_set: str,
+        decision: str,
+        reviewer: str,
+        rationale: str,
+        rollback_criteria: str,
+        reviewed_tickers: list[str],
+        notes: str | None = None,
+        lookback_days: int = 30,
+        review_limit: int = 8,
+        whipsaw_window_sessions: int = 5,
+        outcome_horizon_sessions: int = 5,
+    ) -> dict[str, Any]:
+        with connect() as conn:
+            return create_shadow_review_decision_record(
+                conn,
+                candidate_parameter_set=candidate_parameter_set,
+                decision=decision,
+                reviewer=reviewer,
+                rationale=rationale,
+                rollback_criteria=rollback_criteria,
+                reviewed_tickers=reviewed_tickers,
+                notes=notes,
                 lookback_days=lookback_days,
                 review_limit=review_limit,
                 whipsaw_window_sessions=whipsaw_window_sessions,

--- a/crog-ai-backend/deploy/sql/marketclub_legacy_read_grants.sql
+++ b/crog-ai-backend/deploy/sql/marketclub_legacy_read_grants.sql
@@ -4,3 +4,7 @@ GRANT SELECT ON TABLE
     hedge_fund.market_signals,
     hedge_fund.active_strategies
 TO crog_ai_app;
+
+GRANT SELECT, INSERT ON TABLE
+    hedge_fund.signal_shadow_review_decisions
+TO crog_ai_app;

--- a/crog-ai-backend/deploy/sql/marketclub_shadow_review_decisions.sql
+++ b/crog-ai-backend/deploy/sql/marketclub_shadow_review_decisions.sql
@@ -1,0 +1,43 @@
+CREATE TABLE IF NOT EXISTS hedge_fund.signal_shadow_review_decisions (
+    id                          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    candidate_parameter_set     TEXT NOT NULL,
+    baseline_parameter_set      TEXT NOT NULL,
+    decision                    TEXT NOT NULL,
+    reviewer                    TEXT NOT NULL,
+    rationale                   TEXT NOT NULL,
+    rollback_criteria           TEXT NOT NULL,
+    reviewed_tickers            TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    notes                       TEXT,
+    shadow_review_generated_at  TIMESTAMPTZ NOT NULL,
+    promotion_gate_status       TEXT NOT NULL,
+    recommendation_status       TEXT NOT NULL,
+    evidence_payload            JSONB NOT NULL,
+    created_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CHECK (decision IN (
+        'defer',
+        'continue_shadow',
+        'promote_to_market_signals'
+    )),
+    CHECK (promotion_gate_status IN ('hold', 'review', 'ready_for_shadow')),
+    CHECK (recommendation_status IN (
+        'ready_for_shadow_review',
+        'needs_review',
+        'hold'
+    ))
+);
+
+CREATE INDEX IF NOT EXISTS ix_shadow_review_decisions_candidate_created
+ON hedge_fund.signal_shadow_review_decisions (
+    candidate_parameter_set,
+    created_at DESC
+);
+
+CREATE INDEX IF NOT EXISTS ix_shadow_review_decisions_decision_created
+ON hedge_fund.signal_shadow_review_decisions (
+    decision,
+    created_at DESC
+);
+
+GRANT SELECT, INSERT ON TABLE
+    hedge_fund.signal_shadow_review_decisions
+TO crog_ai_app;

--- a/crog-ai-backend/docs/MARKETCLUB-DOCHIA-BUILD-PLAN.md
+++ b/crog-ai-backend/docs/MARKETCLUB-DOCHIA-BUILD-PLAN.md
@@ -69,6 +69,9 @@ Dochia-derived until independent truth data exists.
   shadow review and explicit promote/defer runbook.
 - Supervised Shadow Review is complete: read-only decision packet, app panel,
   and operator runbook. This still does not approve production writes.
+- Decision Record capture is complete: supervised promote/defer records are
+  persisted with the current Shadow Review evidence packet. This still does not
+  approve production writes by itself.
 
 ### Phase 5 — App Surface
 
@@ -96,6 +99,8 @@ Base app entrypoint: `app.main:app`
 | `GET /api/financial/signals/calibration/daily` | daily MarketClub truth calibration metrics |
 | `GET /api/financial/signals/promotion-gate/daily` | production vs v0.2 Range promotion-gate comparison |
 | `GET /api/financial/signals/shadow-review/daily` | read-only promotion review packet with gate, lane churn, transition pressure, whipsaw evidence, and decision template |
+| `GET /api/financial/signals/shadow-review/decision-records` | recent supervised Shadow Review decision records |
+| `POST /api/financial/signals/shadow-review/decision-records` | persist a supervised promote/defer decision record with the current evidence packet |
 | `GET /api/financial/signals/{ticker}/chart` | EOD bars, rolling channels, and triangle overlay events |
 | `GET /api/financial/signals/{ticker}/whipsaw-risk` | symbol whipsaw count/rate and forward-return evidence |
 | `GET /api/financial/signals/{ticker}` | symbol-level latest score plus recent transitions |
@@ -112,6 +117,9 @@ Useful query params:
   `top_tickers`, `event_window_days`
 - `shadow-review/daily`: `candidate_parameter_set`, `lookback_days`,
   `review_limit`, `whipsaw_window_sessions`, `outcome_horizon_sessions`
+- `shadow-review/decision-records`: `candidate_parameter_set`, `limit` for
+  reads; writes require `decision`, `reviewer`, `rationale`, and
+  `rollback_criteria`
 - `{ticker}/chart`: `sessions`, `as_of`
 - `{ticker}/whipsaw-risk`: `sessions`, `as_of`, optional `parameter_set`,
   `whipsaw_window_sessions`, `outcome_horizon_sessions`
@@ -260,6 +268,12 @@ Useful query params:
   and a human decision template. Live database smoke returned `needs_review`,
   4 lane reviews, 8 transition-pressure tickers, and 8 whipsaw-review tickers.
   Production `market_signals` writes remain blocked.
+- Added supervised Decision Record capture. Backend endpoint
+  `/api/financial/signals/shadow-review/decision-records` persists a
+  promote/defer record with reviewer, rationale, rollback criteria, reviewed
+  tickers, and the current Shadow Review evidence payload. The Hedge Fund
+  cockpit can now record and list those decisions. Production `market_signals`
+  writes remain blocked.
 - Added and enabled `crog-ai-backend.service` on spark-node-2.
 - Promoted the Command Center production build and restarted
   `crog-ai-frontend.service`; `/financial/hedge-fund` is live through
@@ -269,6 +283,6 @@ Useful query params:
   status, and live backend/BFF reads for production, v0.2 candidate, whipsaw,
   Promotion Gate, and Shadow Review selectors.
 
-Next clean build step: capture the supervised Shadow Review human decision
-record. If the decision is `promote_to_market_signals`, build the promotion path
-as dry-run first before any guarded `market_signals` write.
+Next clean build step: after a recorded `promote_to_market_signals` decision,
+build the promotion path as dry-run first before any guarded `market_signals`
+write.

--- a/crog-ai-backend/docs/MARKETCLUB-SHADOW-REVIEW-RUNBOOK.md
+++ b/crog-ai-backend/docs/MARKETCLUB-SHADOW-REVIEW-RUNBOOK.md
@@ -16,6 +16,9 @@ approval mechanism.
 - Live app panel: Command Center -> Financial -> Hedge Fund -> Shadow Review
 - API packet:
   `GET /api/financial/signals/shadow-review/daily?candidate_parameter_set=dochia_v0_2_range_daily`
+- Decision records:
+  `GET /api/financial/signals/shadow-review/decision-records?candidate_parameter_set=dochia_v0_2_range_daily`
+  and `POST /api/financial/signals/shadow-review/decision-records`
 
 ## Review Gates
 
@@ -35,7 +38,7 @@ approval mechanism.
 
 ## Required Decision Record
 
-Capture:
+Capture in the Shadow Review panel or decision-record API:
 
 - Reviewer and timestamp.
 - Candidate parameter set.
@@ -45,6 +48,10 @@ Capture:
 - Whipsaw/backtest tickers reviewed.
 - Decision: `defer`, `continue_shadow`, or `promote_to_market_signals`.
 - Rollback or depromotion criteria.
+
+The API recomputes and stores the current Shadow Review evidence packet with
+the record. A `promote_to_market_signals` decision is still only permission to
+build the next dry-run promotion step; it is not a production write.
 
 ## Hard Stops
 

--- a/crog-ai-backend/tests/test_api_signals.py
+++ b/crog-ai-backend/tests/test_api_signals.py
@@ -10,6 +10,7 @@ from app.main import create_app
 
 PARAMETER_SET_ID = UUID("11111111-1111-1111-1111-111111111111")
 TRANSITION_ID = UUID("22222222-2222-2222-2222-222222222222")
+DECISION_ID = UUID("33333333-3333-3333-3333-333333333333")
 
 
 class FakeSignalStore:
@@ -364,6 +365,61 @@ class FakeSignalStore:
             },
         }
 
+    def shadow_review_decision_records(
+        self,
+        *,
+        candidate_parameter_set: str | None = None,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        return [
+            {
+                "id": DECISION_ID,
+                "candidate_parameter_set": candidate_parameter_set or "dochia_v0_2_range_daily",
+                "baseline_parameter_set": "dochia_v0_estimated",
+                "decision": "continue_shadow",
+                "reviewer": "Gary Knight",
+                "rationale": "Keep watching lane churn and whipsaw pressure.",
+                "rollback_criteria": "Rollback if the promotion gate moves to hold.",
+                "reviewed_tickers": ["AA", "BTU"],
+                "notes": "Operator reviewed the chart overlays.",
+                "shadow_review_generated_at": dt.datetime(2026, 5, 3, 18, 30, tzinfo=dt.UTC),
+                "promotion_gate_status": "ready_for_shadow",
+                "recommendation_status": "needs_review",
+                "created_at": dt.datetime(2026, 5, 3, 19, 0, tzinfo=dt.UTC),
+            }
+        ][:limit]
+
+    def create_shadow_review_decision_record(
+        self,
+        *,
+        candidate_parameter_set: str,
+        decision: str,
+        reviewer: str,
+        rationale: str,
+        rollback_criteria: str,
+        reviewed_tickers: list[str],
+        notes: str | None = None,
+        lookback_days: int = 30,
+        review_limit: int = 8,
+        whipsaw_window_sessions: int = 5,
+        outcome_horizon_sessions: int = 5,
+    ) -> dict[str, Any]:
+        return {
+            "id": DECISION_ID,
+            "candidate_parameter_set": candidate_parameter_set,
+            "baseline_parameter_set": "dochia_v0_estimated",
+            "decision": decision,
+            "reviewer": reviewer,
+            "rationale": rationale,
+            "rollback_criteria": rollback_criteria,
+            "reviewed_tickers": reviewed_tickers,
+            "notes": notes,
+            "shadow_review_generated_at": dt.datetime(2026, 5, 3, 18, 30, tzinfo=dt.UTC),
+            "promotion_gate_status": "ready_for_shadow",
+            "recommendation_status": "needs_review",
+            "created_at": dt.datetime(2026, 5, 3, 19, 1, tzinfo=dt.UTC),
+        }
+
     def symbol_chart(
         self,
         *,
@@ -640,6 +696,52 @@ def test_shadow_review_endpoint_returns_decision_packet() -> None:
     assert payload["transition_pressure"][0]["latest_candidate_transition_type"] == "exit_to_reentry"
     assert payload["whipsaw_reviews"][0]["risk_level"] == "high"
     assert payload["decision_record_template"]["allowed_decisions"][-1] == "promote_to_market_signals"
+
+
+def test_shadow_review_decision_records_endpoint_returns_audit_rows() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/financial/signals/shadow-review/decision-records"
+        "?candidate_parameter_set=dochia_v0_2_range_daily&limit=3"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload[0]["id"] == str(DECISION_ID)
+    assert payload[0]["decision"] == "continue_shadow"
+    assert payload[0]["reviewed_tickers"] == ["AA", "BTU"]
+    assert payload[0]["recommendation_status"] == "needs_review"
+
+
+def test_shadow_review_decision_records_endpoint_creates_audit_row() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/financial/signals/shadow-review/decision-records",
+        json={
+            "candidate_parameter_set": "dochia_v0_2_range_daily",
+            "decision": "promote_to_market_signals",
+            "reviewer": "Gary Knight",
+            "rationale": "Promotion gate cleared and reviewed tickers are acceptable.",
+            "rollback_criteria": "Rollback if whipsaw pressure rises or the gate moves to hold.",
+            "reviewed_tickers": ["aa", "BTU", "AA"],
+            "notes": "Proceed to dry-run only.",
+            "review_limit": 3,
+        },
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["candidate_parameter_set"] == "dochia_v0_2_range_daily"
+    assert payload["decision"] == "promote_to_market_signals"
+    assert payload["reviewer"] == "Gary Knight"
+    assert payload["reviewed_tickers"] == ["AA", "BTU"]
+    assert payload["promotion_gate_status"] == "ready_for_shadow"
 
 
 def test_symbol_chart_endpoint_returns_overlay_data() -> None:

--- a/docs/operational/MASTER-PLAN.md
+++ b/docs/operational/MASTER-PLAN.md
@@ -2,7 +2,7 @@
 
 **Operator:** Gary Knight
 **Established:** 2026-04-29
-**Updated:** 2026-05-03 (v2.1 — Dochia shadow review ready)
+**Updated:** 2026-05-03 (v2.2 — Dochia decision records ready)
 **Cadence:** Updated on change
 
 ---
@@ -262,8 +262,8 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 | v0.3 guardrail research | Closed as research-only: simple guardrails, ATR/cooldowns, ticker clusters, and rolling whipsaw suppressors all miss the promotion gate. Rolling date-safe holdout confirms suppression destroys recall: no candidate keeps at least 95% of raw v0.2 F1; strongest reducers cut 95%+ of events but stay below 7.41% F1 |
 | Candidate persisted state | v0.2 candidate has 328 `signal_scores` rows and 1,624 `signal_transitions` rows under non-production parameter set; internal API/BFF selector live for scanner, transitions, symbol detail, Portfolio Lens, and chart overlays |
 | Candidate lane comparison | v0.2 bullish lane unchanged at 129, risk unchanged at 47, re-entry 164→145, mixed 202→203, 61 daily states/scores change |
-| Promotion contract | Fresh Dochia scores still staged; legacy `market_signals` remains contextual until supervised Shadow Review and a named human promote/defer decision record |
-| UI state | Hedge Fund route live in production at `https://crog-ai.com/financial/hedge-fund` with scanner, synced chart overlays, Whipsaw Risk / Backtest evidence, alert feed, symbol panel, Portfolio Lens, Calibration Baseline, Promotion Gate, Shadow Review, and internal Production/v0.2 Range toggle |
+| Promotion contract | Fresh Dochia scores still staged; legacy `market_signals` remains contextual until a recorded `promote_to_market_signals` decision and a dry-run promotion path |
+| UI state | Hedge Fund route live in production at `https://crog-ai.com/financial/hedge-fund` with scanner, synced chart overlays, Whipsaw Risk / Backtest evidence, alert feed, symbol panel, Portfolio Lens, Calibration Baseline, Promotion Gate, Shadow Review, Decision Records, and internal Production/v0.2 Range toggle |
 
 **Signal doctrine:**
 
@@ -280,8 +280,8 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 2. Database scorer: populate `hedge_fund.signal_scores` and `signal_transitions` idempotently. Complete initial fresh batch.
 3. Calibration harness: compare generated daily state/score against 24,204 MarketClub observations. Baseline complete; refinement remains.
 4. Production contract: promote approved signals to `hedge_fund.market_signals`.
-5. API surface: scanner, symbol detail, portfolio board, alert inbox, backtest lab, model health. Scanner, symbol detail, chart data, whipsaw/backtest evidence, alert feed, watchlist-candidate lanes, daily calibration, promotion-gate comparison, and Shadow Review packet complete.
-6. Command Center UI: Financial / Hedge Fund route with sober cockpit UX, not gamified retail nudges. First route, chart overlays, Whipsaw Risk / Backtest, Portfolio Lens, Calibration Baseline, Promotion Gate, and Shadow Review complete at `/financial/hedge-fund`.
+5. API surface: scanner, symbol detail, portfolio board, alert inbox, backtest lab, model health. Scanner, symbol detail, chart data, whipsaw/backtest evidence, alert feed, watchlist-candidate lanes, daily calibration, promotion-gate comparison, Shadow Review packet, and Decision Records complete.
+6. Command Center UI: Financial / Hedge Fund route with sober cockpit UX, not gamified retail nudges. First route, chart overlays, Whipsaw Risk / Backtest, Portfolio Lens, Calibration Baseline, Promotion Gate, Shadow Review, and Decision Records complete at `/financial/hedge-fund`.
 
 **Product principles:**
 
@@ -292,7 +292,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 - Do not call generated weekly/monthly states "MarketClub truth"; they are Dochia-derived.
 - Avoid gamified trading prompts; build an evidence cockpit.
 
-**Immediate next step:** Capture the supervised Shadow Review human decision record. If the decision is `promote_to_market_signals`, build the promotion path as dry-run first; no production promotion happens without that named approval and rollback criteria.
+**Immediate next step:** If the recorded decision is `promote_to_market_signals`, build the promotion path as dry-run first. No production promotion happens without named approval, rollback criteria, and a guarded dry-run result.
 
 ### 6.6 Architectural follow-ups
 
@@ -356,6 +356,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 - Added the Whipsaw Risk / Backtest backend endpoint and cockpit panel. Selected tickers now show daily whipsaw count/rate, risk level, 5-session forward-return outcome, and recent daily event context for both production and v0.2 Range modes.
 - Added the compact Promotion Gate backend endpoint and cockpit panel. Production and v0.2 Range now compare side by side on signal count, re-entry pressure, calibration match, coverage, score error, and guardrail status before any `market_signals` promotion.
 - Added the supervised Shadow Review backend endpoint, cockpit panel, and runbook. The read-only packet combines Promotion Gate status, lane churn, transition pressure, whipsaw/backtest tickers, a checklist, and an explicit human decision template. Live database smoke returned `needs_review`, 4 lane reviews, 8 transition-pressure tickers, and 8 whipsaw-review tickers. Production `market_signals` writes remain blocked.
+- Added supervised Decision Record capture. The Shadow Review panel can now persist and list named promote/defer records with rationale, reviewed tickers, rollback criteria, and the current Shadow Review evidence payload. Production `market_signals` writes remain blocked.
 - Added internal Production/v0.2 Range toggle to the Command Center Hedge Fund page and promoted the production frontend build.
 - Added chart-data endpoint and chart overlay with close, daily/weekly channel bands, and generated triangle event markers.
 - Refined calibration metrics to separate carried-state agreement from exact new-alert agreement: 40.67% same-day alert match and 52.54% ±3-day alert match.

--- a/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
+++ b/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
@@ -424,6 +424,24 @@ const shadowReview = {
   },
 };
 
+const shadowDecisionRecords = [
+  {
+    id: "33333333-3333-3333-3333-333333333333",
+    candidate_parameter_set: "dochia_v0_2_range_daily",
+    baseline_parameter_set: "dochia_v0_estimated",
+    decision: "continue_shadow",
+    reviewer: "Gary Knight",
+    rationale: "Keep watching lane churn and whipsaw pressure.",
+    rollback_criteria: "Rollback if the promotion gate moves to hold.",
+    reviewed_tickers: ["AA", "BTU"],
+    notes: "Operator reviewed chart overlays.",
+    shadow_review_generated_at: "2026-05-03T18:30:00Z",
+    promotion_gate_status: "ready_for_shadow",
+    recommendation_status: "needs_review",
+    created_at: "2026-05-03T19:00:00Z",
+  },
+];
+
 vi.mock("@/lib/hooks", () => ({
   useFinancialLatestSignals: () => ({
     data: latestSignals,
@@ -491,6 +509,17 @@ vi.mock("@/lib/hooks", () => ({
     isLoading: false,
     refetch: vi.fn(),
   }),
+  useFinancialShadowDecisionRecords: () => ({
+    data: shadowDecisionRecords,
+    isError: false,
+    isFetching: false,
+    isLoading: false,
+    refetch: vi.fn(),
+  }),
+  useCreateFinancialShadowDecisionRecord: () => ({
+    isPending: false,
+    mutateAsync: vi.fn(),
+  }),
 }));
 
 describe("HedgeFundSignalsShell", () => {
@@ -514,6 +543,9 @@ describe("HedgeFundSignalsShell", () => {
     expect(screen.getByText("Needs human review")).toBeInTheDocument();
     expect(screen.getByText("Lane Churn")).toBeInTheDocument();
     expect(screen.getByText("Human Decision Record")).toBeInTheDocument();
+    expect(screen.getByText("Decision Record")).toBeInTheDocument();
+    expect(screen.getByText("Decision Records")).toBeInTheDocument();
+    expect(screen.getAllByText("Continue shadow").length).toBeGreaterThan(0);
     expect(screen.getByText("Chart Overlay")).toBeInTheDocument();
     expect(screen.getByText("1 triangle events")).toBeInTheDocument();
     expect(screen.getByText("Whipsaw Risk / Backtest")).toBeInTheDocument();

--- a/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
+++ b/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
@@ -38,9 +38,11 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import {
+  useCreateFinancialShadowDecisionRecord,
   useFinancialLatestSignals,
   useFinancialDailyCalibration,
   useFinancialPromotionGate,
+  useFinancialShadowDecisionRecords,
   useFinancialShadowReview,
   useFinancialSignalDetail,
   useFinancialSignalChart,
@@ -55,6 +57,9 @@ import type {
   FinancialPromotionGateRecommendationStatus,
   FinancialPromotionGateResponse,
   FinancialShadowReviewChecklistStatus,
+  FinancialShadowReviewDecision,
+  FinancialShadowReviewDecisionRecord,
+  FinancialShadowReviewDecisionRecordCreate,
   FinancialShadowReviewRecommendationStatus,
   FinancialShadowReviewResponse,
   FinancialSignalChartResponse,
@@ -209,6 +214,20 @@ function shadowReviewChecklistClasses(status: FinancialShadowReviewChecklistStat
   }
   if (status === "review") return "border-amber-500/40 bg-amber-500/10 text-amber-600";
   return "border-emerald-500/40 bg-emerald-500/10 text-emerald-600";
+}
+
+function shadowDecisionClasses(decision: FinancialShadowReviewDecision): string {
+  if (decision === "promote_to_market_signals") {
+    return "border-emerald-500/40 bg-emerald-500/10 text-emerald-600";
+  }
+  if (decision === "continue_shadow") return "border-sky-500/40 bg-sky-500/10 text-sky-600";
+  return "border-amber-500/40 bg-amber-500/10 text-amber-600";
+}
+
+function shadowDecisionLabel(decision: FinancialShadowReviewDecision): string {
+  if (decision === "promote_to_market_signals") return "Promote to dry-run";
+  if (decision === "continue_shadow") return "Continue shadow";
+  return "Defer";
 }
 
 function formatSignedNumber(value: number | null | undefined, digits = 0): string {
@@ -1083,11 +1102,26 @@ function ShadowReviewPanel({
   review,
   loading,
   error,
+  decisionRecords,
+  decisionRecordsLoading,
+  onSubmitDecision,
+  submittingDecision,
 }: {
   review: FinancialShadowReviewResponse | null;
   loading: boolean;
   error: boolean;
+  decisionRecords: FinancialShadowReviewDecisionRecord[];
+  decisionRecordsLoading: boolean;
+  onSubmitDecision: (payload: FinancialShadowReviewDecisionRecordCreate) => Promise<void>;
+  submittingDecision: boolean;
 }) {
+  const [decision, setDecision] = useState<FinancialShadowReviewDecision>("continue_shadow");
+  const [reviewer, setReviewer] = useState("Gary Knight");
+  const [rationale, setRationale] = useState("");
+  const [rollbackCriteria, setRollbackCriteria] = useState("");
+  const [reviewedTickers, setReviewedTickers] = useState("");
+  const [notes, setNotes] = useState("");
+
   if (error) {
     return (
       <div className="flex items-center gap-2 border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
@@ -1110,8 +1144,42 @@ function ShadowReviewPanel({
   }
 
   const highestChurn = [...review.lane_reviews].sort((a, b) => b.churn_rate - a.churn_rate)[0];
+  const activeReview = review;
   const topPressure = review.transition_pressure.slice(0, 5);
   const topWhipsaws = review.whipsaw_reviews.slice(0, 5);
+  const canSubmitDecision =
+    reviewer.trim().length >= 2 &&
+    rationale.trim().length >= 12 &&
+    rollbackCriteria.trim().length >= 12;
+
+  async function handleDecisionSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!canSubmitDecision) return;
+    const tickers = reviewedTickers
+      .split(/[\s,]+/)
+      .map((ticker) => ticker.trim().toUpperCase())
+      .filter(Boolean);
+    try {
+      await onSubmitDecision({
+        candidate_parameter_set: activeReview.candidate_parameter_set,
+        decision,
+        reviewer,
+        rationale,
+        rollback_criteria: rollbackCriteria,
+        reviewed_tickers: Array.from(new Set(tickers)),
+        notes: notes.trim() || null,
+        lookback_days: activeReview.lookback_days,
+        review_limit: activeReview.review_limit,
+        whipsaw_window_sessions: 5,
+        outcome_horizon_sessions: 5,
+      });
+      setRationale("");
+      setRollbackCriteria("");
+      setNotes("");
+    } catch {
+      // The mutation hook owns the operator-facing error toast.
+    }
+  }
 
   return (
     <div className="space-y-4">
@@ -1220,6 +1288,122 @@ function ShadowReviewPanel({
       </div>
 
       <p className="text-xs text-muted-foreground">{review.recommendation.rationale}</p>
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.9fr)]">
+        <form className="border border-border p-3" onSubmit={(event) => void handleDecisionSubmit(event)}>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <h2 className="text-sm font-semibold">Decision Record</h2>
+            <Badge variant="outline" className={cn("font-medium", shadowDecisionClasses(decision))}>
+              {shadowDecisionLabel(decision)}
+            </Badge>
+          </div>
+
+          <div className="mt-3 grid gap-3 md:grid-cols-3">
+            {(["defer", "continue_shadow", "promote_to_market_signals"] as const).map((option) => (
+              <Button
+                key={option}
+                type="button"
+                variant={decision === option ? "default" : "outline"}
+                size="sm"
+                className="justify-center"
+                onClick={() => setDecision(option)}
+                aria-pressed={decision === option}
+              >
+                {shadowDecisionLabel(option)}
+              </Button>
+            ))}
+          </div>
+
+          <div className="mt-3 grid gap-3 md:grid-cols-2">
+            <label className="space-y-1 text-xs font-medium">
+              Reviewer
+              <Input
+                value={reviewer}
+                onChange={(event) => setReviewer(event.target.value)}
+                className="h-9"
+              />
+            </label>
+            <label className="space-y-1 text-xs font-medium">
+              Reviewed Tickers
+              <Input
+                value={reviewedTickers}
+                onChange={(event) => setReviewedTickers(event.target.value)}
+                placeholder="AA, BTU"
+                className="h-9 font-mono"
+              />
+            </label>
+          </div>
+
+          <div className="mt-3 grid gap-3 md:grid-cols-2">
+            <label className="space-y-1 text-xs font-medium">
+              Rationale
+              <textarea
+                value={rationale}
+                onChange={(event) => setRationale(event.target.value)}
+                className="min-h-24 w-full resize-y border border-input bg-background px-3 py-2 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+              />
+            </label>
+            <label className="space-y-1 text-xs font-medium">
+              Rollback Criteria
+              <textarea
+                value={rollbackCriteria}
+                onChange={(event) => setRollbackCriteria(event.target.value)}
+                className="min-h-24 w-full resize-y border border-input bg-background px-3 py-2 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+              />
+            </label>
+          </div>
+
+          <label className="mt-3 block space-y-1 text-xs font-medium">
+            Notes
+            <textarea
+              value={notes}
+              onChange={(event) => setNotes(event.target.value)}
+              className="min-h-16 w-full resize-y border border-input bg-background px-3 py-2 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+            />
+          </label>
+
+          <div className="mt-3 flex justify-end">
+            <Button type="submit" disabled={!canSubmitDecision || submittingDecision}>
+              {submittingDecision ? "Saving…" : "Record Decision"}
+            </Button>
+          </div>
+        </form>
+
+        <div className="border border-border p-3">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-sm font-semibold">Decision Records</h2>
+            <span className="text-xs text-muted-foreground">
+              {decisionRecordsLoading ? "Loading" : `${decisionRecords.length} shown`}
+            </span>
+          </div>
+          <div className="mt-3 space-y-2">
+            {decisionRecords.length ? (
+              decisionRecords.map((record) => (
+                <div key={record.id} className="border border-border/70 p-2 text-xs">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <Badge
+                      variant="outline"
+                      className={cn("font-medium", shadowDecisionClasses(record.decision))}
+                    >
+                      {shadowDecisionLabel(record.decision)}
+                    </Badge>
+                    <span className="text-muted-foreground">{formatDate(record.created_at)}</span>
+                  </div>
+                  <p className="mt-2 font-medium">{record.reviewer}</p>
+                  <p className="mt-1 line-clamp-2 text-muted-foreground">{record.rationale}</p>
+                  {record.reviewed_tickers.length ? (
+                    <p className="mt-2 font-mono text-[11px] text-muted-foreground">
+                      {record.reviewed_tickers.join(", ")}
+                    </p>
+                  ) : null}
+                </div>
+              ))
+            ) : (
+              <p className="text-xs text-muted-foreground">No decision records yet.</p>
+            )}
+          </div>
+        </div>
+      </div>
     </div>
   );
 }
@@ -1383,6 +1567,11 @@ export function HedgeFundSignalsShell() {
     whipsaw_window_sessions: 5,
     outcome_horizon_sessions: 5,
   });
+  const shadowDecisionRecords = useFinancialShadowDecisionRecords({
+    candidate_parameter_set: "dochia_v0_2_range_daily",
+    limit: 5,
+  });
+  const createShadowDecisionRecord = useCreateFinancialShadowDecisionRecord();
   const signals = latest.data ?? EMPTY_SIGNALS;
   const alertRows = transitions.data ?? EMPTY_TRANSITIONS;
   const watchlistLanes = watchlistCandidates.data?.lanes ?? EMPTY_LANES;
@@ -1426,7 +1615,13 @@ export function HedgeFundSignalsShell() {
     watchlistCandidates.isFetching ||
     dailyCalibration.isFetching ||
     promotionGate.isFetching ||
-    shadowReview.isFetching;
+    shadowReview.isFetching ||
+    shadowDecisionRecords.isFetching;
+
+  async function handleShadowDecisionSubmit(payload: FinancialShadowReviewDecisionRecordCreate) {
+    await createShadowDecisionRecord.mutateAsync(payload);
+    void shadowDecisionRecords.refetch();
+  }
 
   return (
     <div className="space-y-6">
@@ -1477,6 +1672,7 @@ export function HedgeFundSignalsShell() {
               void dailyCalibration.refetch();
               void promotionGate.refetch();
               void shadowReview.refetch();
+              void shadowDecisionRecords.refetch();
             }}
             disabled={isRefreshing}
             aria-label="Refresh hedge fund signals"
@@ -1589,6 +1785,10 @@ export function HedgeFundSignalsShell() {
             review={shadowReview.data ?? null}
             loading={shadowReview.isLoading}
             error={shadowReview.isError}
+            decisionRecords={shadowDecisionRecords.data ?? []}
+            decisionRecordsLoading={shadowDecisionRecords.isLoading}
+            onSubmitDecision={handleShadowDecisionSubmit}
+            submittingDecision={createShadowDecisionRecord.isPending}
           />
         </CardContent>
       </Card>

--- a/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
@@ -13,6 +13,8 @@ import type {
   DashboardStats,
   FinancialLatestSignal,
   FinancialDailyCalibrationResponse,
+  FinancialShadowReviewDecisionRecord,
+  FinancialShadowReviewDecisionRecordCreate,
   FinancialPromotionGateResponse,
   FinancialShadowReviewResponse,
   FinancialSignalTransition,
@@ -219,6 +221,36 @@ export function useFinancialShadowReview(params?: {
     queryKey: ["financial", "signals", "shadow-review", "daily", params],
     queryFn: () => api.get("/api/financial/signals/shadow-review/daily", params),
     staleTime: 5 * 60_000,
+  });
+}
+
+export function useFinancialShadowDecisionRecords(params?: {
+  candidate_parameter_set?: string;
+  limit?: number;
+}) {
+  return useQuery<FinancialShadowReviewDecisionRecord[]>({
+    queryKey: ["financial", "signals", "shadow-review", "decision-records", params],
+    queryFn: () => api.get("/api/financial/signals/shadow-review/decision-records", params),
+    staleTime: 60_000,
+  });
+}
+
+export function useCreateFinancialShadowDecisionRecord() {
+  const qc = useQueryClient();
+  return useMutation<
+    FinancialShadowReviewDecisionRecord,
+    ApiError,
+    FinancialShadowReviewDecisionRecordCreate
+  >({
+    mutationFn: (payload) =>
+      api.post("/api/financial/signals/shadow-review/decision-records", payload),
+    onSuccess: () => {
+      qc.invalidateQueries({
+        queryKey: ["financial", "signals", "shadow-review", "decision-records"],
+      });
+      toast.success("Decision record saved");
+    },
+    onError: (error) => toast.error(error.message || "Failed to save decision record"),
   });
 }
 

--- a/fortress-guest-platform/apps/command-center/src/lib/types.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/types.ts
@@ -408,6 +408,41 @@ export interface FinancialShadowReviewResponse {
   decision_record_template: FinancialShadowReviewDecisionRecordTemplate;
 }
 
+export type FinancialShadowReviewDecision =
+  | "defer"
+  | "continue_shadow"
+  | "promote_to_market_signals";
+
+export interface FinancialShadowReviewDecisionRecordCreate {
+  candidate_parameter_set: string;
+  decision: FinancialShadowReviewDecision;
+  reviewer: string;
+  rationale: string;
+  rollback_criteria: string;
+  reviewed_tickers?: string[];
+  notes?: string | null;
+  lookback_days?: number;
+  review_limit?: number;
+  whipsaw_window_sessions?: number;
+  outcome_horizon_sessions?: number;
+}
+
+export interface FinancialShadowReviewDecisionRecord {
+  id: string;
+  candidate_parameter_set: string;
+  baseline_parameter_set: string;
+  decision: FinancialShadowReviewDecision;
+  reviewer: string;
+  rationale: string;
+  rollback_criteria: string;
+  reviewed_tickers: string[];
+  notes: string | null;
+  shadow_review_generated_at: string;
+  promotion_gate_status: FinancialPromotionGateRecommendationStatus;
+  recommendation_status: FinancialShadowReviewRecommendationStatus;
+  created_at: string;
+}
+
 export interface FinancialWatchlistCandidate {
   ticker: string;
   bar_date: string;


### PR DESCRIPTION
## Summary

- add supervised Shadow Review decision records for promote/defer/continue-shadow decisions
- persist each record with reviewer, rationale, rollback criteria, reviewed tickers, and the recomputed Shadow Review evidence payload
- add the Hedge Fund cockpit form/list for Decision Records and update the MarketClub plans/runbook

## Verification

- `uv run pytest` in `crog-ai-backend` -> 51 passed
- focused backend ruff on changed Python files and migration -> passed
- `npm test -- financial-hedge-fund-shell.test.tsx` -> 2 passed
- focused Command Center eslint on changed files -> passed
- Command Center `npx tsc --noEmit` -> passed
- Command Center `npm run build` -> passed
- applied `deploy/sql/marketclub_shadow_review_decisions.sql` to `fortress_db`
- rollback smoke: created a `continue_shadow` decision inside a transaction, rolled it back, then listed 0 persisted rows

## Notes

- no `hedge_fund.market_signals` write path is added
- the live database currently references an Alembic revision not present in this repo (`0004_extend_eod_partitions`), so this PR includes both an Alembic migration for clean installs and an idempotent deploy SQL for the current live setup
- CROG-AI CORS now allows `POST` so the Command Center can save records through the BFF
