### PR TITLE
Foundation hardening: DB session + Legal Qdrant source of truth

### DIFF
--- a/docs/architecture/runtime-map.md
+++ b/docs/architecture/runtime-map.md
@@ -82,6 +82,7 @@ Current DB session contract from `backend/core/database.py`:
 - `AsyncSessionLocal`, `async_session_factory`, and `async_session_maker` are compatibility aliases for the same lazy runtime session factory.
 - `get_db()` is the FastAPI dependency; `init_db()` verifies connectivity and only runs `Base.metadata.create_all()` when `DB_AUTO_CREATE_TABLES=true`.
 - Direct imports of `async_engine` are legacy; callers should use `get_async_engine()` so they do not capture a stale `None` before lazy initialization.
+- Legal session targets use `backend/services/legal/db_targets.py`: `LEGAL_CANONICAL_DB=fortress_db` for `LegacySession`, and `LEGAL_PROD_DB=fortress_prod` for mirror `ProdSession`. This helper parses the configured DSN and replaces only the database path, preserving driver, credentials, host, port, and query options deliberately.
 
 CONFLICT: `deploy/fortress-prime-compose.yaml` still defines `DATABASE_URL` against `fortress_guest` with an old role. Treat that compose file as a legacy/dev baseline unless it is brought forward to the current contract.
 

--- a/docs/architecture/runtime-map.md
+++ b/docs/architecture/runtime-map.md
@@ -75,6 +75,14 @@ Current DB contract from `backend/core/config.py`:
 - Allowed DB names are `fortress_prod`, `fortress_shadow`, `fortress_db`, and `fortress_shadow_test`.
 - Allowed Postgres port is `5432`.
 
+Current DB session contract from `backend/core/database.py`:
+
+- `Base` is the shared SQLAlchemy declarative metadata surface for ORM models and Alembic autogenerate.
+- `get_async_engine()` lazily creates one runtime async engine from `POSTGRES_API_URI`.
+- `AsyncSessionLocal`, `async_session_factory`, and `async_session_maker` are compatibility aliases for the same lazy runtime session factory.
+- `get_db()` is the FastAPI dependency; `init_db()` verifies connectivity and only runs `Base.metadata.create_all()` when `DB_AUTO_CREATE_TABLES=true`.
+- Direct imports of `async_engine` are legacy; callers should use `get_async_engine()` so they do not capture a stale `None` before lazy initialization.
+
 CONFLICT: `deploy/fortress-prime-compose.yaml` still defines `DATABASE_URL` against `fortress_guest` with an old role. Treat that compose file as a legacy/dev baseline unless it is brought forward to the current contract.
 
 CONFLICT: Spark-1 current-state docs show `fortress_db`, `fortress_prod`, and `fortress_shadow_test` created on Spark-1, but `fortress_shadow` absent and no service wired to those DBs yet.
@@ -85,10 +93,10 @@ Primary Qdrant URL in code defaults to `http://localhost:6333`. Docs identify th
 
 | Collection / alias | Vector size | Purpose | Current authority / conflict |
 |---|---:|---|---|
-| `legal_ediscovery` | 768 in legacy code/audit | Work-product and nonprivileged legal vault chunks. Hardcoded in `legal_ediscovery.py` and `vault_ingest_legal_case.py`. | **Legacy code authority.** Operational audit reported 738,918 points on 2026-04-29. |
+| `legal_ediscovery` | 768 in legacy code/audit | Work-product and nonprivileged legal vault chunks. Centralized in `backend/services/legal/qdrant_contract.py` and imported by ingest/reprocess/Council callers. | **Legacy code authority.** Operational audit reported 738,918 points on 2026-04-29. |
 | `legal_ediscovery_v2` | 2048 | Reindexed legal e-discovery collection using `legal-embed`. | **New retrieval authority per 2026-05-02 regression doc only when callers use alias.** |
 | `legal_ediscovery_active` | alias | Live alias points to `legal_ediscovery_v2`. | **CONFLICT:** 2026-05-03 live audit found Case I/II `case_slug` counts are zero in the alias target while backend callers still use legacy `legal_ediscovery`. Do not treat this alias as a safe 7IL evidence source yet. |
-| `legal_privileged_communications` | 768 | Physically separate privileged communications collection. | Hardcoded privileged path in `legal_ediscovery.py`. Audit reported 241,167 points. |
+| `legal_privileged_communications` | 768 | Physically separate privileged communications collection. | Centralized in `backend/services/legal/qdrant_contract.py`. Audit reported 241,167 points. |
 | `legal_privileged_communications_v2` | 2048 | Reindexed privileged collection. | Reindex complete but quality report says cutover deferred. Legacy collection remains active. |
 | `legal_caselaw` | 768 | Georgia/state caselaw. | Audit reported 2,711 points. Some docs later accept `legal_caselaw_v2` for caller cutover. |
 | `legal_caselaw_v2` | 2048 | Reindexed caselaw. | Accepted by quality report for cutover, but confirm caller code before relying on it. |

--- a/docs/architecture/runtime-map.md
+++ b/docs/architecture/runtime-map.md
@@ -82,7 +82,7 @@ Current DB session contract from `backend/core/database.py`:
 - `AsyncSessionLocal`, `async_session_factory`, and `async_session_maker` are compatibility aliases for the same lazy runtime session factory.
 - `get_db()` is the FastAPI dependency; `init_db()` verifies connectivity and only runs `Base.metadata.create_all()` when `DB_AUTO_CREATE_TABLES=true`.
 - Direct imports of `async_engine` are legacy; callers should use `get_async_engine()` so they do not capture a stale `None` before lazy initialization.
-- Legal session targets use `backend/services/legal/db_targets.py`: `LEGAL_CANONICAL_DB=fortress_db` for `LegacySession`, and `LEGAL_PROD_DB=fortress_prod` for mirror `ProdSession`. This helper parses the configured DSN and replaces only the database path, preserving driver, credentials, host, port, and query options deliberately.
+- Legal session targets use `backend/services/legal/db_targets.py`: `LEGAL_CANONICAL_DB=fortress_db` for `LegacySession`, and `LEGAL_PROD_DB=fortress_prod` for mirror `ProdSession`. This helper parses the configured DSN and replaces only the database path, preserving driver, credentials, host, port, and query options deliberately. Raw `psycopg` / `psycopg2` scripts use the same helper for connection kwargs.
 
 CONFLICT: `deploy/fortress-prime-compose.yaml` still defines `DATABASE_URL` against `fortress_guest` with an old role. Treat that compose file as a legacy/dev baseline unless it is brought forward to the current contract.
 

--- a/docs/architecture/runtime-map.md
+++ b/docs/architecture/runtime-map.md
@@ -82,7 +82,7 @@ Current DB session contract from `backend/core/database.py`:
 - `AsyncSessionLocal`, `async_session_factory`, and `async_session_maker` are compatibility aliases for the same lazy runtime session factory.
 - `get_db()` is the FastAPI dependency; `init_db()` verifies connectivity and only runs `Base.metadata.create_all()` when `DB_AUTO_CREATE_TABLES=true`.
 - Direct imports of `async_engine` are legacy; callers should use `get_async_engine()` so they do not capture a stale `None` before lazy initialization.
-- Legal session targets use `backend/services/legal/db_targets.py`: `LEGAL_CANONICAL_DB=fortress_db` for `LegacySession`, and `LEGAL_PROD_DB=fortress_prod` for mirror `ProdSession`. This helper parses the configured DSN and replaces only the database path, preserving driver, credentials, host, port, and query options deliberately. Raw `psycopg` / `psycopg2` scripts use the same helper for connection kwargs.
+- Legal session targets use `backend/services/legal/db_targets.py`: `LEGAL_CANONICAL_DB=fortress_db` for `LegacySession`, and `LEGAL_PROD_DB=fortress_prod` for mirror `ProdSession`. This helper parses the configured DSN and replaces only the database path, preserving driver, credentials, host, port, and query options deliberately. Raw `psycopg` / `psycopg2` scripts, OCR layout lookup, and deliberation-vault writes use the same helper for connection kwargs where `POSTGRES_ADMIN_URI` is available.
 
 CONFLICT: `deploy/fortress-prime-compose.yaml` still defines `DATABASE_URL` against `fortress_guest` with an old role. Treat that compose file as a legacy/dev baseline unless it is brought forward to the current contract.
 

--- a/docs/operational/fortress-legal-qdrant-contract-audit-2026-05-03.md
+++ b/docs/operational/fortress-legal-qdrant-contract-audit-2026-05-03.md
@@ -90,17 +90,18 @@ Payload sampling confirmed `legal_ediscovery_v2` points can carry `case_slug`, `
 
 | File | Collection contract | Meaning |
 |---|---|---|
-| `fortress-guest-platform/backend/services/legal_ediscovery.py` | `QDRANT_COLLECTION = "legal_ediscovery"`; `QDRANT_PRIVILEGED_COLLECTION = "legal_privileged_communications"` | Canonical single-file vault upload writes legacy 768-dim work-product and privileged collections. |
-| `fortress-guest-platform/backend/scripts/vault_ingest_legal_case.py` | `QDRANT_COLLECTION = "legal_ediscovery"`; `EXPECTED_VECTOR_SIZE = 768` | Batch ingest preflight requires legacy 768-dim work-product collection. |
-| `fortress-guest-platform/backend/scripts/email_backfill_legal.py` | `legal_ediscovery` and `legal_privileged_communications`; expected vector size 768 | Email backfill follows the same legacy ingest contract. |
-| `fortress-guest-platform/backend/scripts/backfill_vector_ids.py` | `legal_ediscovery` and `legal_privileged_communications` | Backfill/support tooling targets legacy collections. |
+| `fortress-guest-platform/backend/services/legal/qdrant_contract.py` | `LEGAL_WORK_PRODUCT_COLLECTION = "legal_ediscovery"`; `LEGAL_PRIVILEGED_COMMUNICATIONS_COLLECTION = "legal_privileged_communications"`; `LEGAL_LEGACY_VECTOR_SIZE = 768` | Central source of truth for the current 7IL legacy-stable Qdrant contract. |
+| `fortress-guest-platform/backend/services/legal_ediscovery.py` | Imports work-product and privileged collection names from `qdrant_contract.py` | Canonical single-file vault upload writes legacy 768-dim work-product and privileged collections. |
+| `fortress-guest-platform/backend/scripts/vault_ingest_legal_case.py` | Imports work-product collection and expected vector size from `qdrant_contract.py` | Batch ingest preflight requires legacy 768-dim work-product collection. |
+| `fortress-guest-platform/backend/scripts/email_backfill_legal.py` | Imports work-product, privileged, and vector-size contract from `qdrant_contract.py` | Email backfill follows the same legacy ingest contract. |
+| `fortress-guest-platform/backend/scripts/backfill_vector_ids.py` | Imports work-product and privileged collection names from `qdrant_contract.py` | Backfill/support tooling targets legacy collections. |
 
 ### Legal Retrieval Paths
 
 | File | Collection contract | Meaning |
 |---|---|---|
-| `fortress-guest-platform/backend/services/legal_council.py` | `LEGAL_COLLECTION = "legal_ediscovery"` | Council e-discovery context freezing still retrieves from legacy 768-dim `legal_ediscovery`. |
-| `fortress-guest-platform/backend/services/legal_council.py` | `PRIVILEGED_COLLECTION = "legal_privileged_communications"` | Council privileged retrieval still retrieves from legacy 768-dim privileged collection. |
+| `fortress-guest-platform/backend/services/legal_council.py` | `LEGAL_COLLECTION` imports `LEGAL_WORK_PRODUCT_COLLECTION` from `qdrant_contract.py` | Council e-discovery context freezing still retrieves from legacy 768-dim `legal_ediscovery`. |
+| `fortress-guest-platform/backend/services/legal_council.py` | `PRIVILEGED_COLLECTION` imports `LEGAL_PRIVILEGED_COMMUNICATIONS_COLLECTION` from `qdrant_contract.py` | Council privileged retrieval still retrieves from legacy 768-dim privileged collection. |
 | `fortress-guest-platform/backend/services/legal_council.py` | `CASELAW_COLLECTION = "legal_caselaw_v2"` | Council precedent retrieval uses 2048-dim v2 caselaw. |
 | `fortress-guest-platform/backend/services/knowledge_retriever.py` | `LEGAL_COLLECTION = "legal_library_v2"` | Legal-library retrieval uses 2048-dim v2 legal library. |
 | `fortress-guest-platform/backend/services/legal_auditor.py` | `STATUTORY_COLLECTION = "legal_library_v2"` | Statutory/legal-auditor retrieval uses 2048-dim v2 legal library. |
@@ -148,12 +149,12 @@ Safer options are:
 
 ## Recommended Next Move
 
-Do **not** change runtime Qdrant aliases or backend callers in this docs PR.
+Do **not** change runtime Qdrant aliases as part of foundation cleanup.
 
-Next foundation PR should be a targeted design/implementation PR that chooses one of these paths:
+Next migration PR should choose one of these paths:
 
-1. **Legacy-stable path:** explicitly document and enforce that 7IL runtime retrieval remains on `legal_ediscovery` / `legal_privileged_communications` until Wave 7 reindex completes.
+1. **Legacy-stable path:** keep enforcing that 7IL runtime retrieval remains on `legal_ediscovery` / `legal_privileged_communications` until Wave 7 reindex completes.
 2. **V2 migration path:** reindex 7IL Case I/II work-product and privileged points into v2, verify case counts and retrieval quality, then migrate code callers to `legal_ediscovery_active` with matching 2048-dim query embeddings.
 3. **Dual-write path:** preserve legacy reads while adding a tested 2048-dim v2 write/update path for new ingest.
 
-Given the current 7IL priority, the least-risk near-term choice is the legacy-stable path: leave code on legacy collections, prevent any 7IL process from relying on `legal_ediscovery_active`, and schedule v2 migration separately after Case II ingest scope is stable.
+Given the current 7IL priority, the least-risk near-term choice is the legacy-stable path: leave runtime on legacy collections, prevent any 7IL process from relying on `legal_ediscovery_active`, and schedule v2 migration separately after Case II ingest scope is stable. A follow-up hardening PR centralized the legacy-stable collection names in `backend/services/legal/qdrant_contract.py` so future caller changes have a single place to review.

--- a/fortress-guest-platform/backend/core/database.py
+++ b/fortress-guest-platform/backend/core/database.py
@@ -43,6 +43,9 @@ def get_session_factory() -> async_sessionmaker[AsyncSession]:
     """Return the shared async session factory for runtime DB access."""
     global _session_factory
 
+    if not isinstance(AsyncSessionLocal, _LazySessionFactory):
+        return AsyncSessionLocal
+
     if _session_factory is None:
         _session_factory = async_sessionmaker(
             get_async_engine(),
@@ -104,9 +107,17 @@ async def get_db() -> AsyncIterator[AsyncSession]:
 
 async def init_db() -> None:
     """Verify the runtime database contract and prime the connection pool."""
-    async with get_async_engine().connect() as connection:
+    async with get_async_engine().begin() as connection:
         await connection.execute(text("SELECT 1"))
-    logger.info("database_connection_verified", database=settings.database_name)
+        if settings.db_auto_create_tables:
+            await connection.run_sync(Base.metadata.create_all)
+            logger.info("database_tables_ensured", database=settings.database_name)
+        else:
+            logger.info(
+                "database_connection_verified",
+                database=settings.database_name,
+                auto_create_tables=False,
+            )
 
 
 async def close_db() -> None:
@@ -118,73 +129,3 @@ async def close_db() -> None:
         async_engine = None
         _session_factory = None
         logger.info("database_connections_closed")
-"""
-Async database engine, session factory, and FastAPI dependency.
-"""
-from sqlalchemy import text
-import structlog
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
-from sqlalchemy.orm import declarative_base
-
-from backend.core.config import settings
-
-logger = structlog.get_logger()
-
-Base = declarative_base()
-
-def _async_url(url: str) -> str:
-    """Ensure the database URL uses the asyncpg driver."""
-    if url.startswith("postgresql://"):
-        return url.replace("postgresql://", "postgresql+asyncpg://", 1)
-    if url.startswith("postgres://"):
-        return url.replace("postgres://", "postgresql+asyncpg://", 1)
-    return url
-
-async_engine = create_async_engine(
-    _async_url(settings.database_url),
-    echo=False,
-    pool_size=20,
-    max_overflow=10,
-    pool_pre_ping=True,
-)
-
-AsyncSessionLocal = async_sessionmaker(
-    async_engine,
-    class_=AsyncSession,
-    expire_on_commit=False,
-)
-
-# Backward-compatible alias for legacy service imports.
-async_session_maker = AsyncSessionLocal
-
-
-def get_session_factory():
-    """Backward-compatible accessor for legacy async session callers."""
-    return AsyncSessionLocal
-
-
-async def get_db():
-    """FastAPI dependency that yields an async DB session."""
-    async with AsyncSessionLocal() as session:
-        try:
-            yield session
-        except Exception:
-            await session.rollback()
-            raise
-
-
-async def init_db():
-    """Validate connectivity and optionally create tables in opt-in dev mode."""
-    async with async_engine.begin() as conn:
-        await conn.execute(text("SELECT 1"))
-        if settings.db_auto_create_tables:
-            await conn.run_sync(Base.metadata.create_all)
-            logger.info("database_tables_ensured")
-        else:
-            logger.info("database_connection_verified", auto_create_tables=False)
-
-
-async def close_db():
-    """Dispose of the engine connection pool."""
-    await async_engine.dispose()
-    logger.info("database_connections_closed")

--- a/fortress-guest-platform/backend/main.py
+++ b/fortress-guest-platform/backend/main.py
@@ -23,7 +23,7 @@ from fastapi.responses import FileResponse, JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from backend.core.config import settings
-from backend.core.database import init_db, close_db, get_db, async_engine
+from backend.core.database import init_db, close_db, get_db
 from backend.core.public_api_paths import is_public_api_path
 from backend.core.queue import create_arq_pool
 from backend.api import guests, messages, reservations, properties, workorders, analytics, webhooks, webhooks_channex, guestbook

--- a/fortress-guest-platform/backend/scripts/backfill_vector_ids.py
+++ b/fortress-guest-platform/backend/scripts/backfill_vector_ids.py
@@ -53,7 +53,6 @@ import argparse
 import json
 import logging
 import os
-import re
 import socket
 import sys
 import time
@@ -65,6 +64,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from backend.services.legal.db_targets import legal_connect_kwargs
 from backend.services.legal.qdrant_contract import (
     LEGAL_PRIVILEGED_COMMUNICATIONS_COLLECTION,
     LEGAL_WORK_PRODUCT_COLLECTION,
@@ -107,37 +107,9 @@ def _ensure_env_loaded() -> None:
         os.environ.setdefault(k, v)
 
 
-@dataclass
-class _DSN:
-    host: str
-    port: int
-    user: str
-    password: str
-    db: str
-
-
-def _parse_admin_dsn(dbname: str) -> _DSN:
-    uri = os.environ.get("POSTGRES_ADMIN_URI", "")
-    m = re.match(
-        r"postgresql(?:\+\w+)?://([^:]+):([^@]+)@([^:/]+):?(\d+)?/[^?]+",
-        uri,
-    )
-    if not m:
-        raise SystemExit(
-            "POSTGRES_ADMIN_URI not set or unparseable in environ; "
-            "load .env first"
-        )
-    user, pw, host, port = m.groups()
-    return _DSN(host=host, port=int(port or 5432), user=user, password=pw, db=dbname)
-
-
 def _connect(dbname: str):
     import psycopg2
-    dsn = _parse_admin_dsn(dbname)
-    conn = psycopg2.connect(
-        host=dsn.host, port=dsn.port, user=dsn.user,
-        password=dsn.password, dbname=dsn.db,
-    )
+    conn = psycopg2.connect(**legal_connect_kwargs(dbname))
     conn.autocommit = True
     return conn
 

--- a/fortress-guest-platform/backend/scripts/backfill_vector_ids.py
+++ b/fortress-guest-platform/backend/scripts/backfill_vector_ids.py
@@ -65,6 +65,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from backend.services.legal.qdrant_contract import (
+    LEGAL_PRIVILEGED_COMMUNICATIONS_COLLECTION,
+    LEGAL_WORK_PRODUCT_COLLECTION,
+)
+
 logger = logging.getLogger("backfill_vector_ids")
 
 # ─── config ────────────────────────────────────────────────────────────────
@@ -72,8 +77,8 @@ logger = logging.getLogger("backfill_vector_ids")
 ENV_PATH = Path("/home/admin/Fortress-Prime/fortress-guest-platform/.env")
 AUDIT_DIR = Path("/mnt/fortress_nas/audits")
 
-QDRANT_WORK_PRODUCT_COLLECTION = "legal_ediscovery"
-QDRANT_PRIVILEGED_COLLECTION = "legal_privileged_communications"
+QDRANT_WORK_PRODUCT_COLLECTION = LEGAL_WORK_PRODUCT_COLLECTION
+QDRANT_PRIVILEGED_COLLECTION = LEGAL_PRIVILEGED_COMMUNICATIONS_COLLECTION
 QDRANT_SCROLL_BATCH = 512
 
 # DBs that hold legal.vault_documents (kept in lock-step by vault ingestion).

--- a/fortress-guest-platform/backend/scripts/email_backfill_legal.py
+++ b/fortress-guest-platform/backend/scripts/email_backfill_legal.py
@@ -62,6 +62,12 @@ from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Optional
 
+from backend.services.legal.qdrant_contract import (
+    LEGAL_LEGACY_VECTOR_SIZE,
+    LEGAL_PRIVILEGED_COMMUNICATIONS_COLLECTION,
+    LEGAL_WORK_PRODUCT_COLLECTION,
+)
+
 logger = logging.getLogger("email_backfill_legal")
 
 
@@ -78,9 +84,9 @@ FETCH_BATCH         = 100
 RETRY_BACKOFFS_S    = (2.0, 8.0, 20.0)
 BAND_MONTHS         = 6
 
-QDRANT_COLLECTION_WORK_PRODUCT = "legal_ediscovery"
-QDRANT_COLLECTION_PRIVILEGED   = "legal_privileged_communications"
-EXPECTED_VECTOR_SIZE           = 768
+QDRANT_COLLECTION_WORK_PRODUCT = LEGAL_WORK_PRODUCT_COLLECTION
+QDRANT_COLLECTION_PRIVILEGED   = LEGAL_PRIVILEGED_COMMUNICATIONS_COLLECTION
+EXPECTED_VECTOR_SIZE           = LEGAL_LEGACY_VECTOR_SIZE
 
 MAILBOX_REGISTRY = {
     "gary-gk":   ("gary@garyknight.com",                "fortress/mailboxes/gary-garyknight"),

--- a/fortress-guest-platform/backend/scripts/email_backfill_legal.py
+++ b/fortress-guest-platform/backend/scripts/email_backfill_legal.py
@@ -62,6 +62,7 @@ from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Optional
 
+from backend.services.legal.db_targets import legal_connect_kwargs
 from backend.services.legal.qdrant_contract import (
     LEGAL_LEGACY_VECTOR_SIZE,
     LEGAL_PRIVILEGED_COMMUNICATIONS_COLLECTION,
@@ -189,37 +190,9 @@ def _ensure_env_loaded() -> None:
         os.environ.setdefault(k, v)
 
 
-@dataclass
-class _DSN:
-    host: str
-    port: int
-    user: str
-    password: str
-    db: str
-
-
-def _parse_admin_dsn(dbname: str) -> _DSN:
-    uri = os.environ.get("POSTGRES_ADMIN_URI", "")
-    m = re.match(
-        r"postgresql(?:\+\w+)?://([^:]+):([^@]+)@([^:/]+):?(\d+)?/[^?]+",
-        uri,
-    )
-    if not m:
-        raise SystemExit(
-            "POSTGRES_ADMIN_URI not set or unparseable in environ; "
-            "load .env first"
-        )
-    user, pw, host, port = m.groups()
-    return _DSN(host=host, port=int(port or 5432), user=user, password=pw, db=dbname)
-
-
 def _connect(dbname: str):
     import psycopg2
-    dsn = _parse_admin_dsn(dbname)
-    conn = psycopg2.connect(
-        host=dsn.host, port=dsn.port, user=dsn.user,
-        password=dsn.password, dbname=dsn.db,
-    )
+    conn = psycopg2.connect(**legal_connect_kwargs(dbname))
     conn.autocommit = True
     return conn
 

--- a/fortress-guest-platform/backend/scripts/ocr_legal_case.py
+++ b/fortress-guest-platform/backend/scripts/ocr_legal_case.py
@@ -39,6 +39,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from backend.services.legal.db_targets import LEGAL_CANONICAL_DB, legal_connect_kwargs
+
 logger = logging.getLogger("ocr_legal_case")
 
 # ─── config ────────────────────────────────────────────────────────────────
@@ -90,18 +92,18 @@ def _read_env_pgs() -> dict[str, str]:
 def _admin_dsn() -> tuple[str, str, str, str, str]:
     """Return (host, port, user, password, db) for fortress_db (read-only SELECT)."""
     env = _read_env_pgs()
-    uri = env.get("POSTGRES_ADMIN_URI", "")
-    # postgresql+asyncpg://user:pw@host:port/dbname
-    import re
-    m = re.match(
-        r"postgresql(?:\+\w+)?://([^:]+):([^@]+)@([^:/]+):?(\d+)?/([^?]+)",
-        uri,
+    uri = os.environ.get("POSTGRES_ADMIN_URI", "").strip() or env.get("POSTGRES_ADMIN_URI", "")
+    try:
+        dsn = legal_connect_kwargs(LEGAL_CANONICAL_DB, uri)
+    except Exception as exc:
+        raise SystemExit(f"could not parse POSTGRES_ADMIN_URI from {ENV_PATH}: {exc}") from exc
+    return (
+        str(dsn["host"]),
+        str(dsn["port"]),
+        str(dsn["user"]),
+        str(dsn["password"]),
+        str(dsn["dbname"]),
     )
-    if not m:
-        raise SystemExit(f"could not parse POSTGRES_ADMIN_URI from {ENV_PATH}")
-    user, pw, host, port, _ = m.groups()
-    # Layout actually lives in fortress_db (per CLAUDE.md / legal_email_intake).
-    return host, port or "5432", user, pw, "fortress_db"
 
 
 def fetch_case_layout(case_slug: str) -> dict[str, Any]:

--- a/fortress-guest-platform/backend/scripts/reprocess_failed_qdrant_uploads.py
+++ b/fortress-guest-platform/backend/scripts/reprocess_failed_qdrant_uploads.py
@@ -105,6 +105,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
+from backend.services.legal.qdrant_contract import (
+    LEGAL_PRIVILEGED_COMMUNICATIONS_COLLECTION,
+    LEGAL_WORK_PRODUCT_COLLECTION,
+)
+
 logger = logging.getLogger("reprocess_failed_qdrant_uploads")
 
 # ─── config ────────────────────────────────────────────────────────────────
@@ -112,8 +117,8 @@ logger = logging.getLogger("reprocess_failed_qdrant_uploads")
 ENV_PATH = Path("/home/admin/Fortress-Prime/fortress-guest-platform/.env")
 AUDIT_DIR = Path("/mnt/fortress_nas/audits")
 
-QDRANT_WORK_PRODUCT_COLLECTION = "legal_ediscovery"
-QDRANT_PRIVILEGED_COLLECTION = "legal_privileged_communications"
+QDRANT_WORK_PRODUCT_COLLECTION = LEGAL_WORK_PRODUCT_COLLECTION
+QDRANT_PRIVILEGED_COLLECTION = LEGAL_PRIVILEGED_COMMUNICATIONS_COLLECTION
 
 # DBs that hold legal.vault_documents (kept in lock-step by vault ingestion).
 TARGET_DBS = ("fortress_db", "fortress_prod")

--- a/fortress-guest-platform/backend/scripts/reprocess_failed_qdrant_uploads.py
+++ b/fortress-guest-platform/backend/scripts/reprocess_failed_qdrant_uploads.py
@@ -93,7 +93,6 @@ import asyncio
 import json
 import logging
 import os
-import re
 import socket
 import sys
 import time
@@ -105,6 +104,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
+from backend.services.legal.db_targets import legal_connect_kwargs
 from backend.services.legal.qdrant_contract import (
     LEGAL_PRIVILEGED_COMMUNICATIONS_COLLECTION,
     LEGAL_WORK_PRODUCT_COLLECTION,
@@ -155,37 +155,9 @@ def _ensure_env_loaded() -> None:
         os.environ.setdefault(k, v)
 
 
-@dataclass
-class _DSN:
-    host: str
-    port: int
-    user: str
-    password: str
-    db: str
-
-
-def _parse_admin_dsn(dbname: str) -> _DSN:
-    uri = os.environ.get("POSTGRES_ADMIN_URI", "")
-    m = re.match(
-        r"postgresql(?:\+\w+)?://([^:]+):([^@]+)@([^:/]+):?(\d+)?/[^?]+",
-        uri,
-    )
-    if not m:
-        raise SystemExit(
-            "POSTGRES_ADMIN_URI not set or unparseable in environ; "
-            "load .env first"
-        )
-    user, pw, host, port = m.groups()
-    return _DSN(host=host, port=int(port or 5432), user=user, password=pw, db=dbname)
-
-
 def _connect(dbname: str):
     import psycopg2
-    dsn = _parse_admin_dsn(dbname)
-    conn = psycopg2.connect(
-        host=dsn.host, port=dsn.port, user=dsn.user,
-        password=dsn.password, dbname=dsn.db,
-    )
+    conn = psycopg2.connect(**legal_connect_kwargs(dbname))
     conn.autocommit = True
     return conn
 

--- a/fortress-guest-platform/backend/scripts/vault_ingest_legal_case.py
+++ b/fortress-guest-platform/backend/scripts/vault_ingest_legal_case.py
@@ -60,6 +60,10 @@ from backend.services.legal.nas_layout import (
     LayoutNormalizationError,
     normalize_case_layout,
 )
+from backend.services.legal.qdrant_contract import (
+    LEGAL_LEGACY_VECTOR_SIZE,
+    LEGAL_WORK_PRODUCT_COLLECTION,
+)
 
 logger = logging.getLogger("vault_ingest_legal_case")
 
@@ -75,8 +79,8 @@ HASH_STREAM_THRESHOLD_BYTES = 100 * 1024 * 1024  # 100 MB
 DEFAULT_MAX_FILE_SIZE_MB = 500
 DEFAULT_JOBS = 4
 
-QDRANT_COLLECTION = "legal_ediscovery"
-EXPECTED_VECTOR_SIZE = 768
+QDRANT_COLLECTION = LEGAL_WORK_PRODUCT_COLLECTION
+EXPECTED_VECTOR_SIZE = LEGAL_LEGACY_VECTOR_SIZE
 
 # vault_documents statuses that we treat as "already done — skip".
 TERMINAL_STATUSES_FOR_RESUME = (

--- a/fortress-guest-platform/backend/scripts/vault_ingest_legal_case.py
+++ b/fortress-guest-platform/backend/scripts/vault_ingest_legal_case.py
@@ -46,7 +46,6 @@ import json
 import logging
 import mimetypes
 import os
-import re
 import socket
 import sys
 import time
@@ -60,6 +59,7 @@ from backend.services.legal.nas_layout import (
     LayoutNormalizationError,
     normalize_case_layout,
 )
+from backend.services.legal.db_targets import legal_connect_kwargs
 from backend.services.legal.qdrant_contract import (
     LEGAL_LEGACY_VECTOR_SIZE,
     LEGAL_WORK_PRODUCT_COLLECTION,
@@ -110,37 +110,9 @@ def _ensure_env_loaded() -> None:
         os.environ.setdefault(k, v)
 
 
-@dataclass
-class _DSN:
-    host: str
-    port: int
-    user: str
-    password: str
-    db: str
-
-
-def _parse_admin_dsn(dbname: str) -> _DSN:
-    uri = os.environ.get("POSTGRES_ADMIN_URI", "")
-    m = re.match(
-        r"postgresql(?:\+\w+)?://([^:]+):([^@]+)@([^:/]+):?(\d+)?/[^?]+",
-        uri,
-    )
-    if not m:
-        raise SystemExit(
-            "POSTGRES_ADMIN_URI not set or unparseable in environ; "
-            "load .env first"
-        )
-    user, pw, host, port = m.groups()
-    return _DSN(host=host, port=int(port or 5432), user=user, password=pw, db=dbname)
-
-
 def _connect(dbname: str):
     import psycopg2
-    dsn = _parse_admin_dsn(dbname)
-    conn = psycopg2.connect(
-        host=dsn.host, port=dsn.port, user=dsn.user,
-        password=dsn.password, dbname=dsn.db,
-    )
+    conn = psycopg2.connect(**legal_connect_kwargs(dbname))
     conn.autocommit = True
     return conn
 

--- a/fortress-guest-platform/backend/services/deliberation_vault.py
+++ b/fortress-guest-platform/backend/services/deliberation_vault.py
@@ -26,6 +26,8 @@ from typing import Optional
 
 import psycopg2
 
+from backend.services.legal.db_targets import LEGAL_CANONICAL_DB, legal_connect_kwargs
+
 try:
     from dotenv import load_dotenv
 
@@ -45,19 +47,30 @@ logger = logging.getLogger("deliberation_vault")
 # ═══════════════════════════════════════════════════════════════════════
 
 _DB_HOST = os.getenv("DB_HOST", "192.168.0.100")
-_DB_NAME = "fortress_db"
 _DB_USER = os.getenv("DB_USER", os.getenv("FGP_DB_USER", "miner_bot"))
 _DB_PASS = os.getenv("DB_PASS", os.getenv("ADMIN_DB_PASS", ""))
 
 
+def _legacy_vault_connect_kwargs() -> dict[str, object]:
+    """Fallback for older vault deployments without POSTGRES_ADMIN_URI."""
+    return {
+        "host": _DB_HOST,
+        "dbname": LEGAL_CANONICAL_DB,
+        "user": _DB_USER,
+        "password": _DB_PASS,
+    }
+
+
+def _vault_connect_kwargs() -> dict[str, object]:
+    """Return connect kwargs for the canonical deliberation vault DB."""
+    if os.getenv("POSTGRES_ADMIN_URI", "").strip():
+        return legal_connect_kwargs(LEGAL_CANONICAL_DB)
+    return _legacy_vault_connect_kwargs()
+
+
 def _get_vault_conn():
     """Open a connection to fortress_db for vault writes."""
-    return psycopg2.connect(
-        host=_DB_HOST,
-        dbname=_DB_NAME,
-        user=_DB_USER,
-        password=_DB_PASS,
-    )
+    return psycopg2.connect(**_vault_connect_kwargs())
 
 
 def get_vault_connection():

--- a/fortress-guest-platform/backend/services/ediscovery_agent.py
+++ b/fortress-guest-platform/backend/services/ediscovery_agent.py
@@ -31,7 +31,7 @@ from typing import Optional
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
 
-from backend.core.config import settings
+from backend.services.legal.db_targets import LEGAL_CANONICAL_DB, legal_async_database_url
 
 logger = structlog.get_logger()
 
@@ -40,13 +40,7 @@ logger = structlog.get_logger()
 # ═══════════════════════════════════════════════════════════════════════
 
 # Runtime API DB is typically fortress_shadow; legacy legal/ediscovery lives in fortress_db.
-_LEGACY_DB_URL = (
-    settings.database_url.replace("/fortress_guest", "/fortress_db").replace("/fortress_shadow", "/fortress_db")
-)
-if _LEGACY_DB_URL.startswith("postgresql://"):
-    _LEGACY_DB_URL = _LEGACY_DB_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
-elif not _LEGACY_DB_URL.startswith("postgresql+asyncpg://"):
-    _LEGACY_DB_URL = _LEGACY_DB_URL.replace("postgres://", "postgresql+asyncpg://", 1)
+_LEGACY_DB_URL = legal_async_database_url(LEGAL_CANONICAL_DB)
 
 _legacy_engine = create_async_engine(
     _LEGACY_DB_URL,

--- a/fortress-guest-platform/backend/services/ingest_run_tracker.py
+++ b/fortress-guest-platform/backend/services/ingest_run_tracker.py
@@ -34,7 +34,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import re
 import socket
 import sys
 import time
@@ -43,6 +42,8 @@ from dataclasses import dataclass
 from typing import Any
 from uuid import UUID
 
+from backend.services.legal.db_targets import LEGAL_CANONICAL_DB, legal_connect_kwargs
+
 logger = logging.getLogger("ingest_run_tracker")
 
 
@@ -50,35 +51,18 @@ logger = logging.getLogger("ingest_run_tracker")
 
 # Tracker writes target fortress_db (where legal.* lives operationally) — same
 # database the FastAPI handler queries via LegacySession.
-_DEFAULT_TRACKER_DB = "fortress_db"
+_DEFAULT_TRACKER_DB = LEGAL_CANONICAL_DB
 
 _RETRY_BACKOFFS_S = (0.5, 2.0, 8.0)   # sums to 10.5 s + per-attempt latency
 _RETRY_TOTAL_CAP_S = 30.0
 
 
-def _admin_dsn() -> dict[str, str]:
+def _admin_dsn() -> dict[str, object]:
     """
-    Parse POSTGRES_ADMIN_URI from env (loaded by the caller's .env step) and
-    return a psycopg2 connection-keywords dict targeting fortress_db.
+    Return psycopg2 connection-keywords for the tracker target DB.
     """
-    uri = os.environ.get("POSTGRES_ADMIN_URI", "")
-    m = re.match(
-        r"postgresql(?:\+\w+)?://([^:]+):([^@]+)@([^:/]+):?(\d+)?/[^?]+",
-        uri,
-    )
-    if not m:
-        raise RuntimeError(
-            "POSTGRES_ADMIN_URI not set or not parseable; "
-            "tracker requires admin DSN"
-        )
-    user, pw, host, port = m.groups()
-    return {
-        "host":     host,
-        "port":     int(port or 5432),
-        "user":     user,
-        "password": pw,
-        "dbname":   os.environ.get("INGEST_RUN_DB", _DEFAULT_TRACKER_DB),
-    }
+    target_db = os.environ.get("INGEST_RUN_DB", _DEFAULT_TRACKER_DB)
+    return legal_connect_kwargs(target_db)
 
 
 def _connect():

--- a/fortress-guest-platform/backend/services/legal/db_targets.py
+++ b/fortress-guest-platform/backend/services/legal/db_targets.py
@@ -8,8 +8,9 @@ and avoid ad hoc path replacement in session factories.
 
 from __future__ import annotations
 
+import os
 from typing import Final
-from urllib.parse import SplitResult, urlsplit, urlunsplit
+from urllib.parse import SplitResult, unquote, urlsplit, urlunsplit
 
 LEGAL_CANONICAL_DB: Final = "fortress_db"
 LEGAL_PROD_DB: Final = "fortress_prod"
@@ -58,3 +59,33 @@ def legal_sync_database_url(target_db: str, base_url: str | None = None) -> str:
 
         base_url = settings.alembic_database_url
     return _target_url(base_url, target_db, async_driver=False)
+
+
+def legal_connect_kwargs(
+    target_db: str,
+    base_url: str | None = None,
+    *,
+    env_var: str = "POSTGRES_ADMIN_URI",
+) -> dict[str, object]:
+    """Return psycopg/psycopg2 connect kwargs for a Legal runtime target DB."""
+    if base_url is None:
+        base_url = os.environ.get(env_var, "").strip()
+        if not base_url:
+            raise RuntimeError(f"{env_var} is not set; Legal DB connection unavailable")
+
+    sync_url = legal_sync_database_url(target_db, base_url)
+    parsed = urlsplit(sync_url)
+    username = unquote(parsed.username or "")
+    password = unquote(parsed.password or "")
+    hostname = parsed.hostname or ""
+
+    if not username or not hostname:
+        raise ValueError("Legal database target URL is missing username or host")
+
+    return {
+        "host": hostname,
+        "port": parsed.port or 5432,
+        "user": username,
+        "password": password,
+        "dbname": parsed.path.removeprefix("/"),
+    }

--- a/fortress-guest-platform/backend/services/legal/db_targets.py
+++ b/fortress-guest-platform/backend/services/legal/db_targets.py
@@ -1,0 +1,60 @@
+"""
+Canonical Legal database target helpers.
+
+Legal runtime still spans the shared API database plus the operational
+fortress_db / fortress_prod pair. These helpers make target selection explicit
+and avoid ad hoc path replacement in session factories.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+from urllib.parse import SplitResult, urlsplit, urlunsplit
+
+LEGAL_CANONICAL_DB: Final = "fortress_db"
+LEGAL_PROD_DB: Final = "fortress_prod"
+LEGAL_RUNTIME_DBS: Final = frozenset({LEGAL_CANONICAL_DB, LEGAL_PROD_DB})
+
+_ASYNC_SCHEME = "postgresql+asyncpg"
+_SYNC_SCHEME = "postgresql"
+_POSTGRES_SCHEMES = frozenset({"postgres", "postgresql", "postgresql+asyncpg"})
+
+
+def _target_url(base_url: str, target_db: str, *, async_driver: bool) -> str:
+    if target_db not in LEGAL_RUNTIME_DBS:
+        raise ValueError(f"unsupported Legal database target: {target_db!r}")
+
+    parsed = urlsplit(base_url)
+    if parsed.scheme not in _POSTGRES_SCHEMES:
+        raise ValueError("Legal database targets require a PostgreSQL URL")
+    if not parsed.netloc:
+        raise ValueError("Legal database target URL is missing host credentials")
+
+    scheme = _ASYNC_SCHEME if async_driver else _SYNC_SCHEME
+    return urlunsplit(
+        SplitResult(
+            scheme=scheme,
+            netloc=parsed.netloc,
+            path=f"/{target_db}",
+            query=parsed.query,
+            fragment=parsed.fragment,
+        )
+    )
+
+
+def legal_async_database_url(target_db: str, base_url: str | None = None) -> str:
+    """Return an async SQLAlchemy URL for a Legal runtime target DB."""
+    if base_url is None:
+        from backend.core.config import settings
+
+        base_url = settings.database_url
+    return _target_url(base_url, target_db, async_driver=True)
+
+
+def legal_sync_database_url(target_db: str, base_url: str | None = None) -> str:
+    """Return a sync PostgreSQL URL for scripts or psycopg-style clients."""
+    if base_url is None:
+        from backend.core.config import settings
+
+        base_url = settings.alembic_database_url
+    return _target_url(base_url, target_db, async_driver=False)

--- a/fortress-guest-platform/backend/services/legal/qdrant_contract.py
+++ b/fortress-guest-platform/backend/services/legal/qdrant_contract.py
@@ -1,0 +1,29 @@
+"""
+Canonical Legal Qdrant collection names for the current 7IL runtime.
+
+Do not route 7IL evidence through the v2 alias until Case I/II coverage has
+been reindexed and verified. The legacy 768-dim collections remain the active
+work-product and privileged targets for ingest, reprocess, and Council reads.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+LEGAL_WORK_PRODUCT_COLLECTION: Final = "legal_ediscovery"
+LEGAL_PRIVILEGED_COMMUNICATIONS_COLLECTION: Final = "legal_privileged_communications"
+LEGAL_LEGACY_VECTOR_SIZE: Final = 768
+
+LEGAL_EDISCOVERY_ACTIVE_ALIAS: Final = "legal_ediscovery_active"
+LEGAL_EDISCOVERY_V2_COLLECTION: Final = "legal_ediscovery_v2"
+LEGAL_PRIVILEGED_COMMUNICATIONS_V2_COLLECTION: Final = (
+    "legal_privileged_communications_v2"
+)
+
+LEGAL_COLLECTIONS_UNSAFE_FOR_7IL: Final = frozenset(
+    {
+        LEGAL_EDISCOVERY_ACTIVE_ALIAS,
+        LEGAL_EDISCOVERY_V2_COLLECTION,
+        LEGAL_PRIVILEGED_COMMUNICATIONS_V2_COLLECTION,
+    }
+)

--- a/fortress-guest-platform/backend/services/legal_council.py
+++ b/fortress-guest-platform/backend/services/legal_council.py
@@ -42,6 +42,10 @@ from backend.services.deliberation_vault import (
     load_active_roster,
     vault_deliberation,
 )
+from backend.services.legal.qdrant_contract import (
+    LEGAL_PRIVILEGED_COMMUNICATIONS_COLLECTION,
+    LEGAL_WORK_PRODUCT_COLLECTION,
+)
 
 # ═══════════════════════════════════════════════════════════════════════
 # Load environment from root .env (not handled by pydantic-settings for
@@ -76,7 +80,7 @@ PERSONAS_DIR = os.getenv(
 # Legacy `legal_library` and `legal_caselaw` removed from the allowlist so the
 # council strictly uses the cut-over targets.
 LEGAL_ALLOWED_VECTOR_COLLECTIONS = frozenset(
-    {"legal_library_v2", "legal_ediscovery", "legal_caselaw_v2"}
+    {"legal_library_v2", LEGAL_WORK_PRODUCT_COLLECTION, "legal_caselaw_v2"}
 )
 
 # Precedent retrieval knobs — legal_caselaw_v2 holds the controlling-authority corpus
@@ -1191,13 +1195,13 @@ def _dedupe_top(items: List[str], limit: int) -> List[str]:
 
 # legal_ediscovery holds 859+ vectorised chunks for active cases (indexed by process_vault_upload)
 # legal_library has only 3 points (stale/legacy) — use legal_ediscovery for context freezing
-LEGAL_COLLECTION = "legal_ediscovery"
+LEGAL_COLLECTION = LEGAL_WORK_PRODUCT_COLLECTION
 
 # PR G — Council pulls from this collection in addition to LEGAL_COLLECTION when
 # COUNCIL_INCLUDE_PRIVILEGED_RETRIEVAL is enabled. Privileged chunks are kept
 # physically separate so the storage layer enforces the privileged track, not
 # just a payload tag.
-PRIVILEGED_COLLECTION = "legal_privileged_communications"
+PRIVILEGED_COLLECTION = LEGAL_PRIVILEGED_COMMUNICATIONS_COLLECTION
 
 # Warning block appended to deliberation output whenever any privileged chunk
 # was retrieved. Wording is exact per PR G spec; if you change it here, also
@@ -1294,7 +1298,7 @@ async def freeze_context(
         "with_vector": False,
     }
     # Filter to the specific case when querying legal_ediscovery
-    if case_slug and LEGAL_COLLECTION == "legal_ediscovery":
+    if case_slug and LEGAL_COLLECTION == LEGAL_WORK_PRODUCT_COLLECTION:
         body["filter"] = {"must": [{"key": "case_slug", "match": {"value": case_slug}}]}
 
     try:

--- a/fortress-guest-platform/backend/services/legal_ediscovery.py
+++ b/fortress-guest-platform/backend/services/legal_ediscovery.py
@@ -26,6 +26,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.core.config import settings
 from backend.core.http_client import shared_client
+from backend.services.legal.qdrant_contract import (
+    LEGAL_PRIVILEGED_COMMUNICATIONS_COLLECTION,
+    LEGAL_WORK_PRODUCT_COLLECTION,
+)
 from backend.vrs.domain.automations import StreamlineEventPayload
 from backend.vrs.infrastructure.event_bus import publish_vrs_event
 from backend.services.legal_evidence_ingestion import _chunk_document
@@ -34,11 +38,11 @@ logger = structlog.get_logger()
 
 NAS_VAULT_ROOT = Path("/mnt/fortress_nas/legal_vault")
 LOCAL_VAULT_FALLBACK = Path("/home/admin/Fortress-Prime/data/legal_vault")
-QDRANT_COLLECTION = "legal_ediscovery"
+QDRANT_COLLECTION = LEGAL_WORK_PRODUCT_COLLECTION
 # PR G — privileged communications go to a physically separate collection so
 # Council retrieval can distinguish work product from privileged content at
 # the storage layer, not just by payload tag.
-QDRANT_PRIVILEGED_COLLECTION = "legal_privileged_communications"
+QDRANT_PRIVILEGED_COLLECTION = LEGAL_PRIVILEGED_COMMUNICATIONS_COLLECTION
 QDRANT_URL = settings.qdrant_url.rstrip("/")
 EMBED_URL = f"{settings.embed_base_url.rstrip('/')}/api/embeddings"
 EMBED_MODEL = settings.embed_model

--- a/fortress-guest-platform/backend/services/legal_mail_ingester.py
+++ b/fortress-guest-platform/backend/services/legal_mail_ingester.py
@@ -59,6 +59,7 @@ from backend.services.captain_multi_mailbox import (
 )
 from backend.core.config import settings
 from backend.services.ediscovery_agent import LegacySession
+from backend.services.legal.db_targets import LEGAL_PROD_DB, legal_async_database_url
 from backend.services.spark1_session import Spark1Session
 
 
@@ -913,30 +914,14 @@ def classify_inbound(
 #
 # Note on AsyncSessionLocal vs ProdSession: backend/core/database.py's
 # AsyncSessionLocal targets settings.database_url (typically fortress_shadow
-# at runtime). fortress_prod requires its own engine — built here by string-
-# replacing the DB name in settings.database_url, mirroring the pattern in
-# backend/services/ediscovery_agent.py for LegacySession (fortress_db).
+# at runtime). fortress_prod requires its own engine — built here through the
+# Legal DB target helper shared with LegacySession (fortress_db).
 # ─────────────────────────────────────────────────────────────────────────────
 
 
 def _build_prod_db_url() -> str:
-    """Construct the fortress_prod URL by replacing the DB name in settings.database_url.
-
-    Mirrors the LegacySession construction pattern in ediscovery_agent.py.
-    Tolerates whichever runtime DB the API is currently pointed at.
-    """
-    url = (
-        settings.database_url
-        .replace("/fortress_db", "/fortress_prod")
-        .replace("/fortress_shadow_test", "/fortress_prod")
-        .replace("/fortress_shadow", "/fortress_prod")
-        .replace("/fortress_guest", "/fortress_prod")
-    )
-    if url.startswith("postgresql://"):
-        url = url.replace("postgresql://", "postgresql+asyncpg://", 1)
-    elif url.startswith("postgres://"):
-        url = url.replace("postgres://", "postgresql+asyncpg://", 1)
-    return url
+    """Construct the fortress_prod async URL from the configured runtime DSN."""
+    return legal_async_database_url(LEGAL_PROD_DB)
 
 
 _prod_engine = create_async_engine(

--- a/fortress-guest-platform/backend/tests/test_database_qdrant_source_truth.py
+++ b/fortress-guest-platform/backend/tests/test_database_qdrant_source_truth.py
@@ -14,6 +14,7 @@ from backend.scripts import reprocess_failed_qdrant_uploads
 from backend.scripts import vault_ingest_legal_case
 from backend.services import legal_council
 from backend.services import legal_ediscovery
+from backend.services.legal import db_targets
 from backend.services.legal import qdrant_contract
 
 
@@ -156,3 +157,26 @@ def test_legal_qdrant_runtime_callers_share_contract() -> None:
         legal_council.PRIVILEGED_COLLECTION
         == qdrant_contract.LEGAL_PRIVILEGED_COMMUNICATIONS_COLLECTION
     )
+
+
+def test_legal_db_target_urls_are_explicit_and_parsed() -> None:
+    base = (
+        "postgresql://fortress_api:p%40ss@127.0.0.1:5432/"
+        "fortress_shadow_test?sslmode=disable"
+    )
+
+    assert db_targets.legal_async_database_url(db_targets.LEGAL_CANONICAL_DB, base) == (
+        "postgresql+asyncpg://fortress_api:p%40ss@127.0.0.1:5432/"
+        "fortress_db?sslmode=disable"
+    )
+    assert db_targets.legal_async_database_url(db_targets.LEGAL_PROD_DB, base) == (
+        "postgresql+asyncpg://fortress_api:p%40ss@127.0.0.1:5432/"
+        "fortress_prod?sslmode=disable"
+    )
+    assert db_targets.legal_sync_database_url(db_targets.LEGAL_PROD_DB, base) == (
+        "postgresql://fortress_api:p%40ss@127.0.0.1:5432/"
+        "fortress_prod?sslmode=disable"
+    )
+
+    with pytest.raises(ValueError, match="unsupported Legal database target"):
+        db_targets.legal_async_database_url("fortress_shadow", base)

--- a/fortress-guest-platform/backend/tests/test_database_qdrant_source_truth.py
+++ b/fortress-guest-platform/backend/tests/test_database_qdrant_source_truth.py
@@ -10,8 +10,10 @@ os.environ.setdefault("LITELLM_MASTER_KEY", "test-litellm-master-key")
 import backend.core.database as database
 from backend.scripts import backfill_vector_ids
 from backend.scripts import email_backfill_legal
+from backend.scripts import ocr_legal_case
 from backend.scripts import reprocess_failed_qdrant_uploads
 from backend.scripts import vault_ingest_legal_case
+from backend.services import deliberation_vault
 from backend.services import legal_council
 from backend.services import legal_ediscovery
 from backend.services.legal import db_targets
@@ -187,3 +189,53 @@ def test_legal_db_target_urls_are_explicit_and_parsed() -> None:
 
     with pytest.raises(ValueError, match="unsupported Legal database target"):
         db_targets.legal_async_database_url("fortress_shadow", base)
+
+
+def test_ocr_layout_lookup_uses_legal_db_target(monkeypatch: pytest.MonkeyPatch) -> None:
+    base = "postgresql://fortress_admin:p%40ss@127.0.0.1:5432/fortress_shadow"
+
+    monkeypatch.delenv("POSTGRES_ADMIN_URI", raising=False)
+    monkeypatch.setattr(
+        ocr_legal_case,
+        "_read_env_pgs",
+        lambda: {"POSTGRES_ADMIN_URI": base},
+    )
+
+    assert ocr_legal_case._admin_dsn() == (
+        "127.0.0.1",
+        "5432",
+        "fortress_admin",
+        "p@ss",
+        db_targets.LEGAL_CANONICAL_DB,
+    )
+
+
+def test_deliberation_vault_prefers_admin_uri_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base = "postgresql://fortress_admin:p%40ss@127.0.0.1:5432/fortress_shadow"
+    monkeypatch.setenv("POSTGRES_ADMIN_URI", base)
+
+    assert deliberation_vault._vault_connect_kwargs() == {
+        "host": "127.0.0.1",
+        "port": 5432,
+        "user": "fortress_admin",
+        "password": "p@ss",
+        "dbname": db_targets.LEGAL_CANONICAL_DB,
+    }
+
+
+def test_deliberation_vault_keeps_legacy_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("POSTGRES_ADMIN_URI", raising=False)
+    monkeypatch.setattr(deliberation_vault, "_DB_HOST", "10.0.0.5")
+    monkeypatch.setattr(deliberation_vault, "_DB_USER", "legacy_user")
+    monkeypatch.setattr(deliberation_vault, "_DB_PASS", "legacy-pass")
+
+    assert deliberation_vault._vault_connect_kwargs() == {
+        "host": "10.0.0.5",
+        "dbname": db_targets.LEGAL_CANONICAL_DB,
+        "user": "legacy_user",
+        "password": "legacy-pass",
+    }

--- a/fortress-guest-platform/backend/tests/test_database_qdrant_source_truth.py
+++ b/fortress-guest-platform/backend/tests/test_database_qdrant_source_truth.py
@@ -177,6 +177,13 @@ def test_legal_db_target_urls_are_explicit_and_parsed() -> None:
         "postgresql://fortress_api:p%40ss@127.0.0.1:5432/"
         "fortress_prod?sslmode=disable"
     )
+    assert db_targets.legal_connect_kwargs(db_targets.LEGAL_CANONICAL_DB, base) == {
+        "host": "127.0.0.1",
+        "port": 5432,
+        "user": "fortress_api",
+        "password": "p@ss",
+        "dbname": "fortress_db",
+    }
 
     with pytest.raises(ValueError, match="unsupported Legal database target"):
         db_targets.legal_async_database_url("fortress_shadow", base)

--- a/fortress-guest-platform/backend/tests/test_database_qdrant_source_truth.py
+++ b/fortress-guest-platform/backend/tests/test_database_qdrant_source_truth.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("LITELLM_MASTER_KEY", "test-litellm-master-key")
+
+import backend.core.database as database
+from backend.scripts import backfill_vector_ids
+from backend.scripts import email_backfill_legal
+from backend.scripts import reprocess_failed_qdrant_uploads
+from backend.scripts import vault_ingest_legal_case
+from backend.services import legal_council
+from backend.services import legal_ediscovery
+from backend.services.legal import qdrant_contract
+
+
+def test_database_module_has_one_session_contract() -> None:
+    source = Path(database.__file__).read_text()
+
+    assert source.count("async def get_db(") == 1
+    assert source.count("async def init_db(") == 1
+    assert source.count("async def close_db(") == 1
+    assert source.count("AsyncSessionLocal =") == 1
+    assert "declarative_base" not in source
+
+
+def test_get_async_engine_is_lazy_and_singleton(monkeypatch: pytest.MonkeyPatch) -> None:
+    created: list[dict[str, object]] = []
+
+    class DummyEngine:
+        async def dispose(self) -> None:
+            return None
+
+    class DummySettings:
+        database_url = "postgresql+asyncpg://fortress_api:test@127.0.0.1:5432/fortress_shadow_test"
+
+    def fake_create_async_engine(url: str, **kwargs: object) -> DummyEngine:
+        created.append({"url": url, **kwargs})
+        return DummyEngine()
+
+    monkeypatch.setattr(database, "async_engine", None)
+    monkeypatch.setattr(database, "_session_factory", None)
+    monkeypatch.setattr(database, "create_async_engine", fake_create_async_engine)
+    monkeypatch.setattr(database, "settings", DummySettings())
+
+    assert database.async_engine is None
+
+    first = database.get_async_engine()
+    second = database.get_async_engine()
+
+    assert first is second
+    assert len(created) == 1
+    assert created[0]["url"] == DummySettings.database_url
+    assert created[0]["pool_pre_ping"] is True
+    assert created[0]["pool_size"] == 20
+    assert created[0]["max_overflow"] == 10
+
+
+def test_session_factory_uses_lazy_engine(monkeypatch: pytest.MonkeyPatch) -> None:
+    dummy_engine = object()
+    calls: list[dict[str, object]] = []
+
+    class DummySessionFactory:
+        def __call__(self) -> str:
+            return "session"
+
+    def fake_sessionmaker(bind: object, **kwargs: object) -> DummySessionFactory:
+        calls.append({"bind": bind, **kwargs})
+        return DummySessionFactory()
+
+    lazy_factory = database._LazySessionFactory()
+    monkeypatch.setattr(database, "AsyncSessionLocal", lazy_factory)
+    monkeypatch.setattr(database, "async_session_factory", lazy_factory)
+    monkeypatch.setattr(database, "async_session_maker", lazy_factory)
+    monkeypatch.setattr(database, "_session_factory", None)
+    monkeypatch.setattr(database, "get_async_engine", lambda: dummy_engine)
+    monkeypatch.setattr(database, "async_sessionmaker", fake_sessionmaker)
+
+    factory = database.get_session_factory()
+
+    assert factory is database.get_session_factory()
+    assert calls == [
+        {
+            "bind": dummy_engine,
+            "class_": database.AsyncSession,
+            "autoflush": False,
+            "expire_on_commit": False,
+        }
+    ]
+    assert database._LazySessionFactory()() == "session"
+    assert database.async_session_factory is database.AsyncSessionLocal
+    assert database.async_session_maker is database.AsyncSessionLocal
+
+
+def test_session_factory_respects_test_or_runtime_patch(monkeypatch: pytest.MonkeyPatch) -> None:
+    class PatchedFactory:
+        pass
+
+    patched_factory = PatchedFactory()
+
+    monkeypatch.setattr(database, "AsyncSessionLocal", patched_factory)
+    monkeypatch.setattr(database, "_session_factory", None)
+
+    assert database.get_session_factory() is patched_factory
+
+
+def test_legal_qdrant_runtime_callers_share_contract() -> None:
+    assert qdrant_contract.LEGAL_WORK_PRODUCT_COLLECTION == "legal_ediscovery"
+    assert (
+        qdrant_contract.LEGAL_PRIVILEGED_COMMUNICATIONS_COLLECTION
+        == "legal_privileged_communications"
+    )
+    assert qdrant_contract.LEGAL_LEGACY_VECTOR_SIZE == 768
+    assert (
+        qdrant_contract.LEGAL_EDISCOVERY_ACTIVE_ALIAS
+        in qdrant_contract.LEGAL_COLLECTIONS_UNSAFE_FOR_7IL
+    )
+
+    assert legal_ediscovery.QDRANT_COLLECTION == qdrant_contract.LEGAL_WORK_PRODUCT_COLLECTION
+    assert (
+        legal_ediscovery.QDRANT_PRIVILEGED_COLLECTION
+        == qdrant_contract.LEGAL_PRIVILEGED_COMMUNICATIONS_COLLECTION
+    )
+    assert vault_ingest_legal_case.QDRANT_COLLECTION == qdrant_contract.LEGAL_WORK_PRODUCT_COLLECTION
+    assert vault_ingest_legal_case.EXPECTED_VECTOR_SIZE == qdrant_contract.LEGAL_LEGACY_VECTOR_SIZE
+    assert (
+        reprocess_failed_qdrant_uploads.QDRANT_WORK_PRODUCT_COLLECTION
+        == qdrant_contract.LEGAL_WORK_PRODUCT_COLLECTION
+    )
+    assert (
+        reprocess_failed_qdrant_uploads.QDRANT_PRIVILEGED_COLLECTION
+        == qdrant_contract.LEGAL_PRIVILEGED_COMMUNICATIONS_COLLECTION
+    )
+    assert (
+        email_backfill_legal.QDRANT_COLLECTION_WORK_PRODUCT
+        == qdrant_contract.LEGAL_WORK_PRODUCT_COLLECTION
+    )
+    assert (
+        email_backfill_legal.QDRANT_COLLECTION_PRIVILEGED
+        == qdrant_contract.LEGAL_PRIVILEGED_COMMUNICATIONS_COLLECTION
+    )
+    assert email_backfill_legal.EXPECTED_VECTOR_SIZE == qdrant_contract.LEGAL_LEGACY_VECTOR_SIZE
+    assert (
+        backfill_vector_ids.QDRANT_WORK_PRODUCT_COLLECTION
+        == qdrant_contract.LEGAL_WORK_PRODUCT_COLLECTION
+    )
+    assert (
+        backfill_vector_ids.QDRANT_PRIVILEGED_COLLECTION
+        == qdrant_contract.LEGAL_PRIVILEGED_COMMUNICATIONS_COLLECTION
+    )
+    assert legal_council.LEGAL_COLLECTION == qdrant_contract.LEGAL_WORK_PRODUCT_COLLECTION
+    assert (
+        legal_council.PRIVILEGED_COLLECTION
+        == qdrant_contract.LEGAL_PRIVILEGED_COMMUNICATIONS_COLLECTION
+    )


### PR DESCRIPTION
## What this PR does

- Collapses `backend/core/database.py` to one lazy DB/session contract instead of two competing implementations.
- Preserves compatibility names: `AsyncSessionLocal`, `async_session_factory`, `async_session_maker`, `get_session_factory`, `get_async_engine`, `get_db`, `init_db`, `close_db`.
- Keeps `DB_AUTO_CREATE_TABLES` as an explicit opt-in during `init_db`.
- Adds `backend/services/legal/qdrant_contract.py` as the current 7IL Legal Qdrant source of truth.
- Wires legal ingest, reprocess, vector-id backfill, email backfill, e-discovery, and Council retrieval to the shared Qdrant contract.
- Adds `backend/services/legal/db_targets.py` as the explicit Legal DB target helper for `fortress_db` / `fortress_prod` routing.
- Replaces string-rewrite DB URL construction in `LegacySession` and `ProdSession` with parsed target URLs.
- Replaces duplicated `POSTGRES_ADMIN_URI` regex parsing in the Legal tracker and raw `psycopg2` scripts with shared parsed connect kwargs.
- Routes OCR layout lookup and deliberation-vault DB access through the same Legal DB target helper while preserving the deliberation vault legacy fallback when `POSTGRES_ADMIN_URI` is absent.
- Updates runtime-map and Qdrant audit docs to record the authoritative contract and the still-open v2 alias migration risk.

## Verification

- `py_compile` on changed backend modules and tests.
- `pytest backend/tests/test_database_qdrant_source_truth.py backend/tests/test_ocr_legal_case.py -q`: 19 passed.
- `pytest backend/tests/test_vault_ingest_legal_case.py backend/tests/test_legal_7il_restructure.py::test_legal_privileged_communications_collection_constant backend/tests/test_legal_mail_ingester_tz_naive.py backend/tests/test_legal_mail_ingester_uid_watermark.py backend/tests/test_ingest_run_tracker.py backend/tests/test_legal_council_caselaw_retrieval.py -q`: 50 passed.

## Notes

This PR does not switch Qdrant aliases, does not reindex, and does not resume feature work. The safe 7IL runtime remains legacy 768-dim `legal_ediscovery` and `legal_privileged_communications` until a separate v2 migration proves Case I/II coverage.
