### PR TITLE
feat(financial): add promotion dry-run planner

### DIFF
--- a/crog-ai-backend/app/api/signals.py
+++ b/crog-ai-backend/app/api/signals.py
@@ -334,6 +334,62 @@ class ShadowReviewDecisionRecord(BaseModel):
     created_at: dt.datetime
 
 
+class PromotionDryRunApproval(BaseModel):
+    status: Literal["missing_promote_decision", "blocked_by_review", "ready_for_dry_run"]
+    decision_id: UUID | None
+    reviewer: str | None
+    decision_created_at: dt.datetime | None
+    rollback_criteria: str | None
+    detail: str
+
+
+class PromotionDryRunLineage(BaseModel):
+    source_pipeline: str
+    parameter_set: str
+    model_version: str
+    computed_at: dt.datetime
+    explanation_payload: dict[str, object]
+    rollback_marker: str
+
+
+class PromotionDryRunMarketSignalRow(BaseModel):
+    ticker: str
+    action: Literal["BUY", "SELL"]
+    signal_type: str
+    confidence_score: int
+    price_target: Decimal | None
+    source_sender: str
+    source_subject: str
+    raw_reasoning: str
+    model_used: str
+    extracted_at: dt.datetime
+    candidate_bar_date: dt.date
+    composite_score: int
+    lineage: PromotionDryRunLineage
+
+
+class PromotionDryRunSummary(BaseModel):
+    target_table: str
+    target_columns: list[str]
+    write_path_enabled: bool
+    candidate_signal_count: int
+    proposed_insert_count: int
+    bullish_count: int
+    risk_count: int
+    skipped_neutral_count: int
+    latest_bar_date: dt.date | None
+    min_abs_score: int
+
+
+class PromotionDryRunResponse(BaseModel):
+    generated_at: dt.datetime
+    candidate_parameter_set: str
+    baseline_parameter_set: str
+    approval: PromotionDryRunApproval
+    summary: PromotionDryRunSummary
+    proposed_rows: list[PromotionDryRunMarketSignalRow]
+
+
 class SymbolChartBar(BaseModel):
     ticker: str
     bar_date: dt.date
@@ -606,6 +662,24 @@ def create_shadow_review_decision_record_endpoint(
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/promotion-dry-run/daily", response_model=PromotionDryRunResponse)
+def promotion_dry_run_daily(
+    store: Annotated[SignalDataStore, Depends(get_signal_store)],
+    candidate_parameter_set: Annotated[
+        str, Query(min_length=1, max_length=100)
+    ] = "dochia_v0_2_range_daily",
+    decision_id: UUID | None = None,
+    limit: Annotated[int, Query(ge=1, le=500)] = 100,
+    min_abs_score: Annotated[int, Query(ge=1, le=100)] = 50,
+) -> dict[str, object]:
+    return store.promotion_dry_run(
+        candidate_parameter_set=candidate_parameter_set,
+        decision_id=str(decision_id) if decision_id else None,
+        limit=limit,
+        min_abs_score=min_abs_score,
+    )
 
 
 @router.get("/{ticker}/chart", response_model=SymbolSignalChart)

--- a/crog-ai-backend/app/signals/repository.py
+++ b/crog-ai-backend/app/signals/repository.py
@@ -104,6 +104,15 @@ class SignalDataStore(Protocol):
         outcome_horizon_sessions: int = 5,
     ) -> dict[str, Any]: ...
 
+    def promotion_dry_run(
+        self,
+        *,
+        candidate_parameter_set: str,
+        decision_id: str | None = None,
+        limit: int = 100,
+        min_abs_score: int = 50,
+    ) -> dict[str, Any]: ...
+
     def symbol_chart(
         self,
         *,
@@ -967,6 +976,243 @@ def create_shadow_review_decision_record(
     }
 
 
+PROMOTION_DRY_RUN_TARGET_COLUMNS = [
+    "ticker",
+    "signal_type",
+    "action",
+    "confidence_score",
+    "price_target",
+    "source_sender",
+    "source_subject",
+    "raw_reasoning",
+    "model_used",
+    "extracted_at",
+]
+
+
+def _latest_promote_decision_record(
+    conn: psycopg.Connection,
+    *,
+    candidate_parameter_set: str,
+    decision_id: str | None = None,
+) -> dict[str, Any] | None:
+    params: dict[str, Any] = {"candidate_parameter_set": candidate_parameter_set}
+    conditions = [
+        "candidate_parameter_set = %(candidate_parameter_set)s",
+        "decision = 'promote_to_market_signals'",
+    ]
+    if decision_id:
+        conditions.append("id = %(decision_id)s")
+        params["decision_id"] = decision_id
+    where_clause = " AND ".join(conditions)
+    sql = f"""
+        {SHADOW_DECISION_RECORD_SELECT}
+        WHERE {where_clause}
+        ORDER BY created_at DESC
+        LIMIT 1
+    """
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(sql, params)
+        row = cur.fetchone()
+    return dict(row) if row else None
+
+
+def _promotion_dry_run_approval(
+    decision: dict[str, Any] | None,
+    *,
+    decision_id: str | None,
+) -> dict[str, Any]:
+    if decision is None:
+        detail = "No promote decision record found for this candidate."
+        if decision_id:
+            detail = "No promote decision record matched the supplied decision id."
+        return {
+            "status": "missing_promote_decision",
+            "decision_id": None,
+            "reviewer": None,
+            "decision_created_at": None,
+            "rollback_criteria": None,
+            "detail": f"{detail} Dry-run remains preview-only.",
+        }
+
+    if (
+        decision["promotion_gate_status"] == "hold"
+        or decision["recommendation_status"] == "hold"
+    ):
+        return {
+            "status": "blocked_by_review",
+            "decision_id": decision["id"],
+            "reviewer": decision["reviewer"],
+            "decision_created_at": decision["created_at"],
+            "rollback_criteria": decision["rollback_criteria"],
+            "detail": "Promote record exists, but the captured review status is on hold.",
+        }
+
+    return {
+        "status": "ready_for_dry_run",
+        "decision_id": decision["id"],
+        "reviewer": decision["reviewer"],
+        "decision_created_at": decision["created_at"],
+        "rollback_criteria": decision["rollback_criteria"],
+        "detail": "Promote record found; dry-run can be reviewed before any guarded write path.",
+    }
+
+
+def _score_state_label(value: int) -> str:
+    if value > 0:
+        return "green"
+    if value < 0:
+        return "red"
+    return "neutral"
+
+
+def _market_signal_action(score: int) -> str:
+    if score >= 0:
+        return "BUY"
+    return "SELL"
+
+
+def _promotion_signal_type(score: int) -> str:
+    if score >= 50:
+        return "Dochia bullish alignment"
+    if score <= -50:
+        return "Dochia risk alignment"
+    return "Dochia watch"
+
+
+def _promotion_raw_reasoning(row: dict[str, Any]) -> str:
+    score = int(row["composite_score"])
+    states = {
+        "monthly": _score_state_label(int(row["monthly_state"])),
+        "weekly": _score_state_label(int(row["weekly_state"])),
+        "daily": _score_state_label(int(row["daily_state"])),
+        "momentum": _score_state_label(int(row["momentum_state"])),
+    }
+    state_text = ", ".join(f"{key}={value}" for key, value in states.items())
+    return (
+        f"Dochia dry-run signal for {row['ticker']}: composite score {score:+d}; "
+        f"{state_text}; candidate bar {row['bar_date']}."
+    )
+
+
+def _promotion_lineage(row: dict[str, Any], *, candidate_parameter_set: str) -> dict[str, Any]:
+    score = int(row["composite_score"])
+    states = {
+        "monthly": int(row["monthly_state"]),
+        "weekly": int(row["weekly_state"]),
+        "daily": int(row["daily_state"]),
+        "momentum": int(row["momentum_state"]),
+    }
+    return {
+        "source_pipeline": "dochia_signal_scores",
+        "parameter_set": candidate_parameter_set,
+        "model_version": str(row["dochia_version"]),
+        "computed_at": row["computed_at"],
+        "explanation_payload": {
+            "ticker": row["ticker"],
+            "bar_date": row["bar_date"],
+            "composite_score": score,
+            "states": states,
+            "daily_trigger_mode": daily_trigger_mode_for_parameter_set(
+                candidate_parameter_set
+            ).value,
+            "channels": {
+                "monthly_high": row["monthly_channel_high"],
+                "monthly_low": row["monthly_channel_low"],
+                "weekly_high": row["weekly_channel_high"],
+                "weekly_low": row["weekly_channel_low"],
+                "daily_high": row["daily_channel_high"],
+                "daily_low": row["daily_channel_low"],
+            },
+        },
+        "rollback_marker": (
+            f"dochia-dry-run:{candidate_parameter_set}:{row['ticker']}:{row['bar_date']}"
+        ),
+    }
+
+
+def _promotion_dry_run_row(
+    row: dict[str, Any],
+    *,
+    candidate_parameter_set: str,
+) -> dict[str, Any]:
+    score = int(row["composite_score"])
+    return {
+        "ticker": row["ticker"],
+        "action": _market_signal_action(score),
+        "signal_type": _promotion_signal_type(score),
+        "confidence_score": min(100, max(1, abs(score))),
+        "price_target": None,
+        "source_sender": "Dochia Signal Engine",
+        "source_subject": f"Dry-run promotion {candidate_parameter_set}",
+        "raw_reasoning": _promotion_raw_reasoning(row),
+        "model_used": str(row["dochia_version"]),
+        "extracted_at": row["computed_at"],
+        "candidate_bar_date": row["bar_date"],
+        "composite_score": score,
+        "lineage": _promotion_lineage(row, candidate_parameter_set=candidate_parameter_set),
+    }
+
+
+def fetch_promotion_dry_run(
+    conn: psycopg.Connection,
+    *,
+    candidate_parameter_set: str,
+    decision_id: str | None = None,
+    limit: int = 100,
+    min_abs_score: int = 50,
+) -> dict[str, Any]:
+    generated_at = dt.datetime.now(dt.UTC)
+    decision = _latest_promote_decision_record(
+        conn,
+        candidate_parameter_set=candidate_parameter_set,
+        decision_id=decision_id,
+    )
+    candidate_rows = fetch_latest_scores(
+        conn,
+        limit=500,
+        parameter_set=candidate_parameter_set,
+    )
+    eligible_rows: list[dict[str, Any]] = []
+    skipped_neutral_count = 0
+    for row in candidate_rows:
+        score = int(row["composite_score"])
+        if abs(score) < min_abs_score:
+            skipped_neutral_count += 1
+            continue
+        eligible_rows.append(row)
+    eligible_rows.sort(
+        key=lambda row: (-abs(int(row["composite_score"])), str(row["ticker"]))
+    )
+    proposed_rows = [
+        _promotion_dry_run_row(row, candidate_parameter_set=candidate_parameter_set)
+        for row in eligible_rows[:limit]
+    ]
+
+    latest_dates = [row["bar_date"] for row in candidate_rows if row.get("bar_date")]
+    bullish_count = sum(1 for row in proposed_rows if row["action"] == "BUY")
+    risk_count = sum(1 for row in proposed_rows if row["action"] == "SELL")
+    return {
+        "generated_at": generated_at,
+        "candidate_parameter_set": candidate_parameter_set,
+        "baseline_parameter_set": PRODUCTION_PARAMETER_SET,
+        "approval": _promotion_dry_run_approval(decision, decision_id=decision_id),
+        "summary": {
+            "target_table": "hedge_fund.market_signals",
+            "target_columns": PROMOTION_DRY_RUN_TARGET_COLUMNS,
+            "write_path_enabled": False,
+            "candidate_signal_count": len(candidate_rows),
+            "proposed_insert_count": len(proposed_rows),
+            "bullish_count": bullish_count,
+            "risk_count": risk_count,
+            "skipped_neutral_count": skipped_neutral_count,
+            "latest_bar_date": max(latest_dates) if latest_dates else None,
+            "min_abs_score": min_abs_score,
+        },
+        "proposed_rows": proposed_rows,
+    }
+
+
 WATCHLIST_CANDIDATE_BASE_SQL = """
     WITH latest_scores AS (
         SELECT
@@ -1262,6 +1508,24 @@ class PostgresSignalDataStore:
                 review_limit=review_limit,
                 whipsaw_window_sessions=whipsaw_window_sessions,
                 outcome_horizon_sessions=outcome_horizon_sessions,
+            )
+
+    def promotion_dry_run(
+        self,
+        *,
+        candidate_parameter_set: str,
+        decision_id: str | None = None,
+        limit: int = 100,
+        min_abs_score: int = 50,
+    ) -> dict[str, Any]:
+        with connect() as conn:
+            conn.execute("SET default_transaction_read_only = on")
+            return fetch_promotion_dry_run(
+                conn,
+                candidate_parameter_set=candidate_parameter_set,
+                decision_id=decision_id,
+                limit=limit,
+                min_abs_score=min_abs_score,
             )
 
     def symbol_chart(

--- a/crog-ai-backend/docs/MARKETCLUB-DOCHIA-BUILD-PLAN.md
+++ b/crog-ai-backend/docs/MARKETCLUB-DOCHIA-BUILD-PLAN.md
@@ -72,6 +72,9 @@ Dochia-derived until independent truth data exists.
 - Decision Record capture is complete: supervised promote/defer records are
   persisted with the current Shadow Review evidence packet. This still does not
   approve production writes by itself.
+- Promotion Dry-Run is complete: proposed `hedge_fund.market_signals` rows are
+  generated read-only with approval state, lineage payload, and rollback marker.
+  Guarded production writes remain blocked.
 
 ### Phase 5 — App Surface
 
@@ -274,15 +277,21 @@ Useful query params:
   tickers, and the current Shadow Review evidence payload. The Hedge Fund
   cockpit can now record and list those decisions. Production `market_signals`
   writes remain blocked.
+- Added Promotion Dry-Run app surface. Backend endpoint
+  `/api/financial/signals/promotion-dry-run/daily` previews candidate rows that
+  would enter `hedge_fund.market_signals`, including approval state, target
+  columns, source pipeline, parameter set, model version, computed timestamp,
+  explanation payload, and rollback marker. The Hedge Fund cockpit now renders
+  that preview and keeps production writes locked.
 - Added and enabled `crog-ai-backend.service` on spark-node-2.
 - Promoted the Command Center production build and restarted
   `crog-ai-frontend.service`; `/financial/hedge-fund` is live through
   `https://crog-ai.com/financial/hedge-fund`.
-- Latest verification passed: 49 backend tests, ruff, backend health, focused UI
+- Latest verification passed: 52 backend tests, ruff, backend health, focused UI
   tests, focused UI lint, TypeScript, production Command Center build, service
   status, and live backend/BFF reads for production, v0.2 candidate, whipsaw,
-  Promotion Gate, and Shadow Review selectors.
+  Promotion Gate, Shadow Review, and Promotion Dry-Run selectors.
 
-Next clean build step: after a recorded `promote_to_market_signals` decision,
-build the promotion path as dry-run first before any guarded `market_signals`
-write.
+Next clean build step: after a recorded `promote_to_market_signals` decision
+and accepted dry-run output, build the guarded `market_signals` write path with
+explicit rollback/depromotion controls.

--- a/crog-ai-backend/docs/MARKETCLUB-SHADOW-REVIEW-RUNBOOK.md
+++ b/crog-ai-backend/docs/MARKETCLUB-SHADOW-REVIEW-RUNBOOK.md
@@ -1,6 +1,6 @@
 # MarketClub / Dochia Shadow Review Runbook
 
-**Status:** Read-only promotion review
+**Status:** Read-only promotion review + dry-run preview
 **Date:** 2026-05-03
 
 ## Purpose
@@ -19,6 +19,8 @@ approval mechanism.
 - Decision records:
   `GET /api/financial/signals/shadow-review/decision-records?candidate_parameter_set=dochia_v0_2_range_daily`
   and `POST /api/financial/signals/shadow-review/decision-records`
+- Promotion dry-run:
+  `GET /api/financial/signals/promotion-dry-run/daily?candidate_parameter_set=dochia_v0_2_range_daily`
 
 ## Review Gates
 
@@ -53,6 +55,19 @@ The API recomputes and stores the current Shadow Review evidence packet with
 the record. A `promote_to_market_signals` decision is still only permission to
 build the next dry-run promotion step; it is not a production write.
 
+## Promotion Dry-Run Review
+
+The dry-run endpoint and cockpit panel generate proposed `hedge_fund.market_signals`
+rows without inserting them. Review:
+
+- Approval state and decision record id.
+- Proposed BUY/SELL counts and skipped neutral count.
+- Target columns for `hedge_fund.market_signals`.
+- Per-row source pipeline, parameter set, model version, computed timestamp,
+  explanation payload, and rollback marker.
+
+Dry-run output is still preview-only. It does not enable production writes.
+
 ## Hard Stops
 
 - Any Promotion Gate `hold`.
@@ -60,8 +75,9 @@ build the next dry-run promotion step; it is not a production write.
 - Unreviewed high whipsaw-risk ticker in the shadow packet.
 - No named human approver.
 
-## Next Build Step After Approval
+## Next Build Step After Dry-Run Approval
 
-If the decision is `promote_to_market_signals`, build the promotion pipeline as
-dry-run first. It must preserve lineage fields: source pipeline, parameter set,
-model version, computed time, explanation payload, and rollback marker.
+After a recorded `promote_to_market_signals` decision and accepted dry-run
+output, build the guarded write path. It must insert only with named approval,
+preserve lineage fields, attach rollback/depromotion controls, and provide a
+safe way to disable or remove a promoted candidate set.

--- a/crog-ai-backend/tests/test_api_signals.py
+++ b/crog-ai-backend/tests/test_api_signals.py
@@ -420,6 +420,103 @@ class FakeSignalStore:
             "created_at": dt.datetime(2026, 5, 3, 19, 1, tzinfo=dt.UTC),
         }
 
+    def promotion_dry_run(
+        self,
+        *,
+        candidate_parameter_set: str,
+        decision_id: str | None = None,
+        limit: int = 100,
+        min_abs_score: int = 50,
+    ) -> dict[str, Any]:
+        return {
+            "generated_at": dt.datetime(2026, 5, 3, 20, 30, tzinfo=dt.UTC),
+            "candidate_parameter_set": candidate_parameter_set,
+            "baseline_parameter_set": "dochia_v0_estimated",
+            "approval": {
+                "status": "ready_for_dry_run",
+                "decision_id": DECISION_ID,
+                "reviewer": "Gary Knight",
+                "decision_created_at": dt.datetime(2026, 5, 3, 19, 1, tzinfo=dt.UTC),
+                "rollback_criteria": "Rollback if whipsaw pressure rises.",
+                "detail": f"decision_id={decision_id or DECISION_ID}",
+            },
+            "summary": {
+                "target_table": "hedge_fund.market_signals",
+                "target_columns": [
+                    "ticker",
+                    "signal_type",
+                    "action",
+                    "confidence_score",
+                    "price_target",
+                    "source_sender",
+                    "source_subject",
+                    "raw_reasoning",
+                    "model_used",
+                    "extracted_at",
+                ],
+                "write_path_enabled": False,
+                "candidate_signal_count": 3,
+                "proposed_insert_count": min(limit, 2),
+                "bullish_count": 1,
+                "risk_count": 1,
+                "skipped_neutral_count": 1,
+                "latest_bar_date": dt.date(2026, 4, 24),
+                "min_abs_score": min_abs_score,
+            },
+            "proposed_rows": [
+                {
+                    "ticker": "AA",
+                    "action": "BUY",
+                    "signal_type": "Dochia bullish alignment",
+                    "confidence_score": 80,
+                    "price_target": None,
+                    "source_sender": "Dochia Signal Engine",
+                    "source_subject": f"Dry-run promotion {candidate_parameter_set}",
+                    "raw_reasoning": "Dochia dry-run signal for AA: composite score +80.",
+                    "model_used": "v0.2-candidate",
+                    "extracted_at": dt.datetime(2026, 5, 2, 12, 0, tzinfo=dt.UTC),
+                    "candidate_bar_date": dt.date(2026, 4, 24),
+                    "composite_score": 80,
+                    "lineage": {
+                        "source_pipeline": "dochia_signal_scores",
+                        "parameter_set": candidate_parameter_set,
+                        "model_version": "v0.2-candidate",
+                        "computed_at": dt.datetime(2026, 5, 2, 12, 0, tzinfo=dt.UTC),
+                        "explanation_payload": {
+                            "ticker": "AA",
+                            "composite_score": 80,
+                        },
+                        "rollback_marker": "dochia-dry-run:dochia_v0_2_range_daily:AA:2026-04-24",
+                    },
+                },
+                {
+                    "ticker": "AGIO",
+                    "action": "SELL",
+                    "signal_type": "Dochia risk alignment",
+                    "confidence_score": 80,
+                    "price_target": None,
+                    "source_sender": "Dochia Signal Engine",
+                    "source_subject": f"Dry-run promotion {candidate_parameter_set}",
+                    "raw_reasoning": "Dochia dry-run signal for AGIO: composite score -80.",
+                    "model_used": "v0.2-candidate",
+                    "extracted_at": dt.datetime(2026, 5, 2, 12, 0, tzinfo=dt.UTC),
+                    "candidate_bar_date": dt.date(2026, 4, 24),
+                    "composite_score": -80,
+                    "lineage": {
+                        "source_pipeline": "dochia_signal_scores",
+                        "parameter_set": candidate_parameter_set,
+                        "model_version": "v0.2-candidate",
+                        "computed_at": dt.datetime(2026, 5, 2, 12, 0, tzinfo=dt.UTC),
+                        "explanation_payload": {
+                            "ticker": "AGIO",
+                            "composite_score": -80,
+                        },
+                        "rollback_marker": "dochia-dry-run:dochia_v0_2_range_daily:AGIO:2026-04-24",
+                    },
+                },
+            ][:limit],
+        }
+
     def symbol_chart(
         self,
         *,
@@ -742,6 +839,29 @@ def test_shadow_review_decision_records_endpoint_creates_audit_row() -> None:
     assert payload["reviewer"] == "Gary Knight"
     assert payload["reviewed_tickers"] == ["AA", "BTU"]
     assert payload["promotion_gate_status"] == "ready_for_shadow"
+
+
+def test_promotion_dry_run_endpoint_returns_read_only_market_signal_plan() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/financial/signals/promotion-dry-run/daily"
+        "?candidate_parameter_set=dochia_v0_2_range_daily&limit=2&min_abs_score=50"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["candidate_parameter_set"] == "dochia_v0_2_range_daily"
+    assert payload["approval"]["status"] == "ready_for_dry_run"
+    assert payload["summary"]["target_table"] == "hedge_fund.market_signals"
+    assert payload["summary"]["write_path_enabled"] is False
+    assert payload["summary"]["proposed_insert_count"] == 2
+    assert payload["proposed_rows"][0]["action"] == "BUY"
+    assert payload["proposed_rows"][1]["action"] == "SELL"
+    assert payload["proposed_rows"][0]["lineage"]["source_pipeline"] == "dochia_signal_scores"
+    assert "rollback_marker" in payload["proposed_rows"][0]["lineage"]
 
 
 def test_symbol_chart_endpoint_returns_overlay_data() -> None:

--- a/docs/operational/MASTER-PLAN.md
+++ b/docs/operational/MASTER-PLAN.md
@@ -2,7 +2,7 @@
 
 **Operator:** Gary Knight
 **Established:** 2026-04-29
-**Updated:** 2026-05-03 (v2.2 — Dochia decision records ready)
+**Updated:** 2026-05-03 (v2.3 — Dochia promotion dry-run ready)
 **Cadence:** Updated on change
 
 ---
@@ -262,8 +262,8 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 | v0.3 guardrail research | Closed as research-only: simple guardrails, ATR/cooldowns, ticker clusters, and rolling whipsaw suppressors all miss the promotion gate. Rolling date-safe holdout confirms suppression destroys recall: no candidate keeps at least 95% of raw v0.2 F1; strongest reducers cut 95%+ of events but stay below 7.41% F1 |
 | Candidate persisted state | v0.2 candidate has 328 `signal_scores` rows and 1,624 `signal_transitions` rows under non-production parameter set; internal API/BFF selector live for scanner, transitions, symbol detail, Portfolio Lens, and chart overlays |
 | Candidate lane comparison | v0.2 bullish lane unchanged at 129, risk unchanged at 47, re-entry 164→145, mixed 202→203, 61 daily states/scores change |
-| Promotion contract | Fresh Dochia scores still staged; legacy `market_signals` remains contextual until a recorded `promote_to_market_signals` decision and a dry-run promotion path |
-| UI state | Hedge Fund route live in production at `https://crog-ai.com/financial/hedge-fund` with scanner, synced chart overlays, Whipsaw Risk / Backtest evidence, alert feed, symbol panel, Portfolio Lens, Calibration Baseline, Promotion Gate, Shadow Review, Decision Records, and internal Production/v0.2 Range toggle |
+| Promotion contract | Fresh Dochia scores still staged; legacy `market_signals` remains contextual. Dry-run promotion path can now preview proposed rows, lineage, rollback markers, and approval state; production writes remain blocked |
+| UI state | Hedge Fund route live in production at `https://crog-ai.com/financial/hedge-fund` with scanner, synced chart overlays, Whipsaw Risk / Backtest evidence, alert feed, symbol panel, Portfolio Lens, Calibration Baseline, Promotion Gate, Shadow Review, Decision Records, Promotion Dry-Run, and internal Production/v0.2 Range toggle |
 
 **Signal doctrine:**
 
@@ -279,9 +279,9 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 1. Deterministic Trade Triangle engine: pure daily/weekly/monthly state calculation from EOD bars. Complete initial slice.
 2. Database scorer: populate `hedge_fund.signal_scores` and `signal_transitions` idempotently. Complete initial fresh batch.
 3. Calibration harness: compare generated daily state/score against 24,204 MarketClub observations. Baseline complete; refinement remains.
-4. Production contract: promote approved signals to `hedge_fund.market_signals`.
-5. API surface: scanner, symbol detail, portfolio board, alert inbox, backtest lab, model health. Scanner, symbol detail, chart data, whipsaw/backtest evidence, alert feed, watchlist-candidate lanes, daily calibration, promotion-gate comparison, Shadow Review packet, and Decision Records complete.
-6. Command Center UI: Financial / Hedge Fund route with sober cockpit UX, not gamified retail nudges. First route, chart overlays, Whipsaw Risk / Backtest, Portfolio Lens, Calibration Baseline, Promotion Gate, Shadow Review, and Decision Records complete at `/financial/hedge-fund`.
+4. Production contract: promote approved signals to `hedge_fund.market_signals`. Dry-run planner complete; guarded write path remains locked.
+5. API surface: scanner, symbol detail, portfolio board, alert inbox, backtest lab, model health. Scanner, symbol detail, chart data, whipsaw/backtest evidence, alert feed, watchlist-candidate lanes, daily calibration, promotion-gate comparison, Shadow Review packet, Decision Records, and Promotion Dry-Run complete.
+6. Command Center UI: Financial / Hedge Fund route with sober cockpit UX, not gamified retail nudges. First route, chart overlays, Whipsaw Risk / Backtest, Portfolio Lens, Calibration Baseline, Promotion Gate, Shadow Review, Decision Records, and Promotion Dry-Run complete at `/financial/hedge-fund`.
 
 **Product principles:**
 
@@ -292,7 +292,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 - Do not call generated weekly/monthly states "MarketClub truth"; they are Dochia-derived.
 - Avoid gamified trading prompts; build an evidence cockpit.
 
-**Immediate next step:** If the recorded decision is `promote_to_market_signals`, build the promotion path as dry-run first. No production promotion happens without named approval, rollback criteria, and a guarded dry-run result.
+**Immediate next step:** Run and review the Promotion Dry-Run after a recorded `promote_to_market_signals` decision. The next build slice is a guarded production write path only after named approval, rollback criteria, and accepted dry-run output.
 
 ### 6.6 Architectural follow-ups
 
@@ -357,6 +357,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 - Added the compact Promotion Gate backend endpoint and cockpit panel. Production and v0.2 Range now compare side by side on signal count, re-entry pressure, calibration match, coverage, score error, and guardrail status before any `market_signals` promotion.
 - Added the supervised Shadow Review backend endpoint, cockpit panel, and runbook. The read-only packet combines Promotion Gate status, lane churn, transition pressure, whipsaw/backtest tickers, a checklist, and an explicit human decision template. Live database smoke returned `needs_review`, 4 lane reviews, 8 transition-pressure tickers, and 8 whipsaw-review tickers. Production `market_signals` writes remain blocked.
 - Added supervised Decision Record capture. The Shadow Review panel can now persist and list named promote/defer records with rationale, reviewed tickers, rollback criteria, and the current Shadow Review evidence payload. Production `market_signals` writes remain blocked.
+- Added Promotion Dry-Run planning. Backend endpoint previews proposed `hedge_fund.market_signals` rows from the candidate parameter set with source pipeline, parameter set, model version, computed timestamp, explanation payload, rollback marker, and decision-record approval state. The cockpit now shows proposed rows and keeps writes locked.
 - Added internal Production/v0.2 Range toggle to the Command Center Hedge Fund page and promoted the production frontend build.
 - Added chart-data endpoint and chart overlay with close, daily/weekly channel bands, and generated triangle event markers.
 - Refined calibration metrics to separate carried-state agreement from exact new-alert agreement: 40.67% same-day alert match and 52.54% ±3-day alert match.

--- a/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
+++ b/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
@@ -442,6 +442,95 @@ const shadowDecisionRecords = [
   },
 ];
 
+const promotionDryRun = {
+  generated_at: "2026-05-03T20:30:00Z",
+  candidate_parameter_set: "dochia_v0_2_range_daily",
+  baseline_parameter_set: "dochia_v0_estimated",
+  approval: {
+    status: "ready_for_dry_run",
+    decision_id: "33333333-3333-3333-3333-333333333333",
+    reviewer: "Gary Knight",
+    decision_created_at: "2026-05-03T19:00:00Z",
+    rollback_criteria: "Rollback if whipsaw pressure rises.",
+    detail: "Promote record found; dry-run can be reviewed before any guarded write path.",
+  },
+  summary: {
+    target_table: "hedge_fund.market_signals",
+    target_columns: [
+      "ticker",
+      "signal_type",
+      "action",
+      "confidence_score",
+      "price_target",
+      "source_sender",
+      "source_subject",
+      "raw_reasoning",
+      "model_used",
+      "extracted_at",
+    ],
+    write_path_enabled: false,
+    candidate_signal_count: 3,
+    proposed_insert_count: 2,
+    bullish_count: 1,
+    risk_count: 1,
+    skipped_neutral_count: 1,
+    latest_bar_date: "2026-04-24",
+    min_abs_score: 50,
+  },
+  proposed_rows: [
+    {
+      ticker: "AA",
+      action: "BUY",
+      signal_type: "Dochia bullish alignment",
+      confidence_score: 80,
+      price_target: null,
+      source_sender: "Dochia Signal Engine",
+      source_subject: "Dry-run promotion dochia_v0_2_range_daily",
+      raw_reasoning: "Dochia dry-run signal for AA: composite score +80.",
+      model_used: "v0.2-candidate",
+      extracted_at: "2026-05-02T12:00:00Z",
+      candidate_bar_date: "2026-04-24",
+      composite_score: 80,
+      lineage: {
+        source_pipeline: "dochia_signal_scores",
+        parameter_set: "dochia_v0_2_range_daily",
+        model_version: "v0.2-candidate",
+        computed_at: "2026-05-02T12:00:00Z",
+        explanation_payload: {
+          ticker: "AA",
+          composite_score: 80,
+        },
+        rollback_marker: "dochia-dry-run:dochia_v0_2_range_daily:AA:2026-04-24",
+      },
+    },
+    {
+      ticker: "AGIO",
+      action: "SELL",
+      signal_type: "Dochia risk alignment",
+      confidence_score: 80,
+      price_target: null,
+      source_sender: "Dochia Signal Engine",
+      source_subject: "Dry-run promotion dochia_v0_2_range_daily",
+      raw_reasoning: "Dochia dry-run signal for AGIO: composite score -80.",
+      model_used: "v0.2-candidate",
+      extracted_at: "2026-05-02T12:00:00Z",
+      candidate_bar_date: "2026-04-24",
+      composite_score: -80,
+      lineage: {
+        source_pipeline: "dochia_signal_scores",
+        parameter_set: "dochia_v0_2_range_daily",
+        model_version: "v0.2-candidate",
+        computed_at: "2026-05-02T12:00:00Z",
+        explanation_payload: {
+          ticker: "AGIO",
+          composite_score: -80,
+        },
+        rollback_marker: "dochia-dry-run:dochia_v0_2_range_daily:AGIO:2026-04-24",
+      },
+    },
+  ],
+};
+
 vi.mock("@/lib/hooks", () => ({
   useFinancialLatestSignals: () => ({
     data: latestSignals,
@@ -516,6 +605,13 @@ vi.mock("@/lib/hooks", () => ({
     isLoading: false,
     refetch: vi.fn(),
   }),
+  useFinancialPromotionDryRun: () => ({
+    data: promotionDryRun,
+    isError: false,
+    isFetching: false,
+    isLoading: false,
+    refetch: vi.fn(),
+  }),
   useCreateFinancialShadowDecisionRecord: () => ({
     isPending: false,
     mutateAsync: vi.fn(),
@@ -529,11 +625,11 @@ describe("HedgeFundSignalsShell", () => {
     expect(screen.getByRole("heading", { name: "Hedge Fund Signals" })).toBeInTheDocument();
     expect(screen.getByText("Signal Scanner")).toBeInTheDocument();
     expect(screen.getAllByText("AA").length).toBeGreaterThan(0);
-    expect(screen.getByText("AGIO")).toBeInTheDocument();
+    expect(screen.getAllByText("AGIO").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Bullish break").length).toBeGreaterThan(0);
     expect(screen.getByText("Score Distribution")).toBeInTheDocument();
     expect(screen.getByText("Portfolio Lens")).toBeInTheDocument();
-    expect(screen.getByText("BUY")).toBeInTheDocument();
+    expect(screen.getAllByText("BUY").length).toBeGreaterThan(0);
     expect(screen.getByText("Calibration Baseline")).toBeInTheDocument();
     expect(screen.getByText("62.1%")).toBeInTheDocument();
     expect(screen.getAllByText("Promotion Gate").length).toBeGreaterThan(0);
@@ -546,6 +642,10 @@ describe("HedgeFundSignalsShell", () => {
     expect(screen.getByText("Decision Record")).toBeInTheDocument();
     expect(screen.getByText("Decision Records")).toBeInTheDocument();
     expect(screen.getAllByText("Continue shadow").length).toBeGreaterThan(0);
+    expect(screen.getByText("Promotion Dry-Run")).toBeInTheDocument();
+    expect(screen.getByText("market_signals Preview")).toBeInTheDocument();
+    expect(screen.getByText("Ready for dry-run")).toBeInTheDocument();
+    expect(screen.getByText("hedge_fund.market_signals")).toBeInTheDocument();
     expect(screen.getByText("Chart Overlay")).toBeInTheDocument();
     expect(screen.getByText("1 triangle events")).toBeInTheDocument();
     expect(screen.getByText("Whipsaw Risk / Backtest")).toBeInTheDocument();

--- a/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
+++ b/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
@@ -8,6 +8,7 @@ import {
   ArrowUpRight,
   BriefcaseBusiness,
   ClipboardCheck,
+  FileSearch,
   Gauge,
   Info,
   RefreshCw,
@@ -42,6 +43,7 @@ import {
   useFinancialLatestSignals,
   useFinancialDailyCalibration,
   useFinancialPromotionGate,
+  useFinancialPromotionDryRun,
   useFinancialShadowDecisionRecords,
   useFinancialShadowReview,
   useFinancialSignalDetail,
@@ -53,6 +55,9 @@ import {
 import type {
   FinancialDailyCalibrationResponse,
   FinancialLatestSignal,
+  FinancialPromotionDryRunApprovalStatus,
+  FinancialPromotionDryRunMarketSignalRow,
+  FinancialPromotionDryRunResponse,
   FinancialPromotionGateGuardrailStatus,
   FinancialPromotionGateRecommendationStatus,
   FinancialPromotionGateResponse,
@@ -228,6 +233,20 @@ function shadowDecisionLabel(decision: FinancialShadowReviewDecision): string {
   if (decision === "promote_to_market_signals") return "Promote to dry-run";
   if (decision === "continue_shadow") return "Continue shadow";
   return "Defer";
+}
+
+function promotionDryRunApprovalClasses(status: FinancialPromotionDryRunApprovalStatus): string {
+  if (status === "ready_for_dry_run") {
+    return "border-emerald-500/40 bg-emerald-500/10 text-emerald-600";
+  }
+  if (status === "blocked_by_review") return "border-red-500/40 bg-red-500/10 text-red-600";
+  return "border-amber-500/40 bg-amber-500/10 text-amber-600";
+}
+
+function promotionDryRunApprovalLabel(status: FinancialPromotionDryRunApprovalStatus): string {
+  if (status === "ready_for_dry_run") return "Ready for dry-run";
+  if (status === "blocked_by_review") return "Blocked by review";
+  return "Promote decision missing";
 }
 
 function formatSignedNumber(value: number | null | undefined, digits = 0): string {
@@ -1408,6 +1427,150 @@ function ShadowReviewPanel({
   );
 }
 
+function PromotionDryRunRow({ row }: { row: FinancialPromotionDryRunMarketSignalRow }) {
+  return (
+    <div className="grid gap-2 border-b border-border px-3 py-3 text-xs last:border-b-0 lg:grid-cols-[70px_76px_64px_88px_98px_minmax(0,1fr)]">
+      <span className="font-mono font-semibold">{row.ticker}</span>
+      <span>
+        <Badge variant="outline" className={cn("font-medium", legacyActionClasses(row.action))}>
+          {row.action}
+        </Badge>
+      </span>
+      <span className={cn("font-mono font-semibold", scoreClasses(row.composite_score))}>
+        {row.composite_score > 0 ? "+" : ""}
+        {row.composite_score}
+      </span>
+      <span className="font-mono text-muted-foreground">{row.confidence_score}</span>
+      <span className="text-muted-foreground">{formatDate(row.candidate_bar_date)}</span>
+      <span className="min-w-0 truncate font-mono text-[11px] text-muted-foreground">
+        {row.lineage.rollback_marker}
+      </span>
+    </div>
+  );
+}
+
+function PromotionDryRunPanel({
+  dryRun,
+  loading,
+  error,
+}: {
+  dryRun: FinancialPromotionDryRunResponse | null;
+  loading: boolean;
+  error: boolean;
+}) {
+  if (error) {
+    return (
+      <div className="flex items-center gap-2 border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+        <AlertTriangle className="h-4 w-4" />
+        Promotion dry-run unavailable.
+      </div>
+    );
+  }
+
+  if (loading && !dryRun) {
+    return <div className="py-8 text-sm text-muted-foreground">Loading promotion dry-run…</div>;
+  }
+
+  if (!dryRun) {
+    return (
+      <div className="border border-dashed border-border p-5 text-sm text-muted-foreground">
+        No promotion dry-run data.
+      </div>
+    );
+  }
+
+  const summary = dryRun.summary;
+  const previewRows = dryRun.proposed_rows.slice(0, 8);
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold">market_signals Preview</p>
+          <p className="text-xs text-muted-foreground">
+            {dryRun.baseline_parameter_set} → {dryRun.candidate_parameter_set}
+          </p>
+        </div>
+        <div className="flex flex-wrap justify-end gap-2">
+          <Badge
+            variant="outline"
+            className={cn("font-medium", promotionDryRunApprovalClasses(dryRun.approval.status))}
+          >
+            {promotionDryRunApprovalLabel(dryRun.approval.status)}
+          </Badge>
+          <Badge variant="outline" className="border-sky-500/40 bg-sky-500/10 text-sky-600">
+            Writes locked
+          </Badge>
+        </div>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+        <div className="border border-border p-3">
+          <p className="text-xs text-muted-foreground">Proposed Rows</p>
+          <p className="mt-1 font-mono text-2xl font-bold">{summary.proposed_insert_count}</p>
+        </div>
+        <div className="border border-border p-3">
+          <p className="text-xs text-muted-foreground">Bullish</p>
+          <p className="mt-1 font-mono text-2xl font-bold text-emerald-500">
+            {summary.bullish_count}
+          </p>
+        </div>
+        <div className="border border-border p-3">
+          <p className="text-xs text-muted-foreground">Risk</p>
+          <p className="mt-1 font-mono text-2xl font-bold text-red-500">{summary.risk_count}</p>
+        </div>
+        <div className="border border-border p-3">
+          <p className="text-xs text-muted-foreground">Neutral Skipped</p>
+          <p className="mt-1 font-mono text-2xl font-bold">{summary.skipped_neutral_count}</p>
+        </div>
+        <div className="border border-border p-3">
+          <p className="text-xs text-muted-foreground">Target</p>
+          <p className="mt-1 truncate font-mono text-sm font-semibold">{summary.target_table}</p>
+        </div>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_260px]">
+        <div className="overflow-hidden border border-border">
+          <div className="hidden border-b border-border bg-muted/40 px-3 py-2 text-xs font-medium text-muted-foreground lg:grid lg:grid-cols-[70px_76px_64px_88px_98px_minmax(0,1fr)]">
+            <span>Ticker</span>
+            <span>Action</span>
+            <span>Score</span>
+            <span>Confidence</span>
+            <span>Bar</span>
+            <span>Rollback Marker</span>
+          </div>
+          {previewRows.length ? (
+            previewRows.map((row) => <PromotionDryRunRow key={row.lineage.rollback_marker} row={row} />)
+          ) : (
+            <div className="p-4 text-sm text-muted-foreground">No proposed rows clear the threshold.</div>
+          )}
+        </div>
+
+        <div className="border border-border p-3">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-sm font-semibold">Approval</h2>
+            <span className="text-xs text-muted-foreground">{formatDate(dryRun.generated_at)}</span>
+          </div>
+          <p className="mt-3 text-xs text-muted-foreground">{dryRun.approval.detail}</p>
+          <div className="mt-3 space-y-2 text-xs">
+            <div className="grid grid-cols-[86px_minmax(0,1fr)] gap-2">
+              <span className="text-muted-foreground">Reviewer</span>
+              <span className="truncate font-medium">{dryRun.approval.reviewer ?? "—"}</span>
+            </div>
+            <div className="grid grid-cols-[86px_minmax(0,1fr)] gap-2">
+              <span className="text-muted-foreground">Decision</span>
+              <span className="truncate font-mono">{dryRun.approval.decision_id ?? "—"}</span>
+            </div>
+            <div className="grid grid-cols-[86px_minmax(0,1fr)] gap-2">
+              <span className="text-muted-foreground">Columns</span>
+              <span className="truncate font-mono">{summary.target_columns.length}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function SymbolPanel({
   signal,
   transitions,
@@ -1571,6 +1734,11 @@ export function HedgeFundSignalsShell() {
     candidate_parameter_set: "dochia_v0_2_range_daily",
     limit: 5,
   });
+  const promotionDryRun = useFinancialPromotionDryRun({
+    candidate_parameter_set: "dochia_v0_2_range_daily",
+    limit: 25,
+    min_abs_score: 50,
+  });
   const createShadowDecisionRecord = useCreateFinancialShadowDecisionRecord();
   const signals = latest.data ?? EMPTY_SIGNALS;
   const alertRows = transitions.data ?? EMPTY_TRANSITIONS;
@@ -1616,7 +1784,8 @@ export function HedgeFundSignalsShell() {
     dailyCalibration.isFetching ||
     promotionGate.isFetching ||
     shadowReview.isFetching ||
-    shadowDecisionRecords.isFetching;
+    shadowDecisionRecords.isFetching ||
+    promotionDryRun.isFetching;
 
   async function handleShadowDecisionSubmit(payload: FinancialShadowReviewDecisionRecordCreate) {
     await createShadowDecisionRecord.mutateAsync(payload);
@@ -1673,6 +1842,7 @@ export function HedgeFundSignalsShell() {
               void promotionGate.refetch();
               void shadowReview.refetch();
               void shadowDecisionRecords.refetch();
+              void promotionDryRun.refetch();
             }}
             disabled={isRefreshing}
             aria-label="Refresh hedge fund signals"
@@ -1789,6 +1959,25 @@ export function HedgeFundSignalsShell() {
             decisionRecordsLoading={shadowDecisionRecords.isLoading}
             onSubmitDecision={handleShadowDecisionSubmit}
             submittingDecision={createShadowDecisionRecord.isPending}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <FileSearch className="h-5 w-5 text-primary" />
+            <CardTitle>Promotion Dry-Run</CardTitle>
+          </div>
+          <Badge variant="outline">
+            {promotionDryRun.data ? formatDate(promotionDryRun.data.generated_at) : "—"}
+          </Badge>
+        </CardHeader>
+        <CardContent>
+          <PromotionDryRunPanel
+            dryRun={promotionDryRun.data ?? null}
+            loading={promotionDryRun.isLoading}
+            error={promotionDryRun.isError}
           />
         </CardContent>
       </Card>

--- a/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
@@ -15,6 +15,7 @@ import type {
   FinancialDailyCalibrationResponse,
   FinancialShadowReviewDecisionRecord,
   FinancialShadowReviewDecisionRecordCreate,
+  FinancialPromotionDryRunResponse,
   FinancialPromotionGateResponse,
   FinancialShadowReviewResponse,
   FinancialSignalTransition,
@@ -251,6 +252,19 @@ export function useCreateFinancialShadowDecisionRecord() {
       toast.success("Decision record saved");
     },
     onError: (error) => toast.error(error.message || "Failed to save decision record"),
+  });
+}
+
+export function useFinancialPromotionDryRun(params?: {
+  candidate_parameter_set?: string;
+  decision_id?: string;
+  limit?: number;
+  min_abs_score?: number;
+}) {
+  return useQuery<FinancialPromotionDryRunResponse>({
+    queryKey: ["financial", "signals", "promotion-dry-run", "daily", params],
+    queryFn: () => api.get("/api/financial/signals/promotion-dry-run/daily", params),
+    staleTime: 60_000,
   });
 }
 

--- a/fortress-guest-platform/apps/command-center/src/lib/types.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/types.ts
@@ -443,6 +443,67 @@ export interface FinancialShadowReviewDecisionRecord {
   created_at: string;
 }
 
+export type FinancialPromotionDryRunApprovalStatus =
+  | "missing_promote_decision"
+  | "blocked_by_review"
+  | "ready_for_dry_run";
+
+export interface FinancialPromotionDryRunApproval {
+  status: FinancialPromotionDryRunApprovalStatus;
+  decision_id: string | null;
+  reviewer: string | null;
+  decision_created_at: string | null;
+  rollback_criteria: string | null;
+  detail: string;
+}
+
+export interface FinancialPromotionDryRunLineage {
+  source_pipeline: string;
+  parameter_set: string;
+  model_version: string;
+  computed_at: string;
+  explanation_payload: Record<string, unknown>;
+  rollback_marker: string;
+}
+
+export interface FinancialPromotionDryRunMarketSignalRow {
+  ticker: string;
+  action: "BUY" | "SELL";
+  signal_type: string;
+  confidence_score: number;
+  price_target: string | number | null;
+  source_sender: string;
+  source_subject: string;
+  raw_reasoning: string;
+  model_used: string;
+  extracted_at: string;
+  candidate_bar_date: string;
+  composite_score: number;
+  lineage: FinancialPromotionDryRunLineage;
+}
+
+export interface FinancialPromotionDryRunSummary {
+  target_table: string;
+  target_columns: string[];
+  write_path_enabled: boolean;
+  candidate_signal_count: number;
+  proposed_insert_count: number;
+  bullish_count: number;
+  risk_count: number;
+  skipped_neutral_count: number;
+  latest_bar_date: string | null;
+  min_abs_score: number;
+}
+
+export interface FinancialPromotionDryRunResponse {
+  generated_at: string;
+  candidate_parameter_set: string;
+  baseline_parameter_set: string;
+  approval: FinancialPromotionDryRunApproval;
+  summary: FinancialPromotionDryRunSummary;
+  proposed_rows: FinancialPromotionDryRunMarketSignalRow[];
+}
+
 export interface FinancialWatchlistCandidate {
   ticker: string;
   bar_date: string;


### PR DESCRIPTION
## Summary

- add a read-only Promotion Dry-Run endpoint that previews proposed `hedge_fund.market_signals` rows for a candidate parameter set
- include decision-record approval state, target columns, source pipeline, parameter set, model version, computed timestamp, explanation payload, and rollback marker
- add the Hedge Fund cockpit Promotion Dry-Run panel and update the MarketClub master plan/runbook

## Verification

- `PYTHONPATH=. /home/admin/.local/bin/uv run pytest` in `crog-ai-backend` -> 52 passed
- focused backend ruff on changed Python files -> passed
- `npm test -- financial-hedge-fund-shell.test.tsx` -> 2 passed
- focused Command Center eslint on changed files -> passed
- Command Center `npx tsc --noEmit` -> passed
- Command Center `npm run build` -> passed
- read-only live DB smoke from clean worktree -> `missing_promote_decision 5 5 0 False`

## Notes

- no `hedge_fund.market_signals` write path is added
- dry-run preview remains locked when no `promote_to_market_signals` decision record exists
- actual production promotion remains a later guarded-write slice after accepted dry-run output
