### PR TITLE
feat(financial): add dry-run acceptance records

### DIFF
--- a/crog-ai-backend/alembic/versions/0005_promotion_dry_run_acceptances.py
+++ b/crog-ai-backend/alembic/versions/0005_promotion_dry_run_acceptances.py
@@ -1,0 +1,70 @@
+"""Persist accepted MarketClub promotion dry-run snapshots.
+
+Revision ID: 0005_promotion_dry_run_acceptances
+Revises: 0004_shadow_review_decisions
+Create Date: 2026-05-03
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0005_promotion_dry_run_acceptances"
+down_revision = "0004_shadow_review_decisions"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS hedge_fund.signal_promotion_dry_run_acceptances (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            decision_record_id UUID NOT NULL
+                REFERENCES hedge_fund.signal_shadow_review_decisions(id)
+                ON DELETE RESTRICT,
+            candidate_parameter_set VARCHAR(100) NOT NULL,
+            baseline_parameter_set VARCHAR(100) NOT NULL,
+            accepted_by VARCHAR(120) NOT NULL,
+            acceptance_rationale TEXT NOT NULL,
+            rollback_criteria TEXT NOT NULL,
+            dry_run_generated_at TIMESTAMPTZ NOT NULL,
+            dry_run_candidate_signal_count INTEGER NOT NULL,
+            dry_run_proposed_insert_count INTEGER NOT NULL,
+            dry_run_bullish_count INTEGER NOT NULL,
+            dry_run_risk_count INTEGER NOT NULL,
+            dry_run_skipped_neutral_count INTEGER NOT NULL,
+            min_abs_score INTEGER NOT NULL,
+            target_table TEXT NOT NULL,
+            target_columns TEXT[] NOT NULL,
+            dry_run_payload JSONB NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_promotion_dry_run_acceptances_candidate_created
+        ON hedge_fund.signal_promotion_dry_run_acceptances (
+            candidate_parameter_set,
+            created_at DESC
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_promotion_dry_run_acceptances_decision
+        ON hedge_fund.signal_promotion_dry_run_acceptances (decision_record_id)
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP INDEX IF EXISTS hedge_fund.ix_promotion_dry_run_acceptances_decision"
+    )
+    op.execute(
+        "DROP INDEX IF EXISTS hedge_fund.ix_promotion_dry_run_acceptances_candidate_created"
+    )
+    op.execute("DROP TABLE IF EXISTS hedge_fund.signal_promotion_dry_run_acceptances")

--- a/crog-ai-backend/app/api/signals.py
+++ b/crog-ai-backend/app/api/signals.py
@@ -390,6 +390,39 @@ class PromotionDryRunResponse(BaseModel):
     proposed_rows: list[PromotionDryRunMarketSignalRow]
 
 
+class PromotionDryRunAcceptanceCreate(BaseModel):
+    candidate_parameter_set: str = Field(
+        default="dochia_v0_2_range_daily",
+        min_length=1,
+        max_length=100,
+    )
+    decision_id: UUID | None = None
+    accepted_by: str = Field(min_length=2, max_length=120)
+    acceptance_rationale: str = Field(min_length=12, max_length=2000)
+    limit: int = Field(default=500, ge=1, le=500)
+    min_abs_score: int = Field(default=50, ge=1, le=100)
+
+
+class PromotionDryRunAcceptance(BaseModel):
+    id: UUID
+    decision_record_id: UUID
+    candidate_parameter_set: str
+    baseline_parameter_set: str
+    accepted_by: str
+    acceptance_rationale: str
+    rollback_criteria: str
+    dry_run_generated_at: dt.datetime
+    dry_run_candidate_signal_count: int
+    dry_run_proposed_insert_count: int
+    dry_run_bullish_count: int
+    dry_run_risk_count: int
+    dry_run_skipped_neutral_count: int
+    min_abs_score: int
+    target_table: str
+    target_columns: list[str]
+    created_at: dt.datetime
+
+
 class SymbolChartBar(BaseModel):
     ticker: str
     bar_date: dt.date
@@ -680,6 +713,43 @@ def promotion_dry_run_daily(
         limit=limit,
         min_abs_score=min_abs_score,
     )
+
+
+@router.get(
+    "/promotion-dry-run/acceptances",
+    response_model=list[PromotionDryRunAcceptance],
+)
+def promotion_dry_run_acceptances(
+    store: Annotated[SignalDataStore, Depends(get_signal_store)],
+    candidate_parameter_set: Annotated[str | None, Query(min_length=1, max_length=100)] = None,
+    limit: Annotated[int, Query(ge=1, le=50)] = 10,
+) -> list[dict[str, object]]:
+    return store.promotion_dry_run_acceptances(
+        candidate_parameter_set=candidate_parameter_set,
+        limit=limit,
+    )
+
+
+@router.post(
+    "/promotion-dry-run/acceptances",
+    response_model=PromotionDryRunAcceptance,
+    status_code=201,
+)
+def create_promotion_dry_run_acceptance_endpoint(
+    payload: PromotionDryRunAcceptanceCreate,
+    store: Annotated[SignalDataStore, Depends(get_signal_store)],
+) -> dict[str, object]:
+    try:
+        return store.create_promotion_dry_run_acceptance(
+            candidate_parameter_set=payload.candidate_parameter_set,
+            accepted_by=payload.accepted_by.strip(),
+            acceptance_rationale=payload.acceptance_rationale.strip(),
+            decision_id=str(payload.decision_id) if payload.decision_id else None,
+            limit=payload.limit,
+            min_abs_score=payload.min_abs_score,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.get("/{ticker}/chart", response_model=SymbolSignalChart)

--- a/crog-ai-backend/app/signals/repository.py
+++ b/crog-ai-backend/app/signals/repository.py
@@ -113,6 +113,24 @@ class SignalDataStore(Protocol):
         min_abs_score: int = 50,
     ) -> dict[str, Any]: ...
 
+    def promotion_dry_run_acceptances(
+        self,
+        *,
+        candidate_parameter_set: str | None = None,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]: ...
+
+    def create_promotion_dry_run_acceptance(
+        self,
+        *,
+        candidate_parameter_set: str,
+        accepted_by: str,
+        acceptance_rationale: str,
+        decision_id: str | None = None,
+        limit: int = 500,
+        min_abs_score: int = 50,
+    ) -> dict[str, Any]: ...
+
     def symbol_chart(
         self,
         *,
@@ -1213,6 +1231,160 @@ def fetch_promotion_dry_run(
     }
 
 
+PROMOTION_DRY_RUN_ACCEPTANCE_SELECT = """
+    SELECT
+        id,
+        decision_record_id,
+        candidate_parameter_set,
+        baseline_parameter_set,
+        accepted_by,
+        acceptance_rationale,
+        rollback_criteria,
+        dry_run_generated_at,
+        dry_run_candidate_signal_count,
+        dry_run_proposed_insert_count,
+        dry_run_bullish_count,
+        dry_run_risk_count,
+        dry_run_skipped_neutral_count,
+        min_abs_score,
+        target_table,
+        target_columns,
+        created_at
+    FROM hedge_fund.signal_promotion_dry_run_acceptances
+"""
+
+
+def fetch_promotion_dry_run_acceptances(
+    conn: psycopg.Connection,
+    *,
+    candidate_parameter_set: str | None = None,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    params: dict[str, Any] = {"limit": limit}
+    where = ""
+    if candidate_parameter_set:
+        where = "WHERE candidate_parameter_set = %(candidate_parameter_set)s"
+        params["candidate_parameter_set"] = candidate_parameter_set
+    sql = f"""
+        {PROMOTION_DRY_RUN_ACCEPTANCE_SELECT}
+        {where}
+        ORDER BY created_at DESC
+        LIMIT %(limit)s
+    """
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(sql, params)
+        return [dict(row) for row in cur.fetchall()]
+
+
+def create_promotion_dry_run_acceptance(
+    conn: psycopg.Connection,
+    *,
+    candidate_parameter_set: str,
+    accepted_by: str,
+    acceptance_rationale: str,
+    decision_id: str | None = None,
+    limit: int = 500,
+    min_abs_score: int = 50,
+) -> dict[str, Any]:
+    dry_run = fetch_promotion_dry_run(
+        conn,
+        candidate_parameter_set=candidate_parameter_set,
+        decision_id=decision_id,
+        limit=limit,
+        min_abs_score=min_abs_score,
+    )
+    approval = dry_run["approval"]
+    if approval["status"] != "ready_for_dry_run":
+        raise ValueError("Cannot accept dry-run output without a ready promote decision record.")
+    if dry_run["summary"]["proposed_insert_count"] == 0:
+        raise ValueError("Cannot accept dry-run output with no proposed market_signals rows.")
+
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            """
+            INSERT INTO hedge_fund.signal_promotion_dry_run_acceptances (
+                decision_record_id,
+                candidate_parameter_set,
+                baseline_parameter_set,
+                accepted_by,
+                acceptance_rationale,
+                rollback_criteria,
+                dry_run_generated_at,
+                dry_run_candidate_signal_count,
+                dry_run_proposed_insert_count,
+                dry_run_bullish_count,
+                dry_run_risk_count,
+                dry_run_skipped_neutral_count,
+                min_abs_score,
+                target_table,
+                target_columns,
+                dry_run_payload
+            ) VALUES (
+                %(decision_record_id)s,
+                %(candidate_parameter_set)s,
+                %(baseline_parameter_set)s,
+                %(accepted_by)s,
+                %(acceptance_rationale)s,
+                %(rollback_criteria)s,
+                %(dry_run_generated_at)s,
+                %(dry_run_candidate_signal_count)s,
+                %(dry_run_proposed_insert_count)s,
+                %(dry_run_bullish_count)s,
+                %(dry_run_risk_count)s,
+                %(dry_run_skipped_neutral_count)s,
+                %(min_abs_score)s,
+                %(target_table)s,
+                %(target_columns)s,
+                %(dry_run_payload)s
+            )
+            RETURNING *
+            """,
+            {
+                "decision_record_id": approval["decision_id"],
+                "candidate_parameter_set": candidate_parameter_set,
+                "baseline_parameter_set": dry_run["baseline_parameter_set"],
+                "accepted_by": accepted_by,
+                "acceptance_rationale": acceptance_rationale,
+                "rollback_criteria": approval["rollback_criteria"] or "",
+                "dry_run_generated_at": dry_run["generated_at"],
+                "dry_run_candidate_signal_count": dry_run["summary"]["candidate_signal_count"],
+                "dry_run_proposed_insert_count": dry_run["summary"]["proposed_insert_count"],
+                "dry_run_bullish_count": dry_run["summary"]["bullish_count"],
+                "dry_run_risk_count": dry_run["summary"]["risk_count"],
+                "dry_run_skipped_neutral_count": dry_run["summary"]["skipped_neutral_count"],
+                "min_abs_score": min_abs_score,
+                "target_table": dry_run["summary"]["target_table"],
+                "target_columns": dry_run["summary"]["target_columns"],
+                "dry_run_payload": Jsonb(_json_safe(dry_run)),
+            },
+        )
+        row = cur.fetchone()
+    if row is None:
+        raise RuntimeError("promotion dry-run acceptance insert returned no row")
+    return {
+        key: row[key]
+        for key in [
+            "id",
+            "decision_record_id",
+            "candidate_parameter_set",
+            "baseline_parameter_set",
+            "accepted_by",
+            "acceptance_rationale",
+            "rollback_criteria",
+            "dry_run_generated_at",
+            "dry_run_candidate_signal_count",
+            "dry_run_proposed_insert_count",
+            "dry_run_bullish_count",
+            "dry_run_risk_count",
+            "dry_run_skipped_neutral_count",
+            "min_abs_score",
+            "target_table",
+            "target_columns",
+            "created_at",
+        ]
+    }
+
+
 WATCHLIST_CANDIDATE_BASE_SQL = """
     WITH latest_scores AS (
         SELECT
@@ -1523,6 +1695,41 @@ class PostgresSignalDataStore:
             return fetch_promotion_dry_run(
                 conn,
                 candidate_parameter_set=candidate_parameter_set,
+                decision_id=decision_id,
+                limit=limit,
+                min_abs_score=min_abs_score,
+            )
+
+    def promotion_dry_run_acceptances(
+        self,
+        *,
+        candidate_parameter_set: str | None = None,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        with connect() as conn:
+            conn.execute("SET default_transaction_read_only = on")
+            return fetch_promotion_dry_run_acceptances(
+                conn,
+                candidate_parameter_set=candidate_parameter_set,
+                limit=limit,
+            )
+
+    def create_promotion_dry_run_acceptance(
+        self,
+        *,
+        candidate_parameter_set: str,
+        accepted_by: str,
+        acceptance_rationale: str,
+        decision_id: str | None = None,
+        limit: int = 500,
+        min_abs_score: int = 50,
+    ) -> dict[str, Any]:
+        with connect() as conn:
+            return create_promotion_dry_run_acceptance(
+                conn,
+                candidate_parameter_set=candidate_parameter_set,
+                accepted_by=accepted_by,
+                acceptance_rationale=acceptance_rationale,
                 decision_id=decision_id,
                 limit=limit,
                 min_abs_score=min_abs_score,

--- a/crog-ai-backend/deploy/sql/marketclub_legacy_read_grants.sql
+++ b/crog-ai-backend/deploy/sql/marketclub_legacy_read_grants.sql
@@ -6,5 +6,6 @@ GRANT SELECT ON TABLE
 TO crog_ai_app;
 
 GRANT SELECT, INSERT ON TABLE
-    hedge_fund.signal_shadow_review_decisions
+    hedge_fund.signal_shadow_review_decisions,
+    hedge_fund.signal_promotion_dry_run_acceptances
 TO crog_ai_app;

--- a/crog-ai-backend/deploy/sql/marketclub_promotion_dry_run_acceptances.sql
+++ b/crog-ai-backend/deploy/sql/marketclub_promotion_dry_run_acceptances.sql
@@ -1,0 +1,37 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS hedge_fund.signal_promotion_dry_run_acceptances (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    decision_record_id UUID NOT NULL
+        REFERENCES hedge_fund.signal_shadow_review_decisions(id)
+        ON DELETE RESTRICT,
+    candidate_parameter_set VARCHAR(100) NOT NULL,
+    baseline_parameter_set VARCHAR(100) NOT NULL,
+    accepted_by VARCHAR(120) NOT NULL,
+    acceptance_rationale TEXT NOT NULL,
+    rollback_criteria TEXT NOT NULL,
+    dry_run_generated_at TIMESTAMPTZ NOT NULL,
+    dry_run_candidate_signal_count INTEGER NOT NULL,
+    dry_run_proposed_insert_count INTEGER NOT NULL,
+    dry_run_bullish_count INTEGER NOT NULL,
+    dry_run_risk_count INTEGER NOT NULL,
+    dry_run_skipped_neutral_count INTEGER NOT NULL,
+    min_abs_score INTEGER NOT NULL,
+    target_table TEXT NOT NULL,
+    target_columns TEXT[] NOT NULL,
+    dry_run_payload JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS ix_promotion_dry_run_acceptances_candidate_created
+ON hedge_fund.signal_promotion_dry_run_acceptances (
+    candidate_parameter_set,
+    created_at DESC
+);
+
+CREATE INDEX IF NOT EXISTS ix_promotion_dry_run_acceptances_decision
+ON hedge_fund.signal_promotion_dry_run_acceptances (decision_record_id);
+
+GRANT SELECT, INSERT ON TABLE
+    hedge_fund.signal_promotion_dry_run_acceptances
+TO crog_ai_app;

--- a/crog-ai-backend/docs/MARKETCLUB-DOCHIA-BUILD-PLAN.md
+++ b/crog-ai-backend/docs/MARKETCLUB-DOCHIA-BUILD-PLAN.md
@@ -75,6 +75,9 @@ Dochia-derived until independent truth data exists.
 - Promotion Dry-Run is complete: proposed `hedge_fund.market_signals` rows are
   generated read-only with approval state, lineage payload, and rollback marker.
   Guarded production writes remain blocked.
+- Promotion Dry-Run Acceptance is complete: accepted dry-run snapshots are
+  persisted only after a ready `promote_to_market_signals` decision record and
+  non-zero proposed output. Guarded production writes remain blocked.
 
 ### Phase 5 — App Surface
 
@@ -104,6 +107,9 @@ Base app entrypoint: `app.main:app`
 | `GET /api/financial/signals/shadow-review/daily` | read-only promotion review packet with gate, lane churn, transition pressure, whipsaw evidence, and decision template |
 | `GET /api/financial/signals/shadow-review/decision-records` | recent supervised Shadow Review decision records |
 | `POST /api/financial/signals/shadow-review/decision-records` | persist a supervised promote/defer decision record with the current evidence packet |
+| `GET /api/financial/signals/promotion-dry-run/daily` | read-only proposed `hedge_fund.market_signals` rows plus approval state |
+| `GET /api/financial/signals/promotion-dry-run/acceptances` | recent accepted dry-run snapshots for audit review |
+| `POST /api/financial/signals/promotion-dry-run/acceptances` | persist an accepted dry-run snapshot; rejects unless a ready promote decision backs the dry-run |
 | `GET /api/financial/signals/{ticker}/chart` | EOD bars, rolling channels, and triangle overlay events |
 | `GET /api/financial/signals/{ticker}/whipsaw-risk` | symbol whipsaw count/rate and forward-return evidence |
 | `GET /api/financial/signals/{ticker}` | symbol-level latest score plus recent transitions |
@@ -123,6 +129,10 @@ Useful query params:
 - `shadow-review/decision-records`: `candidate_parameter_set`, `limit` for
   reads; writes require `decision`, `reviewer`, `rationale`, and
   `rollback_criteria`
+- `promotion-dry-run/daily`: `candidate_parameter_set`, optional `decision_id`,
+  `limit`, `min_abs_score`
+- `promotion-dry-run/acceptances`: `candidate_parameter_set`, `limit` for
+  reads; writes require `accepted_by` and `acceptance_rationale`
 - `{ticker}/chart`: `sessions`, `as_of`
 - `{ticker}/whipsaw-risk`: `sessions`, `as_of`, optional `parameter_set`,
   `whipsaw_window_sessions`, `outcome_horizon_sessions`
@@ -142,6 +152,9 @@ Useful query params:
 - Live Promotion Gate smoke on 2026-05-03 returned
   `ready_for_shadow` for `dochia_v0_2_range_daily` with 328 production
   signal rows and 328 candidate signal rows.
+- Live dry-run acceptance remains a gate, not a write path: without an actual
+  promote decision record, acceptance creation must reject and no production
+  `market_signals` insert is allowed.
 
 ## Design Guardrails
 

--- a/crog-ai-backend/docs/MARKETCLUB-SHADOW-REVIEW-RUNBOOK.md
+++ b/crog-ai-backend/docs/MARKETCLUB-SHADOW-REVIEW-RUNBOOK.md
@@ -1,6 +1,6 @@
 # MarketClub / Dochia Shadow Review Runbook
 
-**Status:** Read-only promotion review + dry-run preview
+**Status:** Read-only promotion review + dry-run preview + acceptance gate
 **Date:** 2026-05-03
 
 ## Purpose
@@ -21,6 +21,9 @@ approval mechanism.
   and `POST /api/financial/signals/shadow-review/decision-records`
 - Promotion dry-run:
   `GET /api/financial/signals/promotion-dry-run/daily?candidate_parameter_set=dochia_v0_2_range_daily`
+- Promotion dry-run acceptances:
+  `GET /api/financial/signals/promotion-dry-run/acceptances?candidate_parameter_set=dochia_v0_2_range_daily`
+  and `POST /api/financial/signals/promotion-dry-run/acceptances`
 
 ## Review Gates
 
@@ -30,6 +33,8 @@ approval mechanism.
 3. Transition-pressure tickers must be inspected on chart overlay.
 4. High whipsaw-risk tickers must be reviewed in the Whipsaw / Backtest panel.
 5. A human decision record must be captured before promotion.
+6. A dry-run acceptance record must be captured after the promote decision and
+   before any guarded production write path exists.
 
 ## Allowed Decisions
 
@@ -68,12 +73,34 @@ rows without inserting them. Review:
 
 Dry-run output is still preview-only. It does not enable production writes.
 
+## Dry-Run Acceptance
+
+The acceptance endpoint persists an audit snapshot of the exact dry-run output
+reviewed by the operator. It must reject unless the dry-run approval state is
+`ready_for_dry_run`, which requires an actual
+`promote_to_market_signals` decision record.
+
+Capture in the cockpit or acceptance API:
+
+- Accepted by.
+- Acceptance rationale.
+- Candidate parameter set.
+- Decision record id.
+- Dry-run generated timestamp and proposed row counts.
+- Target table and target columns.
+- Rollback criteria inherited from the promote decision.
+
+The acceptance record is still not a production write. It is the final gate
+before building a guarded production write path.
+
 ## Hard Stops
 
 - Any Promotion Gate `hold`.
 - Missing live backend or frontend Promotion Gate data.
 - Unreviewed high whipsaw-risk ticker in the shadow packet.
 - No named human approver.
+- No actual `promote_to_market_signals` decision record.
+- No accepted dry-run snapshot.
 
 ## Next Build Step After Dry-Run Approval
 

--- a/crog-ai-backend/tests/test_api_signals.py
+++ b/crog-ai-backend/tests/test_api_signals.py
@@ -11,6 +11,7 @@ from app.main import create_app
 PARAMETER_SET_ID = UUID("11111111-1111-1111-1111-111111111111")
 TRANSITION_ID = UUID("22222222-2222-2222-2222-222222222222")
 DECISION_ID = UUID("33333333-3333-3333-3333-333333333333")
+ACCEPTANCE_ID = UUID("44444444-4444-4444-4444-444444444444")
 
 
 class FakeSignalStore:
@@ -517,6 +518,69 @@ class FakeSignalStore:
             ][:limit],
         }
 
+    def promotion_dry_run_acceptances(
+        self,
+        *,
+        candidate_parameter_set: str | None = None,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        return [
+            {
+                "id": ACCEPTANCE_ID,
+                "decision_record_id": DECISION_ID,
+                "candidate_parameter_set": candidate_parameter_set or "dochia_v0_2_range_daily",
+                "baseline_parameter_set": "dochia_v0_estimated",
+                "accepted_by": "Gary Knight",
+                "acceptance_rationale": "Dry-run rows match the reviewed promote decision.",
+                "rollback_criteria": "Rollback if whipsaw pressure rises.",
+                "dry_run_generated_at": dt.datetime(2026, 5, 3, 20, 30, tzinfo=dt.UTC),
+                "dry_run_candidate_signal_count": 3,
+                "dry_run_proposed_insert_count": 2,
+                "dry_run_bullish_count": 1,
+                "dry_run_risk_count": 1,
+                "dry_run_skipped_neutral_count": 1,
+                "min_abs_score": 50,
+                "target_table": "hedge_fund.market_signals",
+                "target_columns": [
+                    "ticker",
+                    "signal_type",
+                    "action",
+                    "confidence_score",
+                    "price_target",
+                    "source_sender",
+                    "source_subject",
+                    "raw_reasoning",
+                    "model_used",
+                    "extracted_at",
+                ],
+                "created_at": dt.datetime(2026, 5, 3, 20, 45, tzinfo=dt.UTC),
+            }
+        ][:limit]
+
+    def create_promotion_dry_run_acceptance(
+        self,
+        *,
+        candidate_parameter_set: str,
+        accepted_by: str,
+        acceptance_rationale: str,
+        decision_id: str | None = None,
+        limit: int = 500,
+        min_abs_score: int = 50,
+    ) -> dict[str, Any]:
+        if accepted_by == "Blocked":
+            raise ValueError("Cannot accept dry-run output without a ready promote decision record.")
+        return {
+            **self.promotion_dry_run_acceptances(
+                candidate_parameter_set=candidate_parameter_set,
+                limit=1,
+            )[0],
+            "accepted_by": accepted_by,
+            "acceptance_rationale": acceptance_rationale,
+            "decision_record_id": UUID(decision_id) if decision_id else DECISION_ID,
+            "min_abs_score": min_abs_score,
+            "dry_run_proposed_insert_count": min(limit, 2),
+        }
+
     def symbol_chart(
         self,
         *,
@@ -862,6 +926,67 @@ def test_promotion_dry_run_endpoint_returns_read_only_market_signal_plan() -> No
     assert payload["proposed_rows"][1]["action"] == "SELL"
     assert payload["proposed_rows"][0]["lineage"]["source_pipeline"] == "dochia_signal_scores"
     assert "rollback_marker" in payload["proposed_rows"][0]["lineage"]
+
+
+def test_promotion_dry_run_acceptances_endpoint_returns_audit_rows() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/financial/signals/promotion-dry-run/acceptances"
+        "?candidate_parameter_set=dochia_v0_2_range_daily&limit=3"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload[0]["id"] == str(ACCEPTANCE_ID)
+    assert payload[0]["decision_record_id"] == str(DECISION_ID)
+    assert payload[0]["dry_run_proposed_insert_count"] == 2
+    assert payload[0]["target_table"] == "hedge_fund.market_signals"
+
+
+def test_promotion_dry_run_acceptances_endpoint_creates_audit_row() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/financial/signals/promotion-dry-run/acceptances",
+        json={
+            "candidate_parameter_set": "dochia_v0_2_range_daily",
+            "decision_id": str(DECISION_ID),
+            "accepted_by": "Gary Knight",
+            "acceptance_rationale": "Dry-run output matches the reviewed promote decision.",
+            "limit": 2,
+            "min_abs_score": 50,
+        },
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["accepted_by"] == "Gary Knight"
+    assert payload["decision_record_id"] == str(DECISION_ID)
+    assert payload["acceptance_rationale"] == "Dry-run output matches the reviewed promote decision."
+    assert payload["dry_run_proposed_insert_count"] == 2
+
+
+def test_promotion_dry_run_acceptances_endpoint_rejects_without_ready_decision() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/financial/signals/promotion-dry-run/acceptances",
+        json={
+            "candidate_parameter_set": "dochia_v0_2_range_daily",
+            "accepted_by": "Blocked",
+            "acceptance_rationale": "Dry-run output cannot be accepted without approval.",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "ready promote decision" in response.json()["detail"]
 
 
 def test_symbol_chart_endpoint_returns_overlay_data() -> None:

--- a/docs/operational/MASTER-PLAN.md
+++ b/docs/operational/MASTER-PLAN.md
@@ -2,7 +2,7 @@
 
 **Operator:** Gary Knight
 **Established:** 2026-04-29
-**Updated:** 2026-05-03 (v2.3 — Dochia promotion dry-run ready)
+**Updated:** 2026-05-03 (v2.4 — Dochia dry-run acceptance gate ready)
 **Cadence:** Updated on change
 
 ---
@@ -262,8 +262,8 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 | v0.3 guardrail research | Closed as research-only: simple guardrails, ATR/cooldowns, ticker clusters, and rolling whipsaw suppressors all miss the promotion gate. Rolling date-safe holdout confirms suppression destroys recall: no candidate keeps at least 95% of raw v0.2 F1; strongest reducers cut 95%+ of events but stay below 7.41% F1 |
 | Candidate persisted state | v0.2 candidate has 328 `signal_scores` rows and 1,624 `signal_transitions` rows under non-production parameter set; internal API/BFF selector live for scanner, transitions, symbol detail, Portfolio Lens, and chart overlays |
 | Candidate lane comparison | v0.2 bullish lane unchanged at 129, risk unchanged at 47, re-entry 164→145, mixed 202→203, 61 daily states/scores change |
-| Promotion contract | Fresh Dochia scores still staged; legacy `market_signals` remains contextual. Dry-run promotion path can now preview proposed rows, lineage, rollback markers, and approval state; production writes remain blocked |
-| UI state | Hedge Fund route live in production at `https://crog-ai.com/financial/hedge-fund` with scanner, synced chart overlays, Whipsaw Risk / Backtest evidence, alert feed, symbol panel, Portfolio Lens, Calibration Baseline, Promotion Gate, Shadow Review, Decision Records, Promotion Dry-Run, and internal Production/v0.2 Range toggle |
+| Promotion contract | Fresh Dochia scores still staged; legacy `market_signals` remains contextual. Dry-run promotion path can preview proposed rows, lineage, rollback markers, approval state, and accepted dry-run snapshots; production writes remain blocked |
+| UI state | Hedge Fund route live in production at `https://crog-ai.com/financial/hedge-fund` with scanner, synced chart overlays, Whipsaw Risk / Backtest evidence, alert feed, symbol panel, Portfolio Lens, Calibration Baseline, Promotion Gate, Shadow Review, Decision Records, Promotion Dry-Run, Dry-Run Acceptance, and internal Production/v0.2 Range toggle |
 
 **Signal doctrine:**
 
@@ -279,9 +279,9 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 1. Deterministic Trade Triangle engine: pure daily/weekly/monthly state calculation from EOD bars. Complete initial slice.
 2. Database scorer: populate `hedge_fund.signal_scores` and `signal_transitions` idempotently. Complete initial fresh batch.
 3. Calibration harness: compare generated daily state/score against 24,204 MarketClub observations. Baseline complete; refinement remains.
-4. Production contract: promote approved signals to `hedge_fund.market_signals`. Dry-run planner complete; guarded write path remains locked.
-5. API surface: scanner, symbol detail, portfolio board, alert inbox, backtest lab, model health. Scanner, symbol detail, chart data, whipsaw/backtest evidence, alert feed, watchlist-candidate lanes, daily calibration, promotion-gate comparison, Shadow Review packet, Decision Records, and Promotion Dry-Run complete.
-6. Command Center UI: Financial / Hedge Fund route with sober cockpit UX, not gamified retail nudges. First route, chart overlays, Whipsaw Risk / Backtest, Portfolio Lens, Calibration Baseline, Promotion Gate, Shadow Review, Decision Records, and Promotion Dry-Run complete at `/financial/hedge-fund`.
+4. Production contract: promote approved signals to `hedge_fund.market_signals`. Dry-run planner and acceptance audit record complete; guarded write path remains locked.
+5. API surface: scanner, symbol detail, portfolio board, alert inbox, backtest lab, model health. Scanner, symbol detail, chart data, whipsaw/backtest evidence, alert feed, watchlist-candidate lanes, daily calibration, promotion-gate comparison, Shadow Review packet, Decision Records, Promotion Dry-Run, and Dry-Run Acceptance complete.
+6. Command Center UI: Financial / Hedge Fund route with sober cockpit UX, not gamified retail nudges. First route, chart overlays, Whipsaw Risk / Backtest, Portfolio Lens, Calibration Baseline, Promotion Gate, Shadow Review, Decision Records, Promotion Dry-Run, and Dry-Run Acceptance complete at `/financial/hedge-fund`.
 
 **Product principles:**
 
@@ -292,7 +292,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 - Do not call generated weekly/monthly states "MarketClub truth"; they are Dochia-derived.
 - Avoid gamified trading prompts; build an evidence cockpit.
 
-**Immediate next step:** Run and review the Promotion Dry-Run after a recorded `promote_to_market_signals` decision. The next build slice is a guarded production write path only after named approval, rollback criteria, and accepted dry-run output.
+**Immediate next step:** Record an actual `promote_to_market_signals` decision only after operator review, then accept the generated Promotion Dry-Run output. The next build slice is the guarded production write path, but only after those two durable records exist.
 
 ### 6.6 Architectural follow-ups
 
@@ -358,6 +358,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 - Added the supervised Shadow Review backend endpoint, cockpit panel, and runbook. The read-only packet combines Promotion Gate status, lane churn, transition pressure, whipsaw/backtest tickers, a checklist, and an explicit human decision template. Live database smoke returned `needs_review`, 4 lane reviews, 8 transition-pressure tickers, and 8 whipsaw-review tickers. Production `market_signals` writes remain blocked.
 - Added supervised Decision Record capture. The Shadow Review panel can now persist and list named promote/defer records with rationale, reviewed tickers, rollback criteria, and the current Shadow Review evidence payload. Production `market_signals` writes remain blocked.
 - Added Promotion Dry-Run planning. Backend endpoint previews proposed `hedge_fund.market_signals` rows from the candidate parameter set with source pipeline, parameter set, model version, computed timestamp, explanation payload, rollback marker, and decision-record approval state. The cockpit now shows proposed rows and keeps writes locked.
+- Added Promotion Dry-Run Acceptance records. Backend endpoints list and persist accepted dry-run snapshots only when the dry-run is backed by a `promote_to_market_signals` decision record and has non-zero proposed rows. The cockpit now shows recent acceptances and the acceptance form; production `market_signals` writes remain blocked.
 - Added internal Production/v0.2 Range toggle to the Command Center Hedge Fund page and promoted the production frontend build.
 - Added chart-data endpoint and chart overlay with close, daily/weekly channel bands, and generated triangle event markers.
 - Refined calibration metrics to separate carried-state agreement from exact new-alert agreement: 40.67% same-day alert match and 52.54% ±3-day alert match.
@@ -506,6 +507,7 @@ One chat session per day. Open with status. Plan three priorities. Execute. Clos
 | 2026-04-29 | v1.5 | Late-late-session — SSH alias divergence, NGC CLI installed, IP truth table |
 | 2026-04-29 | v1.6 | Closing-session — F2 PMTU fix, W1 pull pattern, Principles 7+8, 4 new briefs |
 | 2026-04-29 | v1.7 | Embed deployment closing — full 6-STOP journey, W3 weights path proven, Principle 9 (NIM profile class verification), Principle 10 anti-pattern (NGC CLI layout vs HF-cache), §5.4 NIM deployment pattern fully documented end-to-end, 13 briefs total staged for next session |
+| 2026-05-03 | v2.4 | MarketClub / Dochia dry-run acceptance gate added: accepted dry-run snapshots are durable audit records, and guarded production writes remain blocked until actual promote decision plus accepted dry-run output exists |
 
 ---
 

--- a/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
+++ b/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
@@ -531,6 +531,39 @@ const promotionDryRun = {
   ],
 };
 
+const promotionDryRunAcceptances = [
+  {
+    id: "44444444-4444-4444-4444-444444444444",
+    decision_record_id: "33333333-3333-3333-3333-333333333333",
+    candidate_parameter_set: "dochia_v0_2_range_daily",
+    baseline_parameter_set: "dochia_v0_estimated",
+    accepted_by: "MarketClub Operator",
+    acceptance_rationale: "Accepted after dry-run preview matched the promote record.",
+    rollback_criteria: "Rollback if whipsaw pressure rises.",
+    dry_run_generated_at: "2026-05-03T20:30:00Z",
+    dry_run_candidate_signal_count: 3,
+    dry_run_proposed_insert_count: 2,
+    dry_run_bullish_count: 1,
+    dry_run_risk_count: 1,
+    dry_run_skipped_neutral_count: 1,
+    min_abs_score: 50,
+    target_table: "hedge_fund.market_signals",
+    target_columns: [
+      "ticker",
+      "signal_type",
+      "action",
+      "confidence_score",
+      "price_target",
+      "source_sender",
+      "source_subject",
+      "raw_reasoning",
+      "model_used",
+      "extracted_at",
+    ],
+    created_at: "2026-05-03T20:45:00Z",
+  },
+];
+
 vi.mock("@/lib/hooks", () => ({
   useFinancialLatestSignals: () => ({
     data: latestSignals,
@@ -612,7 +645,18 @@ vi.mock("@/lib/hooks", () => ({
     isLoading: false,
     refetch: vi.fn(),
   }),
+  useFinancialPromotionDryRunAcceptances: () => ({
+    data: promotionDryRunAcceptances,
+    isError: false,
+    isFetching: false,
+    isLoading: false,
+    refetch: vi.fn(),
+  }),
   useCreateFinancialShadowDecisionRecord: () => ({
+    isPending: false,
+    mutateAsync: vi.fn(),
+  }),
+  useCreateFinancialPromotionDryRunAcceptance: () => ({
     isPending: false,
     mutateAsync: vi.fn(),
   }),
@@ -646,6 +690,10 @@ describe("HedgeFundSignalsShell", () => {
     expect(screen.getByText("market_signals Preview")).toBeInTheDocument();
     expect(screen.getByText("Ready for dry-run")).toBeInTheDocument();
     expect(screen.getByText("hedge_fund.market_signals")).toBeInTheDocument();
+    expect(screen.getByText("Dry-Run Acceptance")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Accept Dry-Run" })).toBeInTheDocument();
+    expect(screen.getByText("1 saved")).toBeInTheDocument();
+    expect(screen.getByText("MarketClub Operator")).toBeInTheDocument();
     expect(screen.getByText("Chart Overlay")).toBeInTheDocument();
     expect(screen.getByText("1 triangle events")).toBeInTheDocument();
     expect(screen.getByText("Whipsaw Risk / Backtest")).toBeInTheDocument();

--- a/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
+++ b/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
@@ -40,10 +40,12 @@ import {
 } from "@/components/ui/table";
 import {
   useCreateFinancialShadowDecisionRecord,
+  useCreateFinancialPromotionDryRunAcceptance,
   useFinancialLatestSignals,
   useFinancialDailyCalibration,
   useFinancialPromotionGate,
   useFinancialPromotionDryRun,
+  useFinancialPromotionDryRunAcceptances,
   useFinancialShadowDecisionRecords,
   useFinancialShadowReview,
   useFinancialSignalDetail,
@@ -55,6 +57,8 @@ import {
 import type {
   FinancialDailyCalibrationResponse,
   FinancialLatestSignal,
+  FinancialPromotionDryRunAcceptance,
+  FinancialPromotionDryRunAcceptanceCreate,
   FinancialPromotionDryRunApprovalStatus,
   FinancialPromotionDryRunMarketSignalRow,
   FinancialPromotionDryRunResponse,
@@ -1453,11 +1457,22 @@ function PromotionDryRunPanel({
   dryRun,
   loading,
   error,
+  acceptances,
+  acceptancesLoading,
+  onSubmitAcceptance,
+  submittingAcceptance,
 }: {
   dryRun: FinancialPromotionDryRunResponse | null;
   loading: boolean;
   error: boolean;
+  acceptances: FinancialPromotionDryRunAcceptance[];
+  acceptancesLoading: boolean;
+  onSubmitAcceptance: (payload: FinancialPromotionDryRunAcceptanceCreate) => Promise<void>;
+  submittingAcceptance: boolean;
 }) {
+  const [acceptedBy, setAcceptedBy] = useState("Gary Knight");
+  const [acceptanceRationale, setAcceptanceRationale] = useState("");
+
   if (error) {
     return (
       <div className="flex items-center gap-2 border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
@@ -1479,23 +1494,48 @@ function PromotionDryRunPanel({
     );
   }
 
-  const summary = dryRun.summary;
-  const previewRows = dryRun.proposed_rows.slice(0, 8);
+  const activeDryRun = dryRun;
+  const summary = activeDryRun.summary;
+  const previewRows = activeDryRun.proposed_rows.slice(0, 8);
+  const canAccept =
+    activeDryRun.approval.status === "ready_for_dry_run" &&
+    summary.proposed_insert_count > 0 &&
+    acceptedBy.trim().length >= 2 &&
+    acceptanceRationale.trim().length >= 12;
+
+  async function handleAcceptanceSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!canAccept) return;
+    try {
+      await onSubmitAcceptance({
+        candidate_parameter_set: activeDryRun.candidate_parameter_set,
+        decision_id: activeDryRun.approval.decision_id,
+        accepted_by: acceptedBy,
+        acceptance_rationale: acceptanceRationale,
+        limit: 500,
+        min_abs_score: summary.min_abs_score,
+      });
+      setAcceptanceRationale("");
+    } catch {
+      // The mutation hook owns the operator-facing error toast.
+    }
+  }
+
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <p className="text-sm font-semibold">market_signals Preview</p>
           <p className="text-xs text-muted-foreground">
-            {dryRun.baseline_parameter_set} → {dryRun.candidate_parameter_set}
+            {activeDryRun.baseline_parameter_set} → {activeDryRun.candidate_parameter_set}
           </p>
         </div>
         <div className="flex flex-wrap justify-end gap-2">
           <Badge
             variant="outline"
-            className={cn("font-medium", promotionDryRunApprovalClasses(dryRun.approval.status))}
+            className={cn("font-medium", promotionDryRunApprovalClasses(activeDryRun.approval.status))}
           >
-            {promotionDryRunApprovalLabel(dryRun.approval.status)}
+            {promotionDryRunApprovalLabel(activeDryRun.approval.status)}
           </Badge>
           <Badge variant="outline" className="border-sky-500/40 bg-sky-500/10 text-sky-600">
             Writes locked
@@ -1528,7 +1568,7 @@ function PromotionDryRunPanel({
         </div>
       </div>
 
-      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_260px]">
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
         <div className="overflow-hidden border border-border">
           <div className="hidden border-b border-border bg-muted/40 px-3 py-2 text-xs font-medium text-muted-foreground lg:grid lg:grid-cols-[70px_76px_64px_88px_98px_minmax(0,1fr)]">
             <span>Ticker</span>
@@ -1545,29 +1585,77 @@ function PromotionDryRunPanel({
           )}
         </div>
 
-        <div className="border border-border p-3">
-          <div className="flex items-center justify-between gap-3">
-            <h2 className="text-sm font-semibold">Approval</h2>
-            <span className="text-xs text-muted-foreground">{formatDate(dryRun.generated_at)}</span>
+        <div className="space-y-3">
+          <div className="border border-border p-3">
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="text-sm font-semibold">Approval</h2>
+              <span className="text-xs text-muted-foreground">{formatDate(activeDryRun.generated_at)}</span>
+            </div>
+            <p className="mt-3 text-xs text-muted-foreground">{activeDryRun.approval.detail}</p>
+            <div className="mt-3 space-y-2 text-xs">
+              <div className="grid grid-cols-[86px_minmax(0,1fr)] gap-2">
+                <span className="text-muted-foreground">Reviewer</span>
+                <span className="truncate font-medium">{activeDryRun.approval.reviewer ?? "—"}</span>
+              </div>
+              <div className="grid grid-cols-[86px_minmax(0,1fr)] gap-2">
+                <span className="text-muted-foreground">Decision</span>
+                <span className="truncate font-mono">{activeDryRun.approval.decision_id ?? "—"}</span>
+              </div>
+              <div className="grid grid-cols-[86px_minmax(0,1fr)] gap-2">
+                <span className="text-muted-foreground">Columns</span>
+                <span className="truncate font-mono">{summary.target_columns.length}</span>
+              </div>
+            </div>
           </div>
-          <p className="mt-3 text-xs text-muted-foreground">{dryRun.approval.detail}</p>
-          <div className="mt-3 space-y-2 text-xs">
-            <div className="grid grid-cols-[86px_minmax(0,1fr)] gap-2">
-              <span className="text-muted-foreground">Reviewer</span>
-              <span className="truncate font-medium">{dryRun.approval.reviewer ?? "—"}</span>
+
+          <form className="border border-border p-3" onSubmit={(event) => void handleAcceptanceSubmit(event)}>
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="text-sm font-semibold">Dry-Run Acceptance</h2>
+              <Badge variant="outline">
+                {acceptancesLoading ? "Loading" : `${acceptances.length} saved`}
+              </Badge>
             </div>
-            <div className="grid grid-cols-[86px_minmax(0,1fr)] gap-2">
-              <span className="text-muted-foreground">Decision</span>
-              <span className="truncate font-mono">{dryRun.approval.decision_id ?? "—"}</span>
+            <label className="mt-3 block space-y-1 text-xs font-medium">
+              Accepted By
+              <Input
+                value={acceptedBy}
+                onChange={(event) => setAcceptedBy(event.target.value)}
+                className="h-9"
+              />
+            </label>
+            <label className="mt-3 block space-y-1 text-xs font-medium">
+              Acceptance Rationale
+              <textarea
+                value={acceptanceRationale}
+                onChange={(event) => setAcceptanceRationale(event.target.value)}
+                className="min-h-20 w-full resize-y border border-input bg-background px-3 py-2 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+              />
+            </label>
+            <div className="mt-3 flex justify-end">
+              <Button type="submit" disabled={!canAccept || submittingAcceptance}>
+                {submittingAcceptance ? "Saving…" : "Accept Dry-Run"}
+              </Button>
             </div>
-            <div className="grid grid-cols-[86px_minmax(0,1fr)] gap-2">
-              <span className="text-muted-foreground">Columns</span>
-              <span className="truncate font-mono">{summary.target_columns.length}</span>
-            </div>
-          </div>
+
+            {acceptances.length ? (
+              <div className="mt-3 space-y-2">
+                {acceptances.slice(0, 2).map((acceptance) => (
+                  <div key={acceptance.id} className="border border-border/70 p-2 text-xs">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="font-medium">{acceptance.accepted_by}</span>
+                      <span className="text-muted-foreground">{formatDate(acceptance.created_at)}</span>
+                    </div>
+                    <p className="mt-1 line-clamp-2 text-muted-foreground">
+                      {acceptance.acceptance_rationale}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            ) : null}
+          </form>
         </div>
       </div>
-    </div>
+  </div>
   );
 }
 
@@ -1739,7 +1827,12 @@ export function HedgeFundSignalsShell() {
     limit: 25,
     min_abs_score: 50,
   });
+  const promotionDryRunAcceptances = useFinancialPromotionDryRunAcceptances({
+    candidate_parameter_set: "dochia_v0_2_range_daily",
+    limit: 3,
+  });
   const createShadowDecisionRecord = useCreateFinancialShadowDecisionRecord();
+  const createPromotionDryRunAcceptance = useCreateFinancialPromotionDryRunAcceptance();
   const signals = latest.data ?? EMPTY_SIGNALS;
   const alertRows = transitions.data ?? EMPTY_TRANSITIONS;
   const watchlistLanes = watchlistCandidates.data?.lanes ?? EMPTY_LANES;
@@ -1785,11 +1878,19 @@ export function HedgeFundSignalsShell() {
     promotionGate.isFetching ||
     shadowReview.isFetching ||
     shadowDecisionRecords.isFetching ||
-    promotionDryRun.isFetching;
+    promotionDryRun.isFetching ||
+    promotionDryRunAcceptances.isFetching;
 
   async function handleShadowDecisionSubmit(payload: FinancialShadowReviewDecisionRecordCreate) {
     await createShadowDecisionRecord.mutateAsync(payload);
     void shadowDecisionRecords.refetch();
+  }
+
+  async function handlePromotionDryRunAcceptanceSubmit(
+    payload: FinancialPromotionDryRunAcceptanceCreate,
+  ) {
+    await createPromotionDryRunAcceptance.mutateAsync(payload);
+    void promotionDryRunAcceptances.refetch();
   }
 
   return (
@@ -1843,6 +1944,7 @@ export function HedgeFundSignalsShell() {
               void shadowReview.refetch();
               void shadowDecisionRecords.refetch();
               void promotionDryRun.refetch();
+              void promotionDryRunAcceptances.refetch();
             }}
             disabled={isRefreshing}
             aria-label="Refresh hedge fund signals"
@@ -1978,6 +2080,10 @@ export function HedgeFundSignalsShell() {
             dryRun={promotionDryRun.data ?? null}
             loading={promotionDryRun.isLoading}
             error={promotionDryRun.isError}
+            acceptances={promotionDryRunAcceptances.data ?? []}
+            acceptancesLoading={promotionDryRunAcceptances.isLoading}
+            onSubmitAcceptance={handlePromotionDryRunAcceptanceSubmit}
+            submittingAcceptance={createPromotionDryRunAcceptance.isPending}
           />
         </CardContent>
       </Card>

--- a/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
@@ -15,6 +15,8 @@ import type {
   FinancialDailyCalibrationResponse,
   FinancialShadowReviewDecisionRecord,
   FinancialShadowReviewDecisionRecordCreate,
+  FinancialPromotionDryRunAcceptance,
+  FinancialPromotionDryRunAcceptanceCreate,
   FinancialPromotionDryRunResponse,
   FinancialPromotionGateResponse,
   FinancialShadowReviewResponse,
@@ -265,6 +267,36 @@ export function useFinancialPromotionDryRun(params?: {
     queryKey: ["financial", "signals", "promotion-dry-run", "daily", params],
     queryFn: () => api.get("/api/financial/signals/promotion-dry-run/daily", params),
     staleTime: 60_000,
+  });
+}
+
+export function useFinancialPromotionDryRunAcceptances(params?: {
+  candidate_parameter_set?: string;
+  limit?: number;
+}) {
+  return useQuery<FinancialPromotionDryRunAcceptance[]>({
+    queryKey: ["financial", "signals", "promotion-dry-run", "acceptances", params],
+    queryFn: () => api.get("/api/financial/signals/promotion-dry-run/acceptances", params),
+    staleTime: 60_000,
+  });
+}
+
+export function useCreateFinancialPromotionDryRunAcceptance() {
+  const qc = useQueryClient();
+  return useMutation<
+    FinancialPromotionDryRunAcceptance,
+    ApiError,
+    FinancialPromotionDryRunAcceptanceCreate
+  >({
+    mutationFn: (payload) =>
+      api.post("/api/financial/signals/promotion-dry-run/acceptances", payload),
+    onSuccess: () => {
+      qc.invalidateQueries({
+        queryKey: ["financial", "signals", "promotion-dry-run"],
+      });
+      toast.success("Dry-run accepted");
+    },
+    onError: (error) => toast.error(error.message || "Failed to accept dry-run"),
   });
 }
 

--- a/fortress-guest-platform/apps/command-center/src/lib/types.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/types.ts
@@ -504,6 +504,35 @@ export interface FinancialPromotionDryRunResponse {
   proposed_rows: FinancialPromotionDryRunMarketSignalRow[];
 }
 
+export interface FinancialPromotionDryRunAcceptanceCreate {
+  candidate_parameter_set: string;
+  decision_id?: string | null;
+  accepted_by: string;
+  acceptance_rationale: string;
+  limit?: number;
+  min_abs_score?: number;
+}
+
+export interface FinancialPromotionDryRunAcceptance {
+  id: string;
+  decision_record_id: string;
+  candidate_parameter_set: string;
+  baseline_parameter_set: string;
+  accepted_by: string;
+  acceptance_rationale: string;
+  rollback_criteria: string;
+  dry_run_generated_at: string;
+  dry_run_candidate_signal_count: number;
+  dry_run_proposed_insert_count: number;
+  dry_run_bullish_count: number;
+  dry_run_risk_count: number;
+  dry_run_skipped_neutral_count: number;
+  min_abs_score: number;
+  target_table: string;
+  target_columns: string[];
+  created_at: string;
+}
+
 export interface FinancialWatchlistCandidate {
   ticker: string;
   bar_date: string;


### PR DESCRIPTION
Summary:
- add durable signal_promotion_dry_run_acceptances records, migration, and idempotent live SQL
- add GET/POST dry-run acceptance endpoints that recompute the dry-run and reject unless a ready promote_to_market_signals decision backs non-zero proposed output
- add Command Center acceptance form/list, hook/type coverage, and MarketClub plan/runbook updates

Safety:
- no production hedge_fund.market_signals write path is added
- guarded production writes remain blocked until an actual promote decision and accepted dry-run output exist

Verification:
- backend focused tests passed
- backend full suite passed
- backend ruff passed
- frontend focused test passed
- frontend lint, TypeScript, and production build passed