### PR TITLE
Fortress Legal email planner: native .msg source inventory

### DIFF
--- a/docs/operational/fortress-legal-email-intake-foundation.md
+++ b/docs/operational/fortress-legal-email-intake-foundation.md
@@ -1,21 +1,27 @@
 # Fortress Legal Email Intake Foundation
 
-Last updated: 2026-05-03
+Last updated: 2026-05-04
 Status: PR foundation gate, manifest-only
 
 ## Purpose
 
 This pass gives Fortress Legal a safe first step for Wilson Pruitt, Argo,
 closing, and post-closing email source drops. It inventories operator-supplied
-`.eml` files and produces a reviewable manifest before any evidence ingestion.
+`.eml` files and Outlook `.msg` files and produces a reviewable manifest before
+any evidence ingestion.
 
 ## Contract
 
 The source-drop planner:
 
 - Parses `.eml` files from an explicit operator source directory.
+- Inventories `.msg` files as hash-only native review candidates when a full
+  Outlook parser is not configured.
 - Extracts message identity, sender/recipient metadata, dates, thread headers,
-  normalized subject, body preview, and attachment metadata.
+  normalized subject, body preview, and attachment metadata for `.eml` files.
+- Preserves `.msg` source path, relative path, SHA-256, filename-derived subject,
+  case/privilege guesses, and `native_review_required` decision without parsing
+  message bodies or attachments.
 - Computes SHA-256 hashes for the raw email and each attachment.
 - Makes conservative case-slug and privilege-risk guesses.
 - Writes a JSON manifest.
@@ -55,6 +61,11 @@ Each candidate includes:
 - `case_slug_guess` and `case_guess_reason`
 - `privilege_risk` and `privilege_reason`
 - `intake_decision=manifest_only`
+- `source_format`, `parser_status`, and `parser_reason`
+
+For `.msg` files, `intake_decision` is `native_review_required`,
+`parser_status` is `native_inventory_only`, and attachment/message-body fields
+remain empty until a controlled Outlook parser is added.
 
 ## Next Gate
 

--- a/fortress-guest-platform/backend/scripts/legal_email_source_drop_plan.py
+++ b/fortress-guest-platform/backend/scripts/legal_email_source_drop_plan.py
@@ -1,8 +1,9 @@
 """Dry-run planner for Fortress Legal email source drops.
 
 This CLI is intentionally manifest-only. It inventories operator-controlled
-``.eml`` files and writes chain-of-custody metadata so the operator can review
-case/privilege guesses before any DB, Qdrant, NAS vault, or IMAP mutation.
+``.eml`` files, inventories Outlook ``.msg`` files, and writes
+chain-of-custody metadata so the operator can review case/privilege guesses
+before any DB, Qdrant, NAS vault, or IMAP mutation.
 """
 from __future__ import annotations
 
@@ -22,9 +23,9 @@ DEFAULT_AUDIT_DIR = Path("/mnt/fortress_nas/audits")
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Create a manifest-only plan for Fortress Legal .eml source drops",
+        description="Create a manifest-only plan for Fortress Legal email source drops",
     )
-    parser.add_argument("--source-root", required=True, help="Directory containing .eml files")
+    parser.add_argument("--source-root", required=True, help="Directory containing .eml or .msg files")
     parser.add_argument("--limit", type=int, default=None, help="Optional candidate limit")
     parser.add_argument(
         "--output",

--- a/fortress-guest-platform/backend/services/legal/email_intake_foundation.py
+++ b/fortress-guest-platform/backend/services/legal/email_intake_foundation.py
@@ -1,8 +1,9 @@
 """Manifest-only Fortress Legal email source-drop planning.
 
 This module is the safety gate before historical email evidence ingestion. It
-parses operator-controlled ``.eml`` source drops, extracts chain-of-custody
-metadata, makes conservative case/privilege guesses, and emits a manifest.
+parses operator-controlled ``.eml`` source drops, inventories hash-only
+``.msg`` source drops, makes conservative case/privilege guesses, and emits a
+manifest.
 
 It deliberately does not touch IMAP flags, Postgres, Qdrant, the NAS vault, or
 ``process_vault_upload``. Real ingestion stays behind a later operator gate.
@@ -20,7 +21,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
-SUPPORTED_EMAIL_SUFFIXES = frozenset({".eml"})
+PARSED_EMAIL_SUFFIXES = frozenset({".eml"})
+NATIVE_INVENTORY_SUFFIXES = frozenset({".msg"})
+SUPPORTED_EMAIL_SUFFIXES = PARSED_EMAIL_SUFFIXES | NATIVE_INVENTORY_SUFFIXES
 LEGACY_7IL_MIXED_DUMP = Path("/mnt/fortress_nas/legal_vault/7il-v-knight-ndga")
 
 PRIVILEGED_COUNSEL_DOMAINS = frozenset(
@@ -114,6 +117,9 @@ class EmailIntakeCandidate:
     privilege_risk: str
     privilege_reason: str
     intake_decision: str = "manifest_only"
+    source_format: str = "eml"
+    parser_status: str = "parsed"
+    parser_reason: str = "rfc822_message"
 
 
 @dataclass(frozen=True)
@@ -166,6 +172,65 @@ def validate_source_root(source_root: Path, *, allow_legacy_mixed_dump: bool = F
 def parse_email_file(path: Path, *, source_root: Path | None = None) -> EmailIntakeCandidate:
     raw_bytes = path.read_bytes()
     return parse_email_bytes(raw_bytes, source_path=path, source_root=source_root)
+
+
+def inventory_native_email_file(path: Path, *, source_root: Path | None = None) -> EmailIntakeCandidate:
+    """Create a chain-of-custody candidate for native formats we do not parse yet."""
+    raw_bytes = path.read_bytes()
+    root = source_root.expanduser().resolve(strict=False) if source_root else None
+    resolved_path = path.expanduser().resolve(strict=False)
+    relative_path = _relative_path(resolved_path, root)
+    source_sha256 = hashlib.sha256(raw_bytes).hexdigest()
+    subject = _filename_subject(path)
+    normalized_subject = normalize_subject(subject)
+    case_slug, case_reason = classify_case_slug(
+        subject=subject,
+        body_preview="",
+        participants=[],
+        sent_at=None,
+    )
+    privilege_risk, privilege_reason = classify_privilege_risk(
+        subject=subject,
+        body_preview="",
+        participant_domains=[],
+        participants=[],
+    )
+
+    return EmailIntakeCandidate(
+        source_path=str(resolved_path),
+        source_relative_path=relative_path,
+        source_sha256=source_sha256,
+        message_id="",
+        in_reply_to="",
+        references=[],
+        thread_key=thread_key(
+            message_id="",
+            in_reply_to="",
+            references=[],
+            normalized_subject=normalized_subject,
+            sender_email="",
+            source_sha256=source_sha256,
+        ),
+        subject=subject,
+        normalized_subject=normalized_subject,
+        sent_at=None,
+        sender="",
+        sender_email="",
+        to_addresses=[],
+        cc_addresses=[],
+        bcc_addresses=[],
+        participant_domains=[],
+        body_preview="",
+        attachments=[],
+        case_slug_guess=case_slug,
+        case_guess_reason=case_reason,
+        privilege_risk=privilege_risk,
+        privilege_reason=privilege_reason,
+        intake_decision="native_review_required",
+        source_format=path.suffix.lower().lstrip("."),
+        parser_status="native_inventory_only",
+        parser_reason="outlook_msg_parser_not_configured",
+    )
 
 
 def parse_email_bytes(
@@ -264,14 +329,18 @@ def build_source_drop_plan(
 
     for path in _walk_files(root):
         total_seen += 1
-        if path.suffix.lower() not in SUPPORTED_EMAIL_SUFFIXES:
+        suffix = path.suffix.lower()
+        if suffix not in SUPPORTED_EMAIL_SUFFIXES:
             skipped.append(SkippedSourceFile(str(path), "unsupported_suffix"))
             continue
         if limit is not None and len(candidates) >= limit:
             skipped.append(SkippedSourceFile(str(path), "limit_reached"))
             continue
         try:
-            candidates.append(parse_email_file(path, source_root=root))
+            if suffix in NATIVE_INVENTORY_SUFFIXES:
+                candidates.append(inventory_native_email_file(path, source_root=root))
+            else:
+                candidates.append(parse_email_file(path, source_root=root))
         except Exception as exc:  # pragma: no cover - exact parser errors vary
             errors.append(SkippedSourceFile(str(path), f"{type(exc).__name__}: {exc}"))
 
@@ -401,6 +470,10 @@ def _relative_path(path: Path, root: Path | None) -> str:
         return str(path.relative_to(root))
     except ValueError:
         return path.name
+
+
+def _filename_subject(path: Path) -> str:
+    return re.sub(r"\s+", " ", path.stem.replace("_", " ")).strip()
 
 
 def _message_ids(value: str) -> list[str]:

--- a/fortress-guest-platform/backend/tests/test_legal_email_intake_foundation.py
+++ b/fortress-guest-platform/backend/tests/test_legal_email_intake_foundation.py
@@ -97,6 +97,25 @@ def test_build_source_drop_plan_is_manifest_only(tmp_path):
     assert plan.candidates[0].case_slug_guess == "7il-v-knight-ndga-i"
 
 
+def test_build_source_drop_plan_inventories_msg_without_parsing(tmp_path):
+    (tmp_path / "Fwd_ 21-0510 1031_92 Fish Trap Road_7 IL Properties_ LLC_Knight.msg").write_bytes(
+        b"\xd0\xcf\x11\xe0 native outlook bytes"
+    )
+
+    plan = build_source_drop_plan(tmp_path)
+
+    assert plan.candidate_count == 1
+    assert plan.skipped == []
+    candidate = plan.candidates[0]
+    assert candidate.source_format == "msg"
+    assert candidate.parser_status == "native_inventory_only"
+    assert candidate.parser_reason == "outlook_msg_parser_not_configured"
+    assert candidate.intake_decision == "native_review_required"
+    assert candidate.case_slug_guess == "fish-trap-suv2026000013"
+    assert candidate.source_sha256
+    assert candidate.attachments == []
+
+
 def test_write_manifest_includes_summary_counts(tmp_path):
     (tmp_path / "a.eml").write_bytes(_raw_email(subject="Vanderburge easement thread"))
     plan = build_source_drop_plan(tmp_path)


### PR DESCRIPTION
## What this PR does

Extends the manifest-only Fortress Legal email source-drop planner from parsed .eml files to hash-only Outlook .msg inventory candidates.

## Why

The Wilson Pruitt / Dee McBee / Terry Wilson discovery source folders on NAS include Outlook .msg files. The first email foundation PR only parsed .eml, so those native source files would be skipped instead of preserved in the review manifest.

## Safety contract

- .eml files remain fully parsed as before.
- .msg files are not body-parsed and attachments are not extracted.
- .msg files become native_review_required candidates with source path, relative path, SHA-256, filename-derived subject, conservative case/privilege guesses, source_format, parser_status, and parser_reason.
- No IMAP, DB, Qdrant, NAS vault, correspondence, timeline, or process_vault_upload writes.

## Verification

- python3 -m py_compile backend/services/legal/email_intake_foundation.py backend/scripts/legal_email_source_drop_plan.py
- python3 -m pytest backend/tests/test_legal_email_intake_foundation.py -q
- Manifest-only proof run against Discovery/Records - GAND/Received from Gary 6.23.2022/All 6.23.2022emails from Gary: 9 candidates, 0 skipped, 0 errors, all native_inventory_only.

## Operator note

Keep draft until reviewed. This is not ingestion; it only improves pre-ingest source review.