### PR TITLE
Fix Legal XLSX clean-cell extraction

### DIFF
--- a/fortress-guest-platform/backend/services/legal_ediscovery.py
+++ b/fortress-guest-platform/backend/services/legal_ediscovery.py
@@ -12,9 +12,11 @@ from __future__ import annotations
 import email
 import email.policy
 import hashlib
+import io
 import json
 import time
 import structlog
+from decimal import Decimal
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -121,6 +123,58 @@ def _file_hash(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
+def _is_spreadsheet_file(mime_type: str, file_name: str) -> bool:
+    lowered_mime = (mime_type or "").lower()
+    lowered_name = (file_name or "").lower()
+    return (
+        "spreadsheet" in lowered_mime
+        or "officedocument.spreadsheetml.sheet" in lowered_mime
+        or lowered_name.endswith((".xlsx", ".xlsm"))
+    )
+
+
+def _format_spreadsheet_cell(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, datetime):
+        return value.isoformat(sep=" ")
+    if isinstance(value, Decimal):
+        return format(value, "f")
+    return str(value).strip()
+
+
+def _extract_spreadsheet_text(file_bytes: bytes, file_name: str) -> str:
+    try:
+        from openpyxl import load_workbook
+    except ImportError as exc:  # pragma: no cover - dependency is present in runtime
+        logger.warning("xlsx_extraction_dependency_missing", file=file_name, error=str(exc)[:200])
+        return ""
+
+    try:
+        workbook = load_workbook(io.BytesIO(file_bytes), read_only=True, data_only=True)
+    except Exception as exc:
+        logger.warning("xlsx_extraction_failed", file=file_name, error=str(exc)[:200])
+        return ""
+
+    sections: list[str] = []
+    try:
+        for worksheet in workbook.worksheets:
+            rows: list[str] = []
+            for row in worksheet.iter_rows(values_only=True):
+                cells = [_format_spreadsheet_cell(value) for value in row]
+                while cells and not cells[-1]:
+                    cells.pop()
+                if any(cells):
+                    rows.append("\t".join(cells))
+
+            if rows:
+                sections.append(f"Sheet: {worksheet.title}\n" + "\n".join(rows))
+    finally:
+        workbook.close()
+
+    return "\n\n".join(sections)
+
+
 def _extract_text(file_bytes: bytes, mime_type: str, file_name: str) -> str:
     if "pdf" in mime_type.lower():
         try:
@@ -142,6 +196,12 @@ def _extract_text(file_bytes: bytes, mime_type: str, file_name: str) -> str:
         except Exception as exc:
             logger.warning("pypdf_extraction_failed", file=file_name, error=str(exc)[:200])
         return file_bytes.decode("utf-8", errors="ignore")
+
+    if _is_spreadsheet_file(mime_type, file_name):
+        spreadsheet_text = _extract_spreadsheet_text(file_bytes, file_name)
+        if spreadsheet_text.strip():
+            return spreadsheet_text
+        return ""
 
     if "csv" in mime_type.lower():
         return file_bytes.decode("utf-8", errors="ignore")

--- a/fortress-guest-platform/backend/tests/test_legal_ediscovery_xlsx_extraction.py
+++ b/fortress-guest-platform/backend/tests/test_legal_ediscovery_xlsx_extraction.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from io import BytesIO
+
+import run  # noqa: F401  (registers settings + paths)
+from openpyxl import Workbook
+
+from backend.services.legal_ediscovery import _extract_text
+
+
+def _workbook_bytes() -> bytes:
+    workbook = Workbook()
+    worksheet = workbook.active
+    worksheet.title = "Inspection Comments"
+    worksheet.append(["Item", "Observation", "Responsible Party"])
+    worksheet.append(["Driveway", "Repair gravel apron", "Seller"])
+    worksheet.append(["Easement", "Confirm foot path access", "Counsel review"])
+    workbook.create_sheet("Empty Sheet")
+
+    output = BytesIO()
+    workbook.save(output)
+    workbook.close()
+    return output.getvalue()
+
+
+def test_extract_text_uses_clean_xlsx_cell_values() -> None:
+    text = _extract_text(
+        _workbook_bytes(),
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "Inspection Comments(89340812.1).xlsx",
+    )
+
+    assert "Sheet: Inspection Comments" in text
+    assert "Item\tObservation\tResponsible Party" in text
+    assert "Driveway\tRepair gravel apron\tSeller" in text
+    assert "Easement\tConfirm foot path access\tCounsel review" in text
+    assert "Empty Sheet" not in text
+
+
+def test_extract_text_does_not_decode_xlsx_zip_internals() -> None:
+    text = _extract_text(
+        _workbook_bytes(),
+        "application/octet-stream",
+        "inspection-comments.xlsx",
+    )
+
+    assert "[Content_Types].xml" not in text
+    assert "xl/worksheets" not in text
+    assert "PK" not in text[:40]
+    assert "Repair gravel apron" in text


### PR DESCRIPTION
## What this PR does

Fixes Fortress Legal spreadsheet extraction so XLSX/XLSM files are parsed with openpyxl and indexed as clean sheet/cell text instead of raw Office ZIP package bytes.

## Why

Packet 22A found that the selected Case II spreadsheet, Inspection Comments(89340812.1).xlsx, had been indexed mostly as Office package internals. This PR fixes the extraction path used by process_vault_upload and future controlled reprocess runs.

## Validation

- python -m py_compile backend/services/legal_ediscovery.py backend/tests/test_legal_ediscovery_xlsx_extraction.py
- pytest backend/tests/test_legal_ediscovery_xlsx_extraction.py -q: 2 passed
- pytest backend/tests/test_legal_ediscovery_xlsx_extraction.py backend/tests/test_legal_ediscovery_vault.py -q: 9 passed
- Packet 47 validation-only rerun against the selected Case II spreadsheet: PASS_CLEAN_CELL_TEXT
  - Extracted characters: 5311
  - Nonblank lines: 75
  - Tabular lines: 73
  - ZIP/package markers found: 0

## Guardrails

No ingest, no evidence promotion, no DB writes, and no Qdrant writes. Existing Qdrant payload for the selected spreadsheet still needs a later controlled reprocess/reindex step if the operator authorizes it.