### PR TITLE
Add dry-run verification gate for Hedge Fund Signals

### DIFF
--- a/crog-ai-backend/alembic/versions/0006_promotion_dry_run_verification.py
+++ b/crog-ai-backend/alembic/versions/0006_promotion_dry_run_verification.py
@@ -1,0 +1,33 @@
+"""Add promotion dry-run verification helper.
+
+Revision ID: 0006_promotion_dry_run_verification
+Revises: 0005_promotion_dry_run_acceptances
+Create Date: 2026-05-04
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from alembic import op
+
+revision = "0006_promotion_dry_run_verification"
+down_revision = "0005_promotion_dry_run_acceptances"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    sql_path = (
+        Path(__file__).resolve().parents[2]
+        / "deploy"
+        / "sql"
+        / "marketclub_promotion_dry_run_verification.sql"
+    )
+    op.execute(sql_path.read_text())
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP FUNCTION IF EXISTS hedge_fund.verify_promotion_dry_run(TEXT, TEXT)"
+    )

--- a/crog-ai-backend/app/api/signals.py
+++ b/crog-ai-backend/app/api/signals.py
@@ -390,6 +390,50 @@ class PromotionDryRunResponse(BaseModel):
     proposed_rows: list[PromotionDryRunMarketSignalRow]
 
 
+VerificationStatus = Literal["PASS", "FAIL", "INCONCLUSIVE"]
+VerificationConflictType = Literal[
+    "NONE",
+    "CROSS_MODEL_DIAGNOSTIC_ONLY",
+    "CANDIDATE_INTERNAL_CONFLICT",
+    "SOURCE_LINEAGE_MISSING",
+    "SOURCE_LINEAGE_DUPLICATE",
+    "SOURCE_LINEAGE_PARAMETER_MISMATCH",
+    "TRANSITION_UNSUPPORTED",
+]
+
+
+class PromotionDryRunVerificationRow(BaseModel):
+    row_status: VerificationStatus
+    ticker: str
+    candidate_bar_date: dt.date
+    candidate_score: int | None
+    candidate_action: Literal["BUY", "SELL"] | None
+    candidate_monthly_triangle: int | None
+    candidate_weekly_triangle: int | None
+    candidate_daily_triangle: int | None
+    latest_candidate_transition_date: dt.date | None
+    latest_candidate_transition_type: TransitionKind | None
+    prior_score: int | None
+    new_score: int | None
+    production_score: int | None
+    production_daily_triangle: int | None
+    conflict_type: VerificationConflictType
+    explanation: str
+
+
+class PromotionDryRunVerificationResponse(BaseModel):
+    generated_at: dt.datetime
+    candidate_parameter_set: str
+    production_parameter_set: str
+    overall_status: VerificationStatus
+    proposed_rows_checked: int
+    passed_rows: int
+    failed_rows: int
+    inconclusive_rows: int
+    cross_model_diagnostic_only_rows: int
+    rows: list[PromotionDryRunVerificationRow]
+
+
 class PromotionDryRunAcceptanceCreate(BaseModel):
     candidate_parameter_set: str = Field(
         default="dochia_v0_2_range_daily",
@@ -709,6 +753,31 @@ def promotion_dry_run_daily(
 ) -> dict[str, object]:
     return store.promotion_dry_run(
         candidate_parameter_set=candidate_parameter_set,
+        decision_id=str(decision_id) if decision_id else None,
+        limit=limit,
+        min_abs_score=min_abs_score,
+    )
+
+
+@router.get(
+    "/promotion-dry-run/verification",
+    response_model=PromotionDryRunVerificationResponse,
+)
+def promotion_dry_run_verification(
+    store: Annotated[SignalDataStore, Depends(get_signal_store)],
+    candidate_parameter_set: Annotated[
+        str, Query(min_length=1, max_length=100)
+    ] = "dochia_v0_2_range_daily",
+    production_parameter_set: Annotated[
+        str, Query(min_length=1, max_length=100)
+    ] = "dochia_v0_estimated",
+    decision_id: UUID | None = None,
+    limit: Annotated[int, Query(ge=1, le=500)] = 500,
+    min_abs_score: Annotated[int, Query(ge=1, le=100)] = 50,
+) -> dict[str, object]:
+    return store.promotion_dry_run_verification(
+        candidate_parameter_set=candidate_parameter_set,
+        production_parameter_set=production_parameter_set,
         decision_id=str(decision_id) if decision_id else None,
         limit=limit,
         min_abs_score=min_abs_score,

--- a/crog-ai-backend/app/signals/repository.py
+++ b/crog-ai-backend/app/signals/repository.py
@@ -113,6 +113,16 @@ class SignalDataStore(Protocol):
         min_abs_score: int = 50,
     ) -> dict[str, Any]: ...
 
+    def promotion_dry_run_verification(
+        self,
+        *,
+        candidate_parameter_set: str,
+        production_parameter_set: str = PRODUCTION_PARAMETER_SET,
+        decision_id: str | None = None,
+        limit: int = 500,
+        min_abs_score: int = 50,
+    ) -> dict[str, Any]: ...
+
     def promotion_dry_run_acceptances(
         self,
         *,
@@ -1007,6 +1017,21 @@ PROMOTION_DRY_RUN_TARGET_COLUMNS = [
     "extracted_at",
 ]
 
+VERIFICATION_PASS = "PASS"
+VERIFICATION_FAIL = "FAIL"
+VERIFICATION_INCONCLUSIVE = "INCONCLUSIVE"
+
+CONFLICT_NONE = "NONE"
+CONFLICT_CROSS_MODEL_DIAGNOSTIC_ONLY = "CROSS_MODEL_DIAGNOSTIC_ONLY"
+CONFLICT_CANDIDATE_INTERNAL_CONFLICT = "CANDIDATE_INTERNAL_CONFLICT"
+CONFLICT_SOURCE_LINEAGE_MISSING = "SOURCE_LINEAGE_MISSING"
+CONFLICT_SOURCE_LINEAGE_DUPLICATE = "SOURCE_LINEAGE_DUPLICATE"
+CONFLICT_SOURCE_LINEAGE_PARAMETER_MISMATCH = "SOURCE_LINEAGE_PARAMETER_MISMATCH"
+CONFLICT_TRANSITION_UNSUPPORTED = "TRANSITION_UNSUPPORTED"
+
+BULLISH_TRANSITIONS = {"breakout_bullish", "exit_to_reentry", "full_reversal"}
+BEARISH_TRANSITIONS = {"breakout_bearish", "peak_to_exit", "full_reversal"}
+
 
 def _latest_promote_decision_record(
     conn: psycopg.Connection,
@@ -1231,6 +1256,383 @@ def fetch_promotion_dry_run(
     }
 
 
+def _verification_action(score: int) -> str:
+    return "BUY" if score >= 0 else "SELL"
+
+
+def _verification_key(row: dict[str, Any]) -> tuple[str, dt.date]:
+    bar_date = row.get("bar_date") or row.get("candidate_bar_date")
+    if not isinstance(bar_date, dt.date):
+        raise TypeError(f"verification row has non-date bar: {bar_date!r}")
+    return str(row["ticker"]), bar_date
+
+
+def _group_rows_by_key(rows: list[dict[str, Any]]) -> dict[tuple[str, dt.date], list[dict[str, Any]]]:
+    grouped: dict[tuple[str, dt.date], list[dict[str, Any]]] = {}
+    for row in rows:
+        grouped.setdefault(_verification_key(row), []).append(row)
+    return grouped
+
+
+def _latest_transition_for(
+    transitions: list[dict[str, Any]],
+    *,
+    ticker: str,
+    bar_date: dt.date,
+) -> dict[str, Any] | None:
+    eligible = [
+        transition
+        for transition in transitions
+        if transition.get("ticker") == ticker and transition.get("to_bar_date") <= bar_date
+    ]
+    if not eligible:
+        return None
+    return sorted(
+        eligible,
+        key=lambda transition: (
+            transition.get("to_bar_date") or dt.date.min,
+            transition.get("detected_at") or dt.datetime.min.replace(tzinfo=dt.UTC),
+        ),
+        reverse=True,
+    )[0]
+
+
+def _transition_supports_state(
+    transition: dict[str, Any] | None,
+    *,
+    score: int,
+    candidate_monthly: int,
+    candidate_weekly: int,
+    candidate_daily: int,
+) -> tuple[bool, str]:
+    if score >= 50:
+        if candidate_monthly == 1 and candidate_weekly == 1 and candidate_daily == 1:
+            return True, "Candidate is fully aligned monthly/weekly/daily bullish."
+        if transition and str(transition.get("transition_type")) in BULLISH_TRANSITIONS:
+            to_states = transition.get("to_states") or {}
+            if int(transition.get("to_score") or 0) == score and int(to_states.get("daily", 0)) == 1:
+                return True, "Latest candidate transition supports bullish resolved state."
+        return False, "BUY row is not fully aligned and lacks a supporting bullish transition."
+
+    if score <= -50:
+        if candidate_monthly == -1 and candidate_weekly == -1 and candidate_daily == -1:
+            return True, "Candidate is fully aligned monthly/weekly/daily bearish."
+        if transition and str(transition.get("transition_type")) in BEARISH_TRANSITIONS:
+            to_states = transition.get("to_states") or {}
+            if int(transition.get("to_score") or 0) == score and int(to_states.get("daily", 0)) == -1:
+                return True, "Latest candidate transition supports bearish resolved state."
+        return False, "SELL row is not fully aligned and lacks a supporting bearish transition."
+
+    return True, "Dry-run row is below strong promotion threshold."
+
+
+def verify_promotion_dry_run_payload(
+    *,
+    dry_run: dict[str, Any],
+    candidate_source_rows: list[dict[str, Any]],
+    production_source_rows: list[dict[str, Any]],
+    candidate_transition_rows: list[dict[str, Any]],
+    candidate_parameter_set: str,
+    production_parameter_set: str = PRODUCTION_PARAMETER_SET,
+) -> dict[str, Any]:
+    candidate_by_key = _group_rows_by_key(candidate_source_rows)
+    production_by_key = _group_rows_by_key(production_source_rows)
+    verification_rows: list[dict[str, Any]] = []
+
+    for dry_row in dry_run["proposed_rows"]:
+        ticker = str(dry_row["ticker"])
+        bar_date = dry_row["candidate_bar_date"]
+        key = (ticker, bar_date)
+        candidate_rows = candidate_by_key.get(key, [])
+        production_rows = production_by_key.get(key, [])
+        latest_transition = _latest_transition_for(
+            candidate_transition_rows,
+            ticker=ticker,
+            bar_date=bar_date,
+        )
+
+        row_status = VERIFICATION_PASS
+        conflict_type = CONFLICT_NONE
+        explanation_parts: list[str] = []
+        candidate_source = candidate_rows[0] if len(candidate_rows) == 1 else None
+        production_source = production_rows[0] if production_rows else None
+
+        candidate_score: int | None = None
+        candidate_action = str(dry_row["action"])
+        candidate_monthly: int | None = None
+        candidate_weekly: int | None = None
+        candidate_daily: int | None = None
+
+        if not candidate_rows:
+            row_status = VERIFICATION_INCONCLUSIVE
+            conflict_type = CONFLICT_SOURCE_LINEAGE_MISSING
+            explanation_parts.append("No candidate source row traces to the dry-run ticker/bar.")
+        elif len(candidate_rows) > 1:
+            row_status = VERIFICATION_FAIL
+            conflict_type = CONFLICT_SOURCE_LINEAGE_DUPLICATE
+            explanation_parts.append("More than one candidate source row exists for the dry-run ticker/bar.")
+        elif str(candidate_source.get("parameter_set_name")) != candidate_parameter_set:
+            row_status = VERIFICATION_FAIL
+            conflict_type = CONFLICT_SOURCE_LINEAGE_PARAMETER_MISMATCH
+            explanation_parts.append("Candidate source row uses the wrong parameter set.")
+        else:
+            candidate_score = int(candidate_source["composite_score"])
+            candidate_action = _verification_action(candidate_score)
+            candidate_monthly = int(candidate_source["monthly_state"])
+            candidate_weekly = int(candidate_source["weekly_state"])
+            candidate_daily = int(candidate_source["daily_state"])
+            dry_score = int(dry_row["composite_score"])
+            dry_action = str(dry_row["action"])
+            lineage = dry_row.get("lineage") or {}
+            lineage_parameter = lineage.get("parameter_set")
+
+            if lineage_parameter != candidate_parameter_set:
+                row_status = VERIFICATION_FAIL
+                conflict_type = CONFLICT_SOURCE_LINEAGE_PARAMETER_MISMATCH
+                explanation_parts.append("Dry-run lineage parameter does not match the candidate parameter set.")
+            elif dry_score != candidate_score or dry_action != candidate_action:
+                row_status = VERIFICATION_FAIL
+                conflict_type = CONFLICT_CANDIDATE_INTERNAL_CONFLICT
+                explanation_parts.append("Dry-run row does not match the candidate source score/action.")
+            elif dry_action == "BUY" and candidate_daily < 0:
+                row_status = VERIFICATION_FAIL
+                conflict_type = CONFLICT_CANDIDATE_INTERNAL_CONFLICT
+                explanation_parts.append("Candidate proposes BUY while candidate daily triangle is bearish.")
+            elif dry_action == "SELL" and candidate_daily > 0:
+                row_status = VERIFICATION_FAIL
+                conflict_type = CONFLICT_CANDIDATE_INTERNAL_CONFLICT
+                explanation_parts.append("Candidate proposes SELL while candidate daily triangle is bullish.")
+            else:
+                supported, support_explanation = _transition_supports_state(
+                    latest_transition,
+                    score=candidate_score,
+                    candidate_monthly=candidate_monthly,
+                    candidate_weekly=candidate_weekly,
+                    candidate_daily=candidate_daily,
+                )
+                if not supported:
+                    row_status = VERIFICATION_INCONCLUSIVE
+                    conflict_type = CONFLICT_TRANSITION_UNSUPPORTED
+                explanation_parts.append(support_explanation)
+
+            if row_status == VERIFICATION_PASS and production_source:
+                production_score = int(production_source["composite_score"])
+                production_daily = int(production_source["daily_state"])
+                if production_score != candidate_score or production_daily != candidate_daily:
+                    conflict_type = CONFLICT_CROSS_MODEL_DIAGNOSTIC_ONLY
+                    explanation_parts.append(
+                        "Production baseline differs from candidate, but candidate lineage is clean."
+                    )
+
+        production_score = (
+            int(production_source["composite_score"]) if production_source else None
+        )
+        production_daily = int(production_source["daily_state"]) if production_source else None
+        verification_rows.append(
+            {
+                "row_status": row_status,
+                "ticker": ticker,
+                "candidate_bar_date": bar_date,
+                "candidate_score": candidate_score,
+                "candidate_action": candidate_action,
+                "candidate_monthly_triangle": candidate_monthly,
+                "candidate_weekly_triangle": candidate_weekly,
+                "candidate_daily_triangle": candidate_daily,
+                "latest_candidate_transition_date": (
+                    latest_transition.get("to_bar_date") if latest_transition else None
+                ),
+                "latest_candidate_transition_type": (
+                    latest_transition.get("transition_type") if latest_transition else None
+                ),
+                "prior_score": latest_transition.get("from_score") if latest_transition else None,
+                "new_score": latest_transition.get("to_score") if latest_transition else None,
+                "production_score": production_score,
+                "production_daily_triangle": production_daily,
+                "conflict_type": conflict_type,
+                "explanation": " ".join(explanation_parts),
+            }
+        )
+
+    if any(row["row_status"] == VERIFICATION_FAIL for row in verification_rows):
+        overall_status = VERIFICATION_FAIL
+    elif any(row["row_status"] == VERIFICATION_INCONCLUSIVE for row in verification_rows):
+        overall_status = VERIFICATION_INCONCLUSIVE
+    else:
+        overall_status = VERIFICATION_PASS
+
+    return {
+        "generated_at": dt.datetime.now(dt.UTC),
+        "candidate_parameter_set": candidate_parameter_set,
+        "production_parameter_set": production_parameter_set,
+        "overall_status": overall_status,
+        "proposed_rows_checked": len(verification_rows),
+        "passed_rows": sum(row["row_status"] == VERIFICATION_PASS for row in verification_rows),
+        "failed_rows": sum(row["row_status"] == VERIFICATION_FAIL for row in verification_rows),
+        "inconclusive_rows": sum(
+            row["row_status"] == VERIFICATION_INCONCLUSIVE for row in verification_rows
+        ),
+        "cross_model_diagnostic_only_rows": sum(
+            row["conflict_type"] == CONFLICT_CROSS_MODEL_DIAGNOSTIC_ONLY
+            for row in verification_rows
+        ),
+        "rows": verification_rows,
+    }
+
+
+def _fetch_source_rows_for_dry_run(
+    conn: psycopg.Connection,
+    *,
+    dry_run: dict[str, Any],
+    parameter_set: str,
+) -> list[dict[str, Any]]:
+    proposed_rows = dry_run["proposed_rows"]
+    if not proposed_rows:
+        return []
+    tickers = sorted({row["ticker"] for row in proposed_rows})
+    bar_dates = sorted({row["candidate_bar_date"] for row in proposed_rows})
+    sql = """
+        SELECT
+            v.ticker,
+            v.bar_date,
+            v.parameter_set_id,
+            v.parameter_set_name,
+            v.dochia_version,
+            v.monthly_state,
+            v.weekly_state,
+            v.daily_state,
+            v.momentum_state,
+            v.composite_score,
+            v.computed_at,
+            s.monthly_channel_high,
+            s.monthly_channel_low,
+            s.weekly_channel_high,
+            s.weekly_channel_low,
+            s.daily_channel_high,
+            s.daily_channel_low
+        FROM hedge_fund.v_signal_scores_composite v
+        JOIN hedge_fund.signal_scores s
+          ON s.ticker = v.ticker
+         AND s.bar_date = v.bar_date
+         AND s.parameter_set_id = v.parameter_set_id
+        WHERE v.parameter_set_name = %(parameter_set)s
+          AND v.ticker = ANY(%(tickers)s)
+          AND v.bar_date = ANY(%(bar_dates)s)
+        ORDER BY v.ticker, v.bar_date, v.computed_at DESC
+    """
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            sql,
+            {
+                "parameter_set": parameter_set,
+                "tickers": tickers,
+                "bar_dates": bar_dates,
+            },
+        )
+        return [dict(row) for row in cur.fetchall()]
+
+
+def _fetch_candidate_transitions_for_dry_run(
+    conn: psycopg.Connection,
+    *,
+    dry_run: dict[str, Any],
+    candidate_parameter_set: str,
+) -> list[dict[str, Any]]:
+    proposed_rows = dry_run["proposed_rows"]
+    if not proposed_rows:
+        return []
+    tickers = sorted({row["ticker"] for row in proposed_rows})
+    latest_bar_date = max(row["candidate_bar_date"] for row in proposed_rows)
+    sql = """
+        SELECT
+            t.id,
+            t.ticker,
+            p.name AS parameter_set_name,
+            t.transition_type,
+            t.from_score,
+            t.to_score,
+            t.from_bar_date,
+            t.to_bar_date,
+            t.from_states,
+            t.to_states,
+            t.detected_at,
+            t.acknowledged_by_user_id,
+            t.acknowledged_at,
+            t.notes
+        FROM hedge_fund.signal_transitions t
+        JOIN hedge_fund.scoring_parameters p ON p.id = t.parameter_set_id
+        WHERE p.name = %(candidate_parameter_set)s
+          AND t.ticker = ANY(%(tickers)s)
+          AND t.to_bar_date <= %(latest_bar_date)s
+        ORDER BY t.ticker, t.to_bar_date DESC, t.detected_at DESC
+    """
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            sql,
+            {
+                "candidate_parameter_set": candidate_parameter_set,
+                "tickers": tickers,
+                "latest_bar_date": latest_bar_date,
+            },
+        )
+        return [dict(row) for row in cur.fetchall()]
+
+
+def _verify_promotion_dry_run_from_payload(
+    conn: psycopg.Connection,
+    *,
+    dry_run: dict[str, Any],
+    candidate_parameter_set: str,
+    production_parameter_set: str,
+) -> dict[str, Any]:
+    candidate_source_rows = _fetch_source_rows_for_dry_run(
+        conn,
+        dry_run=dry_run,
+        parameter_set=candidate_parameter_set,
+    )
+    production_source_rows = _fetch_source_rows_for_dry_run(
+        conn,
+        dry_run=dry_run,
+        parameter_set=production_parameter_set,
+    )
+    candidate_transition_rows = _fetch_candidate_transitions_for_dry_run(
+        conn,
+        dry_run=dry_run,
+        candidate_parameter_set=candidate_parameter_set,
+    )
+    return verify_promotion_dry_run_payload(
+        dry_run=dry_run,
+        candidate_source_rows=candidate_source_rows,
+        production_source_rows=production_source_rows,
+        candidate_transition_rows=candidate_transition_rows,
+        candidate_parameter_set=candidate_parameter_set,
+        production_parameter_set=production_parameter_set,
+    )
+
+
+def fetch_promotion_dry_run_verification(
+    conn: psycopg.Connection,
+    *,
+    candidate_parameter_set: str,
+    production_parameter_set: str = PRODUCTION_PARAMETER_SET,
+    decision_id: str | None = None,
+    limit: int = 500,
+    min_abs_score: int = 50,
+) -> dict[str, Any]:
+    dry_run = fetch_promotion_dry_run(
+        conn,
+        candidate_parameter_set=candidate_parameter_set,
+        decision_id=decision_id,
+        limit=limit,
+        min_abs_score=min_abs_score,
+    )
+    return _verify_promotion_dry_run_from_payload(
+        conn,
+        dry_run=dry_run,
+        candidate_parameter_set=candidate_parameter_set,
+        production_parameter_set=production_parameter_set,
+    )
+
+
 PROMOTION_DRY_RUN_ACCEPTANCE_SELECT = """
     SELECT
         id,
@@ -1298,6 +1700,17 @@ def create_promotion_dry_run_acceptance(
         raise ValueError("Cannot accept dry-run output without a ready promote decision record.")
     if dry_run["summary"]["proposed_insert_count"] == 0:
         raise ValueError("Cannot accept dry-run output with no proposed market_signals rows.")
+    verification = _verify_promotion_dry_run_from_payload(
+        conn,
+        dry_run=dry_run,
+        candidate_parameter_set=candidate_parameter_set,
+        production_parameter_set=PRODUCTION_PARAMETER_SET,
+    )
+    if verification["overall_status"] != VERIFICATION_PASS:
+        raise ValueError(
+            "Dry-run verification gate blocked acceptance: "
+            f"{verification['overall_status']}."
+        )
 
     with conn.cursor(row_factory=dict_row) as cur:
         cur.execute(
@@ -1695,6 +2108,26 @@ class PostgresSignalDataStore:
             return fetch_promotion_dry_run(
                 conn,
                 candidate_parameter_set=candidate_parameter_set,
+                decision_id=decision_id,
+                limit=limit,
+                min_abs_score=min_abs_score,
+            )
+
+    def promotion_dry_run_verification(
+        self,
+        *,
+        candidate_parameter_set: str,
+        production_parameter_set: str = PRODUCTION_PARAMETER_SET,
+        decision_id: str | None = None,
+        limit: int = 500,
+        min_abs_score: int = 50,
+    ) -> dict[str, Any]:
+        with connect() as conn:
+            conn.execute("SET default_transaction_read_only = on")
+            return fetch_promotion_dry_run_verification(
+                conn,
+                candidate_parameter_set=candidate_parameter_set,
+                production_parameter_set=production_parameter_set,
                 decision_id=decision_id,
                 limit=limit,
                 min_abs_score=min_abs_score,

--- a/crog-ai-backend/deploy/sql/marketclub_promotion_dry_run_verification.sql
+++ b/crog-ai-backend/deploy/sql/marketclub_promotion_dry_run_verification.sql
@@ -1,0 +1,209 @@
+CREATE OR REPLACE FUNCTION hedge_fund.verify_promotion_dry_run(
+    candidate_parameter_set TEXT,
+    production_parameter_set TEXT DEFAULT 'dochia_v0_estimated'
+)
+RETURNS TABLE (
+    overall_status TEXT,
+    ticker TEXT,
+    candidate_bar_date DATE,
+    candidate_score INTEGER,
+    candidate_action TEXT,
+    candidate_monthly_triangle INTEGER,
+    candidate_weekly_triangle INTEGER,
+    candidate_daily_triangle INTEGER,
+    latest_candidate_transition_date DATE,
+    latest_candidate_transition_type TEXT,
+    prior_score INTEGER,
+    new_score INTEGER,
+    production_score INTEGER,
+    production_daily_triangle INTEGER,
+    conflict_type TEXT,
+    explanation TEXT
+)
+LANGUAGE sql
+STABLE
+AS $$
+    WITH candidate_ranked AS (
+        SELECT
+            v.*,
+            ROW_NUMBER() OVER (
+                PARTITION BY v.ticker
+                ORDER BY v.bar_date DESC, v.computed_at DESC
+            ) AS rn
+        FROM hedge_fund.v_signal_scores_composite v
+        WHERE v.parameter_set_name = candidate_parameter_set
+    ),
+    proposed AS (
+        SELECT *
+        FROM candidate_ranked
+        WHERE rn = 1
+          AND abs(composite_score) >= 50
+    ),
+    candidate_counts AS (
+        SELECT
+            v.ticker,
+            v.bar_date,
+            COUNT(*) AS source_count,
+            COUNT(DISTINCT CASE WHEN v.composite_score >= 0 THEN 'BUY' ELSE 'SELL' END)
+                AS action_count,
+            COUNT(DISTINCT v.monthly_state) AS monthly_state_count,
+            COUNT(DISTINCT v.weekly_state) AS weekly_state_count,
+            COUNT(DISTINCT v.daily_state) AS daily_state_count,
+            COUNT(DISTINCT v.composite_score) AS score_count
+        FROM hedge_fund.v_signal_scores_composite v
+        JOIN proposed p
+          ON p.ticker = v.ticker
+         AND p.bar_date = v.bar_date
+        WHERE v.parameter_set_name = candidate_parameter_set
+        GROUP BY v.ticker, v.bar_date
+    ),
+    production_same_bar AS (
+        SELECT DISTINCT ON (v.ticker, v.bar_date)
+            v.ticker,
+            v.bar_date,
+            v.composite_score,
+            v.daily_state
+        FROM hedge_fund.v_signal_scores_composite v
+        JOIN proposed p
+          ON p.ticker = v.ticker
+         AND p.bar_date = v.bar_date
+        WHERE v.parameter_set_name = production_parameter_set
+        ORDER BY v.ticker, v.bar_date, v.computed_at DESC
+    ),
+    latest_transition AS (
+        SELECT DISTINCT ON (t.ticker)
+            t.ticker,
+            t.transition_type,
+            t.from_score,
+            t.to_score,
+            t.to_bar_date,
+            t.to_states,
+            t.notes
+        FROM hedge_fund.signal_transitions t
+        JOIN hedge_fund.scoring_parameters sp ON sp.id = t.parameter_set_id
+        JOIN proposed p ON p.ticker = t.ticker
+        WHERE sp.name = candidate_parameter_set
+          AND t.to_bar_date <= p.bar_date
+        ORDER BY t.ticker, t.to_bar_date DESC, t.detected_at DESC
+    ),
+    row_eval AS (
+        SELECT
+            p.ticker,
+            p.bar_date AS candidate_bar_date,
+            p.composite_score::INTEGER AS candidate_score,
+            CASE WHEN p.composite_score >= 0 THEN 'BUY' ELSE 'SELL' END AS candidate_action,
+            p.monthly_state::INTEGER AS candidate_monthly_triangle,
+            p.weekly_state::INTEGER AS candidate_weekly_triangle,
+            p.daily_state::INTEGER AS candidate_daily_triangle,
+            lt.to_bar_date AS latest_candidate_transition_date,
+            lt.transition_type AS latest_candidate_transition_type,
+            lt.from_score::INTEGER AS prior_score,
+            lt.to_score::INTEGER AS new_score,
+            prod.composite_score::INTEGER AS production_score,
+            prod.daily_state::INTEGER AS production_daily_triangle,
+            CASE
+                WHEN cc.source_count IS NULL THEN 'INCONCLUSIVE'
+                WHEN cc.source_count > 1 THEN 'FAIL'
+                WHEN cc.action_count > 1
+                  OR cc.monthly_state_count > 1
+                  OR cc.weekly_state_count > 1
+                  OR cc.daily_state_count > 1
+                  OR cc.score_count > 1 THEN 'FAIL'
+                WHEN p.composite_score >= 50 AND p.daily_state < 0 THEN 'FAIL'
+                WHEN p.composite_score <= -50 AND p.daily_state > 0 THEN 'FAIL'
+                WHEN p.composite_score >= 50
+                  AND NOT (p.monthly_state = 1 AND p.weekly_state = 1 AND p.daily_state = 1)
+                  AND NOT (
+                    lt.transition_type IN ('breakout_bullish', 'exit_to_reentry', 'full_reversal')
+                    AND lt.to_score = p.composite_score
+                    AND COALESCE((lt.to_states ->> 'daily')::INTEGER, 0) = 1
+                  ) THEN 'INCONCLUSIVE'
+                WHEN p.composite_score <= -50
+                  AND NOT (p.monthly_state = -1 AND p.weekly_state = -1 AND p.daily_state = -1)
+                  AND NOT (
+                    lt.transition_type IN ('breakout_bearish', 'peak_to_exit', 'full_reversal')
+                    AND lt.to_score = p.composite_score
+                    AND COALESCE((lt.to_states ->> 'daily')::INTEGER, 0) = -1
+                  ) THEN 'INCONCLUSIVE'
+                ELSE 'PASS'
+            END AS row_status,
+            CASE
+                WHEN cc.source_count IS NULL THEN 'SOURCE_LINEAGE_MISSING'
+                WHEN cc.source_count > 1 THEN 'SOURCE_LINEAGE_DUPLICATE'
+                WHEN cc.action_count > 1
+                  OR cc.monthly_state_count > 1
+                  OR cc.weekly_state_count > 1
+                  OR cc.daily_state_count > 1
+                  OR cc.score_count > 1 THEN 'CANDIDATE_INTERNAL_CONFLICT'
+                WHEN p.composite_score >= 50 AND p.daily_state < 0 THEN 'CANDIDATE_INTERNAL_CONFLICT'
+                WHEN p.composite_score <= -50 AND p.daily_state > 0 THEN 'CANDIDATE_INTERNAL_CONFLICT'
+                WHEN p.composite_score >= 50
+                  AND NOT (p.monthly_state = 1 AND p.weekly_state = 1 AND p.daily_state = 1)
+                  AND NOT (
+                    lt.transition_type IN ('breakout_bullish', 'exit_to_reentry', 'full_reversal')
+                    AND lt.to_score = p.composite_score
+                    AND COALESCE((lt.to_states ->> 'daily')::INTEGER, 0) = 1
+                  ) THEN 'TRANSITION_UNSUPPORTED'
+                WHEN p.composite_score <= -50
+                  AND NOT (p.monthly_state = -1 AND p.weekly_state = -1 AND p.daily_state = -1)
+                  AND NOT (
+                    lt.transition_type IN ('breakout_bearish', 'peak_to_exit', 'full_reversal')
+                    AND lt.to_score = p.composite_score
+                    AND COALESCE((lt.to_states ->> 'daily')::INTEGER, 0) = -1
+                  ) THEN 'TRANSITION_UNSUPPORTED'
+                WHEN prod.composite_score IS NOT NULL
+                  AND (prod.composite_score <> p.composite_score OR prod.daily_state <> p.daily_state)
+                  THEN 'CROSS_MODEL_DIAGNOSTIC_ONLY'
+                ELSE 'NONE'
+            END AS conflict_type,
+            CASE
+                WHEN cc.source_count IS NULL THEN
+                    'No candidate source row traces to the dry-run ticker/bar.'
+                WHEN cc.source_count > 1 THEN
+                    'More than one candidate source row exists for the dry-run ticker/bar.'
+                WHEN p.composite_score >= 50 AND p.daily_state < 0 THEN
+                    'Candidate proposes BUY while candidate daily triangle is bearish.'
+                WHEN p.composite_score <= -50 AND p.daily_state > 0 THEN
+                    'Candidate proposes SELL while candidate daily triangle is bullish.'
+                WHEN prod.composite_score IS NOT NULL
+                  AND (prod.composite_score <> p.composite_score OR prod.daily_state <> p.daily_state)
+                  THEN 'Production baseline differs from candidate, but candidate lineage is clean.'
+                ELSE 'Candidate dry-run lineage is clean.'
+            END AS explanation
+        FROM proposed p
+        LEFT JOIN candidate_counts cc
+          ON cc.ticker = p.ticker
+         AND cc.bar_date = p.bar_date
+        LEFT JOIN production_same_bar prod
+          ON prod.ticker = p.ticker
+         AND prod.bar_date = p.bar_date
+        LEFT JOIN latest_transition lt ON lt.ticker = p.ticker
+    )
+    SELECT
+        CASE
+            WHEN EXISTS (SELECT 1 FROM row_eval WHERE row_status = 'FAIL') THEN 'FAIL'
+            WHEN EXISTS (SELECT 1 FROM row_eval WHERE row_status = 'INCONCLUSIVE') THEN 'INCONCLUSIVE'
+            ELSE 'PASS'
+        END AS overall_status,
+        ticker,
+        candidate_bar_date,
+        candidate_score,
+        candidate_action,
+        candidate_monthly_triangle,
+        candidate_weekly_triangle,
+        candidate_daily_triangle,
+        latest_candidate_transition_date,
+        latest_candidate_transition_type,
+        prior_score,
+        new_score,
+        production_score,
+        production_daily_triangle,
+        conflict_type,
+        explanation
+    FROM row_eval
+    ORDER BY
+        CASE row_status WHEN 'FAIL' THEN 0 WHEN 'INCONCLUSIVE' THEN 1 ELSE 2 END,
+        ticker;
+$$;
+
+GRANT EXECUTE ON FUNCTION hedge_fund.verify_promotion_dry_run(TEXT, TEXT) TO crog_ai_app;

--- a/crog-ai-backend/tests/test_api_signals.py
+++ b/crog-ai-backend/tests/test_api_signals.py
@@ -518,6 +518,48 @@ class FakeSignalStore:
             ][:limit],
         }
 
+    def promotion_dry_run_verification(
+        self,
+        *,
+        candidate_parameter_set: str,
+        production_parameter_set: str = "dochia_v0_estimated",
+        decision_id: str | None = None,
+        limit: int = 500,
+        min_abs_score: int = 50,
+    ) -> dict[str, Any]:
+        checked = min(limit, 2)
+        return {
+            "generated_at": dt.datetime(2026, 5, 3, 20, 31, tzinfo=dt.UTC),
+            "candidate_parameter_set": candidate_parameter_set,
+            "production_parameter_set": production_parameter_set,
+            "overall_status": "PASS",
+            "proposed_rows_checked": checked,
+            "passed_rows": checked,
+            "failed_rows": 0,
+            "inconclusive_rows": 0,
+            "cross_model_diagnostic_only_rows": 1,
+            "rows": [
+                {
+                    "row_status": "PASS",
+                    "ticker": "ACLX",
+                    "candidate_bar_date": dt.date(2026, 4, 24),
+                    "candidate_score": 80,
+                    "candidate_action": "BUY",
+                    "candidate_monthly_triangle": 1,
+                    "candidate_weekly_triangle": 1,
+                    "candidate_daily_triangle": 1,
+                    "latest_candidate_transition_date": dt.date(2026, 4, 23),
+                    "latest_candidate_transition_type": "breakout_bullish",
+                    "prior_score": 50,
+                    "new_score": 80,
+                    "production_score": 50,
+                    "production_daily_triangle": -1,
+                    "conflict_type": "CROSS_MODEL_DIAGNOSTIC_ONLY",
+                    "explanation": "Production baseline differs from candidate, but candidate lineage is clean.",
+                }
+            ][:checked],
+        }
+
     def promotion_dry_run_acceptances(
         self,
         *,
@@ -926,6 +968,27 @@ def test_promotion_dry_run_endpoint_returns_read_only_market_signal_plan() -> No
     assert payload["proposed_rows"][1]["action"] == "SELL"
     assert payload["proposed_rows"][0]["lineage"]["source_pipeline"] == "dochia_signal_scores"
     assert "rollback_marker" in payload["proposed_rows"][0]["lineage"]
+
+
+def test_promotion_dry_run_verification_endpoint_returns_gate_summary() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/financial/signals/promotion-dry-run/verification"
+        "?candidate_parameter_set=dochia_v0_2_range_daily"
+        "&production_parameter_set=dochia_v0_estimated"
+        "&limit=2"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["overall_status"] == "PASS"
+    assert payload["proposed_rows_checked"] == 2
+    assert payload["cross_model_diagnostic_only_rows"] == 1
+    assert payload["rows"][0]["ticker"] == "ACLX"
+    assert payload["rows"][0]["conflict_type"] == "CROSS_MODEL_DIAGNOSTIC_ONLY"
 
 
 def test_promotion_dry_run_acceptances_endpoint_returns_audit_rows() -> None:

--- a/crog-ai-backend/tests/test_promotion_dry_run_verification.py
+++ b/crog-ai-backend/tests/test_promotion_dry_run_verification.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import inspect
 
 import pytest
 
@@ -93,6 +94,68 @@ def _verify(
         candidate_parameter_set="dochia_v0_2_range_daily",
         production_parameter_set="dochia_v0_estimated",
     )
+
+
+def test_verification_code_path_has_no_acceptance_or_market_signal_insert() -> None:
+    verification_source = "\n".join(
+        [
+            inspect.getsource(repository._fetch_source_rows_for_dry_run),
+            inspect.getsource(repository._fetch_candidate_transitions_for_dry_run),
+            inspect.getsource(repository._verify_promotion_dry_run_from_payload),
+            inspect.getsource(repository.fetch_promotion_dry_run_verification),
+            inspect.getsource(repository.PostgresSignalDataStore.promotion_dry_run_verification),
+        ]
+    )
+
+    assert "INSERT INTO hedge_fund.market_signals" not in verification_source
+    assert (
+        "INSERT INTO hedge_fund.signal_promotion_dry_run_acceptances"
+        not in verification_source
+    )
+    assert "SET default_transaction_read_only = on" in verification_source
+
+
+def test_store_verification_runs_in_read_only_transaction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executed: list[str] = []
+
+    class FakeConnection:
+        def __enter__(self) -> "FakeConnection":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def execute(self, sql: str, *args: object, **kwargs: object) -> None:
+            executed.append(sql)
+
+    monkeypatch.setattr(repository, "connect", lambda: FakeConnection())
+
+    def fake_fetch_verification(*args: object, **kwargs: object) -> dict[str, object]:
+        assert executed == ["SET default_transaction_read_only = on"]
+        return {
+            "overall_status": "PASS",
+            "proposed_rows_checked": 0,
+            "passed_rows": 0,
+            "failed_rows": 0,
+            "inconclusive_rows": 0,
+            "cross_model_diagnostic_only_rows": 0,
+            "rows": [],
+        }
+
+    monkeypatch.setattr(
+        repository,
+        "fetch_promotion_dry_run_verification",
+        fake_fetch_verification,
+    )
+
+    result = repository.PostgresSignalDataStore().promotion_dry_run_verification(
+        candidate_parameter_set="dochia_v0_2_range_daily"
+    )
+
+    assert result["overall_status"] == "PASS"
+    assert executed == ["SET default_transaction_read_only = on"]
 
 
 def test_verification_passes_cross_model_diagnostic_only_aclx_case() -> None:

--- a/crog-ai-backend/tests/test_promotion_dry_run_verification.py
+++ b/crog-ai-backend/tests/test_promotion_dry_run_verification.py
@@ -1,0 +1,206 @@
+import datetime as dt
+
+import pytest
+
+from app.signals import repository
+
+
+def _dry_run_row(
+    *,
+    ticker: str = "ACLX",
+    score: int = 80,
+    action: str = "BUY",
+    bar_date: dt.date = dt.date(2026, 4, 24),
+    parameter_set: str = "dochia_v0_2_range_daily",
+) -> dict[str, object]:
+    return {
+        "ticker": ticker,
+        "action": action,
+        "composite_score": score,
+        "candidate_bar_date": bar_date,
+        "lineage": {
+            "parameter_set": parameter_set,
+            "rollback_marker": f"dochia-dry-run:{parameter_set}:{ticker}:{bar_date}",
+        },
+    }
+
+
+def _dry_run(rows: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "candidate_parameter_set": "dochia_v0_2_range_daily",
+        "baseline_parameter_set": "dochia_v0_estimated",
+        "proposed_rows": rows,
+    }
+
+
+def _source_row(
+    *,
+    ticker: str = "ACLX",
+    score: int = 80,
+    monthly: int = 1,
+    weekly: int = 1,
+    daily: int = 1,
+    bar_date: dt.date = dt.date(2026, 4, 24),
+    parameter_set: str = "dochia_v0_2_range_daily",
+) -> dict[str, object]:
+    return {
+        "ticker": ticker,
+        "bar_date": bar_date,
+        "parameter_set_name": parameter_set,
+        "monthly_state": monthly,
+        "weekly_state": weekly,
+        "daily_state": daily,
+        "momentum_state": 0,
+        "composite_score": score,
+    }
+
+
+def _transition(
+    *,
+    ticker: str = "ACLX",
+    transition_type: str = "breakout_bullish",
+    from_score: int = 50,
+    to_score: int = 80,
+    daily: int = 1,
+    to_bar_date: dt.date = dt.date(2026, 4, 24),
+) -> dict[str, object]:
+    return {
+        "ticker": ticker,
+        "transition_type": transition_type,
+        "from_score": from_score,
+        "to_score": to_score,
+        "from_bar_date": dt.date(2026, 4, 21),
+        "to_bar_date": to_bar_date,
+        "from_states": {"monthly": 1, "weekly": 1, "daily": -daily, "momentum": 0},
+        "to_states": {"monthly": daily, "weekly": daily, "daily": daily, "momentum": 0},
+        "detected_at": dt.datetime(2026, 5, 2, 12, 0, tzinfo=dt.UTC),
+        "notes": "candidate resolved state",
+    }
+
+
+def _verify(
+    *,
+    dry_run_rows: list[dict[str, object]],
+    candidate_rows: list[dict[str, object]],
+    production_rows: list[dict[str, object]] | None = None,
+    transitions: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    return repository.verify_promotion_dry_run_payload(
+        dry_run=_dry_run(dry_run_rows),
+        candidate_source_rows=candidate_rows,
+        production_source_rows=production_rows or [],
+        candidate_transition_rows=transitions or [],
+        candidate_parameter_set="dochia_v0_2_range_daily",
+        production_parameter_set="dochia_v0_estimated",
+    )
+
+
+def test_verification_passes_cross_model_diagnostic_only_aclx_case() -> None:
+    result = _verify(
+        dry_run_rows=[_dry_run_row()],
+        candidate_rows=[_source_row(score=80, daily=1)],
+        production_rows=[
+            _source_row(
+                score=50,
+                daily=-1,
+                parameter_set="dochia_v0_estimated",
+            )
+        ],
+        transitions=[_transition()],
+    )
+
+    assert result["overall_status"] == "PASS"
+    assert result["cross_model_diagnostic_only_rows"] == 1
+    assert result["rows"][0]["conflict_type"] == "CROSS_MODEL_DIAGNOSTIC_ONLY"
+    assert result["rows"][0]["candidate_daily_triangle"] == 1
+    assert result["rows"][0]["production_daily_triangle"] == -1
+
+
+def test_verification_fails_candidate_buy_with_bearish_daily() -> None:
+    result = _verify(
+        dry_run_rows=[_dry_run_row(score=80, action="BUY")],
+        candidate_rows=[_source_row(score=80, daily=-1)],
+        transitions=[],
+    )
+
+    assert result["overall_status"] == "FAIL"
+    assert result["failed_rows"] == 1
+    assert result["rows"][0]["conflict_type"] == "CANDIDATE_INTERNAL_CONFLICT"
+    assert "BUY while candidate daily triangle is bearish" in result["rows"][0]["explanation"]
+
+
+def test_verification_fails_duplicate_same_bar_different_actions() -> None:
+    result = _verify(
+        dry_run_rows=[_dry_run_row(score=80, action="BUY")],
+        candidate_rows=[
+            _source_row(score=80, daily=1),
+            _source_row(score=-80, monthly=-1, weekly=-1, daily=-1),
+        ],
+    )
+
+    assert result["overall_status"] == "FAIL"
+    assert result["failed_rows"] == 1
+    assert result["rows"][0]["conflict_type"] == "SOURCE_LINEAGE_DUPLICATE"
+
+
+def test_verification_is_inconclusive_without_traceable_candidate_source() -> None:
+    result = _verify(
+        dry_run_rows=[_dry_run_row()],
+        candidate_rows=[],
+    )
+
+    assert result["overall_status"] == "INCONCLUSIVE"
+    assert result["inconclusive_rows"] == 1
+    assert result["rows"][0]["conflict_type"] == "SOURCE_LINEAGE_MISSING"
+
+
+def test_verification_passes_clean_buy_with_full_alignment() -> None:
+    result = _verify(
+        dry_run_rows=[_dry_run_row(ticker="AEP")],
+        candidate_rows=[_source_row(ticker="AEP", score=80, monthly=1, weekly=1, daily=1)],
+        transitions=[],
+    )
+
+    assert result["overall_status"] == "PASS"
+    assert result["passed_rows"] == 1
+    assert result["rows"][0]["conflict_type"] == "NONE"
+
+
+def test_acceptance_creation_blocks_failed_verification(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        repository,
+        "fetch_promotion_dry_run",
+        lambda *args, **kwargs: {
+            "generated_at": dt.datetime(2026, 5, 4, 12, 0, tzinfo=dt.UTC),
+            "candidate_parameter_set": "dochia_v0_2_range_daily",
+            "baseline_parameter_set": "dochia_v0_estimated",
+            "approval": {
+                "status": "ready_for_dry_run",
+                "decision_id": "33333333-3333-3333-3333-333333333333",
+                "rollback_criteria": "Rollback if verification fails.",
+            },
+            "summary": {
+                "candidate_signal_count": 1,
+                "proposed_insert_count": 1,
+                "bullish_count": 1,
+                "risk_count": 0,
+                "skipped_neutral_count": 0,
+                "target_table": "hedge_fund.market_signals",
+                "target_columns": [],
+            },
+            "proposed_rows": [_dry_run_row()],
+        },
+    )
+    monkeypatch.setattr(
+        repository,
+        "_verify_promotion_dry_run_from_payload",
+        lambda *args, **kwargs: {"overall_status": "FAIL"},
+    )
+
+    with pytest.raises(ValueError, match="Dry-run verification gate blocked acceptance"):
+        repository.create_promotion_dry_run_acceptance(
+            object(),  # type: ignore[arg-type]
+            candidate_parameter_set="dochia_v0_2_range_daily",
+            accepted_by="Gary Knight",
+            acceptance_rationale="Operator reviewed the dry-run.",
+        )

--- a/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
+++ b/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
@@ -564,6 +564,38 @@ const promotionDryRunAcceptances = [
   },
 ];
 
+const promotionDryRunVerification = {
+  generated_at: "2026-05-03T20:31:00Z",
+  candidate_parameter_set: "dochia_v0_2_range_daily",
+  production_parameter_set: "dochia_v0_estimated",
+  overall_status: "PASS",
+  proposed_rows_checked: 2,
+  passed_rows: 2,
+  failed_rows: 0,
+  inconclusive_rows: 0,
+  cross_model_diagnostic_only_rows: 1,
+  rows: [
+    {
+      row_status: "PASS",
+      ticker: "ACLX",
+      candidate_bar_date: "2026-04-24",
+      candidate_score: 80,
+      candidate_action: "BUY",
+      candidate_monthly_triangle: 1,
+      candidate_weekly_triangle: 1,
+      candidate_daily_triangle: 1,
+      latest_candidate_transition_date: "2026-04-23",
+      latest_candidate_transition_type: "breakout_bullish",
+      prior_score: 50,
+      new_score: 80,
+      production_score: 50,
+      production_daily_triangle: -1,
+      conflict_type: "CROSS_MODEL_DIAGNOSTIC_ONLY",
+      explanation: "Production baseline differs from candidate, but candidate lineage is clean.",
+    },
+  ],
+};
+
 vi.mock("@/lib/hooks", () => ({
   useFinancialLatestSignals: () => ({
     data: latestSignals,
@@ -645,6 +677,13 @@ vi.mock("@/lib/hooks", () => ({
     isLoading: false,
     refetch: vi.fn(),
   }),
+  useFinancialPromotionDryRunVerification: () => ({
+    data: promotionDryRunVerification,
+    isError: false,
+    isFetching: false,
+    isLoading: false,
+    refetch: vi.fn(),
+  }),
   useFinancialPromotionDryRunAcceptances: () => ({
     data: promotionDryRunAcceptances,
     isError: false,
@@ -690,6 +729,9 @@ describe("HedgeFundSignalsShell", () => {
     expect(screen.getByText("market_signals Preview")).toBeInTheDocument();
     expect(screen.getByText("Ready for dry-run")).toBeInTheDocument();
     expect(screen.getByText("hedge_fund.market_signals")).toBeInTheDocument();
+    expect(screen.getByText("Dry-Run Verification Gate")).toBeInTheDocument();
+    expect(screen.getByText("Eligible for operator dry-run acceptance review")).toBeInTheDocument();
+    expect(screen.getByText("CROSS_MODEL_DIAGNOSTIC_ONLY")).toBeInTheDocument();
     expect(screen.getByText("Dry-Run Acceptance")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Accept Dry-Run" })).toBeInTheDocument();
     expect(screen.getByText("1 saved")).toBeInTheDocument();

--- a/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
+++ b/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
@@ -46,6 +46,7 @@ import {
   useFinancialPromotionGate,
   useFinancialPromotionDryRun,
   useFinancialPromotionDryRunAcceptances,
+  useFinancialPromotionDryRunVerification,
   useFinancialShadowDecisionRecords,
   useFinancialShadowReview,
   useFinancialSignalDetail,
@@ -62,6 +63,8 @@ import type {
   FinancialPromotionDryRunApprovalStatus,
   FinancialPromotionDryRunMarketSignalRow,
   FinancialPromotionDryRunResponse,
+  FinancialPromotionDryRunVerificationResponse,
+  FinancialPromotionDryRunVerificationStatus,
   FinancialPromotionGateGuardrailStatus,
   FinancialPromotionGateRecommendationStatus,
   FinancialPromotionGateResponse,
@@ -251,6 +254,23 @@ function promotionDryRunApprovalLabel(status: FinancialPromotionDryRunApprovalSt
   if (status === "ready_for_dry_run") return "Ready for dry-run";
   if (status === "blocked_by_review") return "Blocked by review";
   return "Promote decision missing";
+}
+
+function promotionDryRunVerificationClasses(
+  status: FinancialPromotionDryRunVerificationStatus,
+): string {
+  if (status === "PASS") return "border-emerald-500/40 bg-emerald-500/10 text-emerald-600";
+  if (status === "FAIL") return "border-red-500/40 bg-red-500/10 text-red-600";
+  return "border-amber-500/40 bg-amber-500/10 text-amber-600";
+}
+
+function promotionDryRunVerificationMessage(
+  status: FinancialPromotionDryRunVerificationStatus | null,
+): string {
+  if (status === "PASS") return "Eligible for operator dry-run acceptance review";
+  if (status === "FAIL") return "Dry-run acceptance blocked";
+  if (status === "INCONCLUSIVE") return "Source lineage unclear; acceptance blocked";
+  return "Verification pending";
 }
 
 function formatSignedNumber(value: number | null | undefined, digits = 0): string {
@@ -1457,6 +1477,9 @@ function PromotionDryRunPanel({
   dryRun,
   loading,
   error,
+  verification,
+  verificationLoading,
+  verificationError,
   acceptances,
   acceptancesLoading,
   onSubmitAcceptance,
@@ -1465,6 +1488,9 @@ function PromotionDryRunPanel({
   dryRun: FinancialPromotionDryRunResponse | null;
   loading: boolean;
   error: boolean;
+  verification: FinancialPromotionDryRunVerificationResponse | null;
+  verificationLoading: boolean;
+  verificationError: boolean;
   acceptances: FinancialPromotionDryRunAcceptance[];
   acceptancesLoading: boolean;
   onSubmitAcceptance: (payload: FinancialPromotionDryRunAcceptanceCreate) => Promise<void>;
@@ -1497,8 +1523,12 @@ function PromotionDryRunPanel({
   const activeDryRun = dryRun;
   const summary = activeDryRun.summary;
   const previewRows = activeDryRun.proposed_rows.slice(0, 8);
+  const verificationStatus = verification?.overall_status ?? null;
+  const flaggedVerificationRows =
+    verification?.rows.filter((row) => row.conflict_type !== "NONE" || row.row_status !== "PASS") ?? [];
   const canAccept =
     activeDryRun.approval.status === "ready_for_dry_run" &&
+    verificationStatus === "PASS" &&
     summary.proposed_insert_count > 0 &&
     acceptedBy.trim().length >= 2 &&
     acceptanceRationale.trim().length >= 12;
@@ -1609,6 +1639,92 @@ function PromotionDryRunPanel({
           </div>
 
           <form className="border border-border p-3" onSubmit={(event) => void handleAcceptanceSubmit(event)}>
+            <div className="mb-3 border border-border/80 p-3">
+              <div className="flex items-center justify-between gap-3">
+                <h2 className="text-sm font-semibold">Dry-Run Verification Gate</h2>
+                <Badge
+                  variant="outline"
+                  className={cn(
+                    "font-medium",
+                    verificationStatus
+                      ? promotionDryRunVerificationClasses(verificationStatus)
+                      : "border-border bg-muted/30 text-muted-foreground",
+                  )}
+                >
+                  {verificationLoading ? "Checking" : verificationStatus ?? "Pending"}
+                </Badge>
+              </div>
+              <p className="mt-2 text-xs text-muted-foreground">
+                {verificationError
+                  ? "Source lineage unclear; acceptance blocked"
+                  : promotionDryRunVerificationMessage(verificationStatus)}
+              </p>
+              <div className="mt-3 grid grid-cols-2 gap-2 text-xs sm:grid-cols-5">
+                <div className="bg-muted/40 p-2">
+                  <span className="text-muted-foreground">Checked</span>
+                  <p className="mt-1 font-mono font-semibold">
+                    {verification?.proposed_rows_checked ?? 0}
+                  </p>
+                </div>
+                <div className="bg-muted/40 p-2">
+                  <span className="text-muted-foreground">Passed</span>
+                  <p className="mt-1 font-mono font-semibold text-emerald-500">
+                    {verification?.passed_rows ?? 0}
+                  </p>
+                </div>
+                <div className="bg-muted/40 p-2">
+                  <span className="text-muted-foreground">Failed</span>
+                  <p className="mt-1 font-mono font-semibold text-red-500">
+                    {verification?.failed_rows ?? 0}
+                  </p>
+                </div>
+                <div className="bg-muted/40 p-2">
+                  <span className="text-muted-foreground">Unclear</span>
+                  <p className="mt-1 font-mono font-semibold text-amber-500">
+                    {verification?.inconclusive_rows ?? 0}
+                  </p>
+                </div>
+                <div className="bg-muted/40 p-2">
+                  <span className="text-muted-foreground">X-Model</span>
+                  <p className="mt-1 font-mono font-semibold">
+                    {verification?.cross_model_diagnostic_only_rows ?? 0}
+                  </p>
+                </div>
+              </div>
+              {flaggedVerificationRows.length ? (
+                <div className="mt-3 space-y-2">
+                  {flaggedVerificationRows.slice(0, 4).map((row) => (
+                    <div
+                      key={`${row.ticker}-${row.candidate_bar_date}-${row.conflict_type}`}
+                      className="border border-border/70 p-2 text-xs"
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="font-mono font-semibold">{row.ticker}</span>
+                        <Badge
+                          variant="outline"
+                          className={cn(
+                            "max-w-[180px] truncate text-[10px]",
+                            promotionDryRunVerificationClasses(row.row_status),
+                          )}
+                        >
+                          {row.conflict_type}
+                        </Badge>
+                      </div>
+                      <div className="mt-2 grid grid-cols-2 gap-2 font-mono text-[11px] text-muted-foreground">
+                        <span>
+                          C {row.candidate_score ?? "—"} / D{row.candidate_daily_triangle ?? "—"}
+                        </span>
+                        <span>
+                          P {row.production_score ?? "—"} / D{row.production_daily_triangle ?? "—"}
+                        </span>
+                      </div>
+                      <p className="mt-1 line-clamp-2 text-muted-foreground">{row.explanation}</p>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+
             <div className="flex items-center justify-between gap-3">
               <h2 className="text-sm font-semibold">Dry-Run Acceptance</h2>
               <Badge variant="outline">
@@ -1827,6 +1943,12 @@ export function HedgeFundSignalsShell() {
     limit: 25,
     min_abs_score: 50,
   });
+  const promotionDryRunVerification = useFinancialPromotionDryRunVerification({
+    candidate_parameter_set: "dochia_v0_2_range_daily",
+    production_parameter_set: "dochia_v0_estimated",
+    limit: 500,
+    min_abs_score: 50,
+  });
   const promotionDryRunAcceptances = useFinancialPromotionDryRunAcceptances({
     candidate_parameter_set: "dochia_v0_2_range_daily",
     limit: 3,
@@ -1879,6 +2001,7 @@ export function HedgeFundSignalsShell() {
     shadowReview.isFetching ||
     shadowDecisionRecords.isFetching ||
     promotionDryRun.isFetching ||
+    promotionDryRunVerification.isFetching ||
     promotionDryRunAcceptances.isFetching;
 
   async function handleShadowDecisionSubmit(payload: FinancialShadowReviewDecisionRecordCreate) {
@@ -1944,6 +2067,7 @@ export function HedgeFundSignalsShell() {
               void shadowReview.refetch();
               void shadowDecisionRecords.refetch();
               void promotionDryRun.refetch();
+              void promotionDryRunVerification.refetch();
               void promotionDryRunAcceptances.refetch();
             }}
             disabled={isRefreshing}
@@ -2080,6 +2204,9 @@ export function HedgeFundSignalsShell() {
             dryRun={promotionDryRun.data ?? null}
             loading={promotionDryRun.isLoading}
             error={promotionDryRun.isError}
+            verification={promotionDryRunVerification.data ?? null}
+            verificationLoading={promotionDryRunVerification.isLoading}
+            verificationError={promotionDryRunVerification.isError}
             acceptances={promotionDryRunAcceptances.data ?? []}
             acceptancesLoading={promotionDryRunAcceptances.isLoading}
             onSubmitAcceptance={handlePromotionDryRunAcceptanceSubmit}

--- a/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
@@ -17,6 +17,7 @@ import type {
   FinancialShadowReviewDecisionRecordCreate,
   FinancialPromotionDryRunAcceptance,
   FinancialPromotionDryRunAcceptanceCreate,
+  FinancialPromotionDryRunVerificationResponse,
   FinancialPromotionDryRunResponse,
   FinancialPromotionGateResponse,
   FinancialShadowReviewResponse,
@@ -266,6 +267,20 @@ export function useFinancialPromotionDryRun(params?: {
   return useQuery<FinancialPromotionDryRunResponse>({
     queryKey: ["financial", "signals", "promotion-dry-run", "daily", params],
     queryFn: () => api.get("/api/financial/signals/promotion-dry-run/daily", params),
+    staleTime: 60_000,
+  });
+}
+
+export function useFinancialPromotionDryRunVerification(params?: {
+  candidate_parameter_set?: string;
+  production_parameter_set?: string;
+  decision_id?: string;
+  limit?: number;
+  min_abs_score?: number;
+}) {
+  return useQuery<FinancialPromotionDryRunVerificationResponse>({
+    queryKey: ["financial", "signals", "promotion-dry-run", "verification", params],
+    queryFn: () => api.get("/api/financial/signals/promotion-dry-run/verification", params),
     staleTime: 60_000,
   });
 }

--- a/fortress-guest-platform/apps/command-center/src/lib/types.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/types.ts
@@ -504,6 +504,49 @@ export interface FinancialPromotionDryRunResponse {
   proposed_rows: FinancialPromotionDryRunMarketSignalRow[];
 }
 
+export type FinancialPromotionDryRunVerificationStatus = "PASS" | "FAIL" | "INCONCLUSIVE";
+
+export type FinancialPromotionDryRunVerificationConflictType =
+  | "NONE"
+  | "CROSS_MODEL_DIAGNOSTIC_ONLY"
+  | "CANDIDATE_INTERNAL_CONFLICT"
+  | "SOURCE_LINEAGE_MISSING"
+  | "SOURCE_LINEAGE_DUPLICATE"
+  | "SOURCE_LINEAGE_PARAMETER_MISMATCH"
+  | "TRANSITION_UNSUPPORTED";
+
+export interface FinancialPromotionDryRunVerificationRow {
+  row_status: FinancialPromotionDryRunVerificationStatus;
+  ticker: string;
+  candidate_bar_date: string;
+  candidate_score: number | null;
+  candidate_action: "BUY" | "SELL" | null;
+  candidate_monthly_triangle: number | null;
+  candidate_weekly_triangle: number | null;
+  candidate_daily_triangle: number | null;
+  latest_candidate_transition_date: string | null;
+  latest_candidate_transition_type: FinancialTransitionType | null;
+  prior_score: number | null;
+  new_score: number | null;
+  production_score: number | null;
+  production_daily_triangle: number | null;
+  conflict_type: FinancialPromotionDryRunVerificationConflictType;
+  explanation: string;
+}
+
+export interface FinancialPromotionDryRunVerificationResponse {
+  generated_at: string;
+  candidate_parameter_set: string;
+  production_parameter_set: string;
+  overall_status: FinancialPromotionDryRunVerificationStatus;
+  proposed_rows_checked: number;
+  passed_rows: number;
+  failed_rows: number;
+  inconclusive_rows: number;
+  cross_model_diagnostic_only_rows: number;
+  rows: FinancialPromotionDryRunVerificationRow[];
+}
+
 export interface FinancialPromotionDryRunAcceptanceCreate {
   candidate_parameter_set: string;
   decision_id?: string | null;


### PR DESCRIPTION
Adds the automated dry-run verification gate for candidate lineage, same-bar conflicts, transition support, and cross-model diagnostics. Blocks dry-run acceptance unless verification passes. Safety: does not write market_signals, create acceptances, fake decisions, loosen RLS, or bypass operator review. Tests passed: backend pytest/ruff, frontend vitest/eslint/tsc/build.