### PR TITLE
Add guarded production write path for Hedge Fund Signals

### DIFF
--- a/crog-ai-backend/alembic/versions/0007_guarded_promotion_execution.py
+++ b/crog-ai-backend/alembic/versions/0007_guarded_promotion_execution.py
@@ -1,0 +1,37 @@
+"""Add guarded promotion execution path.
+
+Revision ID: 0007_guarded_promotion_execution
+Revises: 0006_promotion_dry_run_verification
+Create Date: 2026-05-04 08:10:00.000000
+"""
+
+from pathlib import Path
+
+from alembic import op
+
+revision = "0007_guarded_promotion_execution"
+down_revision = "0006_promotion_dry_run_verification"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    sql_path = (
+        Path(__file__).resolve().parents[2]
+        / "deploy"
+        / "sql"
+        / "marketclub_guarded_promotion_execution.sql"
+    )
+    op.execute(sql_path.read_text(encoding="utf-8"))
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP FUNCTION IF EXISTS hedge_fund.rollback_guarded_signal_promotion(UUID, TEXT, TEXT)"
+    )
+    op.execute(
+        "DROP FUNCTION IF EXISTS hedge_fund.execute_guarded_signal_promotion(UUID, TEXT, TEXT, TEXT)"
+    )
+    op.execute("DROP TABLE IF EXISTS hedge_fund.signal_promotion_execution_rows")
+    op.execute("DROP TABLE IF EXISTS hedge_fund.signal_promotion_executions")
+    op.execute("DROP TABLE IF EXISTS hedge_fund.signal_operator_memberships")

--- a/crog-ai-backend/app/api/signals.py
+++ b/crog-ai-backend/app/api/signals.py
@@ -3,17 +3,25 @@
 from __future__ import annotations
 
 import datetime as dt
+import hashlib
 from decimal import Decimal
 from enum import StrEnum
 from typing import Annotated, Literal
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from fastapi import APIRouter, Depends, Header, HTTPException, Path, Query
 from pydantic import BaseModel, ConfigDict, Field, computed_field
 
 from app.signals.repository import PostgresSignalDataStore, SignalDataStore
 
 router = APIRouter(prefix="/api/financial/signals", tags=["financial-signals"])
+
+
+OperatorToken = Annotated[str, Header(alias="X-MarketClub-Operator-Token", min_length=16)]
+
+
+def _operator_token_sha256(operator_token: str) -> str:
+    return hashlib.sha256(operator_token.strip().encode("utf-8")).hexdigest()
 
 
 class TransitionKind(StrEnum):
@@ -467,6 +475,43 @@ class PromotionDryRunAcceptance(BaseModel):
     created_at: dt.datetime
 
 
+class PromotionExecutionCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    acceptance_id: UUID
+    execution_rationale: str = Field(min_length=12, max_length=2000)
+    idempotency_key: str | None = Field(default=None, min_length=8, max_length=160)
+
+
+class PromotionExecutionRollbackCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    rollback_reason: str = Field(min_length=12, max_length=2000)
+
+
+class PromotionExecution(BaseModel):
+    id: UUID
+    acceptance_id: UUID
+    decision_record_id: UUID
+    candidate_parameter_set: str
+    baseline_parameter_set: str
+    operator_membership_id: UUID
+    executed_by: str
+    execution_rationale: str
+    idempotency_key: str
+    dry_run_generated_at: dt.datetime
+    dry_run_proposed_insert_count: int
+    verification_status: VerificationStatus
+    inserted_market_signal_ids: list[int]
+    rollback_markers: list[str]
+    rollback_status: Literal["active", "rolled_back"]
+    rollback_operator_membership_id: UUID | None
+    rollback_by: str | None
+    rollback_reason: str | None
+    rolled_back_at: dt.datetime | None
+    created_at: dt.datetime
+
+
 class SymbolChartBar(BaseModel):
     ticker: str
     bar_date: dt.date
@@ -816,6 +861,62 @@ def create_promotion_dry_run_acceptance_endpoint(
             decision_id=str(payload.decision_id) if payload.decision_id else None,
             limit=payload.limit,
             min_abs_score=payload.min_abs_score,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get(
+    "/promotion-dry-run/executions",
+    response_model=list[PromotionExecution],
+)
+def promotion_executions(
+    store: Annotated[SignalDataStore, Depends(get_signal_store)],
+    candidate_parameter_set: Annotated[str | None, Query(min_length=1, max_length=100)] = None,
+    limit: Annotated[int, Query(ge=1, le=50)] = 10,
+) -> list[dict[str, object]]:
+    return store.promotion_executions(
+        candidate_parameter_set=candidate_parameter_set,
+        limit=limit,
+    )
+
+
+@router.post(
+    "/promotion-dry-run/executions",
+    response_model=PromotionExecution,
+    status_code=201,
+)
+def execute_guarded_promotion(
+    payload: PromotionExecutionCreate,
+    store: Annotated[SignalDataStore, Depends(get_signal_store)],
+    operator_token: OperatorToken,
+) -> dict[str, object]:
+    try:
+        return store.execute_guarded_promotion(
+            acceptance_id=str(payload.acceptance_id),
+            operator_token_sha256=_operator_token_sha256(operator_token),
+            execution_rationale=payload.execution_rationale.strip(),
+            idempotency_key=payload.idempotency_key.strip() if payload.idempotency_key else None,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post(
+    "/promotion-dry-run/executions/{execution_id}/rollback",
+    response_model=PromotionExecution,
+)
+def rollback_promotion_execution(
+    execution_id: UUID,
+    payload: PromotionExecutionRollbackCreate,
+    store: Annotated[SignalDataStore, Depends(get_signal_store)],
+    operator_token: OperatorToken,
+) -> dict[str, object]:
+    try:
+        return store.rollback_promotion_execution(
+            execution_id=str(execution_id),
+            operator_token_sha256=_operator_token_sha256(operator_token),
+            rollback_reason=payload.rollback_reason.strip(),
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/crog-ai-backend/app/signals/repository.py
+++ b/crog-ai-backend/app/signals/repository.py
@@ -141,6 +141,30 @@ class SignalDataStore(Protocol):
         min_abs_score: int = 50,
     ) -> dict[str, Any]: ...
 
+    def promotion_executions(
+        self,
+        *,
+        candidate_parameter_set: str | None = None,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]: ...
+
+    def execute_guarded_promotion(
+        self,
+        *,
+        acceptance_id: str,
+        operator_token_sha256: str,
+        execution_rationale: str,
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]: ...
+
+    def rollback_promotion_execution(
+        self,
+        *,
+        execution_id: str,
+        operator_token_sha256: str,
+        rollback_reason: str,
+    ) -> dict[str, Any]: ...
+
     def symbol_chart(
         self,
         *,
@@ -1798,6 +1822,152 @@ def create_promotion_dry_run_acceptance(
     }
 
 
+PROMOTION_EXECUTION_SELECT = """
+    SELECT
+        id,
+        acceptance_id,
+        decision_record_id,
+        candidate_parameter_set,
+        baseline_parameter_set,
+        operator_membership_id,
+        executed_by,
+        execution_rationale,
+        idempotency_key,
+        dry_run_generated_at,
+        dry_run_proposed_insert_count,
+        verification_status,
+        inserted_market_signal_ids,
+        rollback_markers,
+        rollback_status,
+        rollback_operator_membership_id,
+        rollback_by,
+        rollback_reason,
+        rolled_back_at,
+        created_at
+    FROM hedge_fund.signal_promotion_executions
+"""
+
+
+PROMOTION_EXECUTION_FIELDS = [
+    "id",
+    "acceptance_id",
+    "decision_record_id",
+    "candidate_parameter_set",
+    "baseline_parameter_set",
+    "operator_membership_id",
+    "executed_by",
+    "execution_rationale",
+    "idempotency_key",
+    "dry_run_generated_at",
+    "dry_run_proposed_insert_count",
+    "verification_status",
+    "inserted_market_signal_ids",
+    "rollback_markers",
+    "rollback_status",
+    "rollback_operator_membership_id",
+    "rollback_by",
+    "rollback_reason",
+    "rolled_back_at",
+    "created_at",
+]
+
+
+def _promotion_execution_response(row: dict[str, Any]) -> dict[str, Any]:
+    response = {key: row[key] for key in PROMOTION_EXECUTION_FIELDS}
+    response["inserted_market_signal_ids"] = list(response["inserted_market_signal_ids"] or [])
+    response["rollback_markers"] = list(response["rollback_markers"] or [])
+    return response
+
+
+def fetch_promotion_executions(
+    conn: psycopg.Connection,
+    *,
+    candidate_parameter_set: str | None = None,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    params: dict[str, Any] = {"limit": limit}
+    where = ""
+    if candidate_parameter_set:
+        where = "WHERE candidate_parameter_set = %(candidate_parameter_set)s"
+        params["candidate_parameter_set"] = candidate_parameter_set
+    sql = f"""
+        {PROMOTION_EXECUTION_SELECT}
+        {where}
+        ORDER BY created_at DESC
+        LIMIT %(limit)s
+    """
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(sql, params)
+        return [_promotion_execution_response(dict(row)) for row in cur.fetchall()]
+
+
+def execute_guarded_promotion(
+    conn: psycopg.Connection,
+    *,
+    acceptance_id: str,
+    operator_token_sha256: str,
+    execution_rationale: str,
+    idempotency_key: str | None = None,
+) -> dict[str, Any]:
+    try:
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                """
+                SELECT *
+                FROM hedge_fund.execute_guarded_signal_promotion(
+                    %(acceptance_id)s::uuid,
+                    %(operator_token_sha256)s,
+                    %(execution_rationale)s,
+                    %(idempotency_key)s
+                )
+                """,
+                {
+                    "acceptance_id": acceptance_id,
+                    "operator_token_sha256": operator_token_sha256,
+                    "execution_rationale": execution_rationale,
+                    "idempotency_key": idempotency_key,
+                },
+            )
+            row = cur.fetchone()
+    except psycopg.Error as exc:
+        raise ValueError(str(exc).splitlines()[0]) from exc
+    if row is None:
+        raise RuntimeError("guarded promotion execution returned no row")
+    return _promotion_execution_response(dict(row))
+
+
+def rollback_promotion_execution(
+    conn: psycopg.Connection,
+    *,
+    execution_id: str,
+    operator_token_sha256: str,
+    rollback_reason: str,
+) -> dict[str, Any]:
+    try:
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                """
+                SELECT *
+                FROM hedge_fund.rollback_guarded_signal_promotion(
+                    %(execution_id)s::uuid,
+                    %(operator_token_sha256)s,
+                    %(rollback_reason)s
+                )
+                """,
+                {
+                    "execution_id": execution_id,
+                    "operator_token_sha256": operator_token_sha256,
+                    "rollback_reason": rollback_reason,
+                },
+            )
+            row = cur.fetchone()
+    except psycopg.Error as exc:
+        raise ValueError(str(exc).splitlines()[0]) from exc
+    if row is None:
+        raise RuntimeError("guarded promotion rollback returned no row")
+    return _promotion_execution_response(dict(row))
+
+
 WATCHLIST_CANDIDATE_BASE_SQL = """
     WITH latest_scores AS (
         SELECT
@@ -2166,6 +2336,52 @@ class PostgresSignalDataStore:
                 decision_id=decision_id,
                 limit=limit,
                 min_abs_score=min_abs_score,
+            )
+
+    def promotion_executions(
+        self,
+        *,
+        candidate_parameter_set: str | None = None,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        with connect() as conn:
+            conn.execute("SET default_transaction_read_only = on")
+            return fetch_promotion_executions(
+                conn,
+                candidate_parameter_set=candidate_parameter_set,
+                limit=limit,
+            )
+
+    def execute_guarded_promotion(
+        self,
+        *,
+        acceptance_id: str,
+        operator_token_sha256: str,
+        execution_rationale: str,
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
+        with connect() as conn:
+            return execute_guarded_promotion(
+                conn,
+                acceptance_id=acceptance_id,
+                operator_token_sha256=operator_token_sha256,
+                execution_rationale=execution_rationale,
+                idempotency_key=idempotency_key,
+            )
+
+    def rollback_promotion_execution(
+        self,
+        *,
+        execution_id: str,
+        operator_token_sha256: str,
+        rollback_reason: str,
+    ) -> dict[str, Any]:
+        with connect() as conn:
+            return rollback_promotion_execution(
+                conn,
+                execution_id=execution_id,
+                operator_token_sha256=operator_token_sha256,
+                rollback_reason=rollback_reason,
             )
 
     def symbol_chart(

--- a/crog-ai-backend/deploy/sql/marketclub_guarded_promotion_execution.sql
+++ b/crog-ai-backend/deploy/sql/marketclub_guarded_promotion_execution.sql
@@ -1,0 +1,422 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS hedge_fund.signal_operator_memberships (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    operator_label VARCHAR(120) NOT NULL,
+    role TEXT NOT NULL,
+    token_sha256 TEXT NOT NULL UNIQUE,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    revoked_at TIMESTAMPTZ,
+    CONSTRAINT ck_signal_operator_memberships_role
+        CHECK (role IN ('signal_viewer', 'signal_operator', 'signal_admin')),
+    CONSTRAINT ck_signal_operator_memberships_token_sha256
+        CHECK (token_sha256 ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT ck_signal_operator_memberships_active_revoked
+        CHECK (
+            (is_active = TRUE AND revoked_at IS NULL)
+            OR (is_active = FALSE)
+        )
+);
+
+CREATE INDEX IF NOT EXISTS ix_signal_operator_memberships_role_active
+ON hedge_fund.signal_operator_memberships (
+    role,
+    is_active
+);
+
+CREATE TABLE IF NOT EXISTS hedge_fund.signal_promotion_executions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    acceptance_id UUID NOT NULL
+        REFERENCES hedge_fund.signal_promotion_dry_run_acceptances(id)
+        ON DELETE RESTRICT,
+    decision_record_id UUID NOT NULL
+        REFERENCES hedge_fund.signal_shadow_review_decisions(id)
+        ON DELETE RESTRICT,
+    candidate_parameter_set VARCHAR(100) NOT NULL,
+    baseline_parameter_set VARCHAR(100) NOT NULL,
+    operator_membership_id UUID NOT NULL
+        REFERENCES hedge_fund.signal_operator_memberships(id)
+        ON DELETE RESTRICT,
+    executed_by VARCHAR(120) NOT NULL,
+    execution_rationale TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    dry_run_generated_at TIMESTAMPTZ NOT NULL,
+    dry_run_proposed_insert_count INTEGER NOT NULL,
+    verification_status TEXT NOT NULL,
+    verification_payload JSONB NOT NULL,
+    dry_run_payload JSONB NOT NULL,
+    inserted_market_signal_ids INTEGER[] NOT NULL DEFAULT ARRAY[]::INTEGER[],
+    rollback_markers TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    rollback_status TEXT NOT NULL DEFAULT 'active',
+    rollback_operator_membership_id UUID
+        REFERENCES hedge_fund.signal_operator_memberships(id)
+        ON DELETE RESTRICT,
+    rollback_by VARCHAR(120),
+    rollback_reason TEXT,
+    rolled_back_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT uq_signal_promotion_executions_acceptance UNIQUE (acceptance_id),
+    CONSTRAINT uq_signal_promotion_executions_idempotency UNIQUE (idempotency_key),
+    CONSTRAINT ck_signal_promotion_executions_verification_status
+        CHECK (verification_status IN ('PASS')),
+    CONSTRAINT ck_signal_promotion_executions_rollback_status
+        CHECK (rollback_status IN ('active', 'rolled_back')),
+    CONSTRAINT ck_signal_promotion_executions_nonempty_rationale
+        CHECK (length(trim(execution_rationale)) >= 12)
+);
+
+CREATE TABLE IF NOT EXISTS hedge_fund.signal_promotion_execution_rows (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    execution_id UUID NOT NULL
+        REFERENCES hedge_fund.signal_promotion_executions(id)
+        ON DELETE CASCADE,
+    market_signal_id INTEGER NOT NULL,
+    ticker TEXT NOT NULL,
+    action TEXT NOT NULL,
+    confidence_score INTEGER NOT NULL,
+    candidate_bar_date DATE NOT NULL,
+    rollback_marker TEXT NOT NULL,
+    row_payload JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT uq_signal_promotion_execution_rows_signal UNIQUE (market_signal_id),
+    CONSTRAINT uq_signal_promotion_execution_rows_marker UNIQUE (execution_id, rollback_marker)
+);
+
+CREATE INDEX IF NOT EXISTS ix_signal_promotion_executions_candidate_created
+ON hedge_fund.signal_promotion_executions (
+    candidate_parameter_set,
+    created_at DESC
+);
+
+CREATE INDEX IF NOT EXISTS ix_signal_promotion_executions_rollback_status
+ON hedge_fund.signal_promotion_executions (
+    rollback_status,
+    created_at DESC
+);
+
+CREATE INDEX IF NOT EXISTS ix_signal_promotion_execution_rows_execution
+ON hedge_fund.signal_promotion_execution_rows (execution_id);
+
+CREATE OR REPLACE FUNCTION hedge_fund.execute_guarded_signal_promotion(
+    p_acceptance_id UUID,
+    p_operator_token_sha256 TEXT,
+    p_execution_rationale TEXT,
+    p_idempotency_key TEXT DEFAULT NULL
+)
+RETURNS hedge_fund.signal_promotion_executions
+LANGUAGE plpgsql
+-- SECURITY DEFINER is intentionally narrow here: crog_ai_app gets EXECUTE on
+-- this function, not direct INSERT/DELETE on hedge_fund.market_signals. The
+-- function re-checks human decision, accepted dry-run, verification PASS,
+-- idempotency, audit creation, and rollback markers before any production write.
+SECURITY DEFINER
+SET search_path = pg_catalog, hedge_fund
+AS $$
+DECLARE
+    v_operator RECORD;
+    v_acceptance RECORD;
+    v_existing hedge_fund.signal_promotion_executions%ROWTYPE;
+    v_execution hedge_fund.signal_promotion_executions%ROWTYPE;
+    v_effective_idempotency_key TEXT;
+    v_verification_status TEXT;
+    v_verification_payload JSONB;
+    v_proposed_row_count INTEGER;
+    v_inserted_market_signal_id INTEGER;
+    v_inserted_market_signal_ids INTEGER[] := ARRAY[]::INTEGER[];
+    v_rollback_marker TEXT;
+    v_rollback_markers TEXT[] := ARRAY[]::TEXT[];
+    v_execution_rows JSONB := '[]'::JSONB;
+    v_row JSONB;
+BEGIN
+    -- No exception handler is used in this function. Any failure after
+    -- market_signals insertion aborts the whole statement/transaction, so
+    -- production rows cannot commit without the execution audit rows.
+    v_effective_idempotency_key := COALESCE(
+        NULLIF(trim(p_idempotency_key), ''),
+        'acceptance:' || p_acceptance_id::TEXT
+    );
+
+    IF length(trim(COALESCE(p_execution_rationale, ''))) < 12 THEN
+        RAISE EXCEPTION 'execution_rationale is required for guarded promotion execution';
+    END IF;
+
+    SELECT id, operator_label, role
+    INTO v_operator
+    FROM hedge_fund.signal_operator_memberships
+    WHERE token_sha256 = lower(trim(COALESCE(p_operator_token_sha256, '')))
+      AND is_active = TRUE
+      AND role IN ('signal_operator', 'signal_admin')
+    LIMIT 1;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Active signal operator membership is required for guarded promotion execution';
+    END IF;
+
+    SELECT
+        a.*,
+        d.decision AS shadow_decision
+    INTO v_acceptance
+    FROM hedge_fund.signal_promotion_dry_run_acceptances a
+    JOIN hedge_fund.signal_shadow_review_decisions d
+      ON d.id = a.decision_record_id
+    WHERE a.id = p_acceptance_id
+    FOR UPDATE OF a;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'No dry-run acceptance exists for guarded promotion execution';
+    END IF;
+
+    IF v_acceptance.shadow_decision <> 'promote_to_market_signals' THEN
+        RAISE EXCEPTION 'Human promote_to_market_signals decision is required before execution';
+    END IF;
+
+    SELECT *
+    INTO v_existing
+    FROM hedge_fund.signal_promotion_executions
+    WHERE idempotency_key = v_effective_idempotency_key
+    LIMIT 1;
+
+    IF v_existing.id IS NOT NULL THEN
+        IF v_existing.acceptance_id <> p_acceptance_id THEN
+            RAISE EXCEPTION 'Idempotency key is already attached to another promotion execution';
+        END IF;
+        RETURN v_existing;
+    END IF;
+
+    SELECT *
+    INTO v_existing
+    FROM hedge_fund.signal_promotion_executions
+    WHERE acceptance_id = p_acceptance_id
+    LIMIT 1;
+
+    IF v_existing.id IS NOT NULL THEN
+        RAISE EXCEPTION 'Dry-run acceptance has already been executed';
+    END IF;
+
+    SELECT
+        MAX(v.overall_status),
+        COALESCE(jsonb_agg(to_jsonb(v)), '[]'::JSONB)
+    INTO v_verification_status, v_verification_payload
+    FROM hedge_fund.verify_promotion_dry_run(
+        v_acceptance.candidate_parameter_set,
+        v_acceptance.baseline_parameter_set
+    ) v;
+
+    IF v_verification_status IS DISTINCT FROM 'PASS' THEN
+        RAISE EXCEPTION 'Promotion verification gate blocked execution: %',
+            COALESCE(v_verification_status, 'INCONCLUSIVE');
+    END IF;
+
+    IF v_acceptance.target_table <> 'hedge_fund.market_signals' THEN
+        RAISE EXCEPTION 'Dry-run acceptance target table is not hedge_fund.market_signals';
+    END IF;
+
+    v_proposed_row_count := jsonb_array_length(
+        COALESCE(v_acceptance.dry_run_payload -> 'proposed_rows', '[]'::JSONB)
+    );
+
+    IF v_proposed_row_count < 1 THEN
+        RAISE EXCEPTION 'Dry-run acceptance has no market_signals rows to execute';
+    END IF;
+
+    IF v_proposed_row_count <> v_acceptance.dry_run_proposed_insert_count THEN
+        RAISE EXCEPTION 'Dry-run acceptance payload count does not match accepted summary';
+    END IF;
+
+    FOR v_row IN
+        SELECT value
+        FROM jsonb_array_elements(v_acceptance.dry_run_payload -> 'proposed_rows')
+    LOOP
+        v_rollback_marker := v_row #>> '{lineage,rollback_marker}';
+        IF v_rollback_marker IS NULL OR length(trim(v_rollback_marker)) = 0 THEN
+            RAISE EXCEPTION 'Every promotion row requires a rollback marker';
+        END IF;
+
+        INSERT INTO hedge_fund.market_signals (
+            ticker,
+            signal_type,
+            action,
+            confidence_score,
+            price_target,
+            source_sender,
+            source_subject,
+            raw_reasoning,
+            model_used,
+            extracted_at
+        ) VALUES (
+            v_row ->> 'ticker',
+            v_row ->> 'signal_type',
+            v_row ->> 'action',
+            (v_row ->> 'confidence_score')::INTEGER,
+            NULLIF(v_row ->> 'price_target', '')::NUMERIC,
+            v_row ->> 'source_sender',
+            v_row ->> 'source_subject',
+            CONCAT(
+                COALESCE(v_row ->> 'raw_reasoning', ''),
+                E'\nRollback marker: ',
+                v_rollback_marker
+            ),
+            v_row ->> 'model_used',
+            ((v_row ->> 'extracted_at')::TIMESTAMPTZ AT TIME ZONE 'UTC')
+        )
+        RETURNING id INTO v_inserted_market_signal_id;
+
+        v_inserted_market_signal_ids :=
+            array_append(v_inserted_market_signal_ids, v_inserted_market_signal_id);
+        v_rollback_markers := array_append(v_rollback_markers, v_rollback_marker);
+        v_execution_rows := v_execution_rows || jsonb_build_array(
+            jsonb_build_object(
+                'market_signal_id', v_inserted_market_signal_id,
+                'ticker', v_row ->> 'ticker',
+                'action', v_row ->> 'action',
+                'confidence_score', (v_row ->> 'confidence_score')::INTEGER,
+                'candidate_bar_date', v_row ->> 'candidate_bar_date',
+                'rollback_marker', v_rollback_marker,
+                'row_payload', v_row
+            )
+        );
+    END LOOP;
+
+    INSERT INTO hedge_fund.signal_promotion_executions (
+        acceptance_id,
+        decision_record_id,
+        candidate_parameter_set,
+        baseline_parameter_set,
+        operator_membership_id,
+        executed_by,
+        execution_rationale,
+        idempotency_key,
+        dry_run_generated_at,
+        dry_run_proposed_insert_count,
+        verification_status,
+        verification_payload,
+        dry_run_payload,
+        inserted_market_signal_ids,
+        rollback_markers
+    ) VALUES (
+        v_acceptance.id,
+        v_acceptance.decision_record_id,
+        v_acceptance.candidate_parameter_set,
+        v_acceptance.baseline_parameter_set,
+        v_operator.id,
+        v_operator.operator_label,
+        trim(p_execution_rationale),
+        v_effective_idempotency_key,
+        v_acceptance.dry_run_generated_at,
+        v_acceptance.dry_run_proposed_insert_count,
+        v_verification_status,
+        v_verification_payload,
+        v_acceptance.dry_run_payload,
+        v_inserted_market_signal_ids,
+        v_rollback_markers
+    )
+    RETURNING * INTO v_execution;
+
+    INSERT INTO hedge_fund.signal_promotion_execution_rows (
+        execution_id,
+        market_signal_id,
+        ticker,
+        action,
+        confidence_score,
+        candidate_bar_date,
+        rollback_marker,
+        row_payload
+    )
+    SELECT
+        v_execution.id,
+        row_data.market_signal_id,
+        row_data.ticker,
+        row_data.action,
+        row_data.confidence_score,
+        row_data.candidate_bar_date,
+        row_data.rollback_marker,
+        row_data.row_payload
+    FROM jsonb_to_recordset(v_execution_rows) AS row_data (
+        market_signal_id INTEGER,
+        ticker TEXT,
+        action TEXT,
+        confidence_score INTEGER,
+        candidate_bar_date DATE,
+        rollback_marker TEXT,
+        row_payload JSONB
+    );
+
+    RETURN v_execution;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION hedge_fund.rollback_guarded_signal_promotion(
+    p_execution_id UUID,
+    p_operator_token_sha256 TEXT,
+    p_rollback_reason TEXT
+)
+RETURNS hedge_fund.signal_promotion_executions
+LANGUAGE plpgsql
+-- Rollback is scoped exclusively to IDs captured in the execution audit row.
+-- It never deletes by ticker, date, action, or candidate parameter set.
+SECURITY DEFINER
+SET search_path = pg_catalog, hedge_fund
+AS $$
+DECLARE
+    v_operator RECORD;
+    v_execution hedge_fund.signal_promotion_executions%ROWTYPE;
+BEGIN
+    IF length(trim(COALESCE(p_rollback_reason, ''))) < 12 THEN
+        RAISE EXCEPTION 'rollback_reason is required for guarded promotion rollback';
+    END IF;
+
+    SELECT id, operator_label, role
+    INTO v_operator
+    FROM hedge_fund.signal_operator_memberships
+    WHERE token_sha256 = lower(trim(COALESCE(p_operator_token_sha256, '')))
+      AND is_active = TRUE
+      AND role = 'signal_admin'
+    LIMIT 1;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Active signal admin membership is required for guarded promotion rollback';
+    END IF;
+
+    SELECT *
+    INTO v_execution
+    FROM hedge_fund.signal_promotion_executions
+    WHERE id = p_execution_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'No guarded promotion execution found for rollback';
+    END IF;
+
+    IF v_execution.rollback_status = 'rolled_back' THEN
+        RETURN v_execution;
+    END IF;
+
+    DELETE FROM hedge_fund.market_signals
+    WHERE id = ANY(v_execution.inserted_market_signal_ids);
+
+    UPDATE hedge_fund.signal_promotion_executions
+    SET rollback_status = 'rolled_back',
+        rollback_operator_membership_id = v_operator.id,
+        rollback_by = v_operator.operator_label,
+        rollback_reason = trim(p_rollback_reason),
+        rolled_back_at = now()
+    WHERE id = p_execution_id
+    RETURNING * INTO v_execution;
+
+    RETURN v_execution;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION hedge_fund.execute_guarded_signal_promotion(UUID, TEXT, TEXT, TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION hedge_fund.rollback_guarded_signal_promotion(UUID, TEXT, TEXT) FROM PUBLIC;
+
+GRANT SELECT ON TABLE
+    hedge_fund.signal_promotion_executions,
+    hedge_fund.signal_promotion_execution_rows
+TO crog_ai_app;
+
+GRANT EXECUTE ON FUNCTION
+    hedge_fund.execute_guarded_signal_promotion(UUID, TEXT, TEXT, TEXT),
+    hedge_fund.rollback_guarded_signal_promotion(UUID, TEXT, TEXT)
+TO crog_ai_app;

--- a/crog-ai-backend/tests/test_api_signals.py
+++ b/crog-ai-backend/tests/test_api_signals.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import hashlib
 from decimal import Decimal
 from typing import Any
 from uuid import UUID
@@ -12,6 +13,10 @@ PARAMETER_SET_ID = UUID("11111111-1111-1111-1111-111111111111")
 TRANSITION_ID = UUID("22222222-2222-2222-2222-222222222222")
 DECISION_ID = UUID("33333333-3333-3333-3333-333333333333")
 ACCEPTANCE_ID = UUID("44444444-4444-4444-4444-444444444444")
+EXECUTION_ID = UUID("55555555-5555-5555-5555-555555555555")
+OPERATOR_MEMBERSHIP_ID = UUID("66666666-6666-6666-6666-666666666666")
+OPERATOR_TOKEN = "marketclub-operator-token"
+OPERATOR_TOKEN_SHA256 = hashlib.sha256(OPERATOR_TOKEN.encode("utf-8")).hexdigest()
 
 
 class FakeSignalStore:
@@ -623,6 +628,81 @@ class FakeSignalStore:
             "dry_run_proposed_insert_count": min(limit, 2),
         }
 
+    def _promotion_execution(
+        self,
+        *,
+        rollback_status: str = "active",
+        rollback_by: str | None = None,
+        rollback_reason: str | None = None,
+        rolled_back_at: dt.datetime | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "id": EXECUTION_ID,
+            "acceptance_id": ACCEPTANCE_ID,
+            "decision_record_id": DECISION_ID,
+            "candidate_parameter_set": "dochia_v0_2_range_daily",
+            "baseline_parameter_set": "dochia_v0_estimated",
+            "operator_membership_id": OPERATOR_MEMBERSHIP_ID,
+            "executed_by": "MarketClub Operator",
+            "execution_rationale": "Operator accepted the verified dry-run output.",
+            "idempotency_key": f"acceptance:{ACCEPTANCE_ID}",
+            "dry_run_generated_at": dt.datetime(2026, 5, 3, 20, 30, tzinfo=dt.UTC),
+            "dry_run_proposed_insert_count": 2,
+            "verification_status": "PASS",
+            "inserted_market_signal_ids": [1201, 1202],
+            "rollback_markers": [
+                "dochia-dry-run:dochia_v0_2_range_daily:AA:2026-04-24",
+                "dochia-dry-run:dochia_v0_2_range_daily:AGIO:2026-04-24",
+            ],
+            "rollback_status": rollback_status,
+            "rollback_operator_membership_id": OPERATOR_MEMBERSHIP_ID if rollback_by else None,
+            "rollback_by": rollback_by,
+            "rollback_reason": rollback_reason,
+            "rolled_back_at": rolled_back_at,
+            "created_at": dt.datetime(2026, 5, 3, 21, 0, tzinfo=dt.UTC),
+        }
+
+    def promotion_executions(
+        self,
+        *,
+        candidate_parameter_set: str | None = None,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        return [self._promotion_execution()][:limit]
+
+    def execute_guarded_promotion(
+        self,
+        *,
+        acceptance_id: str,
+        operator_token_sha256: str,
+        execution_rationale: str,
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
+        if operator_token_sha256 != OPERATOR_TOKEN_SHA256:
+            raise ValueError("Promotion verification gate blocked execution: FAIL")
+        return {
+            **self._promotion_execution(),
+            "acceptance_id": UUID(acceptance_id),
+            "execution_rationale": execution_rationale,
+            "idempotency_key": idempotency_key or f"acceptance:{acceptance_id}",
+        }
+
+    def rollback_promotion_execution(
+        self,
+        *,
+        execution_id: str,
+        operator_token_sha256: str,
+        rollback_reason: str,
+    ) -> dict[str, Any]:
+        if operator_token_sha256 != OPERATOR_TOKEN_SHA256:
+            raise ValueError("Active signal admin membership is required")
+        return self._promotion_execution(
+            rollback_status="rolled_back",
+            rollback_by="MarketClub Operator",
+            rollback_reason=rollback_reason,
+            rolled_back_at=dt.datetime(2026, 5, 3, 21, 30, tzinfo=dt.UTC),
+        ) | {"id": UUID(execution_id)}
+
     def symbol_chart(
         self,
         *,
@@ -1050,6 +1130,124 @@ def test_promotion_dry_run_acceptances_endpoint_rejects_without_ready_decision()
 
     assert response.status_code == 400
     assert "ready promote decision" in response.json()["detail"]
+
+
+def test_promotion_executions_endpoint_returns_audit_rows() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/financial/signals/promotion-dry-run/executions"
+        "?candidate_parameter_set=dochia_v0_2_range_daily&limit=3"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload[0]["id"] == str(EXECUTION_ID)
+    assert payload[0]["acceptance_id"] == str(ACCEPTANCE_ID)
+    assert payload[0]["verification_status"] == "PASS"
+    assert payload[0]["inserted_market_signal_ids"] == [1201, 1202]
+    assert payload[0]["rollback_status"] == "active"
+
+
+def test_execute_guarded_promotion_endpoint_returns_execution_record() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/financial/signals/promotion-dry-run/executions",
+        headers={"X-MarketClub-Operator-Token": OPERATOR_TOKEN},
+        json={
+            "acceptance_id": str(ACCEPTANCE_ID),
+            "execution_rationale": "Operator accepted the verified dry-run output.",
+            "idempotency_key": "operator-accepted-dry-run-20260504",
+        },
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["acceptance_id"] == str(ACCEPTANCE_ID)
+    assert payload["operator_membership_id"] == str(OPERATOR_MEMBERSHIP_ID)
+    assert payload["executed_by"] == "MarketClub Operator"
+    assert payload["idempotency_key"] == "operator-accepted-dry-run-20260504"
+    assert payload["verification_status"] == "PASS"
+    assert payload["rollback_markers"][0].startswith("dochia-dry-run:")
+
+
+def test_execute_guarded_promotion_endpoint_requires_operator_token() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/financial/signals/promotion-dry-run/executions",
+        json={
+            "acceptance_id": str(ACCEPTANCE_ID),
+            "execution_rationale": "Operator attempted execution without authentication.",
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_execute_guarded_promotion_endpoint_rejects_spoofed_operator_body() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/financial/signals/promotion-dry-run/executions",
+        headers={"X-MarketClub-Operator-Token": OPERATOR_TOKEN},
+        json={
+            "acceptance_id": str(ACCEPTANCE_ID),
+            "executed_by": "Spoofed Operator",
+            "execution_rationale": "Operator attempted execution with spoofed body.",
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_execute_guarded_promotion_endpoint_rejects_failed_gate() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/financial/signals/promotion-dry-run/executions",
+        headers={"X-MarketClub-Operator-Token": "wrong-operator-token"},
+        json={
+            "acceptance_id": str(ACCEPTANCE_ID),
+            "execution_rationale": "Operator attempted execution after verification failed.",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "verification gate blocked execution" in response.json()["detail"]
+
+
+def test_rollback_promotion_execution_endpoint_returns_rolled_back_record() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    response = client.post(
+        f"/api/financial/signals/promotion-dry-run/executions/{EXECUTION_ID}/rollback",
+        headers={"X-MarketClub-Operator-Token": OPERATOR_TOKEN},
+        json={
+            "rollback_reason": "Operator rollback after post-promotion review.",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["id"] == str(EXECUTION_ID)
+    assert payload["rollback_status"] == "rolled_back"
+    assert payload["rollback_operator_membership_id"] == str(OPERATOR_MEMBERSHIP_ID)
+    assert payload["rollback_by"] == "MarketClub Operator"
+    assert payload["rollback_reason"] == "Operator rollback after post-promotion review."
 
 
 def test_symbol_chart_endpoint_returns_overlay_data() -> None:

--- a/crog-ai-backend/tests/test_guarded_promotion_execution.py
+++ b/crog-ai-backend/tests/test_guarded_promotion_execution.py
@@ -1,0 +1,220 @@
+import datetime as dt
+import inspect
+from pathlib import Path
+from uuid import UUID
+
+from app.signals import repository
+
+ACCEPTANCE_ID = UUID("44444444-4444-4444-4444-444444444444")
+DECISION_ID = UUID("33333333-3333-3333-3333-333333333333")
+EXECUTION_ID = UUID("55555555-5555-5555-5555-555555555555")
+OPERATOR_MEMBERSHIP_ID = UUID("66666666-6666-6666-6666-666666666666")
+OPERATOR_TOKEN_SHA256 = "a" * 64
+
+
+def _execution_row(**overrides: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "id": EXECUTION_ID,
+        "acceptance_id": ACCEPTANCE_ID,
+        "decision_record_id": DECISION_ID,
+        "candidate_parameter_set": "dochia_v0_2_range_daily",
+        "baseline_parameter_set": "dochia_v0_estimated",
+        "operator_membership_id": OPERATOR_MEMBERSHIP_ID,
+        "executed_by": "Gary Knight",
+        "execution_rationale": "Operator accepted the verified dry-run output.",
+        "idempotency_key": f"acceptance:{ACCEPTANCE_ID}",
+        "dry_run_generated_at": dt.datetime(2026, 5, 4, 12, 0, tzinfo=dt.UTC),
+        "dry_run_proposed_insert_count": 2,
+        "verification_status": "PASS",
+        "inserted_market_signal_ids": [1201, 1202],
+        "rollback_markers": [
+            "dochia-dry-run:dochia_v0_2_range_daily:AA:2026-04-24",
+            "dochia-dry-run:dochia_v0_2_range_daily:AGIO:2026-04-24",
+        ],
+        "rollback_status": "active",
+        "rollback_operator_membership_id": None,
+        "rollback_by": None,
+        "rollback_reason": None,
+        "rolled_back_at": None,
+        "created_at": dt.datetime(2026, 5, 4, 12, 5, tzinfo=dt.UTC),
+    }
+    row.update(overrides)
+    return row
+
+
+class FakeCursor:
+    def __init__(self, row: dict[str, object]) -> None:
+        self.row = row
+        self.sql = ""
+        self.params: dict[str, object] = {}
+
+    def __enter__(self) -> "FakeCursor":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def execute(self, sql: str, params: dict[str, object]) -> None:
+        self.sql = sql
+        self.params = params
+
+    def fetchone(self) -> dict[str, object]:
+        return self.row
+
+
+class FakeConnection:
+    def __init__(self, row: dict[str, object]) -> None:
+        self.cursor_instance = FakeCursor(row)
+
+    def cursor(self, *args: object, **kwargs: object) -> FakeCursor:
+        return self.cursor_instance
+
+
+def _guarded_execution_sql() -> str:
+    return (
+        Path(__file__).resolve().parents[1]
+        / "deploy"
+        / "sql"
+        / "marketclub_guarded_promotion_execution.sql"
+    ).read_text(encoding="utf-8")
+
+
+def test_repository_executes_locked_database_function_not_raw_market_signal_insert() -> None:
+    conn = FakeConnection(_execution_row())
+
+    result = repository.execute_guarded_promotion(
+        conn,  # type: ignore[arg-type]
+        acceptance_id=str(ACCEPTANCE_ID),
+        operator_token_sha256=OPERATOR_TOKEN_SHA256,
+        execution_rationale="Operator accepted the verified dry-run output.",
+        idempotency_key="operator-accepted-dry-run-20260504",
+    )
+
+    assert result["id"] == EXECUTION_ID
+    assert "hedge_fund.execute_guarded_signal_promotion" in conn.cursor_instance.sql
+    assert "INSERT INTO hedge_fund.market_signals" not in conn.cursor_instance.sql
+    assert conn.cursor_instance.params["acceptance_id"] == str(ACCEPTANCE_ID)
+    assert conn.cursor_instance.params["operator_token_sha256"] == OPERATOR_TOKEN_SHA256
+    assert conn.cursor_instance.params["idempotency_key"] == "operator-accepted-dry-run-20260504"
+
+
+def test_repository_rollback_uses_locked_database_function() -> None:
+    conn = FakeConnection(
+        _execution_row(
+            rollback_status="rolled_back",
+            rollback_operator_membership_id=OPERATOR_MEMBERSHIP_ID,
+            rollback_by="Gary Knight",
+            rollback_reason="Operator rollback after review.",
+            rolled_back_at=dt.datetime(2026, 5, 4, 12, 30, tzinfo=dt.UTC),
+        )
+    )
+
+    result = repository.rollback_promotion_execution(
+        conn,  # type: ignore[arg-type]
+        execution_id=str(EXECUTION_ID),
+        operator_token_sha256=OPERATOR_TOKEN_SHA256,
+        rollback_reason="Operator rollback after review.",
+    )
+
+    assert result["rollback_status"] == "rolled_back"
+    assert "hedge_fund.rollback_guarded_signal_promotion" in conn.cursor_instance.sql
+    assert conn.cursor_instance.params["execution_id"] == str(EXECUTION_ID)
+    assert conn.cursor_instance.params["operator_token_sha256"] == OPERATOR_TOKEN_SHA256
+
+
+def test_python_execution_path_contains_no_direct_market_signals_write() -> None:
+    source = "\n".join(
+        [
+            inspect.getsource(repository.execute_guarded_promotion),
+            inspect.getsource(repository.PostgresSignalDataStore.execute_guarded_promotion),
+        ]
+    )
+
+    assert "INSERT INTO hedge_fund.market_signals" not in source
+    assert "hedge_fund.execute_guarded_signal_promotion" in source
+
+
+def test_sql_contract_enforces_full_guarded_execution_flow() -> None:
+    sql = _guarded_execution_sql()
+
+    assert "No dry-run acceptance exists for guarded promotion execution" in sql
+    assert "signal_operator_memberships" in sql
+    assert "Active signal operator membership is required" in sql
+    assert "JOIN hedge_fund.signal_shadow_review_decisions" in sql
+    assert "signal_promotion_dry_run_acceptances" in sql
+    assert "promote_to_market_signals" in sql
+    assert "hedge_fund.verify_promotion_dry_run" in sql
+    assert "v_verification_status IS DISTINCT FROM 'PASS'" in sql
+    assert "Promotion verification gate blocked execution" in sql
+    assert "INSERT INTO hedge_fund.market_signals" in sql
+    assert "INSERT INTO hedge_fund.signal_promotion_executions" in sql
+    assert "INSERT INTO hedge_fund.signal_promotion_execution_rows" in sql
+    assert "rollback_marker" in sql
+
+
+def test_sql_contract_keeps_signal_and_audit_writes_transactional() -> None:
+    sql = _guarded_execution_sql()
+
+    market_signal_insert = sql.index("INSERT INTO hedge_fund.market_signals")
+    execution_audit_insert = sql.index("INSERT INTO hedge_fund.signal_promotion_executions")
+    row_audit_insert = sql.index("INSERT INTO hedge_fund.signal_promotion_execution_rows")
+
+    assert market_signal_insert < execution_audit_insert < row_audit_insert
+    assert "No exception handler is used in this function" in sql
+    assert "production rows cannot commit without the execution audit rows" in sql
+    assert "\nEXCEPTION\n" not in sql
+
+
+def test_sql_contract_has_idempotency_and_rollback_support() -> None:
+    sql = _guarded_execution_sql()
+
+    assert "uq_signal_promotion_executions_acceptance UNIQUE (acceptance_id)" in sql
+    assert "uq_signal_promotion_executions_idempotency UNIQUE (idempotency_key)" in sql
+    assert "RETURN v_existing" in sql
+    assert "Dry-run acceptance has already been executed" in sql
+    assert "CREATE OR REPLACE FUNCTION hedge_fund.rollback_guarded_signal_promotion" in sql
+    assert "DELETE FROM hedge_fund.market_signals" in sql
+    assert "rollback_status = 'rolled_back'" in sql
+    assert "GRANT EXECUTE ON FUNCTION" in sql
+
+
+def test_sql_contract_requires_operator_roles_for_execution_and_rollback() -> None:
+    sql = _guarded_execution_sql()
+
+    assert "role IN ('signal_operator', 'signal_admin')" in sql
+    assert "role = 'signal_admin'" in sql
+    assert "Active signal admin membership is required for guarded promotion rollback" in sql
+    assert "operator_membership_id UUID NOT NULL" in sql
+    assert "rollback_operator_membership_id UUID" in sql
+    assert "GRANT SELECT ON TABLE\n    hedge_fund.signal_operator_memberships" not in sql
+    assert "GRANT INSERT ON TABLE\n    hedge_fund.signal_operator_memberships" not in sql
+
+
+def test_sql_contract_scopes_rollback_to_audited_market_signal_ids_only() -> None:
+    sql = _guarded_execution_sql()
+
+    delete_block = sql.split("DELETE FROM hedge_fund.market_signals", 1)[1].split(
+        "UPDATE hedge_fund.signal_promotion_executions", 1
+    )[0]
+    assert "WHERE id = ANY(v_execution.inserted_market_signal_ids)" in delete_block
+    assert "ticker" not in delete_block.lower()
+    assert "candidate_bar_date" not in delete_block.lower()
+    assert "candidate_parameter_set" not in delete_block.lower()
+
+
+def test_sql_contract_makes_second_rollback_safe_noop() -> None:
+    sql = _guarded_execution_sql()
+
+    assert "IF v_execution.rollback_status = 'rolled_back' THEN" in sql
+    assert "RETURN v_execution;" in sql
+
+
+def test_sql_contract_keeps_security_definer_narrow() -> None:
+    sql = _guarded_execution_sql()
+
+    assert "SECURITY DEFINER" in sql
+    assert "SET search_path = pg_catalog, hedge_fund" in sql
+    assert "REVOKE ALL ON FUNCTION hedge_fund.execute_guarded_signal_promotion" in sql
+    assert "REVOKE ALL ON FUNCTION hedge_fund.rollback_guarded_signal_promotion" in sql
+    assert "GRANT EXECUTE ON FUNCTION" in sql
+    assert "GRANT INSERT ON TABLE\n    hedge_fund.market_signals" not in sql


### PR DESCRIPTION
## Summary
- add locked database functions for guarded promotion execution and rollback
- add execution audit tables linking acceptances, market_signals ids, and rollback markers
- add backend API endpoints to list executions, execute accepted dry-runs, and rollback executions
- keep execution server-side; no UI-only button path

## Guarded flow
human promote decision -> dry-run acceptance -> verification gate PASS -> guarded execution function -> transactional market_signals writes -> execution audit record -> rollback marker mapping

## Safety
- app calls SECURITY DEFINER database functions instead of raw market_signals inserts
- execution is idempotent by acceptance and idempotency key
- rollback only deletes market_signals ids recorded by the execution audit record
- no execution was run against live data; SQL was validated in a rolled-back transaction

## Tests
- PYTHONPATH=. /home/admin/.local/bin/uv run pytest
- /home/admin/.local/bin/uv run ruff check app/api/signals.py app/signals/repository.py tests/test_api_signals.py tests/test_guarded_promotion_execution.py alembic/versions/0007_guarded_promotion_execution.py
- SQL creation validated with psql inside BEGIN/ROLLBACK