### PR TITLE
feat(financial): show promotion execution observability

### DIFF
--- a/fortress-guest-platform/apps/command-center/src/__tests__/components/admin-operations-glass.test.tsx
+++ b/fortress-guest-platform/apps/command-center/src/__tests__/components/admin-operations-glass.test.tsx
@@ -131,6 +131,7 @@ vi.mock("@/lib/hooks", () => ({
       properties: [],
     },
   }),
+  useAsyncJobArchivePrune: () => ({ mutate: vi.fn(), isPending: false }),
 }));
 
 vi.mock("@/lib/store", () => ({

--- a/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
+++ b/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
@@ -564,6 +564,31 @@ const promotionDryRunAcceptances = [
   },
 ];
 
+const promotionExecutions = [
+  {
+    id: "55555555-5555-5555-5555-555555555555",
+    acceptance_id: "44444444-4444-4444-4444-444444444444",
+    decision_record_id: "33333333-3333-3333-3333-333333333333",
+    candidate_parameter_set: "dochia_v0_2_range_daily",
+    baseline_parameter_set: "dochia_v0_estimated",
+    operator_membership_id: "66666666-6666-6666-6666-666666666666",
+    executed_by: "MarketClub Operator",
+    execution_rationale: "Operator accepted the verified dry-run output.",
+    idempotency_key: "operator-accepted-dry-run-20260504",
+    dry_run_generated_at: "2026-05-03T20:30:00Z",
+    dry_run_proposed_insert_count: 2,
+    verification_status: "PASS",
+    inserted_market_signal_ids: [1201, 1202],
+    rollback_markers: ["dochia-dry-run:dochia_v0_2_range_daily:AA:2026-04-24"],
+    rollback_status: "active",
+    rollback_operator_membership_id: null,
+    rollback_by: null,
+    rollback_reason: null,
+    rolled_back_at: null,
+    created_at: "2026-05-04T12:52:00Z",
+  },
+];
+
 const promotionDryRunVerification = {
   generated_at: "2026-05-03T20:31:00Z",
   candidate_parameter_set: "dochia_v0_2_range_daily",
@@ -691,6 +716,13 @@ vi.mock("@/lib/hooks", () => ({
     isLoading: false,
     refetch: vi.fn(),
   }),
+  useFinancialPromotionExecutions: () => ({
+    data: promotionExecutions,
+    isError: false,
+    isFetching: false,
+    isLoading: false,
+    refetch: vi.fn(),
+  }),
   useCreateFinancialShadowDecisionRecord: () => ({
     isPending: false,
     mutateAsync: vi.fn(),
@@ -735,7 +767,16 @@ describe("HedgeFundSignalsShell", () => {
     expect(screen.getByText("Dry-Run Acceptance")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Accept Dry-Run" })).toBeInTheDocument();
     expect(screen.getByText("1 saved")).toBeInTheDocument();
-    expect(screen.getByText("MarketClub Operator")).toBeInTheDocument();
+    expect(screen.getByText("Execution Records")).toBeInTheDocument();
+    expect(screen.getByText("1 recorded")).toBeInTheDocument();
+    expect(screen.getByText("Inserted rows")).toBeInTheDocument();
+    expect(screen.getAllByText("Active").length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText("dochia-dry-run:dochia_v0_2_range_daily:AA:2026-04-24").length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByRole("button", { name: /execute/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /rollback/i })).not.toBeInTheDocument();
+    expect(screen.getAllByText("MarketClub Operator").length).toBeGreaterThan(0);
     expect(screen.getByText("Chart Overlay")).toBeInTheDocument();
     expect(screen.getByText("1 triangle events")).toBeInTheDocument();
     expect(screen.getByText("Whipsaw Risk / Backtest")).toBeInTheDocument();

--- a/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
+++ b/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
@@ -47,6 +47,7 @@ import {
   useFinancialPromotionDryRun,
   useFinancialPromotionDryRunAcceptances,
   useFinancialPromotionDryRunVerification,
+  useFinancialPromotionExecutions,
   useFinancialShadowDecisionRecords,
   useFinancialShadowReview,
   useFinancialSignalDetail,
@@ -65,6 +66,7 @@ import type {
   FinancialPromotionDryRunResponse,
   FinancialPromotionDryRunVerificationResponse,
   FinancialPromotionDryRunVerificationStatus,
+  FinancialPromotionExecution,
   FinancialPromotionGateGuardrailStatus,
   FinancialPromotionGateRecommendationStatus,
   FinancialPromotionGateResponse,
@@ -133,6 +135,19 @@ function formatDate(value?: string | null): string {
     month: "short",
     day: "numeric",
     year: "numeric",
+  });
+}
+
+function formatDateTime(value?: string | null): string {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
   });
 }
 
@@ -271,6 +286,11 @@ function promotionDryRunVerificationMessage(
   if (status === "FAIL") return "Dry-run acceptance blocked";
   if (status === "INCONCLUSIVE") return "Source lineage unclear; acceptance blocked";
   return "Verification pending";
+}
+
+function promotionExecutionRollbackClasses(status: FinancialPromotionExecution["rollback_status"]): string {
+  if (status === "rolled_back") return "border-amber-500/40 bg-amber-500/10 text-amber-600";
+  return "border-emerald-500/40 bg-emerald-500/10 text-emerald-600";
 }
 
 function formatSignedNumber(value: number | null | undefined, digits = 0): string {
@@ -1482,6 +1502,8 @@ function PromotionDryRunPanel({
   verificationError,
   acceptances,
   acceptancesLoading,
+  executions,
+  executionsLoading,
   onSubmitAcceptance,
   submittingAcceptance,
 }: {
@@ -1493,6 +1515,8 @@ function PromotionDryRunPanel({
   verificationError: boolean;
   acceptances: FinancialPromotionDryRunAcceptance[];
   acceptancesLoading: boolean;
+  executions: FinancialPromotionExecution[];
+  executionsLoading: boolean;
   onSubmitAcceptance: (payload: FinancialPromotionDryRunAcceptanceCreate) => Promise<void>;
   submittingAcceptance: boolean;
 }) {
@@ -1769,6 +1793,57 @@ function PromotionDryRunPanel({
               </div>
             ) : null}
           </form>
+
+          <div className="border border-border p-3">
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="text-sm font-semibold">Execution Records</h2>
+              <Badge variant="outline">
+                {executionsLoading ? "Loading" : `${executions.length} recorded`}
+              </Badge>
+            </div>
+            {executions.length ? (
+              <div className="mt-3 space-y-2">
+                {executions.slice(0, 3).map((execution) => (
+                  <div key={execution.id} className="border border-border/70 p-2 text-xs">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="truncate font-medium">{execution.executed_by}</span>
+                      <Badge
+                        variant="outline"
+                        className={cn(
+                          "text-[10px]",
+                          promotionExecutionRollbackClasses(execution.rollback_status),
+                        )}
+                      >
+                        {execution.rollback_status === "rolled_back" ? "Rolled back" : "Active"}
+                      </Badge>
+                    </div>
+                    <div className="mt-2 grid grid-cols-2 gap-2">
+                      <div>
+                        <span className="text-muted-foreground">Inserted rows</span>
+                        <p className="font-mono font-semibold">
+                          {execution.inserted_market_signal_ids.length}
+                        </p>
+                      </div>
+                      <div>
+                        <span className="text-muted-foreground">Executed</span>
+                        <p className="truncate font-medium">{formatDateTime(execution.created_at)}</p>
+                      </div>
+                    </div>
+                    <div className="mt-2">
+                      <span className="text-muted-foreground">Rollback marker</span>
+                      <p className="mt-1 truncate font-mono text-[11px]">
+                        {execution.rollback_markers[0] ?? "—"}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="mt-3 text-xs text-muted-foreground">
+                No guarded executions recorded.
+              </p>
+            )}
+          </div>
         </div>
       </div>
   </div>
@@ -1953,6 +2028,10 @@ export function HedgeFundSignalsShell() {
     candidate_parameter_set: "dochia_v0_2_range_daily",
     limit: 3,
   });
+  const promotionExecutions = useFinancialPromotionExecutions({
+    candidate_parameter_set: "dochia_v0_2_range_daily",
+    limit: 5,
+  });
   const createShadowDecisionRecord = useCreateFinancialShadowDecisionRecord();
   const createPromotionDryRunAcceptance = useCreateFinancialPromotionDryRunAcceptance();
   const signals = latest.data ?? EMPTY_SIGNALS;
@@ -2002,7 +2081,8 @@ export function HedgeFundSignalsShell() {
     shadowDecisionRecords.isFetching ||
     promotionDryRun.isFetching ||
     promotionDryRunVerification.isFetching ||
-    promotionDryRunAcceptances.isFetching;
+    promotionDryRunAcceptances.isFetching ||
+    promotionExecutions.isFetching;
 
   async function handleShadowDecisionSubmit(payload: FinancialShadowReviewDecisionRecordCreate) {
     await createShadowDecisionRecord.mutateAsync(payload);
@@ -2069,6 +2149,7 @@ export function HedgeFundSignalsShell() {
               void promotionDryRun.refetch();
               void promotionDryRunVerification.refetch();
               void promotionDryRunAcceptances.refetch();
+              void promotionExecutions.refetch();
             }}
             disabled={isRefreshing}
             aria-label="Refresh hedge fund signals"
@@ -2209,6 +2290,8 @@ export function HedgeFundSignalsShell() {
             verificationError={promotionDryRunVerification.isError}
             acceptances={promotionDryRunAcceptances.data ?? []}
             acceptancesLoading={promotionDryRunAcceptances.isLoading}
+            executions={promotionExecutions.data ?? []}
+            executionsLoading={promotionExecutions.isLoading}
             onSubmitAcceptance={handlePromotionDryRunAcceptanceSubmit}
             submittingAcceptance={createPromotionDryRunAcceptance.isPending}
           />

--- a/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
@@ -17,6 +17,7 @@ import type {
   FinancialShadowReviewDecisionRecordCreate,
   FinancialPromotionDryRunAcceptance,
   FinancialPromotionDryRunAcceptanceCreate,
+  FinancialPromotionExecution,
   FinancialPromotionDryRunVerificationResponse,
   FinancialPromotionDryRunResponse,
   FinancialPromotionGateResponse,
@@ -292,6 +293,17 @@ export function useFinancialPromotionDryRunAcceptances(params?: {
   return useQuery<FinancialPromotionDryRunAcceptance[]>({
     queryKey: ["financial", "signals", "promotion-dry-run", "acceptances", params],
     queryFn: () => api.get("/api/financial/signals/promotion-dry-run/acceptances", params),
+    staleTime: 60_000,
+  });
+}
+
+export function useFinancialPromotionExecutions(params?: {
+  candidate_parameter_set?: string;
+  limit?: number;
+}) {
+  return useQuery<FinancialPromotionExecution[]>({
+    queryKey: ["financial", "signals", "promotion-dry-run", "executions", params],
+    queryFn: () => api.get("/api/financial/signals/promotion-dry-run/executions", params),
     staleTime: 60_000,
   });
 }

--- a/fortress-guest-platform/apps/command-center/src/lib/types.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/types.ts
@@ -576,6 +576,31 @@ export interface FinancialPromotionDryRunAcceptance {
   created_at: string;
 }
 
+export type FinancialPromotionExecutionRollbackStatus = "active" | "rolled_back";
+
+export interface FinancialPromotionExecution {
+  id: string;
+  acceptance_id: string;
+  decision_record_id: string;
+  candidate_parameter_set: string;
+  baseline_parameter_set: string;
+  operator_membership_id: string;
+  executed_by: string;
+  execution_rationale: string;
+  idempotency_key: string;
+  dry_run_generated_at: string;
+  dry_run_proposed_insert_count: number;
+  verification_status: FinancialPromotionDryRunVerificationStatus;
+  inserted_market_signal_ids: number[];
+  rollback_markers: string[];
+  rollback_status: FinancialPromotionExecutionRollbackStatus;
+  rollback_operator_membership_id: string | null;
+  rollback_by: string | null;
+  rollback_reason: string | null;
+  rolled_back_at: string | null;
+  created_at: string;
+}
+
 export interface FinancialWatchlistCandidate {
   ticker: string;
   bar_date: string;


### PR DESCRIPTION
Summary: Adds read-only cockpit visibility for guarded promotion execution records, including inserted row count, rollback marker, executed_by, executed timestamp, and rollback status. Wires the existing execution-record API without adding execute or rollback controls. Also repairs a stale admin operations test hook mock so the command-center suite is green. Verification: npm test -- financial-hedge-fund-shell.test.tsx; npm test -- admin-operations-glass.test.tsx; npm test; npx eslint targeted files; npx tsc --noEmit; npm run build. Safety: read-only observability only; no execution button; no rollback button; no production write path invoked.