### PR TITLE
feat(financial): add rollback drill observability

### DIFF
--- a/crog-ai-backend/alembic/versions/0008_rollback_drill_observability.py
+++ b/crog-ai-backend/alembic/versions/0008_rollback_drill_observability.py
@@ -1,0 +1,29 @@
+"""Add read-only rollback drill observability.
+
+Revision ID: 0008_rollback_drill_observability
+Revises: 0007_guarded_promotion_execution
+Create Date: 2026-05-04 09:15:00.000000
+"""
+
+from pathlib import Path
+
+from alembic import op
+
+revision = "0008_rollback_drill_observability"
+down_revision = "0007_guarded_promotion_execution"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    sql_path = (
+        Path(__file__).resolve().parents[2]
+        / "deploy"
+        / "sql"
+        / "marketclub_rollback_drill_observability.sql"
+    )
+    op.execute(sql_path.read_text(encoding="utf-8"))
+
+
+def downgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS hedge_fund.v_signal_promotion_rollback_drill")

--- a/crog-ai-backend/app/api/signals.py
+++ b/crog-ai-backend/app/api/signals.py
@@ -512,6 +512,32 @@ class PromotionExecution(BaseModel):
     created_at: dt.datetime
 
 
+class PromotionRollbackDrill(BaseModel):
+    execution_id: UUID
+    dry_run_acceptance_id: UUID
+    candidate_parameter_set: str
+    baseline_parameter_set: str
+    executed_by: str
+    executed_at: dt.datetime
+    inserted_market_signal_ids: list[int]
+    rollback_markers: list[str]
+    audited_market_signal_ids: list[int]
+    rollback_preview_market_signal_ids: list[int]
+    rollback_preview_count: int
+    rollback_eligibility: Literal[
+        "ELIGIBLE",
+        "ELIGIBLE_PARTIAL_AUDITED_ROWS",
+        "ALREADY_ROLLED_BACK",
+        "NOT_ELIGIBLE_NO_AUDITED_ROWS",
+        "NOT_ELIGIBLE_NO_LIVE_AUDITED_ROWS",
+    ]
+    already_rolled_back: bool
+    rollback_status: Literal["active", "rolled_back"]
+    rollback_by: str | None
+    rollback_attempted_at: dt.datetime | None
+    rolled_back_at: dt.datetime | None
+
+
 class SymbolChartBar(BaseModel):
     ticker: str
     bar_date: dt.date
@@ -876,6 +902,21 @@ def promotion_executions(
     limit: Annotated[int, Query(ge=1, le=50)] = 10,
 ) -> list[dict[str, object]]:
     return store.promotion_executions(
+        candidate_parameter_set=candidate_parameter_set,
+        limit=limit,
+    )
+
+
+@router.get(
+    "/promotion-dry-run/executions/rollback-drill",
+    response_model=list[PromotionRollbackDrill],
+)
+def promotion_rollback_drills(
+    store: Annotated[SignalDataStore, Depends(get_signal_store)],
+    candidate_parameter_set: Annotated[str | None, Query(min_length=1, max_length=100)] = None,
+    limit: Annotated[int, Query(ge=1, le=50)] = 10,
+) -> list[dict[str, object]]:
+    return store.promotion_rollback_drills(
         candidate_parameter_set=candidate_parameter_set,
         limit=limit,
     )

--- a/crog-ai-backend/app/signals/repository.py
+++ b/crog-ai-backend/app/signals/repository.py
@@ -148,6 +148,13 @@ class SignalDataStore(Protocol):
         limit: int = 10,
     ) -> list[dict[str, Any]]: ...
 
+    def promotion_rollback_drills(
+        self,
+        *,
+        candidate_parameter_set: str | None = None,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]: ...
+
     def execute_guarded_promotion(
         self,
         *,
@@ -1901,6 +1908,83 @@ def fetch_promotion_executions(
         return [_promotion_execution_response(dict(row)) for row in cur.fetchall()]
 
 
+PROMOTION_ROLLBACK_DRILL_SELECT = """
+    SELECT
+        execution_id,
+        dry_run_acceptance_id,
+        candidate_parameter_set,
+        baseline_parameter_set,
+        executed_by,
+        executed_at,
+        inserted_market_signal_ids,
+        rollback_markers,
+        audited_market_signal_ids,
+        rollback_preview_market_signal_ids,
+        rollback_preview_count,
+        rollback_eligibility,
+        already_rolled_back,
+        rollback_status,
+        rollback_by,
+        rollback_attempted_at,
+        rolled_back_at
+    FROM hedge_fund.v_signal_promotion_rollback_drill
+"""
+
+
+PROMOTION_ROLLBACK_DRILL_FIELDS = [
+    "execution_id",
+    "dry_run_acceptance_id",
+    "candidate_parameter_set",
+    "baseline_parameter_set",
+    "executed_by",
+    "executed_at",
+    "inserted_market_signal_ids",
+    "rollback_markers",
+    "audited_market_signal_ids",
+    "rollback_preview_market_signal_ids",
+    "rollback_preview_count",
+    "rollback_eligibility",
+    "already_rolled_back",
+    "rollback_status",
+    "rollback_by",
+    "rollback_attempted_at",
+    "rolled_back_at",
+]
+
+
+def _promotion_rollback_drill_response(row: dict[str, Any]) -> dict[str, Any]:
+    response = {key: row[key] for key in PROMOTION_ROLLBACK_DRILL_FIELDS}
+    response["inserted_market_signal_ids"] = list(response["inserted_market_signal_ids"] or [])
+    response["rollback_markers"] = list(response["rollback_markers"] or [])
+    response["audited_market_signal_ids"] = list(response["audited_market_signal_ids"] or [])
+    response["rollback_preview_market_signal_ids"] = list(
+        response["rollback_preview_market_signal_ids"] or []
+    )
+    return response
+
+
+def fetch_promotion_rollback_drills(
+    conn: psycopg.Connection,
+    *,
+    candidate_parameter_set: str | None = None,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    params: dict[str, Any] = {"limit": limit}
+    where = ""
+    if candidate_parameter_set:
+        where = "WHERE candidate_parameter_set = %(candidate_parameter_set)s"
+        params["candidate_parameter_set"] = candidate_parameter_set
+    sql = f"""
+        {PROMOTION_ROLLBACK_DRILL_SELECT}
+        {where}
+        ORDER BY executed_at DESC
+        LIMIT %(limit)s
+    """
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(sql, params)
+        return [_promotion_rollback_drill_response(dict(row)) for row in cur.fetchall()]
+
+
 def execute_guarded_promotion(
     conn: psycopg.Connection,
     *,
@@ -2347,6 +2431,20 @@ class PostgresSignalDataStore:
         with connect() as conn:
             conn.execute("SET default_transaction_read_only = on")
             return fetch_promotion_executions(
+                conn,
+                candidate_parameter_set=candidate_parameter_set,
+                limit=limit,
+            )
+
+    def promotion_rollback_drills(
+        self,
+        *,
+        candidate_parameter_set: str | None = None,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        with connect() as conn:
+            conn.execute("SET default_transaction_read_only = on")
+            return fetch_promotion_rollback_drills(
                 conn,
                 candidate_parameter_set=candidate_parameter_set,
                 limit=limit,

--- a/crog-ai-backend/deploy/sql/marketclub_rollback_drill_observability.sql
+++ b/crog-ai-backend/deploy/sql/marketclub_rollback_drill_observability.sql
@@ -1,0 +1,88 @@
+CREATE OR REPLACE VIEW hedge_fund.v_signal_promotion_rollback_drill AS
+WITH audited_rows AS (
+    SELECT
+        e.id AS execution_id,
+        e.acceptance_id AS dry_run_acceptance_id,
+        e.candidate_parameter_set,
+        e.baseline_parameter_set,
+        e.executed_by,
+        e.rollback_status,
+        e.rollback_by,
+        e.rolled_back_at,
+        e.created_at AS executed_at,
+        e.inserted_market_signal_ids,
+        e.rollback_markers,
+        r.market_signal_id AS audited_market_signal_id,
+        ms.id AS live_market_signal_id
+    FROM hedge_fund.signal_promotion_executions e
+    LEFT JOIN hedge_fund.signal_promotion_execution_rows r
+      ON r.execution_id = e.id
+    LEFT JOIN hedge_fund.market_signals ms
+      ON ms.id = r.market_signal_id
+),
+rollup AS (
+    SELECT
+        execution_id,
+        dry_run_acceptance_id,
+        candidate_parameter_set,
+        baseline_parameter_set,
+        executed_by,
+        rollback_status,
+        rollback_by,
+        rolled_back_at,
+        executed_at,
+        inserted_market_signal_ids,
+        rollback_markers,
+        COALESCE(
+            array_agg(audited_market_signal_id ORDER BY audited_market_signal_id)
+                FILTER (WHERE audited_market_signal_id IS NOT NULL),
+            ARRAY[]::INTEGER[]
+        ) AS audited_market_signal_ids,
+        COALESCE(
+            array_agg(live_market_signal_id ORDER BY live_market_signal_id)
+                FILTER (WHERE live_market_signal_id IS NOT NULL),
+            ARRAY[]::INTEGER[]
+        ) AS rollback_preview_market_signal_ids
+    FROM audited_rows
+    GROUP BY
+        execution_id,
+        dry_run_acceptance_id,
+        candidate_parameter_set,
+        baseline_parameter_set,
+        executed_by,
+        rollback_status,
+        rollback_by,
+        rolled_back_at,
+        executed_at,
+        inserted_market_signal_ids,
+        rollback_markers
+)
+SELECT
+    execution_id,
+    dry_run_acceptance_id,
+    candidate_parameter_set,
+    baseline_parameter_set,
+    executed_by,
+    executed_at,
+    inserted_market_signal_ids,
+    rollback_markers,
+    audited_market_signal_ids,
+    rollback_preview_market_signal_ids,
+    cardinality(rollback_preview_market_signal_ids)::INTEGER AS rollback_preview_count,
+    CASE
+        WHEN rollback_status = 'rolled_back' THEN 'ALREADY_ROLLED_BACK'
+        WHEN cardinality(audited_market_signal_ids) = 0 THEN 'NOT_ELIGIBLE_NO_AUDITED_ROWS'
+        WHEN cardinality(rollback_preview_market_signal_ids) = 0 THEN 'NOT_ELIGIBLE_NO_LIVE_AUDITED_ROWS'
+        WHEN cardinality(rollback_preview_market_signal_ids) < cardinality(audited_market_signal_ids)
+            THEN 'ELIGIBLE_PARTIAL_AUDITED_ROWS'
+        ELSE 'ELIGIBLE'
+    END AS rollback_eligibility,
+    rollback_status = 'rolled_back' AS already_rolled_back,
+    rollback_status,
+    rollback_by,
+    rolled_back_at AS rollback_attempted_at,
+    rolled_back_at
+FROM rollup;
+
+REVOKE ALL ON TABLE hedge_fund.v_signal_promotion_rollback_drill FROM PUBLIC;
+GRANT SELECT ON TABLE hedge_fund.v_signal_promotion_rollback_drill TO crog_ai_app;

--- a/crog-ai-backend/tests/test_api_signals.py
+++ b/crog-ai-backend/tests/test_api_signals.py
@@ -662,6 +662,37 @@ class FakeSignalStore:
             "created_at": dt.datetime(2026, 5, 3, 21, 0, tzinfo=dt.UTC),
         }
 
+    def _promotion_rollback_drill(
+        self,
+        *,
+        rollback_status: str = "active",
+        rollback_by: str | None = None,
+        rolled_back_at: dt.datetime | None = None,
+    ) -> dict[str, Any]:
+        already_rolled_back = rollback_status == "rolled_back"
+        return {
+            "execution_id": EXECUTION_ID,
+            "dry_run_acceptance_id": ACCEPTANCE_ID,
+            "candidate_parameter_set": "dochia_v0_2_range_daily",
+            "baseline_parameter_set": "dochia_v0_estimated",
+            "executed_by": "MarketClub Operator",
+            "executed_at": dt.datetime(2026, 5, 3, 21, 0, tzinfo=dt.UTC),
+            "inserted_market_signal_ids": [1201, 1202],
+            "rollback_markers": [
+                "dochia-dry-run:dochia_v0_2_range_daily:AA:2026-04-24",
+                "dochia-dry-run:dochia_v0_2_range_daily:AGIO:2026-04-24",
+            ],
+            "audited_market_signal_ids": [1201, 1202],
+            "rollback_preview_market_signal_ids": [] if already_rolled_back else [1201, 1202],
+            "rollback_preview_count": 0 if already_rolled_back else 2,
+            "rollback_eligibility": "ALREADY_ROLLED_BACK" if already_rolled_back else "ELIGIBLE",
+            "already_rolled_back": already_rolled_back,
+            "rollback_status": rollback_status,
+            "rollback_by": rollback_by,
+            "rollback_attempted_at": rolled_back_at,
+            "rolled_back_at": rolled_back_at,
+        }
+
     def promotion_executions(
         self,
         *,
@@ -669,6 +700,21 @@ class FakeSignalStore:
         limit: int = 10,
     ) -> list[dict[str, Any]]:
         return [self._promotion_execution()][:limit]
+
+    def promotion_rollback_drills(
+        self,
+        *,
+        candidate_parameter_set: str | None = None,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        return [
+            self._promotion_rollback_drill(),
+            self._promotion_rollback_drill(
+                rollback_status="rolled_back",
+                rollback_by="MarketClub Operator",
+                rolled_back_at=dt.datetime(2026, 5, 3, 21, 30, tzinfo=dt.UTC),
+            ),
+        ][:limit]
 
     def execute_guarded_promotion(
         self,
@@ -1149,6 +1195,31 @@ def test_promotion_executions_endpoint_returns_audit_rows() -> None:
     assert payload[0]["verification_status"] == "PASS"
     assert payload[0]["inserted_market_signal_ids"] == [1201, 1202]
     assert payload[0]["rollback_status"] == "active"
+
+
+def test_promotion_rollback_drill_endpoint_returns_read_only_scope() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/financial/signals/promotion-dry-run/executions/rollback-drill"
+        "?candidate_parameter_set=dochia_v0_2_range_daily&limit=2"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload[0]["execution_id"] == str(EXECUTION_ID)
+    assert payload[0]["dry_run_acceptance_id"] == str(ACCEPTANCE_ID)
+    assert payload[0]["inserted_market_signal_ids"] == [1201, 1202]
+    assert payload[0]["rollback_markers"][0].startswith("dochia-dry-run:")
+    assert payload[0]["rollback_eligibility"] == "ELIGIBLE"
+    assert payload[0]["rollback_preview_count"] == 2
+    assert payload[0]["already_rolled_back"] is False
+    assert payload[0]["rollback_attempted_at"] is None
+    assert payload[1]["rollback_eligibility"] == "ALREADY_ROLLED_BACK"
+    assert payload[1]["already_rolled_back"] is True
+    assert payload[1]["rolled_back_at"] == "2026-05-03T21:30:00Z"
 
 
 def test_execute_guarded_promotion_endpoint_returns_execution_record() -> None:

--- a/crog-ai-backend/tests/test_guarded_promotion_execution.py
+++ b/crog-ai-backend/tests/test_guarded_promotion_execution.py
@@ -61,6 +61,9 @@ class FakeCursor:
     def fetchone(self) -> dict[str, object]:
         return self.row
 
+    def fetchall(self) -> list[dict[str, object]]:
+        return [self.row]
+
 
 class FakeConnection:
     def __init__(self, row: dict[str, object]) -> None:
@@ -77,6 +80,42 @@ def _guarded_execution_sql() -> str:
         / "sql"
         / "marketclub_guarded_promotion_execution.sql"
     ).read_text(encoding="utf-8")
+
+
+def _rollback_drill_sql() -> str:
+    return (
+        Path(__file__).resolve().parents[1]
+        / "deploy"
+        / "sql"
+        / "marketclub_rollback_drill_observability.sql"
+    ).read_text(encoding="utf-8")
+
+
+def _rollback_drill_row(**overrides: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "execution_id": EXECUTION_ID,
+        "dry_run_acceptance_id": ACCEPTANCE_ID,
+        "candidate_parameter_set": "dochia_v0_2_range_daily",
+        "baseline_parameter_set": "dochia_v0_estimated",
+        "executed_by": "Gary Knight",
+        "executed_at": dt.datetime(2026, 5, 4, 12, 5, tzinfo=dt.UTC),
+        "inserted_market_signal_ids": [1201, 1202],
+        "rollback_markers": [
+            "dochia-dry-run:dochia_v0_2_range_daily:AA:2026-04-24",
+            "dochia-dry-run:dochia_v0_2_range_daily:AGIO:2026-04-24",
+        ],
+        "audited_market_signal_ids": [1201, 1202],
+        "rollback_preview_market_signal_ids": [1201],
+        "rollback_preview_count": 1,
+        "rollback_eligibility": "ELIGIBLE_PARTIAL_AUDITED_ROWS",
+        "already_rolled_back": False,
+        "rollback_status": "active",
+        "rollback_by": None,
+        "rollback_attempted_at": None,
+        "rolled_back_at": None,
+    }
+    row.update(overrides)
+    return row
 
 
 def test_repository_executes_locked_database_function_not_raw_market_signal_insert() -> None:
@@ -120,6 +159,24 @@ def test_repository_rollback_uses_locked_database_function() -> None:
     assert "hedge_fund.rollback_guarded_signal_promotion" in conn.cursor_instance.sql
     assert conn.cursor_instance.params["execution_id"] == str(EXECUTION_ID)
     assert conn.cursor_instance.params["operator_token_sha256"] == OPERATOR_TOKEN_SHA256
+
+
+def test_repository_fetches_read_only_rollback_drill_view() -> None:
+    conn = FakeConnection(_rollback_drill_row())
+
+    result = repository.fetch_promotion_rollback_drills(
+        conn,  # type: ignore[arg-type]
+        candidate_parameter_set="dochia_v0_2_range_daily",
+        limit=3,
+    )
+
+    assert result[0]["execution_id"] == EXECUTION_ID
+    assert result[0]["dry_run_acceptance_id"] == ACCEPTANCE_ID
+    assert result[0]["rollback_preview_count"] == 1
+    assert result[0]["rollback_preview_market_signal_ids"] == [1201]
+    assert "hedge_fund.v_signal_promotion_rollback_drill" in conn.cursor_instance.sql
+    assert "DELETE FROM hedge_fund.market_signals" not in conn.cursor_instance.sql
+    assert conn.cursor_instance.params["candidate_parameter_set"] == "dochia_v0_2_range_daily"
 
 
 def test_python_execution_path_contains_no_direct_market_signals_write() -> None:
@@ -207,6 +264,64 @@ def test_sql_contract_makes_second_rollback_safe_noop() -> None:
 
     assert "IF v_execution.rollback_status = 'rolled_back' THEN" in sql
     assert "RETURN v_execution;" in sql
+
+
+def test_rollback_drill_preview_only_includes_audited_market_signal_ids() -> None:
+    sql = _rollback_drill_sql()
+
+    assert "CREATE OR REPLACE VIEW hedge_fund.v_signal_promotion_rollback_drill" in sql
+    assert "LEFT JOIN hedge_fund.signal_promotion_execution_rows r" in sql
+    assert "LEFT JOIN hedge_fund.market_signals ms" in sql
+    assert "ON ms.id = r.market_signal_id" in sql
+    assert "rollback_preview_market_signal_ids" in sql
+    assert "cardinality(rollback_preview_market_signal_ids)::INTEGER" in sql
+
+
+def test_rollback_drill_preview_does_not_match_by_ticker_or_date() -> None:
+    sql = _rollback_drill_sql()
+    live_signal_join = sql.split("LEFT JOIN hedge_fund.market_signals ms", 1)[1].split(
+        "),\nrollup AS", 1
+    )[0]
+
+    assert "ms.id = r.market_signal_id" in live_signal_join
+    assert "ticker" not in live_signal_join.lower()
+    assert "candidate_bar_date" not in live_signal_join.lower()
+    assert "bar_date" not in live_signal_join.lower()
+
+
+def test_rollback_drill_exposes_rolled_back_visibility() -> None:
+    sql = _rollback_drill_sql()
+    conn = FakeConnection(
+        _rollback_drill_row(
+            rollback_preview_market_signal_ids=[],
+            rollback_preview_count=0,
+            rollback_eligibility="ALREADY_ROLLED_BACK",
+            already_rolled_back=True,
+            rollback_status="rolled_back",
+            rollback_by="Gary Knight",
+            rollback_attempted_at=dt.datetime(2026, 5, 4, 12, 30, tzinfo=dt.UTC),
+            rolled_back_at=dt.datetime(2026, 5, 4, 12, 30, tzinfo=dt.UTC),
+        )
+    )
+
+    result = repository.fetch_promotion_rollback_drills(conn)  # type: ignore[arg-type]
+
+    assert "rollback_status = 'rolled_back' AS already_rolled_back" in sql
+    assert "rolled_back_at AS rollback_attempted_at" in sql
+    assert result[0]["already_rolled_back"] is True
+    assert result[0]["rollback_eligibility"] == "ALREADY_ROLLED_BACK"
+    assert result[0]["rolled_back_at"] == dt.datetime(2026, 5, 4, 12, 30, tzinfo=dt.UTC)
+
+
+def test_rollback_drill_is_read_only_and_cannot_affect_unaudited_rows() -> None:
+    sql = _rollback_drill_sql()
+    normalized = sql.upper()
+
+    assert " DELETE " not in normalized
+    assert " UPDATE " not in normalized
+    assert " INSERT " not in normalized
+    assert "GRANT SELECT ON TABLE hedge_fund.v_signal_promotion_rollback_drill" in sql
+    assert "GRANT EXECUTE" not in sql
 
 
 def test_sql_contract_keeps_security_definer_narrow() -> None:

--- a/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
+++ b/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
@@ -589,6 +589,28 @@ const promotionExecutions = [
   },
 ];
 
+const promotionRollbackDrills = [
+  {
+    execution_id: "55555555-5555-5555-5555-555555555555",
+    dry_run_acceptance_id: "44444444-4444-4444-4444-444444444444",
+    candidate_parameter_set: "dochia_v0_2_range_daily",
+    baseline_parameter_set: "dochia_v0_estimated",
+    executed_by: "MarketClub Operator",
+    executed_at: "2026-05-04T12:52:00Z",
+    inserted_market_signal_ids: [1201, 1202],
+    rollback_markers: ["dochia-dry-run:dochia_v0_2_range_daily:AA:2026-04-24"],
+    audited_market_signal_ids: [1201, 1202],
+    rollback_preview_market_signal_ids: [1201, 1202],
+    rollback_preview_count: 2,
+    rollback_eligibility: "ELIGIBLE",
+    already_rolled_back: false,
+    rollback_status: "active",
+    rollback_by: null,
+    rollback_attempted_at: null,
+    rolled_back_at: null,
+  },
+];
+
 const promotionDryRunVerification = {
   generated_at: "2026-05-03T20:31:00Z",
   candidate_parameter_set: "dochia_v0_2_range_daily",
@@ -723,6 +745,13 @@ vi.mock("@/lib/hooks", () => ({
     isLoading: false,
     refetch: vi.fn(),
   }),
+  useFinancialPromotionRollbackDrills: () => ({
+    data: promotionRollbackDrills,
+    isError: false,
+    isFetching: false,
+    isLoading: false,
+    refetch: vi.fn(),
+  }),
   useCreateFinancialShadowDecisionRecord: () => ({
     isPending: false,
     mutateAsync: vi.fn(),
@@ -770,6 +799,14 @@ describe("HedgeFundSignalsShell", () => {
     expect(screen.getByText("Execution Records")).toBeInTheDocument();
     expect(screen.getByText("1 recorded")).toBeInTheDocument();
     expect(screen.getByText("Inserted rows")).toBeInTheDocument();
+    expect(screen.getByText("Rollback Drill")).toBeInTheDocument();
+    expect(screen.getByText("1 checked")).toBeInTheDocument();
+    expect(screen.getByText("Dry-run acceptance ID")).toBeInTheDocument();
+    expect(screen.getByText("Rollback preview count")).toBeInTheDocument();
+    expect(screen.getByText("Inserted market_signal IDs")).toBeInTheDocument();
+    expect(screen.getByText("1201, 1202")).toBeInTheDocument();
+    expect(screen.getByText("Already rolled back")).toBeInTheDocument();
+    expect(screen.getByText("No")).toBeInTheDocument();
     expect(screen.getAllByText("Active").length).toBeGreaterThan(0);
     expect(
       screen.getAllByText("dochia-dry-run:dochia_v0_2_range_daily:AA:2026-04-24").length,

--- a/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
+++ b/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
@@ -48,6 +48,7 @@ import {
   useFinancialPromotionDryRunAcceptances,
   useFinancialPromotionDryRunVerification,
   useFinancialPromotionExecutions,
+  useFinancialPromotionRollbackDrills,
   useFinancialShadowDecisionRecords,
   useFinancialShadowReview,
   useFinancialSignalDetail,
@@ -67,6 +68,8 @@ import type {
   FinancialPromotionDryRunVerificationResponse,
   FinancialPromotionDryRunVerificationStatus,
   FinancialPromotionExecution,
+  FinancialPromotionRollbackDrill,
+  FinancialPromotionRollbackEligibility,
   FinancialPromotionGateGuardrailStatus,
   FinancialPromotionGateRecommendationStatus,
   FinancialPromotionGateResponse,
@@ -291,6 +294,36 @@ function promotionDryRunVerificationMessage(
 function promotionExecutionRollbackClasses(status: FinancialPromotionExecution["rollback_status"]): string {
   if (status === "rolled_back") return "border-amber-500/40 bg-amber-500/10 text-amber-600";
   return "border-emerald-500/40 bg-emerald-500/10 text-emerald-600";
+}
+
+function promotionRollbackEligibilityLabel(status: FinancialPromotionRollbackEligibility): string {
+  switch (status) {
+    case "ELIGIBLE":
+      return "Eligible";
+    case "ELIGIBLE_PARTIAL_AUDITED_ROWS":
+      return "Partial audited rows";
+    case "ALREADY_ROLLED_BACK":
+      return "Already rolled back";
+    case "NOT_ELIGIBLE_NO_AUDITED_ROWS":
+      return "No audited rows";
+    case "NOT_ELIGIBLE_NO_LIVE_AUDITED_ROWS":
+      return "No live audited rows";
+    default:
+      return status;
+  }
+}
+
+function promotionRollbackEligibilityClasses(status: FinancialPromotionRollbackEligibility): string {
+  if (status === "ELIGIBLE") return "border-emerald-500/40 bg-emerald-500/10 text-emerald-600";
+  if (status === "ALREADY_ROLLED_BACK") return "border-amber-500/40 bg-amber-500/10 text-amber-600";
+  if (status === "ELIGIBLE_PARTIAL_AUDITED_ROWS") {
+    return "border-sky-500/40 bg-sky-500/10 text-sky-600";
+  }
+  return "border-red-500/40 bg-red-500/10 text-red-600";
+}
+
+function formatIdList(values: number[]): string {
+  return values.length ? values.join(", ") : "—";
 }
 
 function formatSignedNumber(value: number | null | undefined, digits = 0): string {
@@ -1504,6 +1537,8 @@ function PromotionDryRunPanel({
   acceptancesLoading,
   executions,
   executionsLoading,
+  rollbackDrills,
+  rollbackDrillsLoading,
   onSubmitAcceptance,
   submittingAcceptance,
 }: {
@@ -1517,6 +1552,8 @@ function PromotionDryRunPanel({
   acceptancesLoading: boolean;
   executions: FinancialPromotionExecution[];
   executionsLoading: boolean;
+  rollbackDrills: FinancialPromotionRollbackDrill[];
+  rollbackDrillsLoading: boolean;
   onSubmitAcceptance: (payload: FinancialPromotionDryRunAcceptanceCreate) => Promise<void>;
   submittingAcceptance: boolean;
 }) {
@@ -1844,6 +1881,75 @@ function PromotionDryRunPanel({
               </p>
             )}
           </div>
+
+          <div className="border border-border p-3">
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="text-sm font-semibold">Rollback Drill</h2>
+              <Badge variant="outline">
+                {rollbackDrillsLoading ? "Loading" : `${rollbackDrills.length} checked`}
+              </Badge>
+            </div>
+            {rollbackDrills.length ? (
+              <div className="mt-3 space-y-2">
+                {rollbackDrills.slice(0, 3).map((drill) => (
+                  <div key={drill.execution_id} className="border border-border/70 p-2 text-xs">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="truncate font-mono text-[11px]">
+                        {drill.execution_id}
+                      </span>
+                      <Badge
+                        variant="outline"
+                        className={cn(
+                          "text-[10px]",
+                          promotionRollbackEligibilityClasses(drill.rollback_eligibility),
+                        )}
+                      >
+                        {promotionRollbackEligibilityLabel(drill.rollback_eligibility)}
+                      </Badge>
+                    </div>
+                    <div className="mt-2 grid grid-cols-2 gap-2">
+                      <div>
+                        <span className="text-muted-foreground">Dry-run acceptance ID</span>
+                        <p className="truncate font-mono text-[11px]">
+                          {drill.dry_run_acceptance_id}
+                        </p>
+                      </div>
+                      <div>
+                        <span className="text-muted-foreground">Rollback preview count</span>
+                        <p className="font-mono font-semibold">{drill.rollback_preview_count}</p>
+                      </div>
+                      <div>
+                        <span className="text-muted-foreground">Already rolled back</span>
+                        <p className="font-medium">{drill.already_rolled_back ? "Yes" : "No"}</p>
+                      </div>
+                      <div>
+                        <span className="text-muted-foreground">Rollback time</span>
+                        <p className="truncate font-medium">
+                          {formatDateTime(drill.rollback_attempted_at ?? drill.rolled_back_at)}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="mt-2">
+                      <span className="text-muted-foreground">Inserted market_signal IDs</span>
+                      <p className="mt-1 truncate font-mono text-[11px]">
+                        {formatIdList(drill.inserted_market_signal_ids)}
+                      </p>
+                    </div>
+                    <div className="mt-2">
+                      <span className="text-muted-foreground">Rollback markers</span>
+                      <p className="mt-1 truncate font-mono text-[11px]">
+                        {drill.rollback_markers.join(", ") || "—"}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="mt-3 text-xs text-muted-foreground">
+                No rollback drill records available.
+              </p>
+            )}
+          </div>
         </div>
       </div>
   </div>
@@ -2032,6 +2138,10 @@ export function HedgeFundSignalsShell() {
     candidate_parameter_set: "dochia_v0_2_range_daily",
     limit: 5,
   });
+  const promotionRollbackDrills = useFinancialPromotionRollbackDrills({
+    candidate_parameter_set: "dochia_v0_2_range_daily",
+    limit: 5,
+  });
   const createShadowDecisionRecord = useCreateFinancialShadowDecisionRecord();
   const createPromotionDryRunAcceptance = useCreateFinancialPromotionDryRunAcceptance();
   const signals = latest.data ?? EMPTY_SIGNALS;
@@ -2082,7 +2192,8 @@ export function HedgeFundSignalsShell() {
     promotionDryRun.isFetching ||
     promotionDryRunVerification.isFetching ||
     promotionDryRunAcceptances.isFetching ||
-    promotionExecutions.isFetching;
+    promotionExecutions.isFetching ||
+    promotionRollbackDrills.isFetching;
 
   async function handleShadowDecisionSubmit(payload: FinancialShadowReviewDecisionRecordCreate) {
     await createShadowDecisionRecord.mutateAsync(payload);
@@ -2150,6 +2261,7 @@ export function HedgeFundSignalsShell() {
               void promotionDryRunVerification.refetch();
               void promotionDryRunAcceptances.refetch();
               void promotionExecutions.refetch();
+              void promotionRollbackDrills.refetch();
             }}
             disabled={isRefreshing}
             aria-label="Refresh hedge fund signals"
@@ -2292,6 +2404,8 @@ export function HedgeFundSignalsShell() {
             acceptancesLoading={promotionDryRunAcceptances.isLoading}
             executions={promotionExecutions.data ?? []}
             executionsLoading={promotionExecutions.isLoading}
+            rollbackDrills={promotionRollbackDrills.data ?? []}
+            rollbackDrillsLoading={promotionRollbackDrills.isLoading}
             onSubmitAcceptance={handlePromotionDryRunAcceptanceSubmit}
             submittingAcceptance={createPromotionDryRunAcceptance.isPending}
           />

--- a/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
@@ -18,6 +18,7 @@ import type {
   FinancialPromotionDryRunAcceptance,
   FinancialPromotionDryRunAcceptanceCreate,
   FinancialPromotionExecution,
+  FinancialPromotionRollbackDrill,
   FinancialPromotionDryRunVerificationResponse,
   FinancialPromotionDryRunResponse,
   FinancialPromotionGateResponse,
@@ -304,6 +305,18 @@ export function useFinancialPromotionExecutions(params?: {
   return useQuery<FinancialPromotionExecution[]>({
     queryKey: ["financial", "signals", "promotion-dry-run", "executions", params],
     queryFn: () => api.get("/api/financial/signals/promotion-dry-run/executions", params),
+    staleTime: 60_000,
+  });
+}
+
+export function useFinancialPromotionRollbackDrills(params?: {
+  candidate_parameter_set?: string;
+  limit?: number;
+}) {
+  return useQuery<FinancialPromotionRollbackDrill[]>({
+    queryKey: ["financial", "signals", "promotion-dry-run", "rollback-drill", params],
+    queryFn: () =>
+      api.get("/api/financial/signals/promotion-dry-run/executions/rollback-drill", params),
     staleTime: 60_000,
   });
 }

--- a/fortress-guest-platform/apps/command-center/src/lib/types.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/types.ts
@@ -601,6 +601,33 @@ export interface FinancialPromotionExecution {
   created_at: string;
 }
 
+export type FinancialPromotionRollbackEligibility =
+  | "ELIGIBLE"
+  | "ELIGIBLE_PARTIAL_AUDITED_ROWS"
+  | "ALREADY_ROLLED_BACK"
+  | "NOT_ELIGIBLE_NO_AUDITED_ROWS"
+  | "NOT_ELIGIBLE_NO_LIVE_AUDITED_ROWS";
+
+export interface FinancialPromotionRollbackDrill {
+  execution_id: string;
+  dry_run_acceptance_id: string;
+  candidate_parameter_set: string;
+  baseline_parameter_set: string;
+  executed_by: string;
+  executed_at: string;
+  inserted_market_signal_ids: number[];
+  rollback_markers: string[];
+  audited_market_signal_ids: number[];
+  rollback_preview_market_signal_ids: number[];
+  rollback_preview_count: number;
+  rollback_eligibility: FinancialPromotionRollbackEligibility;
+  already_rolled_back: boolean;
+  rollback_status: FinancialPromotionExecutionRollbackStatus;
+  rollback_by: string | null;
+  rollback_attempted_at: string | null;
+  rolled_back_at: string | null;
+}
+
 export interface FinancialWatchlistCandidate {
   ticker: string;
   bar_date: string;


### PR DESCRIPTION
Summary: Adds read-only rollback drill observability for Hedge Fund Signals. The backend adds a read-only rollback drill view and GET endpoint that previews rollback scope using only audited signal_promotion_execution_rows.market_signal_id values. The cockpit shows execution ID, dry-run acceptance ID, inserted market_signal IDs, rollback markers, eligibility, preview count, rolled-back state, and rollback timestamps without adding execute or rollback controls. Tests cover audited-ID-only preview scope, no ticker/date matching, safe second rollback contract, rolled-back visibility, and no unaudited market_signals effects. Verification: PYTHONPATH=. .venv-test/bin/python -m pytest; PYTHONPATH=. .venv-test/bin/python -m ruff check targeted backend files; npm test -- financial-hedge-fund-shell.test.tsx; npm test; npx eslint targeted frontend files; npx tsc --noEmit; npm run build. Safety: read-only cockpit only; no production write controls; no market_signals write path invoked.