### PR TITLE
feat(financial): add operator dry-run execution action

### DIFF
--- a/crog-ai-backend/tests/test_api_signals.py
+++ b/crog-ai-backend/tests/test_api_signals.py
@@ -858,6 +858,49 @@ class FakeSignalStore:
         }
 
 
+class NoAcceptanceSignalStore(FakeSignalStore):
+    def execute_guarded_promotion(
+        self,
+        *,
+        acceptance_id: str,
+        operator_token_sha256: str,
+        execution_rationale: str,
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
+        raise ValueError("No dry-run acceptance exists for guarded promotion execution")
+
+
+class NoDecisionSignalStore(FakeSignalStore):
+    def execute_guarded_promotion(
+        self,
+        *,
+        acceptance_id: str,
+        operator_token_sha256: str,
+        execution_rationale: str,
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
+        raise ValueError("Human promote_to_market_signals decision is required before execution")
+
+
+class ConflictingExecutionKeySignalStore(FakeSignalStore):
+    def execute_guarded_promotion(
+        self,
+        *,
+        acceptance_id: str,
+        operator_token_sha256: str,
+        execution_rationale: str,
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
+        if idempotency_key == "operator-accepted-dry-run-20260505":
+            raise ValueError("Dry-run acceptance has already been executed")
+        return super().execute_guarded_promotion(
+            acceptance_id=acceptance_id,
+            operator_token_sha256=operator_token_sha256,
+            execution_rationale=execution_rationale,
+            idempotency_key=idempotency_key,
+        )
+
+
 def test_latest_scores_endpoint_returns_scanner_rows() -> None:
     app = create_app()
     app.dependency_overrides[get_signal_store] = FakeSignalStore
@@ -1250,6 +1293,136 @@ def test_execute_guarded_promotion_endpoint_returns_execution_record() -> None:
     assert payload["idempotency_key"] == "operator-accepted-dry-run-20260504"
     assert payload["verification_status"] == "PASS"
     assert payload["rollback_markers"][0].startswith("dochia-dry-run:")
+
+
+def test_execute_guarded_promotion_endpoint_rejects_without_acceptance() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = NoAcceptanceSignalStore
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/financial/signals/promotion-dry-run/executions",
+        headers={"X-MarketClub-Operator-Token": OPERATOR_TOKEN},
+        json={
+            "acceptance_id": "77777777-7777-7777-7777-777777777777",
+            "execution_rationale": "Operator attempted execution without acceptance.",
+            "idempotency_key": "operator-no-acceptance-20260504",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "No dry-run acceptance exists" in response.json()["detail"]
+
+
+def test_execute_guarded_promotion_endpoint_rejects_without_human_decision() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = NoDecisionSignalStore
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/financial/signals/promotion-dry-run/executions",
+        headers={"X-MarketClub-Operator-Token": OPERATOR_TOKEN},
+        json={
+            "acceptance_id": str(ACCEPTANCE_ID),
+            "execution_rationale": "Operator attempted execution without promote decision.",
+            "idempotency_key": "operator-no-decision-20260504",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "Human promote_to_market_signals decision is required" in response.json()["detail"]
+
+
+def test_execute_guarded_promotion_endpoint_is_idempotent_for_same_key() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+    payload = {
+        "acceptance_id": str(ACCEPTANCE_ID),
+        "execution_rationale": "Operator accepted the verified dry-run output.",
+        "idempotency_key": "operator-accepted-dry-run-20260504",
+    }
+
+    first = client.post(
+        "/api/financial/signals/promotion-dry-run/executions",
+        headers={"X-MarketClub-Operator-Token": OPERATOR_TOKEN},
+        json=payload,
+    )
+    second = client.post(
+        "/api/financial/signals/promotion-dry-run/executions",
+        headers={"X-MarketClub-Operator-Token": OPERATOR_TOKEN},
+        json=payload,
+    )
+
+    assert first.status_code == 201
+    assert second.status_code == 201
+    assert second.json()["id"] == first.json()["id"]
+    assert second.json()["inserted_market_signal_ids"] == first.json()["inserted_market_signal_ids"]
+
+
+def test_execute_guarded_promotion_endpoint_rejects_conflicting_key_after_execution() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = ConflictingExecutionKeySignalStore
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/financial/signals/promotion-dry-run/executions",
+        headers={"X-MarketClub-Operator-Token": OPERATOR_TOKEN},
+        json={
+            "acceptance_id": str(ACCEPTANCE_ID),
+            "execution_rationale": "Operator attempted duplicate execution with another key.",
+            "idempotency_key": "operator-accepted-dry-run-20260505",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "already been executed" in response.json()["detail"]
+
+
+def test_execute_guarded_promotion_endpoint_refuses_ticker_date_payload() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/financial/signals/promotion-dry-run/executions",
+        headers={"X-MarketClub-Operator-Token": OPERATOR_TOKEN},
+        json={
+            "acceptance_id": str(ACCEPTANCE_ID),
+            "execution_rationale": "Operator attempted execution with ticker date scope.",
+            "idempotency_key": "operator-ticker-date-20260504",
+            "ticker": "AA",
+            "candidate_bar_date": "2026-04-24",
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_execute_guarded_promotion_endpoint_links_audit_and_rollback_eligibility() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    execution = client.post(
+        "/api/financial/signals/promotion-dry-run/executions",
+        headers={"X-MarketClub-Operator-Token": OPERATOR_TOKEN},
+        json={
+            "acceptance_id": str(ACCEPTANCE_ID),
+            "execution_rationale": "Operator accepted the verified dry-run output.",
+            "idempotency_key": "operator-accepted-dry-run-20260504",
+        },
+    )
+    rollback_drill = client.get(
+        "/api/financial/signals/promotion-dry-run/executions/rollback-drill"
+        "?candidate_parameter_set=dochia_v0_2_range_daily&limit=1"
+    )
+
+    assert execution.status_code == 201
+    assert rollback_drill.status_code == 200
+    assert execution.json()["inserted_market_signal_ids"] == [1201, 1202]
+    assert rollback_drill.json()[0]["dry_run_acceptance_id"] == str(ACCEPTANCE_ID)
+    assert rollback_drill.json()[0]["rollback_eligible"] is True
 
 
 def test_execute_guarded_promotion_endpoint_requires_operator_token() -> None:

--- a/crog-ai-backend/tests/test_guarded_promotion_execution.py
+++ b/crog-ai-backend/tests/test_guarded_promotion_execution.py
@@ -219,6 +219,30 @@ def test_sql_contract_enforces_full_guarded_execution_flow() -> None:
     assert "rollback_marker" in sql
 
 
+def test_sql_contract_blocks_execution_without_acceptance_or_human_decision() -> None:
+    sql = _guarded_execution_sql()
+    acceptance_lookup = sql.index("FROM hedge_fund.signal_promotion_dry_run_acceptances a")
+    decision_join = sql.index("JOIN hedge_fund.signal_shadow_review_decisions d")
+    market_insert = sql.index("INSERT INTO hedge_fund.market_signals")
+
+    assert decision_join > acceptance_lookup
+    assert "WHERE a.id = p_acceptance_id" in sql
+    assert "FOR UPDATE OF a" in sql
+    assert "No dry-run acceptance exists for guarded promotion execution" in sql
+    assert "Human promote_to_market_signals decision is required before execution" in sql
+    assert acceptance_lookup < market_insert
+
+
+def test_sql_contract_blocks_execution_when_verification_fails_or_inconclusive() -> None:
+    sql = _guarded_execution_sql()
+    verification_lookup = sql.index("FROM hedge_fund.verify_promotion_dry_run")
+    market_insert = sql.index("INSERT INTO hedge_fund.market_signals")
+
+    assert "v_verification_status IS DISTINCT FROM 'PASS'" in sql
+    assert "Promotion verification gate blocked execution" in sql
+    assert verification_lookup < market_insert
+
+
 def test_sql_contract_keeps_signal_and_audit_writes_transactional() -> None:
     sql = _guarded_execution_sql()
 
@@ -243,6 +267,28 @@ def test_sql_contract_has_idempotency_and_rollback_support() -> None:
     assert "DELETE FROM hedge_fund.market_signals" in sql
     assert "rollback_status = 'rolled_back'" in sql
     assert "GRANT EXECUTE ON FUNCTION" in sql
+
+
+def test_sql_contract_returns_same_execution_for_same_idempotency_key_before_double_write_check() -> None:
+    sql = _guarded_execution_sql()
+    idempotency_lookup = sql.index("WHERE idempotency_key = v_effective_idempotency_key")
+    same_key_return = sql.index("RETURN v_existing", idempotency_lookup)
+    acceptance_execution_lookup = sql.index("WHERE acceptance_id = p_acceptance_id")
+
+    assert idempotency_lookup < same_key_return < acceptance_execution_lookup
+    assert "Idempotency key is already attached to another promotion execution" in sql
+    assert "Dry-run acceptance has already been executed" in sql
+
+
+def test_sql_contract_records_inserted_market_signal_ids_for_rollback_after_execution() -> None:
+    sql = _guarded_execution_sql()
+
+    assert "v_inserted_market_signal_ids :=\n            array_append" in sql
+    assert "inserted_market_signal_ids" in sql
+    assert "signal_promotion_execution_rows" in sql
+    assert "market_signal_id" in sql
+    assert "row_payload" in sql
+    assert "rollback_markers" in sql
 
 
 def test_sql_contract_requires_operator_roles_for_execution_and_rollback() -> None:

--- a/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
+++ b/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { HedgeFundSignalsShell } from "@/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell";
 
@@ -562,6 +562,36 @@ const promotionDryRunAcceptances = [
     ],
     created_at: "2026-05-03T20:45:00Z",
   },
+  {
+    id: "77777777-7777-7777-7777-777777777777",
+    decision_record_id: "33333333-3333-3333-3333-333333333333",
+    candidate_parameter_set: "dochia_v0_2_range_daily",
+    baseline_parameter_set: "dochia_v0_estimated",
+    accepted_by: "MarketClub Operator",
+    acceptance_rationale: "Accepted after a second reviewed dry-run preview cleared the gate.",
+    rollback_criteria: "Rollback if whipsaw pressure rises.",
+    dry_run_generated_at: "2026-05-03T20:30:00Z",
+    dry_run_candidate_signal_count: 3,
+    dry_run_proposed_insert_count: 2,
+    dry_run_bullish_count: 1,
+    dry_run_risk_count: 1,
+    dry_run_skipped_neutral_count: 1,
+    min_abs_score: 50,
+    target_table: "hedge_fund.market_signals",
+    target_columns: [
+      "ticker",
+      "signal_type",
+      "action",
+      "confidence_score",
+      "price_target",
+      "source_sender",
+      "source_subject",
+      "raw_reasoning",
+      "model_used",
+      "extracted_at",
+    ],
+    created_at: "2026-05-04T12:45:00Z",
+  },
 ];
 
 const promotionExecutions = [
@@ -643,6 +673,10 @@ const promotionDryRunVerification = {
     },
   ],
 };
+
+let promotionDryRunAcceptancesMock = promotionDryRunAcceptances;
+let promotionExecutionsMock = promotionExecutions;
+let promotionDryRunVerificationMock = promotionDryRunVerification;
 
 vi.mock("@/lib/hooks", () => ({
   useFinancialLatestSignals: () => ({
@@ -726,21 +760,21 @@ vi.mock("@/lib/hooks", () => ({
     refetch: vi.fn(),
   }),
   useFinancialPromotionDryRunVerification: () => ({
-    data: promotionDryRunVerification,
+    data: promotionDryRunVerificationMock,
     isError: false,
     isFetching: false,
     isLoading: false,
     refetch: vi.fn(),
   }),
   useFinancialPromotionDryRunAcceptances: () => ({
-    data: promotionDryRunAcceptances,
+    data: promotionDryRunAcceptancesMock,
     isError: false,
     isFetching: false,
     isLoading: false,
     refetch: vi.fn(),
   }),
   useFinancialPromotionExecutions: () => ({
-    data: promotionExecutions,
+    data: promotionExecutionsMock,
     isError: false,
     isFetching: false,
     isLoading: false,
@@ -761,6 +795,10 @@ vi.mock("@/lib/hooks", () => ({
     isPending: false,
     mutateAsync: vi.fn(),
   }),
+  useExecuteFinancialPromotionDryRunAcceptance: () => ({
+    isPending: false,
+    mutateAsync: vi.fn(),
+  }),
   useRollbackFinancialPromotionExecution: () => ({
     isPending: false,
     mutateAsync: vi.fn(),
@@ -768,6 +806,12 @@ vi.mock("@/lib/hooks", () => ({
 }));
 
 describe("HedgeFundSignalsShell", () => {
+  beforeEach(() => {
+    promotionDryRunAcceptancesMock = promotionDryRunAcceptances;
+    promotionExecutionsMock = promotionExecutions;
+    promotionDryRunVerificationMock = promotionDryRunVerification;
+  });
+
   it("renders latest signals, score context, and transition feed", () => {
     render(<HedgeFundSignalsShell />);
 
@@ -800,7 +844,12 @@ describe("HedgeFundSignalsShell", () => {
     expect(screen.getByText("CROSS_MODEL_DIAGNOSTIC_ONLY")).toBeInTheDocument();
     expect(screen.getByText("Dry-Run Acceptance")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Accept Dry-Run" })).toBeInTheDocument();
-    expect(screen.getByText("1 saved")).toBeInTheDocument();
+    expect(screen.getByText("2 saved")).toBeInTheDocument();
+    expect(screen.getByText("Operator Execution")).toBeInTheDocument();
+    expect(screen.getByLabelText("Execution Operator Token")).toBeInTheDocument();
+    expect(screen.getByLabelText("Execution Rationale")).toBeInTheDocument();
+    expect(screen.getByLabelText("Execution Idempotency Key")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Execute accepted dry-run" })).toBeDisabled();
     expect(screen.getByText("Execution Records")).toBeInTheDocument();
     expect(screen.getByText("1 recorded")).toBeInTheDocument();
     expect(screen.getByText("Inserted rows")).toBeInTheDocument();
@@ -819,7 +868,6 @@ describe("HedgeFundSignalsShell", () => {
     expect(
       screen.getAllByText("dochia-dry-run:dochia_v0_2_range_daily:AA:2026-04-24").length,
     ).toBeGreaterThan(0);
-    expect(screen.queryByRole("button", { name: /execute/i })).not.toBeInTheDocument();
     expect(screen.getAllByText("MarketClub Operator").length).toBeGreaterThan(0);
     expect(screen.getByText("Chart Overlay")).toBeInTheDocument();
     expect(screen.getByText("1 triangle events")).toBeInTheDocument();
@@ -839,5 +887,27 @@ describe("HedgeFundSignalsShell", () => {
       "aria-pressed",
       "true",
     );
+  });
+
+  it("hides the execution action when the gate fails or every acceptance has executed", () => {
+    promotionDryRunVerificationMock = {
+      ...promotionDryRunVerification,
+      overall_status: "FAIL",
+      failed_rows: 1,
+      passed_rows: 1,
+    };
+
+    const { unmount } = render(<HedgeFundSignalsShell />);
+
+    expect(screen.queryByRole("button", { name: "Execute accepted dry-run" })).not.toBeInTheDocument();
+    unmount();
+
+    promotionDryRunVerificationMock = promotionDryRunVerification;
+    promotionDryRunAcceptancesMock = [promotionDryRunAcceptances[0]];
+    promotionExecutionsMock = promotionExecutions;
+
+    render(<HedgeFundSignalsShell />);
+
+    expect(screen.queryByRole("button", { name: "Execute accepted dry-run" })).not.toBeInTheDocument();
   });
 });

--- a/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
+++ b/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
@@ -41,6 +41,7 @@ import {
 import {
   useCreateFinancialShadowDecisionRecord,
   useCreateFinancialPromotionDryRunAcceptance,
+  useExecuteFinancialPromotionDryRunAcceptance,
   useFinancialLatestSignals,
   useFinancialDailyCalibration,
   useFinancialPromotionGate,
@@ -69,6 +70,7 @@ import type {
   FinancialPromotionDryRunVerificationResponse,
   FinancialPromotionDryRunVerificationStatus,
   FinancialPromotionExecution,
+  FinancialPromotionExecutionCreate,
   FinancialPromotionExecutionRollbackCreate,
   FinancialPromotionRollbackDrill,
   FinancialPromotionRollbackEligibility,
@@ -1543,6 +1545,8 @@ function PromotionDryRunPanel({
   rollbackDrillsLoading,
   onSubmitAcceptance,
   submittingAcceptance,
+  onSubmitExecution,
+  submittingExecution,
   onSubmitRollback,
   submittingRollback,
 }: {
@@ -1560,11 +1564,16 @@ function PromotionDryRunPanel({
   rollbackDrillsLoading: boolean;
   onSubmitAcceptance: (payload: FinancialPromotionDryRunAcceptanceCreate) => Promise<void>;
   submittingAcceptance: boolean;
+  onSubmitExecution: (payload: FinancialPromotionExecutionCreate) => Promise<void>;
+  submittingExecution: boolean;
   onSubmitRollback: (payload: FinancialPromotionExecutionRollbackCreate) => Promise<void>;
   submittingRollback: boolean;
 }) {
   const [acceptedBy, setAcceptedBy] = useState("Gary Knight");
   const [acceptanceRationale, setAcceptanceRationale] = useState("");
+  const [executionOperatorToken, setExecutionOperatorToken] = useState("");
+  const [executionRationale, setExecutionRationale] = useState("");
+  const [executionIdempotencyKey, setExecutionIdempotencyKey] = useState("");
   const [rollbackOperatorToken, setRollbackOperatorToken] = useState("");
   const [rollbackReason, setRollbackReason] = useState("");
 
@@ -1595,6 +1604,16 @@ function PromotionDryRunPanel({
   const verificationStatus = verification?.overall_status ?? null;
   const flaggedVerificationRows =
     verification?.rows.filter((row) => row.conflict_type !== "NONE" || row.row_status !== "PASS") ?? [];
+  const executedAcceptanceIds = new Set(executions.map((execution) => execution.acceptance_id));
+  const executableAcceptance =
+    acceptances.find((acceptance) => !executedAcceptanceIds.has(acceptance.id)) ?? null;
+  const effectiveExecutionIdempotencyKey = executableAcceptance
+    ? executionIdempotencyKey.trim() || `acceptance:${executableAcceptance.id}`
+    : "";
+  const showExecutionAction =
+    verificationStatus === "PASS" &&
+    Boolean(executableAcceptance) &&
+    !verificationError;
   const eligibleRollbackDrillCount = rollbackDrills.filter((drill) => drill.rollback_eligible).length;
   const canAccept =
     activeDryRun.approval.status === "ready_for_dry_run" &&
@@ -1602,6 +1621,12 @@ function PromotionDryRunPanel({
     summary.proposed_insert_count > 0 &&
     acceptedBy.trim().length >= 2 &&
     acceptanceRationale.trim().length >= 12;
+  const canExecute =
+    showExecutionAction &&
+    executionOperatorToken.trim().length >= 16 &&
+    executionRationale.trim().length >= 12 &&
+    effectiveExecutionIdempotencyKey.length >= 8 &&
+    !submittingExecution;
   const canSubmitRollback =
     rollbackOperatorToken.trim().length >= 8 &&
     rollbackReason.trim().length >= 12 &&
@@ -1620,6 +1645,22 @@ function PromotionDryRunPanel({
         min_abs_score: summary.min_abs_score,
       });
       setAcceptanceRationale("");
+    } catch {
+      // The mutation hook owns the operator-facing error toast.
+    }
+  }
+
+  async function handleExecutionSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!canExecute || !executableAcceptance) return;
+    try {
+      await onSubmitExecution({
+        dry_run_acceptance_id: executableAcceptance.id,
+        operator_token: executionOperatorToken.trim(),
+        execution_rationale: executionRationale.trim(),
+        idempotency_key: effectiveExecutionIdempotencyKey,
+      });
+      setExecutionRationale("");
     } catch {
       // The mutation hook owns the operator-facing error toast.
     }
@@ -1857,6 +1898,63 @@ function PromotionDryRunPanel({
               </div>
             ) : null}
           </form>
+
+          {showExecutionAction && executableAcceptance ? (
+            <form
+              className="border border-emerald-500/30 bg-emerald-500/5 p-3"
+              onSubmit={(event) => void handleExecutionSubmit(event)}
+            >
+              <div className="flex items-center justify-between gap-3">
+                <h2 className="text-sm font-semibold">Operator Execution</h2>
+                <Badge variant="outline" className="border-emerald-500/40 bg-emerald-500/10 text-emerald-600">
+                  Accepted
+                </Badge>
+              </div>
+              <div className="mt-3 grid gap-2 text-xs">
+                <div className="grid grid-cols-[92px_minmax(0,1fr)] gap-2">
+                  <span className="text-muted-foreground">Acceptance</span>
+                  <span className="truncate font-mono">{executableAcceptance.id}</span>
+                </div>
+                <div className="grid grid-cols-[92px_minmax(0,1fr)] gap-2">
+                  <span className="text-muted-foreground">Gate</span>
+                  <span className="font-medium">PASS</span>
+                </div>
+              </div>
+              <label className="mt-3 block space-y-1 text-xs font-medium">
+                Execution Operator Token
+                <Input
+                  value={executionOperatorToken}
+                  onChange={(event) => setExecutionOperatorToken(event.target.value)}
+                  className="h-9"
+                  type="password"
+                  autoComplete="off"
+                />
+              </label>
+              <label className="mt-3 block space-y-1 text-xs font-medium">
+                Execution Rationale
+                <textarea
+                  value={executionRationale}
+                  onChange={(event) => setExecutionRationale(event.target.value)}
+                  className="min-h-20 w-full resize-y border border-input bg-background px-3 py-2 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+                />
+              </label>
+              <label className="mt-3 block space-y-1 text-xs font-medium">
+                Execution Idempotency Key
+                <Input
+                  value={executionIdempotencyKey}
+                  onChange={(event) => setExecutionIdempotencyKey(event.target.value)}
+                  className="h-9 font-mono text-xs"
+                  placeholder={`acceptance:${executableAcceptance.id}`}
+                />
+              </label>
+              <div className="mt-3 flex justify-end">
+                <Button type="submit" disabled={!canExecute}>
+                  <ArrowUpRight className="mr-2 h-4 w-4" />
+                  {submittingExecution ? "Executing…" : "Execute accepted dry-run"}
+                </Button>
+              </div>
+            </form>
+          ) : null}
 
           <div className="border border-border p-3">
             <div className="flex items-center justify-between gap-3">
@@ -2206,6 +2304,7 @@ export function HedgeFundSignalsShell() {
   });
   const createShadowDecisionRecord = useCreateFinancialShadowDecisionRecord();
   const createPromotionDryRunAcceptance = useCreateFinancialPromotionDryRunAcceptance();
+  const executePromotionDryRunAcceptance = useExecuteFinancialPromotionDryRunAcceptance();
   const rollbackPromotionExecution = useRollbackFinancialPromotionExecution();
   const signals = latest.data ?? EMPTY_SIGNALS;
   const alertRows = transitions.data ?? EMPTY_TRANSITIONS;
@@ -2268,6 +2367,12 @@ export function HedgeFundSignalsShell() {
   ) {
     await createPromotionDryRunAcceptance.mutateAsync(payload);
     void promotionDryRunAcceptances.refetch();
+  }
+
+  async function handlePromotionExecutionSubmit(payload: FinancialPromotionExecutionCreate) {
+    await executePromotionDryRunAcceptance.mutateAsync(payload);
+    void promotionExecutions.refetch();
+    void promotionRollbackDrills.refetch();
   }
 
   async function handlePromotionRollbackSubmit(payload: FinancialPromotionExecutionRollbackCreate) {
@@ -2477,6 +2582,8 @@ export function HedgeFundSignalsShell() {
             rollbackDrillsLoading={promotionRollbackDrills.isLoading}
             onSubmitAcceptance={handlePromotionDryRunAcceptanceSubmit}
             submittingAcceptance={createPromotionDryRunAcceptance.isPending}
+            onSubmitExecution={handlePromotionExecutionSubmit}
+            submittingExecution={executePromotionDryRunAcceptance.isPending}
             onSubmitRollback={handlePromotionRollbackSubmit}
             submittingRollback={rollbackPromotionExecution.isPending}
           />

--- a/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
@@ -18,6 +18,7 @@ import type {
   FinancialPromotionDryRunAcceptance,
   FinancialPromotionDryRunAcceptanceCreate,
   FinancialPromotionExecution,
+  FinancialPromotionExecutionCreate,
   FinancialPromotionExecutionRollbackCreate,
   FinancialPromotionRollbackDrill,
   FinancialPromotionDryRunVerificationResponse,
@@ -319,6 +320,34 @@ export function useFinancialPromotionRollbackDrills(params?: {
     queryFn: () =>
       api.get("/api/financial/signals/promotion-dry-run/executions/rollback-drill", params),
     staleTime: 60_000,
+  });
+}
+
+export function useExecuteFinancialPromotionDryRunAcceptance() {
+  const qc = useQueryClient();
+  return useMutation<FinancialPromotionExecution, ApiError, FinancialPromotionExecutionCreate>({
+    mutationFn: ({
+      dry_run_acceptance_id,
+      operator_token,
+      execution_rationale,
+      idempotency_key,
+    }) =>
+      api.post(
+        "/api/financial/signals/promotion-dry-run/executions",
+        {
+          acceptance_id: dry_run_acceptance_id,
+          execution_rationale,
+          idempotency_key,
+        },
+        { headers: { "X-MarketClub-Operator-Token": operator_token } },
+      ),
+    onSuccess: () => {
+      qc.invalidateQueries({
+        queryKey: ["financial", "signals", "promotion-dry-run"],
+      });
+      toast.success("Promotion execution recorded");
+    },
+    onError: (error) => toast.error(error.message || "Failed to execute dry-run promotion"),
   });
 }
 

--- a/fortress-guest-platform/apps/command-center/src/lib/types.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/types.ts
@@ -635,6 +635,13 @@ export interface FinancialPromotionExecutionRollbackCreate {
   rollback_reason: string;
 }
 
+export interface FinancialPromotionExecutionCreate {
+  dry_run_acceptance_id: string;
+  operator_token: string;
+  execution_rationale: string;
+  idempotency_key: string;
+}
+
 export interface FinancialWatchlistCandidate {
   ticker: string;
   bar_date: string;


### PR DESCRIPTION
Summary
- add cockpit operator execution form that appears only for PASS verification, an accepted dry-run, and no prior execution for that acceptance
- route execution through the backend-locked promotion execution API with operator token, rationale, and idempotency key
- add backend/API/UI tests for missing decision, missing acceptance, verification failure, duplicate retry, conflicting key, audit linkage, rollback eligibility, and hidden UI states

Tests
- PYTHONPATH=. .venv-test/bin/python -m pytest
- npm test
- npx tsc --noEmit
- npx eslint src/lib/hooks.ts src/lib/types.ts src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx src/__tests__/components/financial-hedge-fund-shell.test.tsx
- npm run build