### PR TITLE
feat(financial): add promotion audit observability

### DIFF
--- a/crog-ai-backend/alembic/versions/0010_promotion_audit_observability.py
+++ b/crog-ai-backend/alembic/versions/0010_promotion_audit_observability.py
@@ -1,0 +1,64 @@
+"""Add promotion lifecycle audit observability.
+
+Revision ID: 0010_promotion_audit_observability
+Revises: 0009_operator_rollback_action
+Create Date: 2026-05-04 12:35:00.000000
+"""
+
+from pathlib import Path
+
+from alembic import op
+
+revision = "0010_promotion_audit_observability"
+down_revision = "0009_operator_rollback_action"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    sql_path = (
+        Path(__file__).resolve().parents[2]
+        / "deploy"
+        / "sql"
+        / "marketclub_promotion_audit_observability.sql"
+    )
+    op.execute(sql_path.read_text(encoding="utf-8"))
+
+
+def downgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS hedge_fund.v_signal_promotion_reconciliation")
+    op.execute("DROP VIEW IF EXISTS hedge_fund.v_signal_promotion_lifecycle_timeline")
+    op.execute(
+        """
+        DROP TRIGGER IF EXISTS trg_signal_promotion_rollback_snapshot_hash
+        ON hedge_fund.signal_promotion_rollback_audits
+        """
+    )
+    op.execute(
+        """
+        DROP TRIGGER IF EXISTS trg_signal_promotion_execution_snapshot_hash
+        ON hedge_fund.signal_promotion_executions
+        """
+    )
+    op.execute("DROP FUNCTION IF EXISTS hedge_fund.set_signal_promotion_rollback_snapshot_hash()")
+    op.execute("DROP FUNCTION IF EXISTS hedge_fund.set_signal_promotion_execution_snapshot_hash()")
+    op.execute(
+        """
+        ALTER TABLE hedge_fund.signal_promotion_rollback_audits
+            DROP COLUMN IF EXISTS deleted_market_signal_ids_hash
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE hedge_fund.signal_promotion_executions
+            DROP COLUMN IF EXISTS inserted_market_signal_ids_hash
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE hedge_fund.signal_promotion_dry_run_acceptances
+            DROP COLUMN IF EXISTS candidate_set_hash,
+            DROP COLUMN IF EXISTS verification_payload_snapshot,
+            DROP COLUMN IF EXISTS verification_status_snapshot
+        """
+    )

--- a/crog-ai-backend/app/api/signals.py
+++ b/crog-ai-backend/app/api/signals.py
@@ -539,6 +539,36 @@ class PromotionRollbackDrill(BaseModel):
     rolled_back_at: dt.datetime | None
 
 
+class PromotionLifecycleEvent(BaseModel):
+    ts: dt.datetime
+    type: Literal[
+        "DECISION_CREATED",
+        "DRY_RUN_GENERATED",
+        "VERIFICATION_RESULT",
+        "ACCEPTANCE_CREATED",
+        "EXECUTION_COMPLETED",
+        "ROLLBACK_ELIGIBLE",
+        "ROLLBACK_COMPLETED",
+    ]
+    decision_id: UUID | None
+    acceptance_id: UUID | None
+    execution_id: UUID | None
+    candidate_id: str
+    actor: str | None
+    meta: dict[str, object]
+
+
+class PromotionReconciliation(BaseModel):
+    execution_id: UUID | None
+    acceptance_id: UUID
+    candidate_id: str
+    status: Literal["HEALTHY", "WARNING", "ERROR"]
+    checks: dict[str, Literal["PASS", "FAIL", "NA"]]
+    warnings: dict[str, object]
+    drilldown: dict[str, object]
+    explanation: str
+
+
 class SymbolChartBar(BaseModel):
     ticker: str
     bar_date: dt.date
@@ -919,6 +949,36 @@ def promotion_rollback_drills(
 ) -> list[dict[str, object]]:
     return store.promotion_rollback_drills(
         candidate_parameter_set=candidate_parameter_set,
+        limit=limit,
+    )
+
+
+@router.get(
+    "/promotion/{promotion_id}/timeline",
+    response_model=list[PromotionLifecycleEvent],
+)
+def promotion_lifecycle_timeline(
+    promotion_id: Annotated[str, Path(min_length=1, max_length=120)],
+    store: Annotated[SignalDataStore, Depends(get_signal_store)],
+    limit: Annotated[int, Query(ge=1, le=100)] = 50,
+) -> list[dict[str, object]]:
+    return store.promotion_lifecycle_timeline(
+        promotion_id=promotion_id,
+        limit=limit,
+    )
+
+
+@router.get(
+    "/promotion/{promotion_id}/reconciliation",
+    response_model=list[PromotionReconciliation],
+)
+def promotion_reconciliation(
+    promotion_id: Annotated[str, Path(min_length=1, max_length=120)],
+    store: Annotated[SignalDataStore, Depends(get_signal_store)],
+    limit: Annotated[int, Query(ge=1, le=50)] = 10,
+) -> list[dict[str, object]]:
+    return store.promotion_reconciliation(
+        promotion_id=promotion_id,
         limit=limit,
     )
 

--- a/crog-ai-backend/app/signals/repository.py
+++ b/crog-ai-backend/app/signals/repository.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import datetime as dt
+import hashlib
+import json
 from collections import Counter
 from decimal import Decimal
 from typing import Any, Protocol
@@ -152,6 +154,20 @@ class SignalDataStore(Protocol):
         self,
         *,
         candidate_parameter_set: str | None = None,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]: ...
+
+    def promotion_lifecycle_timeline(
+        self,
+        *,
+        promotion_id: str,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]: ...
+
+    def promotion_reconciliation(
+        self,
+        *,
+        promotion_id: str,
         limit: int = 10,
     ) -> list[dict[str, Any]]: ...
 
@@ -892,6 +908,15 @@ def _json_safe(value: Any) -> Any:
     if isinstance(value, list):
         return [_json_safe(item) for item in value]
     return value
+
+
+def _stable_json_hash(value: Any) -> str:
+    encoded = json.dumps(
+        _json_safe(value),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
 
 
 SHADOW_DECISION_RECORD_SELECT = """
@@ -1762,7 +1787,10 @@ def create_promotion_dry_run_acceptance(
                 min_abs_score,
                 target_table,
                 target_columns,
-                dry_run_payload
+                dry_run_payload,
+                verification_status_snapshot,
+                verification_payload_snapshot,
+                candidate_set_hash
             ) VALUES (
                 %(decision_record_id)s,
                 %(candidate_parameter_set)s,
@@ -1779,7 +1807,10 @@ def create_promotion_dry_run_acceptance(
                 %(min_abs_score)s,
                 %(target_table)s,
                 %(target_columns)s,
-                %(dry_run_payload)s
+                %(dry_run_payload)s,
+                %(verification_status_snapshot)s,
+                %(verification_payload_snapshot)s,
+                %(candidate_set_hash)s
             )
             RETURNING *
             """,
@@ -1800,6 +1831,9 @@ def create_promotion_dry_run_acceptance(
                 "target_table": dry_run["summary"]["target_table"],
                 "target_columns": dry_run["summary"]["target_columns"],
                 "dry_run_payload": Jsonb(_json_safe(dry_run)),
+                "verification_status_snapshot": verification["overall_status"],
+                "verification_payload_snapshot": Jsonb(_json_safe(verification)),
+                "candidate_set_hash": _stable_json_hash(dry_run["proposed_rows"]),
             },
         )
         row = cur.fetchone()
@@ -1985,6 +2019,97 @@ def fetch_promotion_rollback_drills(
     with conn.cursor(row_factory=dict_row) as cur:
         cur.execute(sql, params)
         return [_promotion_rollback_drill_response(dict(row)) for row in cur.fetchall()]
+
+
+PROMOTION_LIFECYCLE_TIMELINE_FIELDS = [
+    "ts",
+    "event_type",
+    "decision_id",
+    "acceptance_id",
+    "execution_id",
+    "candidate_id",
+    "actor",
+    "meta",
+]
+
+
+def fetch_promotion_lifecycle_timeline(
+    conn: psycopg.Connection,
+    *,
+    promotion_id: str,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    sql = """
+        SELECT
+            ts,
+            event_type,
+            decision_id,
+            acceptance_id,
+            execution_id,
+            candidate_id,
+            actor,
+            meta
+        FROM hedge_fund.v_signal_promotion_lifecycle_timeline
+        WHERE candidate_id = %(promotion_id)s
+           OR decision_id::TEXT = %(promotion_id)s
+           OR acceptance_id::TEXT = %(promotion_id)s
+           OR execution_id::TEXT = %(promotion_id)s
+        ORDER BY ts DESC, event_type DESC
+        LIMIT %(limit)s
+    """
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(sql, {"promotion_id": promotion_id, "limit": limit})
+        rows: list[dict[str, Any]] = []
+        for row in cur.fetchall():
+            payload = {key: row[key] for key in PROMOTION_LIFECYCLE_TIMELINE_FIELDS}
+            payload["type"] = payload.pop("event_type")
+            rows.append(payload)
+        return rows
+
+
+PROMOTION_RECONCILIATION_FIELDS = [
+    "execution_id",
+    "acceptance_id",
+    "candidate_id",
+    "status",
+    "checks",
+    "warnings",
+    "drilldown",
+    "explanation",
+]
+
+
+def fetch_promotion_reconciliation(
+    conn: psycopg.Connection,
+    *,
+    promotion_id: str,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    sql = """
+        SELECT
+            execution_id,
+            acceptance_id,
+            candidate_id,
+            status,
+            checks,
+            warnings,
+            drilldown,
+            explanation
+        FROM hedge_fund.v_signal_promotion_reconciliation
+        WHERE candidate_id = %(promotion_id)s
+           OR acceptance_id::TEXT = %(promotion_id)s
+           OR execution_id::TEXT = %(promotion_id)s
+        ORDER BY
+            CASE status WHEN 'ERROR' THEN 0 WHEN 'WARNING' THEN 1 ELSE 2 END,
+            execution_id DESC NULLS LAST
+        LIMIT %(limit)s
+    """
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(sql, {"promotion_id": promotion_id, "limit": limit})
+        return [
+            {key: row[key] for key in PROMOTION_RECONCILIATION_FIELDS}
+            for row in cur.fetchall()
+        ]
 
 
 def execute_guarded_promotion(
@@ -2449,6 +2574,34 @@ class PostgresSignalDataStore:
             return fetch_promotion_rollback_drills(
                 conn,
                 candidate_parameter_set=candidate_parameter_set,
+                limit=limit,
+            )
+
+    def promotion_lifecycle_timeline(
+        self,
+        *,
+        promotion_id: str,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        with connect() as conn:
+            conn.execute("SET default_transaction_read_only = on")
+            return fetch_promotion_lifecycle_timeline(
+                conn,
+                promotion_id=promotion_id,
+                limit=limit,
+            )
+
+    def promotion_reconciliation(
+        self,
+        *,
+        promotion_id: str,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        with connect() as conn:
+            conn.execute("SET default_transaction_read_only = on")
+            return fetch_promotion_reconciliation(
+                conn,
+                promotion_id=promotion_id,
                 limit=limit,
             )
 

--- a/crog-ai-backend/deploy/sql/marketclub_guarded_promotion_execution.sql
+++ b/crog-ai-backend/deploy/sql/marketclub_guarded_promotion_execution.sql
@@ -47,6 +47,7 @@ CREATE TABLE IF NOT EXISTS hedge_fund.signal_promotion_executions (
     verification_payload JSONB NOT NULL,
     dry_run_payload JSONB NOT NULL,
     inserted_market_signal_ids INTEGER[] NOT NULL DEFAULT ARRAY[]::INTEGER[],
+    inserted_market_signal_ids_hash TEXT,
     rollback_markers TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
     rollback_status TEXT NOT NULL DEFAULT 'active',
     rollback_operator_membership_id UUID
@@ -293,6 +294,7 @@ BEGIN
         verification_payload,
         dry_run_payload,
         inserted_market_signal_ids,
+        inserted_market_signal_ids_hash,
         rollback_markers
     ) VALUES (
         v_acceptance.id,
@@ -309,6 +311,7 @@ BEGIN
         v_verification_payload,
         v_acceptance.dry_run_payload,
         v_inserted_market_signal_ids,
+        md5(array_to_string(v_inserted_market_signal_ids, ',')),
         v_rollback_markers
     )
     RETURNING * INTO v_execution;

--- a/crog-ai-backend/deploy/sql/marketclub_operator_rollback_action.sql
+++ b/crog-ai-backend/deploy/sql/marketclub_operator_rollback_action.sql
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS hedge_fund.signal_promotion_rollback_audits (
     rollback_reason TEXT NOT NULL,
     rollback_status TEXT NOT NULL,
     deleted_market_signal_ids INTEGER[] NOT NULL DEFAULT ARRAY[]::INTEGER[],
+    deleted_market_signal_ids_hash TEXT,
     rollback_marker_count INTEGER NOT NULL DEFAULT 0,
     attempted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     completed_at TIMESTAMPTZ,
@@ -86,6 +87,7 @@ BEGIN
             rollback_reason,
             rollback_status,
             deleted_market_signal_ids,
+            deleted_market_signal_ids_hash,
             rollback_marker_count,
             completed_at
         ) VALUES (
@@ -95,6 +97,7 @@ BEGIN
             trim(p_rollback_reason),
             'already_rolled_back',
             ARRAY[]::INTEGER[],
+            md5(''),
             cardinality(v_execution.rollback_markers),
             now()
         );
@@ -132,6 +135,7 @@ BEGIN
         rollback_reason,
         rollback_status,
         deleted_market_signal_ids,
+        deleted_market_signal_ids_hash,
         rollback_marker_count,
         completed_at
     ) VALUES (
@@ -141,6 +145,7 @@ BEGIN
         trim(p_rollback_reason),
         'rolled_back',
         v_deleted_market_signal_ids,
+        md5(array_to_string(v_deleted_market_signal_ids, ',')),
         cardinality(v_execution.rollback_markers),
         v_execution.rolled_back_at
     );
@@ -149,7 +154,8 @@ BEGIN
 END;
 $$;
 
-CREATE OR REPLACE VIEW hedge_fund.v_signal_promotion_rollback_drill AS
+CREATE OR REPLACE VIEW hedge_fund.v_signal_promotion_rollback_drill
+WITH (security_invoker = true) AS
 WITH latest_rollback_audit AS (
     SELECT DISTINCT ON (a.execution_id)
         a.execution_id,
@@ -263,5 +269,8 @@ REVOKE ALL ON FUNCTION hedge_fund.rollback_guarded_signal_promotion(UUID, TEXT, 
 REVOKE ALL ON TABLE hedge_fund.signal_promotion_rollback_audits FROM PUBLIC;
 REVOKE ALL ON TABLE hedge_fund.v_signal_promotion_rollback_drill FROM PUBLIC;
 
-GRANT SELECT ON TABLE hedge_fund.v_signal_promotion_rollback_drill TO crog_ai_app;
+GRANT SELECT ON TABLE
+    hedge_fund.signal_promotion_rollback_audits,
+    hedge_fund.v_signal_promotion_rollback_drill
+TO crog_ai_app;
 GRANT EXECUTE ON FUNCTION hedge_fund.rollback_guarded_signal_promotion(UUID, TEXT, TEXT) TO crog_ai_app;

--- a/crog-ai-backend/deploy/sql/marketclub_promotion_audit_observability.sql
+++ b/crog-ai-backend/deploy/sql/marketclub_promotion_audit_observability.sql
@@ -1,0 +1,394 @@
+ALTER TABLE hedge_fund.signal_promotion_dry_run_acceptances
+    ADD COLUMN IF NOT EXISTS verification_status_snapshot TEXT,
+    ADD COLUMN IF NOT EXISTS verification_payload_snapshot JSONB,
+    ADD COLUMN IF NOT EXISTS candidate_set_hash TEXT;
+
+ALTER TABLE hedge_fund.signal_promotion_executions
+    ADD COLUMN IF NOT EXISTS inserted_market_signal_ids_hash TEXT;
+
+ALTER TABLE hedge_fund.signal_promotion_rollback_audits
+    ADD COLUMN IF NOT EXISTS deleted_market_signal_ids_hash TEXT;
+
+CREATE OR REPLACE FUNCTION hedge_fund.set_signal_promotion_execution_snapshot_hash()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = pg_catalog, hedge_fund
+AS $$
+BEGIN
+    NEW.inserted_market_signal_ids_hash :=
+        md5(array_to_string(COALESCE(NEW.inserted_market_signal_ids, ARRAY[]::INTEGER[]), ','));
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_signal_promotion_execution_snapshot_hash
+ON hedge_fund.signal_promotion_executions;
+
+CREATE TRIGGER trg_signal_promotion_execution_snapshot_hash
+BEFORE INSERT OR UPDATE OF inserted_market_signal_ids
+ON hedge_fund.signal_promotion_executions
+FOR EACH ROW
+EXECUTE FUNCTION hedge_fund.set_signal_promotion_execution_snapshot_hash();
+
+CREATE OR REPLACE FUNCTION hedge_fund.set_signal_promotion_rollback_snapshot_hash()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = pg_catalog, hedge_fund
+AS $$
+BEGIN
+    NEW.deleted_market_signal_ids_hash :=
+        md5(array_to_string(COALESCE(NEW.deleted_market_signal_ids, ARRAY[]::INTEGER[]), ','));
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_signal_promotion_rollback_snapshot_hash
+ON hedge_fund.signal_promotion_rollback_audits;
+
+CREATE TRIGGER trg_signal_promotion_rollback_snapshot_hash
+BEFORE INSERT OR UPDATE OF deleted_market_signal_ids
+ON hedge_fund.signal_promotion_rollback_audits
+FOR EACH ROW
+EXECUTE FUNCTION hedge_fund.set_signal_promotion_rollback_snapshot_hash();
+
+ALTER VIEW IF EXISTS hedge_fund.v_signal_promotion_rollback_drill
+SET (security_invoker = true);
+
+CREATE OR REPLACE VIEW hedge_fund.v_signal_promotion_lifecycle_timeline
+WITH (security_invoker = true) AS
+WITH latest_rollback_audit AS (
+    SELECT DISTINCT ON (a.execution_id)
+        a.execution_id,
+        a.rollback_status,
+        a.deleted_market_signal_ids,
+        a.deleted_market_signal_ids_hash,
+        a.rollback_marker_count,
+        a.attempted_at,
+        a.completed_at
+    FROM hedge_fund.signal_promotion_rollback_audits a
+    ORDER BY a.execution_id, a.attempted_at DESC
+),
+rollback_eligible AS (
+    SELECT
+        d.execution_id,
+        d.executed_at,
+        d.rollback_preview_count,
+        d.rollback_markers
+    FROM hedge_fund.v_signal_promotion_rollback_drill d
+    WHERE d.rollback_eligibility = 'ELIGIBLE'
+)
+SELECT
+    d.created_at AS ts,
+    'DECISION_CREATED'::TEXT AS event_type,
+    d.id AS decision_id,
+    NULL::UUID AS acceptance_id,
+    NULL::UUID AS execution_id,
+    d.candidate_parameter_set AS candidate_id,
+    d.reviewer AS actor,
+    jsonb_build_object(
+        'decision', d.decision,
+        'rationale', d.rationale,
+        'rollback_criteria', d.rollback_criteria,
+        'reviewed_tickers', d.reviewed_tickers,
+        'promotion_gate_status', d.promotion_gate_status,
+        'recommendation_status', d.recommendation_status
+    ) AS meta
+FROM hedge_fund.signal_shadow_review_decisions d
+
+UNION ALL
+
+SELECT
+    a.dry_run_generated_at AS ts,
+    'DRY_RUN_GENERATED'::TEXT AS event_type,
+    a.decision_record_id AS decision_id,
+    a.id AS acceptance_id,
+    NULL::UUID AS execution_id,
+    a.candidate_parameter_set AS candidate_id,
+    a.accepted_by AS actor,
+    jsonb_build_object(
+        'proposed_rows', a.dry_run_proposed_insert_count,
+        'bullish', a.dry_run_bullish_count,
+        'risk', a.dry_run_risk_count,
+        'candidate_signal_count', a.dry_run_candidate_signal_count,
+        'skipped_neutral', a.dry_run_skipped_neutral_count,
+        'candidate_set_hash', a.candidate_set_hash
+    ) AS meta
+FROM hedge_fund.signal_promotion_dry_run_acceptances a
+
+UNION ALL
+
+SELECT
+    a.created_at AS ts,
+    'VERIFICATION_RESULT'::TEXT AS event_type,
+    a.decision_record_id AS decision_id,
+    a.id AS acceptance_id,
+    NULL::UUID AS execution_id,
+    a.candidate_parameter_set AS candidate_id,
+    a.accepted_by AS actor,
+    jsonb_build_object(
+        'status', a.verification_status_snapshot,
+        'checked', COALESCE((a.verification_payload_snapshot ->> 'proposed_rows_checked')::INTEGER, 0),
+        'passed', COALESCE((a.verification_payload_snapshot ->> 'passed_rows')::INTEGER, 0),
+        'fail', COALESCE((a.verification_payload_snapshot ->> 'failed_rows')::INTEGER, 0),
+        'inconclusive', COALESCE((a.verification_payload_snapshot ->> 'inconclusive_rows')::INTEGER, 0),
+        'cross_model_only', COALESCE((a.verification_payload_snapshot ->> 'cross_model_diagnostic_only_rows')::INTEGER, 0)
+    ) AS meta
+FROM hedge_fund.signal_promotion_dry_run_acceptances a
+WHERE a.verification_status_snapshot IS NOT NULL
+
+UNION ALL
+
+SELECT
+    a.created_at AS ts,
+    'ACCEPTANCE_CREATED'::TEXT AS event_type,
+    a.decision_record_id AS decision_id,
+    a.id AS acceptance_id,
+    NULL::UUID AS execution_id,
+    a.candidate_parameter_set AS candidate_id,
+    a.accepted_by AS actor,
+    jsonb_build_object(
+        'rationale', a.acceptance_rationale,
+        'rollback_criteria', a.rollback_criteria,
+        'target_table', a.target_table,
+        'proposed_rows', a.dry_run_proposed_insert_count
+    ) AS meta
+FROM hedge_fund.signal_promotion_dry_run_acceptances a
+
+UNION ALL
+
+SELECT
+    e.created_at AS ts,
+    'EXECUTION_COMPLETED'::TEXT AS event_type,
+    e.decision_record_id AS decision_id,
+    e.acceptance_id,
+    e.id AS execution_id,
+    e.candidate_parameter_set AS candidate_id,
+    e.executed_by AS actor,
+    jsonb_build_object(
+        'inserted_count', cardinality(e.inserted_market_signal_ids),
+        'idempotency_key', e.idempotency_key,
+        'inserted_market_signal_ids', e.inserted_market_signal_ids,
+        'rollback_markers', e.rollback_markers,
+        'ids_hash', e.inserted_market_signal_ids_hash
+    ) AS meta
+FROM hedge_fund.signal_promotion_executions e
+
+UNION ALL
+
+SELECT
+    re.executed_at AS ts,
+    'ROLLBACK_ELIGIBLE'::TEXT AS event_type,
+    e.decision_record_id AS decision_id,
+    e.acceptance_id,
+    re.execution_id,
+    e.candidate_parameter_set AS candidate_id,
+    e.executed_by AS actor,
+    jsonb_build_object(
+        'rollback_preview_count', re.rollback_preview_count,
+        'rollback_markers', re.rollback_markers
+    ) AS meta
+FROM rollback_eligible re
+JOIN hedge_fund.signal_promotion_executions e ON e.id = re.execution_id
+
+UNION ALL
+
+SELECT
+    COALESCE(a.completed_at, a.attempted_at) AS ts,
+    'ROLLBACK_COMPLETED'::TEXT AS event_type,
+    e.decision_record_id AS decision_id,
+    e.acceptance_id,
+    a.execution_id,
+    e.candidate_parameter_set AS candidate_id,
+    e.rollback_by AS actor,
+    jsonb_build_object(
+        'removed_count', cardinality(a.deleted_market_signal_ids),
+        'removed_market_signal_ids', a.deleted_market_signal_ids,
+        'rollback_marker_count', a.rollback_marker_count,
+        'ids_hash', a.deleted_market_signal_ids_hash,
+        'rollback_status', a.rollback_status
+    ) AS meta
+FROM latest_rollback_audit a
+JOIN hedge_fund.signal_promotion_executions e ON e.id = a.execution_id
+WHERE a.rollback_status = 'rolled_back';
+
+CREATE OR REPLACE VIEW hedge_fund.v_signal_promotion_reconciliation
+WITH (security_invoker = true) AS
+WITH execution_base AS (
+    SELECT
+        e.*,
+        (
+            SELECT COALESCE(array_agg(id ORDER BY id), ARRAY[]::INTEGER[])
+            FROM unnest(e.inserted_market_signal_ids) AS id
+        ) AS inserted_ids_sorted,
+        COUNT(*) OVER (PARTITION BY e.acceptance_id) AS executions_for_acceptance,
+        COUNT(*) OVER (PARTITION BY e.acceptance_id, e.idempotency_key) AS executions_for_acceptance_key
+    FROM hedge_fund.signal_promotion_executions e
+),
+latest_rollback_audit AS (
+    SELECT DISTINCT ON (a.execution_id)
+        a.execution_id,
+        a.rollback_status,
+        a.deleted_market_signal_ids,
+        a.deleted_market_signal_ids_hash,
+        a.attempted_at,
+        a.completed_at
+    FROM hedge_fund.signal_promotion_rollback_audits a
+    ORDER BY a.execution_id, a.attempted_at DESC
+),
+row_rollup AS (
+    SELECT
+        e.id AS execution_id,
+        COALESCE(array_agg(r.market_signal_id ORDER BY r.market_signal_id)
+            FILTER (WHERE r.market_signal_id IS NOT NULL), ARRAY[]::INTEGER[]) AS audited_ids,
+        COUNT(r.market_signal_id)::INTEGER AS audited_count,
+        COALESCE(array_agg(ms.id ORDER BY ms.id)
+            FILTER (WHERE ms.id IS NOT NULL), ARRAY[]::INTEGER[]) AS live_audited_ids,
+        COUNT(ms.id)::INTEGER AS live_audited_count,
+        COUNT(DISTINCT r.market_signal_id)::INTEGER AS distinct_audited_count
+    FROM execution_base e
+    LEFT JOIN hedge_fund.signal_promotion_execution_rows r ON r.execution_id = e.id
+    LEFT JOIN hedge_fund.market_signals ms ON ms.id = r.market_signal_id
+    GROUP BY e.id
+),
+evidence_flags AS (
+    SELECT
+        d.id AS decision_id,
+        EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(COALESCE(d.evidence_payload -> 'lane_reviews', '[]'::JSONB)) lane
+            WHERE COALESCE((lane ->> 'churn_rate')::NUMERIC, 0) >= 0.50
+        ) AS high_churn_flag,
+        EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(COALESCE(d.evidence_payload -> 'whipsaw_reviews', '[]'::JSONB)) whipsaw
+            WHERE whipsaw ->> 'risk_level' IN ('high', 'elevated')
+        ) AS whipsaw_flag
+    FROM hedge_fund.signal_shadow_review_decisions d
+),
+checks AS (
+    SELECT
+        e.id AS execution_id,
+        a.id AS acceptance_id,
+        a.candidate_parameter_set AS candidate_id,
+        CASE
+            WHEN d.id IS NOT NULL
+             AND a.decision_record_id = d.id
+             AND d.candidate_parameter_set = a.candidate_parameter_set
+                THEN 'PASS'
+            ELSE 'FAIL'
+        END AS decision_link,
+        CASE
+            WHEN a.verification_status_snapshot = 'PASS'
+             AND a.verification_payload_snapshot IS NOT NULL
+                THEN 'PASS'
+            ELSE 'FAIL'
+        END AS verification_gate,
+        CASE
+            WHEN e.id IS NULL THEN 'NA'
+            WHEN e.dry_run_proposed_insert_count = r.audited_count
+             AND e.dry_run_proposed_insert_count = cardinality(e.inserted_market_signal_ids)
+                THEN 'PASS'
+            ELSE 'FAIL'
+        END AS execution_count_match,
+        CASE
+            WHEN e.id IS NULL THEN 'NA'
+            WHEN e.rollback_status = 'rolled_back' THEN 'PASS'
+            WHEN r.live_audited_count = r.audited_count
+             AND r.audited_count > 0
+                THEN 'PASS'
+            ELSE 'FAIL'
+        END AS write_integrity,
+        CASE
+            WHEN e.id IS NULL THEN 'NA'
+            WHEN e.inserted_ids_sorted = r.audited_ids
+             AND r.audited_count = r.distinct_audited_count
+                THEN 'PASS'
+            ELSE 'FAIL'
+        END AS extraneous_writes,
+        CASE
+            WHEN e.id IS NULL THEN 'NA'
+            WHEN e.rollback_status <> 'rolled_back' THEN 'NA'
+            WHEN r.live_audited_count = 0
+             AND cardinality(COALESCE(ra.deleted_market_signal_ids, ARRAY[]::INTEGER[])) = r.audited_count
+                THEN 'PASS'
+            ELSE 'FAIL'
+        END AS rollback_integrity,
+        CASE
+            WHEN e.id IS NULL THEN 'NA'
+            WHEN e.executions_for_acceptance = 1
+             AND e.executions_for_acceptance_key = 1
+             AND r.audited_count = r.distinct_audited_count
+                THEN 'PASS'
+            ELSE 'FAIL'
+        END AS idempotency,
+        COALESCE((a.verification_payload_snapshot ->> 'cross_model_diagnostic_only_rows')::INTEGER, 0)
+            AS cross_model_diagnostic_only,
+        COALESCE(flags.high_churn_flag, FALSE) AS high_churn_flag,
+        COALESCE(flags.whipsaw_flag, FALSE) AS whipsaw_flag,
+        COALESCE(r.audited_ids, ARRAY[]::INTEGER[]) AS audited_ids,
+        COALESCE(r.live_audited_ids, ARRAY[]::INTEGER[]) AS live_audited_ids,
+        COALESCE(ra.deleted_market_signal_ids, ARRAY[]::INTEGER[]) AS deleted_market_signal_ids,
+        ra.deleted_market_signal_ids_hash
+    FROM hedge_fund.signal_promotion_dry_run_acceptances a
+    LEFT JOIN execution_base e ON e.acceptance_id = a.id
+    LEFT JOIN hedge_fund.signal_shadow_review_decisions d ON d.id = a.decision_record_id
+    LEFT JOIN row_rollup r ON r.execution_id = e.id
+    LEFT JOIN latest_rollback_audit ra ON ra.execution_id = e.id
+    LEFT JOIN evidence_flags flags ON flags.decision_id = d.id
+),
+classified AS (
+    SELECT
+        *,
+        ARRAY[
+            decision_link,
+            verification_gate,
+            execution_count_match,
+            write_integrity,
+            extraneous_writes,
+            rollback_integrity,
+            idempotency
+        ] AS check_values,
+        (cross_model_diagnostic_only > 0 OR high_churn_flag OR whipsaw_flag) AS has_warning
+    FROM checks
+)
+SELECT
+    execution_id,
+    acceptance_id,
+    candidate_id,
+    CASE
+        WHEN 'FAIL' = ANY(check_values) THEN 'ERROR'
+        WHEN has_warning THEN 'WARNING'
+        ELSE 'HEALTHY'
+    END AS status,
+    jsonb_build_object(
+        'decision_link', decision_link,
+        'verification_gate', verification_gate,
+        'execution_count_match', execution_count_match,
+        'write_integrity', write_integrity,
+        'extraneous_writes', extraneous_writes,
+        'rollback_integrity', rollback_integrity,
+        'idempotency', idempotency
+    ) AS checks,
+    jsonb_build_object(
+        'cross_model_diagnostic_only', cross_model_diagnostic_only,
+        'high_churn_flag', high_churn_flag,
+        'whipsaw_flag', whipsaw_flag
+    ) AS warnings,
+    jsonb_build_object(
+        'audited_market_signal_ids', audited_ids,
+        'live_audited_market_signal_ids', live_audited_ids,
+        'removed_market_signal_ids', deleted_market_signal_ids,
+        'removed_ids_hash', deleted_market_signal_ids_hash
+    ) AS drilldown,
+    CASE
+        WHEN 'FAIL' = ANY(check_values) THEN 'One or more audited promotion invariants failed.'
+        WHEN has_warning THEN 'Promotion audit is internally consistent with non-fatal diagnostic warnings.'
+        ELSE 'Promotion audit is healthy across decision, acceptance, execution, and rollback invariants.'
+    END AS explanation
+FROM classified;
+
+GRANT SELECT ON TABLE
+    hedge_fund.signal_promotion_rollback_audits,
+    hedge_fund.v_signal_promotion_lifecycle_timeline,
+    hedge_fund.v_signal_promotion_reconciliation
+TO crog_ai_app;

--- a/crog-ai-backend/deploy/sql/marketclub_promotion_dry_run_acceptances.sql
+++ b/crog-ai-backend/deploy/sql/marketclub_promotion_dry_run_acceptances.sql
@@ -20,6 +20,9 @@ CREATE TABLE IF NOT EXISTS hedge_fund.signal_promotion_dry_run_acceptances (
     target_table TEXT NOT NULL,
     target_columns TEXT[] NOT NULL,
     dry_run_payload JSONB NOT NULL,
+    verification_status_snapshot TEXT,
+    verification_payload_snapshot JSONB,
+    candidate_set_hash TEXT,
     created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 

--- a/crog-ai-backend/deploy/sql/marketclub_rollback_drill_observability.sql
+++ b/crog-ai-backend/deploy/sql/marketclub_rollback_drill_observability.sql
@@ -1,4 +1,5 @@
-CREATE OR REPLACE VIEW hedge_fund.v_signal_promotion_rollback_drill AS
+CREATE OR REPLACE VIEW hedge_fund.v_signal_promotion_rollback_drill
+WITH (security_invoker = true) AS
 WITH audited_rows AS (
     SELECT
         e.id AS execution_id,

--- a/crog-ai-backend/docs/OPERATOR-AUDIT-PLAYBOOK.md
+++ b/crog-ai-backend/docs/OPERATOR-AUDIT-PLAYBOOK.md
@@ -1,0 +1,62 @@
+# Operator Audit Playbook
+
+This playbook describes the read-only audit surface for Hedge Fund Signals promotions.
+
+## Lifecycle Timeline
+
+Use `GET /api/financial/signals/promotion/{id}/timeline` with a candidate parameter set, decision id, dry-run acceptance id, or execution id. The timeline only emits events backed by audited rows:
+
+- `DECISION_CREATED`
+- `DRY_RUN_GENERATED`
+- `VERIFICATION_RESULT`
+- `ACCEPTANCE_CREATED`
+- `EXECUTION_COMPLETED`
+- `ROLLBACK_ELIGIBLE`
+- `ROLLBACK_COMPLETED`
+
+The timeline view is `hedge_fund.v_signal_promotion_lifecycle_timeline`.
+
+## Reconciliation
+
+Use `GET /api/financial/signals/promotion/{id}/reconciliation`. The reconciliation view is `hedge_fund.v_signal_promotion_reconciliation`.
+
+The view checks:
+
+- decision to acceptance linkage
+- acceptance verification snapshot
+- execution row count vs audited row count
+- live write integrity for non-rolled-back executions
+- audited ID integrity without ticker/date matching
+- rollback integrity when rolled back
+- idempotency for one execution per accepted dry-run
+
+Acceptance rows are included even before execution. In that state, execution,
+write, rollback, and idempotency checks are `NA`; a missing PASS verification
+snapshot still returns `ERROR`.
+
+Any failed invariant returns `ERROR`. Clean invariants with cross-model, high-churn, or whipsaw warnings return `WARNING`. Fully clean rows return `HEALTHY`.
+
+## Snapshots
+
+Acceptance records persist:
+
+- verification status snapshot
+- verification payload snapshot
+- candidate set hash
+
+Execution records persist:
+
+- inserted `market_signals` ids hash
+
+Rollback audit records persist:
+
+- removed `market_signals` ids hash
+
+These snapshots keep the audit stable if upstream scanner data changes later.
+
+## Safety Rules
+
+- Do not reconcile by ticker/date.
+- Do not auto-heal or backfill from the cockpit.
+- Use audited ids from `signal_promotion_execution_rows` for execution and rollback drilldowns.
+- Treat `CROSS_MODEL_DIAGNOSTIC_ONLY` as a warning, not an execution failure.

--- a/crog-ai-backend/tests/test_api_signals.py
+++ b/crog-ai-backend/tests/test_api_signals.py
@@ -717,6 +717,94 @@ class FakeSignalStore:
             ),
         ][:limit]
 
+    def promotion_lifecycle_timeline(
+        self,
+        *,
+        promotion_id: str,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        return [
+            {
+                "ts": dt.datetime(2026, 5, 3, 19, 0, tzinfo=dt.UTC),
+                "type": "DECISION_CREATED",
+                "decision_id": DECISION_ID,
+                "acceptance_id": None,
+                "execution_id": None,
+                "candidate_id": "dochia_v0_2_range_daily",
+                "actor": "Gary Knight",
+                "meta": {
+                    "rationale": "Keep watching lane churn and whipsaw pressure.",
+                    "risk_flags": ["churn", "whipsaw"],
+                },
+            },
+            {
+                "ts": dt.datetime(2026, 5, 3, 20, 45, tzinfo=dt.UTC),
+                "type": "ACCEPTANCE_CREATED",
+                "decision_id": DECISION_ID,
+                "acceptance_id": ACCEPTANCE_ID,
+                "execution_id": None,
+                "candidate_id": "dochia_v0_2_range_daily",
+                "actor": "Gary Knight",
+                "meta": {"proposed_rows": 2},
+            },
+            {
+                "ts": dt.datetime(2026, 5, 3, 21, 0, tzinfo=dt.UTC),
+                "type": "EXECUTION_COMPLETED",
+                "decision_id": DECISION_ID,
+                "acceptance_id": ACCEPTANCE_ID,
+                "execution_id": EXECUTION_ID,
+                "candidate_id": "dochia_v0_2_range_daily",
+                "actor": "MarketClub Operator",
+                "meta": {"inserted_count": 2, "idempotency_key": f"acceptance:{ACCEPTANCE_ID}"},
+            },
+            {
+                "ts": dt.datetime(2026, 5, 3, 21, 30, tzinfo=dt.UTC),
+                "type": "ROLLBACK_COMPLETED",
+                "decision_id": DECISION_ID,
+                "acceptance_id": ACCEPTANCE_ID,
+                "execution_id": EXECUTION_ID,
+                "candidate_id": "dochia_v0_2_range_daily",
+                "actor": "MarketClub Operator",
+                "meta": {"removed_count": 2},
+            },
+        ][:limit]
+
+    def promotion_reconciliation(
+        self,
+        *,
+        promotion_id: str,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        return [
+            {
+                "execution_id": EXECUTION_ID,
+                "acceptance_id": ACCEPTANCE_ID,
+                "candidate_id": "dochia_v0_2_range_daily",
+                "status": "HEALTHY",
+                "checks": {
+                    "decision_link": "PASS",
+                    "verification_gate": "PASS",
+                    "execution_count_match": "PASS",
+                    "write_integrity": "PASS",
+                    "extraneous_writes": "PASS",
+                    "rollback_integrity": "NA",
+                    "idempotency": "PASS",
+                },
+                "warnings": {
+                    "cross_model_diagnostic_only": 0,
+                    "high_churn_flag": False,
+                    "whipsaw_flag": False,
+                },
+                "drilldown": {
+                    "audited_market_signal_ids": [1201, 1202],
+                    "live_audited_market_signal_ids": [1201, 1202],
+                    "removed_market_signal_ids": [],
+                    "removed_ids_hash": None,
+                },
+                "explanation": "Promotion audit is healthy across audited invariants.",
+            }
+        ][:limit]
+
     def execute_guarded_promotion(
         self,
         *,
@@ -1268,6 +1356,46 @@ def test_promotion_rollback_drill_endpoint_returns_read_only_scope() -> None:
     assert payload[1]["rollback_eligible"] is False
     assert payload[1]["already_rolled_back"] is True
     assert payload[1]["rolled_back_at"] == "2026-05-03T21:30:00Z"
+
+
+def test_promotion_lifecycle_timeline_endpoint_returns_audited_events() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    response = client.get(
+        f"/api/financial/signals/promotion/{EXECUTION_ID}/timeline?limit=10"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [event["type"] for event in payload] == [
+        "DECISION_CREATED",
+        "ACCEPTANCE_CREATED",
+        "EXECUTION_COMPLETED",
+        "ROLLBACK_COMPLETED",
+    ]
+    assert payload[2]["execution_id"] == str(EXECUTION_ID)
+    assert payload[2]["meta"]["inserted_count"] == 2
+    assert payload[3]["meta"]["removed_count"] == 2
+
+
+def test_promotion_reconciliation_endpoint_returns_invariant_checks() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    response = client.get(
+        f"/api/financial/signals/promotion/{EXECUTION_ID}/reconciliation?limit=1"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload[0]["status"] == "HEALTHY"
+    assert payload[0]["checks"]["decision_link"] == "PASS"
+    assert payload[0]["checks"]["verification_gate"] == "PASS"
+    assert payload[0]["checks"]["idempotency"] == "PASS"
+    assert payload[0]["drilldown"]["audited_market_signal_ids"] == [1201, 1202]
 
 
 def test_execute_guarded_promotion_endpoint_returns_execution_record() -> None:

--- a/crog-ai-backend/tests/test_guarded_promotion_execution.py
+++ b/crog-ai-backend/tests/test_guarded_promotion_execution.py
@@ -393,6 +393,7 @@ def test_rollback_drill_preview_only_includes_audited_market_signal_ids() -> Non
     sql = _rollback_drill_sql()
 
     assert "CREATE OR REPLACE VIEW hedge_fund.v_signal_promotion_rollback_drill" in sql
+    assert "WITH (security_invoker = true) AS" in sql
     assert "LEFT JOIN hedge_fund.signal_promotion_execution_rows r" in sql
     assert "LEFT JOIN hedge_fund.market_signals ms" in sql
     assert "ON ms.id = r.market_signal_id" in sql

--- a/crog-ai-backend/tests/test_promotion_audit_observability.py
+++ b/crog-ai-backend/tests/test_promotion_audit_observability.py
@@ -1,0 +1,118 @@
+from pathlib import Path
+
+
+def _audit_sql() -> str:
+    return (
+        Path(__file__).resolve().parents[1]
+        / "deploy"
+        / "sql"
+        / "marketclub_promotion_audit_observability.sql"
+    ).read_text(encoding="utf-8")
+
+
+def test_audit_observability_adds_stable_snapshots() -> None:
+    sql = _audit_sql()
+
+    assert "verification_status_snapshot" in sql
+    assert "verification_payload_snapshot" in sql
+    assert "candidate_set_hash" in sql
+    assert "inserted_market_signal_ids_hash" in sql
+    assert "deleted_market_signal_ids_hash" in sql
+    assert "trg_signal_promotion_execution_snapshot_hash" in sql
+    assert "trg_signal_promotion_rollback_snapshot_hash" in sql
+    assert "ALTER VIEW IF EXISTS hedge_fund.v_signal_promotion_rollback_drill" in sql
+    assert "hedge_fund.signal_promotion_rollback_audits" in sql
+
+
+def test_lifecycle_timeline_uses_audited_sources_only() -> None:
+    sql = _audit_sql()
+
+    assert "CREATE OR REPLACE VIEW hedge_fund.v_signal_promotion_lifecycle_timeline" in sql
+    assert "WITH (security_invoker = true) AS" in sql
+    assert "DECISION_CREATED" in sql
+    assert "DRY_RUN_GENERATED" in sql
+    assert "VERIFICATION_RESULT" in sql
+    assert "ACCEPTANCE_CREATED" in sql
+    assert "EXECUTION_COMPLETED" in sql
+    assert "ROLLBACK_ELIGIBLE" in sql
+    assert "ROLLBACK_COMPLETED" in sql
+    assert "signal_shadow_review_decisions" in sql
+    assert "signal_promotion_dry_run_acceptances" in sql
+    assert "signal_promotion_executions" in sql
+    assert "signal_promotion_rollback_audits" in sql
+
+
+def test_reconciliation_healthy_path_requires_all_checks_pass() -> None:
+    sql = _audit_sql()
+
+    assert "CREATE OR REPLACE VIEW hedge_fund.v_signal_promotion_reconciliation" in sql
+    assert sql.count("WITH (security_invoker = true) AS") >= 2
+    assert "decision_link" in sql
+    assert "verification_gate" in sql
+    assert "execution_count_match" in sql
+    assert "write_integrity" in sql
+    assert "extraneous_writes" in sql
+    assert "rollback_integrity" in sql
+    assert "idempotency" in sql
+    assert "ELSE 'HEALTHY'" in sql
+
+
+def test_reconciliation_missing_verification_returns_error() -> None:
+    sql = _audit_sql()
+
+    assert "FROM hedge_fund.signal_promotion_dry_run_acceptances a" in sql
+    assert "LEFT JOIN execution_base e ON e.acceptance_id = a.id" in sql
+    assert "a.verification_status_snapshot = 'PASS'" in sql
+    assert "a.verification_payload_snapshot IS NOT NULL" in sql
+    assert "ELSE 'FAIL'\n        END AS verification_gate" in sql
+    assert "WHEN 'FAIL' = ANY(check_values) THEN 'ERROR'" in sql
+    assert "WHEN e.id IS NULL THEN 'NA'" in sql
+
+
+def test_reconciliation_count_mismatch_returns_error() -> None:
+    sql = _audit_sql()
+
+    assert "e.dry_run_proposed_insert_count = r.audited_count" in sql
+    assert "e.dry_run_proposed_insert_count = cardinality(e.inserted_market_signal_ids)" in sql
+    assert "END AS execution_count_match" in sql
+
+
+def test_reconciliation_extraneous_write_check_uses_audited_ids_not_ticker_date() -> None:
+    sql = _audit_sql()
+    extraneous_block = sql.split("END AS write_integrity", 1)[1].split(
+        "END AS rollback_integrity", 1
+    )[0]
+
+    assert "e.inserted_ids_sorted = r.audited_ids" in extraneous_block
+    assert "r.audited_count = r.distinct_audited_count" in extraneous_block
+    assert "ticker" not in extraneous_block.lower()
+    assert "candidate_bar_date" not in extraneous_block.lower()
+
+
+def test_reconciliation_partial_rollback_returns_error() -> None:
+    sql = _audit_sql()
+
+    assert "WHEN e.rollback_status <> 'rolled_back' THEN 'NA'" in sql
+    assert "r.live_audited_count = 0" in sql
+    assert "cardinality(COALESCE(ra.deleted_market_signal_ids" in sql
+    assert "END AS rollback_integrity" in sql
+
+
+def test_reconciliation_double_execute_attempt_keeps_idempotency_explicit() -> None:
+    sql = _audit_sql()
+
+    assert "COUNT(*) OVER (PARTITION BY e.acceptance_id) AS executions_for_acceptance" in sql
+    assert (
+        "COUNT(*) OVER (PARTITION BY e.acceptance_id, e.idempotency_key) "
+        "AS executions_for_acceptance_key"
+    ) in sql
+    assert "e.executions_for_acceptance = 1" in sql
+    assert "e.executions_for_acceptance_key = 1" in sql
+
+
+def test_reconciliation_cross_model_only_returns_warning_not_error() -> None:
+    sql = _audit_sql()
+
+    assert "cross_model_diagnostic_only" in sql
+    assert "cross_model_diagnostic_only > 0 OR high_churn_flag OR whipsaw_flag" in sql
+    assert "WHEN has_warning THEN 'WARNING'" in sql

--- a/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
+++ b/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
@@ -674,6 +674,77 @@ const promotionDryRunVerification = {
   ],
 };
 
+const promotionLifecycleTimeline = [
+  {
+    ts: "2026-05-03T21:30:00Z",
+    type: "ROLLBACK_COMPLETED",
+    decision_id: "33333333-3333-3333-3333-333333333333",
+    acceptance_id: "44444444-4444-4444-4444-444444444444",
+    execution_id: "55555555-5555-5555-5555-555555555555",
+    candidate_id: "dochia_v0_2_range_daily",
+    actor: "MarketClub Operator",
+    meta: {
+      removed_count: 2,
+      removed_market_signal_ids: [1201, 1202],
+    },
+  },
+  {
+    ts: "2026-05-03T21:00:00Z",
+    type: "EXECUTION_COMPLETED",
+    decision_id: "33333333-3333-3333-3333-333333333333",
+    acceptance_id: "44444444-4444-4444-4444-444444444444",
+    execution_id: "55555555-5555-5555-5555-555555555555",
+    candidate_id: "dochia_v0_2_range_daily",
+    actor: "MarketClub Operator",
+    meta: {
+      inserted_count: 2,
+      idempotency_key: "operator-accepted-dry-run-20260504",
+    },
+  },
+  {
+    ts: "2026-05-03T20:45:00Z",
+    type: "ACCEPTANCE_CREATED",
+    decision_id: "33333333-3333-3333-3333-333333333333",
+    acceptance_id: "44444444-4444-4444-4444-444444444444",
+    execution_id: null,
+    candidate_id: "dochia_v0_2_range_daily",
+    actor: "Gary Knight",
+    meta: {
+      proposed_rows: 2,
+    },
+  },
+];
+
+const promotionReconciliation = [
+  {
+    execution_id: "55555555-5555-5555-5555-555555555555",
+    acceptance_id: "44444444-4444-4444-4444-444444444444",
+    candidate_id: "dochia_v0_2_range_daily",
+    status: "HEALTHY",
+    checks: {
+      decision_link: "PASS",
+      verification_gate: "PASS",
+      execution_count_match: "PASS",
+      write_integrity: "PASS",
+      extraneous_writes: "PASS",
+      rollback_integrity: "NA",
+      idempotency: "PASS",
+    },
+    warnings: {
+      cross_model_diagnostic_only: 1,
+      high_churn_flag: true,
+      whipsaw_flag: true,
+    },
+    drilldown: {
+      audited_market_signal_ids: [1201, 1202],
+      live_audited_market_signal_ids: [1201, 1202],
+      removed_market_signal_ids: [1201, 1202],
+      removed_ids_hash: "audit-hash",
+    },
+    explanation: "Promotion audit is healthy across audited invariants.",
+  },
+];
+
 let promotionDryRunAcceptancesMock = promotionDryRunAcceptances;
 let promotionExecutionsMock = promotionExecutions;
 let promotionDryRunVerificationMock = promotionDryRunVerification;
@@ -787,6 +858,20 @@ vi.mock("@/lib/hooks", () => ({
     isLoading: false,
     refetch: vi.fn(),
   }),
+  useFinancialPromotionLifecycleTimeline: () => ({
+    data: promotionLifecycleTimeline,
+    isError: false,
+    isFetching: false,
+    isLoading: false,
+    refetch: vi.fn(),
+  }),
+  useFinancialPromotionReconciliation: () => ({
+    data: promotionReconciliation,
+    isError: false,
+    isFetching: false,
+    isLoading: false,
+    refetch: vi.fn(),
+  }),
   useCreateFinancialShadowDecisionRecord: () => ({
     isPending: false,
     mutateAsync: vi.fn(),
@@ -839,6 +924,16 @@ describe("HedgeFundSignalsShell", () => {
     expect(screen.getByText("market_signals Preview")).toBeInTheDocument();
     expect(screen.getByText("Ready for dry-run")).toBeInTheDocument();
     expect(screen.getByText("hedge_fund.market_signals")).toBeInTheDocument();
+    expect(screen.getByText("Lifecycle Timeline")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Latest first" })).toBeInTheDocument();
+    expect(screen.getByText("Rollback Completed")).toBeInTheDocument();
+    expect(screen.getByText("Execution Completed")).toBeInTheDocument();
+    expect(screen.getByText("Acceptance Created")).toBeInTheDocument();
+    expect(screen.getByText("Reconciliation")).toBeInTheDocument();
+    expect(screen.getByText("HEALTHY")).toBeInTheDocument();
+    expect(screen.getByText("decision link")).toBeInTheDocument();
+    expect(screen.getByText("Cross-model diagnostic")).toBeInTheDocument();
+    expect(screen.getByText("Execution Drilldown")).toBeInTheDocument();
     expect(screen.getByText("Dry-Run Verification Gate")).toBeInTheDocument();
     expect(screen.getByText("Eligible for operator dry-run acceptance review")).toBeInTheDocument();
     expect(screen.getByText("CROSS_MODEL_DIAGNOSTIC_ONLY")).toBeInTheDocument();
@@ -858,7 +953,7 @@ describe("HedgeFundSignalsShell", () => {
     expect(screen.getByText("Dry-run acceptance ID")).toBeInTheDocument();
     expect(screen.getByText("Rollback preview count")).toBeInTheDocument();
     expect(screen.getByText("Inserted market_signal IDs")).toBeInTheDocument();
-    expect(screen.getByText("1201, 1202")).toBeInTheDocument();
+    expect(screen.getAllByText("1201, 1202").length).toBeGreaterThan(0);
     expect(screen.getByText("Already rolled back")).toBeInTheDocument();
     expect(screen.getByText("No")).toBeInTheDocument();
     expect(screen.getByLabelText("Operator Token")).toBeInTheDocument();
@@ -882,7 +977,7 @@ describe("HedgeFundSignalsShell", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "v0.2 Range" }));
 
-    expect(screen.getByText("dochia_v0_2_range_daily")).toBeInTheDocument();
+    expect(screen.getAllByText("dochia_v0_2_range_daily").length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: "v0.2 Range" })).toHaveAttribute(
       "aria-pressed",
       "true",

--- a/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
+++ b/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
@@ -7,10 +7,12 @@ import {
   ArrowDownRight,
   ArrowUpRight,
   BriefcaseBusiness,
+  CircleDot,
   ClipboardCheck,
   FileSearch,
   Gauge,
   Info,
+  ListChecks,
   RefreshCw,
   Search,
   ShieldAlert,
@@ -49,6 +51,8 @@ import {
   useFinancialPromotionDryRunAcceptances,
   useFinancialPromotionDryRunVerification,
   useFinancialPromotionExecutions,
+  useFinancialPromotionLifecycleTimeline,
+  useFinancialPromotionReconciliation,
   useFinancialPromotionRollbackDrills,
   useRollbackFinancialPromotionExecution,
   useFinancialShadowDecisionRecords,
@@ -72,6 +76,8 @@ import type {
   FinancialPromotionExecution,
   FinancialPromotionExecutionCreate,
   FinancialPromotionExecutionRollbackCreate,
+  FinancialPromotionLifecycleEvent,
+  FinancialPromotionReconciliation,
   FinancialPromotionRollbackDrill,
   FinancialPromotionRollbackEligibility,
   FinancialPromotionGateGuardrailStatus,
@@ -324,6 +330,36 @@ function promotionRollbackEligibilityClasses(status: FinancialPromotionRollbackE
     return "border-sky-500/40 bg-sky-500/10 text-sky-600";
   }
   return "border-red-500/40 bg-red-500/10 text-red-600";
+}
+
+function promotionAuditStatusClasses(status: FinancialPromotionReconciliation["status"]): string {
+  if (status === "HEALTHY") return "border-emerald-500/40 bg-emerald-500/10 text-emerald-600";
+  if (status === "WARNING") return "border-amber-500/40 bg-amber-500/10 text-amber-600";
+  return "border-red-500/40 bg-red-500/10 text-red-600";
+}
+
+function promotionAuditCheckClasses(status: string): string {
+  if (status === "PASS") return "border-emerald-500/40 bg-emerald-500/10 text-emerald-600";
+  if (status === "NA") return "border-border bg-muted/30 text-muted-foreground";
+  return "border-red-500/40 bg-red-500/10 text-red-600";
+}
+
+function promotionLifecycleEventClasses(type: FinancialPromotionLifecycleEvent["type"]): string {
+  if (type === "ROLLBACK_COMPLETED" || type === "VERIFICATION_RESULT") {
+    return "border-amber-500/40 bg-amber-500/10 text-amber-600";
+  }
+  if (type === "EXECUTION_COMPLETED" || type === "ACCEPTANCE_CREATED" || type === "ROLLBACK_ELIGIBLE") {
+    return "border-emerald-500/40 bg-emerald-500/10 text-emerald-600";
+  }
+  return "border-sky-500/40 bg-sky-500/10 text-sky-600";
+}
+
+function promotionLifecycleEventLabel(type: FinancialPromotionLifecycleEvent["type"]): string {
+  return type
+    .toLowerCase()
+    .split("_")
+    .map((part) => part[0]?.toUpperCase() + part.slice(1))
+    .join(" ");
 }
 
 function formatIdList(values: number[]): string {
@@ -1530,6 +1566,199 @@ function PromotionDryRunRow({ row }: { row: FinancialPromotionDryRunMarketSignal
   );
 }
 
+function LifecycleTimeline({
+  events,
+  loading,
+  error,
+}: {
+  events: FinancialPromotionLifecycleEvent[];
+  loading: boolean;
+  error: boolean;
+}) {
+  const [latestFirst, setLatestFirst] = useState(true);
+  const orderedEvents = [...events].sort((a, b) => {
+    const delta = new Date(a.ts).getTime() - new Date(b.ts).getTime();
+    return latestFirst ? -delta : delta;
+  });
+
+  return (
+    <div className="border border-border p-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <CircleDot className="h-4 w-4 text-primary" />
+          <h2 className="text-sm font-semibold">Lifecycle Timeline</h2>
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="h-8"
+          onClick={() => setLatestFirst((value) => !value)}
+        >
+          {latestFirst ? "Latest first" : "Oldest first"}
+        </Button>
+      </div>
+
+      {error ? (
+        <p className="mt-3 text-xs text-destructive">Lifecycle audit unavailable.</p>
+      ) : loading && !events.length ? (
+        <p className="mt-3 text-xs text-muted-foreground">Loading lifecycle audit…</p>
+      ) : orderedEvents.length ? (
+        <div className="mt-3 space-y-2">
+          {orderedEvents.map((event) => (
+            <details
+              key={`${event.type}-${event.ts}-${event.execution_id ?? event.acceptance_id ?? event.decision_id}`}
+              className="border border-border/70 p-2 text-xs"
+            >
+              <summary className="flex cursor-pointer list-none items-center justify-between gap-3">
+                <span className="flex min-w-0 items-center gap-2">
+                  <Badge
+                    variant="outline"
+                    className={cn("shrink-0 text-[10px]", promotionLifecycleEventClasses(event.type))}
+                  >
+                    {promotionLifecycleEventLabel(event.type)}
+                  </Badge>
+                  <span className="truncate text-muted-foreground">{event.actor ?? "system"}</span>
+                </span>
+                <span className="shrink-0 font-mono text-[11px] text-muted-foreground">
+                  {formatDateTime(event.ts)}
+                </span>
+              </summary>
+              <div className="mt-3 grid gap-2">
+                <div className="grid grid-cols-[88px_minmax(0,1fr)] gap-2">
+                  <span className="text-muted-foreground">Candidate</span>
+                  <span className="truncate font-mono">{event.candidate_id}</span>
+                </div>
+                <div className="grid grid-cols-[88px_minmax(0,1fr)] gap-2">
+                  <span className="text-muted-foreground">Decision</span>
+                  <span className="truncate font-mono">{event.decision_id ?? "—"}</span>
+                </div>
+                <div className="grid grid-cols-[88px_minmax(0,1fr)] gap-2">
+                  <span className="text-muted-foreground">Acceptance</span>
+                  <span className="truncate font-mono">{event.acceptance_id ?? "—"}</span>
+                </div>
+                <div className="grid grid-cols-[88px_minmax(0,1fr)] gap-2">
+                  <span className="text-muted-foreground">Execution</span>
+                  <span className="truncate font-mono">{event.execution_id ?? "—"}</span>
+                </div>
+                <pre className="max-h-40 overflow-auto bg-muted/40 p-2 text-[11px] text-muted-foreground">
+                  {JSON.stringify(event.meta, null, 2)}
+                </pre>
+              </div>
+            </details>
+          ))}
+        </div>
+      ) : (
+        <p className="mt-3 text-xs text-muted-foreground">No audited lifecycle events yet.</p>
+      )}
+    </div>
+  );
+}
+
+function ReconciliationPanel({
+  reconciliations,
+  loading,
+  error,
+}: {
+  reconciliations: FinancialPromotionReconciliation[];
+  loading: boolean;
+  error: boolean;
+}) {
+  const reconciliation = reconciliations[0] ?? null;
+  const checkRows = reconciliation ? Object.entries(reconciliation.checks) : [];
+  const warnings = reconciliation?.warnings ?? {};
+  const warningRows = [
+    ["Cross-model diagnostic", warnings.cross_model_diagnostic_only ?? 0],
+    ["High churn flag", warnings.high_churn_flag ? "Yes" : "No"],
+    ["Whipsaw flag", warnings.whipsaw_flag ? "Yes" : "No"],
+  ];
+  const auditedIds = Array.isArray(reconciliation?.drilldown.audited_market_signal_ids)
+    ? reconciliation.drilldown.audited_market_signal_ids.filter(
+        (value): value is number => typeof value === "number",
+      )
+    : [];
+  const removedIds = Array.isArray(reconciliation?.drilldown.removed_market_signal_ids)
+    ? reconciliation.drilldown.removed_market_signal_ids.filter(
+        (value): value is number => typeof value === "number",
+      )
+    : [];
+
+  return (
+    <div className="border border-border p-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <ListChecks className="h-4 w-4 text-primary" />
+          <h2 className="text-sm font-semibold">Reconciliation</h2>
+        </div>
+        <Badge
+          variant="outline"
+          className={cn(
+            "font-medium",
+            reconciliation
+              ? promotionAuditStatusClasses(reconciliation.status)
+              : "border-border bg-muted/30 text-muted-foreground",
+          )}
+        >
+          {loading && !reconciliation ? "Checking" : reconciliation?.status ?? "No audit"}
+        </Badge>
+      </div>
+
+      {error ? (
+        <p className="mt-3 text-xs text-destructive">Reconciliation audit unavailable.</p>
+      ) : loading && !reconciliation ? (
+        <p className="mt-3 text-xs text-muted-foreground">Loading reconciliation…</p>
+      ) : reconciliation ? (
+        <div className="mt-3 space-y-3 text-xs">
+          <p className="text-muted-foreground">{reconciliation.explanation}</p>
+          <div className="grid gap-2">
+            {checkRows.map(([label, status]) => (
+              <div key={label} className="flex items-center justify-between gap-3 border border-border/70 p-2">
+                <span className="capitalize">{label.replaceAll("_", " ")}</span>
+                <Badge variant="outline" className={cn("text-[10px]", promotionAuditCheckClasses(status))}>
+                  {status}
+                </Badge>
+              </div>
+            ))}
+          </div>
+          <div className="grid gap-2 sm:grid-cols-3">
+            {warningRows.map(([label, value]) => (
+              <div key={label} className="bg-muted/40 p-2">
+                <span className="text-muted-foreground">{label}</span>
+                <p className="mt-1 font-mono font-semibold">{String(value)}</p>
+              </div>
+            ))}
+          </div>
+          <details className="border border-border/70 p-2">
+            <summary className="cursor-pointer list-none font-medium">Execution Drilldown</summary>
+            <div className="mt-2 space-y-2">
+              <div>
+                <span className="text-muted-foreground">Inserted / audited IDs</span>
+                <p className="mt-1 max-h-16 overflow-auto font-mono text-[11px]">
+                  {formatIdList(auditedIds)}
+                </p>
+              </div>
+              <div>
+                <span className="text-muted-foreground">Removed IDs</span>
+                <p className="mt-1 max-h-16 overflow-auto font-mono text-[11px]">
+                  {formatIdList(removedIds)}
+                </p>
+              </div>
+              <div>
+                <span className="text-muted-foreground">Removed IDs hash</span>
+                <p className="mt-1 truncate font-mono text-[11px]">
+                  {reconciliation.drilldown.removed_ids_hash ?? "—"}
+                </p>
+              </div>
+            </div>
+          </details>
+        </div>
+      ) : (
+        <p className="mt-3 text-xs text-muted-foreground">No execution reconciliation rows yet.</p>
+      )}
+    </div>
+  );
+}
+
 function PromotionDryRunPanel({
   dryRun,
   loading,
@@ -1543,6 +1772,12 @@ function PromotionDryRunPanel({
   executionsLoading,
   rollbackDrills,
   rollbackDrillsLoading,
+  lifecycleEvents,
+  lifecycleLoading,
+  lifecycleError,
+  reconciliations,
+  reconciliationLoading,
+  reconciliationError,
   onSubmitAcceptance,
   submittingAcceptance,
   onSubmitExecution,
@@ -1562,6 +1797,12 @@ function PromotionDryRunPanel({
   executionsLoading: boolean;
   rollbackDrills: FinancialPromotionRollbackDrill[];
   rollbackDrillsLoading: boolean;
+  lifecycleEvents: FinancialPromotionLifecycleEvent[];
+  lifecycleLoading: boolean;
+  lifecycleError: boolean;
+  reconciliations: FinancialPromotionReconciliation[];
+  reconciliationLoading: boolean;
+  reconciliationError: boolean;
   onSubmitAcceptance: (payload: FinancialPromotionDryRunAcceptanceCreate) => Promise<void>;
   submittingAcceptance: boolean;
   onSubmitExecution: (payload: FinancialPromotionExecutionCreate) => Promise<void>;
@@ -1725,6 +1966,19 @@ function PromotionDryRunPanel({
           <p className="text-xs text-muted-foreground">Target</p>
           <p className="mt-1 truncate font-mono text-sm font-semibold">{summary.target_table}</p>
         </div>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.9fr)]">
+        <LifecycleTimeline
+          events={lifecycleEvents}
+          loading={lifecycleLoading}
+          error={lifecycleError}
+        />
+        <ReconciliationPanel
+          reconciliations={reconciliations}
+          loading={reconciliationLoading}
+          error={reconciliationError}
+        />
       </div>
 
       <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
@@ -2302,6 +2556,16 @@ export function HedgeFundSignalsShell() {
     candidate_parameter_set: "dochia_v0_2_range_daily",
     limit: 5,
   });
+  const promotionAuditId =
+    promotionExecutions.data?.[0]?.id ??
+    promotionDryRunAcceptances.data?.[0]?.id ??
+    "dochia_v0_2_range_daily";
+  const promotionLifecycleTimeline = useFinancialPromotionLifecycleTimeline(promotionAuditId, {
+    limit: 50,
+  });
+  const promotionReconciliation = useFinancialPromotionReconciliation(promotionAuditId, {
+    limit: 5,
+  });
   const createShadowDecisionRecord = useCreateFinancialShadowDecisionRecord();
   const createPromotionDryRunAcceptance = useCreateFinancialPromotionDryRunAcceptance();
   const executePromotionDryRunAcceptance = useExecuteFinancialPromotionDryRunAcceptance();
@@ -2355,7 +2619,9 @@ export function HedgeFundSignalsShell() {
     promotionDryRunVerification.isFetching ||
     promotionDryRunAcceptances.isFetching ||
     promotionExecutions.isFetching ||
-    promotionRollbackDrills.isFetching;
+    promotionRollbackDrills.isFetching ||
+    promotionLifecycleTimeline.isFetching ||
+    promotionReconciliation.isFetching;
 
   async function handleShadowDecisionSubmit(payload: FinancialShadowReviewDecisionRecordCreate) {
     await createShadowDecisionRecord.mutateAsync(payload);
@@ -2367,18 +2633,24 @@ export function HedgeFundSignalsShell() {
   ) {
     await createPromotionDryRunAcceptance.mutateAsync(payload);
     void promotionDryRunAcceptances.refetch();
+    void promotionLifecycleTimeline.refetch();
+    void promotionReconciliation.refetch();
   }
 
   async function handlePromotionExecutionSubmit(payload: FinancialPromotionExecutionCreate) {
     await executePromotionDryRunAcceptance.mutateAsync(payload);
     void promotionExecutions.refetch();
     void promotionRollbackDrills.refetch();
+    void promotionLifecycleTimeline.refetch();
+    void promotionReconciliation.refetch();
   }
 
   async function handlePromotionRollbackSubmit(payload: FinancialPromotionExecutionRollbackCreate) {
     await rollbackPromotionExecution.mutateAsync(payload);
     void promotionExecutions.refetch();
     void promotionRollbackDrills.refetch();
+    void promotionLifecycleTimeline.refetch();
+    void promotionReconciliation.refetch();
   }
 
   return (
@@ -2436,6 +2708,8 @@ export function HedgeFundSignalsShell() {
               void promotionDryRunAcceptances.refetch();
               void promotionExecutions.refetch();
               void promotionRollbackDrills.refetch();
+              void promotionLifecycleTimeline.refetch();
+              void promotionReconciliation.refetch();
             }}
             disabled={isRefreshing}
             aria-label="Refresh hedge fund signals"
@@ -2580,6 +2854,12 @@ export function HedgeFundSignalsShell() {
             executionsLoading={promotionExecutions.isLoading}
             rollbackDrills={promotionRollbackDrills.data ?? []}
             rollbackDrillsLoading={promotionRollbackDrills.isLoading}
+            lifecycleEvents={promotionLifecycleTimeline.data ?? []}
+            lifecycleLoading={promotionLifecycleTimeline.isLoading}
+            lifecycleError={promotionLifecycleTimeline.isError}
+            reconciliations={promotionReconciliation.data ?? []}
+            reconciliationLoading={promotionReconciliation.isLoading}
+            reconciliationError={promotionReconciliation.isError}
             onSubmitAcceptance={handlePromotionDryRunAcceptanceSubmit}
             submittingAcceptance={createPromotionDryRunAcceptance.isPending}
             onSubmitExecution={handlePromotionExecutionSubmit}

--- a/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
@@ -20,6 +20,8 @@ import type {
   FinancialPromotionExecution,
   FinancialPromotionExecutionCreate,
   FinancialPromotionExecutionRollbackCreate,
+  FinancialPromotionLifecycleEvent,
+  FinancialPromotionReconciliation,
   FinancialPromotionRollbackDrill,
   FinancialPromotionDryRunVerificationResponse,
   FinancialPromotionDryRunResponse,
@@ -319,6 +321,38 @@ export function useFinancialPromotionRollbackDrills(params?: {
     queryKey: ["financial", "signals", "promotion-dry-run", "rollback-drill", params],
     queryFn: () =>
       api.get("/api/financial/signals/promotion-dry-run/executions/rollback-drill", params),
+    staleTime: 60_000,
+  });
+}
+
+export function useFinancialPromotionLifecycleTimeline(
+  promotionId: string | null,
+  params?: { limit?: number },
+) {
+  return useQuery<FinancialPromotionLifecycleEvent[]>({
+    queryKey: ["financial", "signals", "promotion", promotionId, "timeline", params],
+    queryFn: () =>
+      api.get(
+        `/api/financial/signals/promotion/${encodeURIComponent(promotionId ?? "")}/timeline`,
+        params,
+      ),
+    enabled: Boolean(promotionId),
+    staleTime: 60_000,
+  });
+}
+
+export function useFinancialPromotionReconciliation(
+  promotionId: string | null,
+  params?: { limit?: number },
+) {
+  return useQuery<FinancialPromotionReconciliation[]>({
+    queryKey: ["financial", "signals", "promotion", promotionId, "reconciliation", params],
+    queryFn: () =>
+      api.get(
+        `/api/financial/signals/promotion/${encodeURIComponent(promotionId ?? "")}/reconciliation`,
+        params,
+      ),
+    enabled: Boolean(promotionId),
     staleTime: 60_000,
   });
 }

--- a/fortress-guest-platform/apps/command-center/src/lib/types.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/types.ts
@@ -642,6 +642,51 @@ export interface FinancialPromotionExecutionCreate {
   idempotency_key: string;
 }
 
+export type FinancialPromotionLifecycleEventType =
+  | "DECISION_CREATED"
+  | "DRY_RUN_GENERATED"
+  | "VERIFICATION_RESULT"
+  | "ACCEPTANCE_CREATED"
+  | "EXECUTION_COMPLETED"
+  | "ROLLBACK_ELIGIBLE"
+  | "ROLLBACK_COMPLETED";
+
+export interface FinancialPromotionLifecycleEvent {
+  ts: string;
+  type: FinancialPromotionLifecycleEventType;
+  decision_id: string | null;
+  acceptance_id: string | null;
+  execution_id: string | null;
+  candidate_id: string;
+  actor: string | null;
+  meta: Record<string, unknown>;
+}
+
+export type FinancialPromotionReconciliationStatus = "HEALTHY" | "WARNING" | "ERROR";
+export type FinancialPromotionReconciliationCheck = "PASS" | "FAIL" | "NA";
+
+export interface FinancialPromotionReconciliation {
+  execution_id: string | null;
+  acceptance_id: string;
+  candidate_id: string;
+  status: FinancialPromotionReconciliationStatus;
+  checks: Record<string, FinancialPromotionReconciliationCheck>;
+  warnings: {
+    cross_model_diagnostic_only?: number;
+    high_churn_flag?: boolean;
+    whipsaw_flag?: boolean;
+    [key: string]: unknown;
+  };
+  drilldown: {
+    audited_market_signal_ids?: number[];
+    live_audited_market_signal_ids?: number[];
+    removed_market_signal_ids?: number[];
+    removed_ids_hash?: string | null;
+    [key: string]: unknown;
+  };
+  explanation: string;
+}
+
 export interface FinancialWatchlistCandidate {
   ticker: string;
   bar_date: string;


### PR DESCRIPTION
## Summary
- Add audited lifecycle timeline and reconciliation views for Hedge Fund signal promotions.
- Persist acceptance verification snapshots, candidate set hash, execution ids hash, and rollback ids hash.
- Add read-only timeline/reconciliation APIs and cockpit panels with audited ID drilldowns, rollback markers, warnings, and invariant checks.
- Add Operator Audit Playbook documentation.

## Safety
- New audit endpoints are read-only.
- Reconciliation uses audited IDs, not ticker/date inference.
- Views are `security_invoker` so read security/RLS is preserved.
- No auto-healing, no backfill, and no new mutate buttons were added by this slice.

## Tests
- `PYTHONPATH=. .venv-test/bin/python -m pytest`
- `PYTHONPATH=. .venv-test/bin/python -m pytest tests/test_promotion_audit_observability.py tests/test_api_signals.py tests/test_guarded_promotion_execution.py`
- `PYTHONPATH=. .venv-test/bin/python -m ruff check app/api/signals.py app/signals/repository.py tests/test_api_signals.py tests/test_promotion_audit_observability.py tests/test_guarded_promotion_execution.py`
- `npx tsc --noEmit`
- `npx eslint src/lib/hooks.ts src/lib/types.ts "src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx" src/__tests__/components/financial-hedge-fund-shell.test.tsx`
- `npm test`
- `npm test -- financial-hedge-fund-shell.test.tsx`
- `npm run build`
