### PR TITLE
feat(financial): add post-execution monitoring

### DIFF
--- a/crog-ai-backend/alembic/versions/0011_post_execution_monitoring.py
+++ b/crog-ai-backend/alembic/versions/0011_post_execution_monitoring.py
@@ -1,0 +1,29 @@
+"""Add post-execution promotion monitoring.
+
+Revision ID: 0011_post_execution_monitoring
+Revises: 0010_promotion_audit_observability
+Create Date: 2026-05-04 13:05:00.000000
+"""
+
+from pathlib import Path
+
+from alembic import op
+
+revision = "0011_post_execution_monitoring"
+down_revision = "0010_promotion_audit_observability"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    sql_path = (
+        Path(__file__).resolve().parents[2]
+        / "deploy"
+        / "sql"
+        / "marketclub_post_execution_monitoring.sql"
+    )
+    op.execute(sql_path.read_text(encoding="utf-8"))
+
+
+def downgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS hedge_fund.v_signal_promotion_post_execution_monitoring")

--- a/crog-ai-backend/app/api/signals.py
+++ b/crog-ai-backend/app/api/signals.py
@@ -569,6 +569,87 @@ class PromotionReconciliation(BaseModel):
     explanation: str
 
 
+class PromotionPostExecutionMonitoringSummary(BaseModel):
+    rows_checked: int
+    live_rows: int
+    pending_rows: int
+    healthy_rows: int
+    warning_rows: int
+    rollback_warning_rows: int
+    whipsaw_after_promotion_rows: int
+    signal_decay_rows: int
+    adverse_5d_rows: int
+    adverse_20d_rows: int
+
+
+class PromotionPostExecutionMonitoringRow(BaseModel):
+    execution_id: UUID
+    acceptance_id: UUID
+    decision_record_id: UUID
+    candidate_id: str
+    baseline_parameter_set: str
+    executed_by: str
+    executed_at: dt.datetime
+    rollback_status: Literal["active", "rolled_back"]
+    market_signal_id: int
+    market_signal_live: bool
+    ticker: str
+    action: Literal["BUY", "SELL"]
+    confidence_score: int
+    candidate_bar_date: dt.date
+    rollback_marker: str
+    candidate_score: int
+    candidate_monthly_triangle: int | None
+    candidate_weekly_triangle: int | None
+    candidate_daily_triangle: int | None
+    entry_close: Decimal | None
+    outcome_1d_bar_date: dt.date | None
+    outcome_1d_close: Decimal | None
+    outcome_1d_directional_return: Decimal | None
+    outcome_5d_bar_date: dt.date | None
+    outcome_5d_close: Decimal | None
+    outcome_5d_directional_return: Decimal | None
+    outcome_20d_bar_date: dt.date | None
+    outcome_20d_close: Decimal | None
+    outcome_20d_directional_return: Decimal | None
+    latest_candidate_bar_date: dt.date | None
+    latest_candidate_score: int | None
+    latest_monthly_triangle: int | None
+    latest_weekly_triangle: int | None
+    latest_daily_triangle: int | None
+    score_delta: int | None
+    signal_decay_flag: bool
+    signal_decay_date: dt.date | None
+    signal_decay_score: int | None
+    signal_decay_daily_triangle: int | None
+    whipsaw_after_promotion_flag: bool
+    whipsaw_transition_date: dt.date | None
+    whipsaw_transition_type: TransitionKind | None
+    whipsaw_to_score: int | None
+    drift_status: Literal[
+        "PENDING",
+        "IN_LINE",
+        "PRICE_DRIFT",
+        "SCORE_DRIFT",
+        "PRICE_AND_SCORE_DRIFT",
+    ]
+    rollback_recommendation: Literal[
+        "NO_WARNING",
+        "WATCH_WARNING",
+        "REVIEW_ROLLBACK_WARNING",
+        "NO_ACTION_ROLLED_BACK",
+    ]
+    monitoring_status: Literal["PENDING", "HEALTHY", "WARNING", "ROLLED_BACK"]
+    explanation: str
+
+
+class PromotionPostExecutionMonitoringResponse(BaseModel):
+    generated_at: dt.datetime
+    promotion_id: str
+    summary: PromotionPostExecutionMonitoringSummary
+    rows: list[PromotionPostExecutionMonitoringRow]
+
+
 class SymbolChartBar(BaseModel):
     ticker: str
     bar_date: dt.date
@@ -978,6 +1059,21 @@ def promotion_reconciliation(
     limit: Annotated[int, Query(ge=1, le=50)] = 10,
 ) -> list[dict[str, object]]:
     return store.promotion_reconciliation(
+        promotion_id=promotion_id,
+        limit=limit,
+    )
+
+
+@router.get(
+    "/promotion/{promotion_id}/monitoring",
+    response_model=PromotionPostExecutionMonitoringResponse,
+)
+def promotion_post_execution_monitoring(
+    promotion_id: Annotated[str, Path(min_length=1, max_length=120)],
+    store: Annotated[SignalDataStore, Depends(get_signal_store)],
+    limit: Annotated[int, Query(ge=1, le=500)] = 100,
+) -> dict[str, object]:
+    return store.promotion_post_execution_monitoring(
         promotion_id=promotion_id,
         limit=limit,
     )

--- a/crog-ai-backend/app/signals/repository.py
+++ b/crog-ai-backend/app/signals/repository.py
@@ -171,6 +171,13 @@ class SignalDataStore(Protocol):
         limit: int = 10,
     ) -> list[dict[str, Any]]: ...
 
+    def promotion_post_execution_monitoring(
+        self,
+        *,
+        promotion_id: str,
+        limit: int = 100,
+    ) -> dict[str, Any]: ...
+
     def execute_guarded_promotion(
         self,
         *,
@@ -2112,6 +2119,170 @@ def fetch_promotion_reconciliation(
         ]
 
 
+PROMOTION_POST_EXECUTION_MONITORING_FIELDS = [
+    "execution_id",
+    "acceptance_id",
+    "decision_record_id",
+    "candidate_id",
+    "baseline_parameter_set",
+    "executed_by",
+    "executed_at",
+    "rollback_status",
+    "market_signal_id",
+    "market_signal_live",
+    "ticker",
+    "action",
+    "confidence_score",
+    "candidate_bar_date",
+    "rollback_marker",
+    "candidate_score",
+    "candidate_monthly_triangle",
+    "candidate_weekly_triangle",
+    "candidate_daily_triangle",
+    "entry_close",
+    "outcome_1d_bar_date",
+    "outcome_1d_close",
+    "outcome_1d_directional_return",
+    "outcome_5d_bar_date",
+    "outcome_5d_close",
+    "outcome_5d_directional_return",
+    "outcome_20d_bar_date",
+    "outcome_20d_close",
+    "outcome_20d_directional_return",
+    "latest_candidate_bar_date",
+    "latest_candidate_score",
+    "latest_monthly_triangle",
+    "latest_weekly_triangle",
+    "latest_daily_triangle",
+    "score_delta",
+    "signal_decay_flag",
+    "signal_decay_date",
+    "signal_decay_score",
+    "signal_decay_daily_triangle",
+    "whipsaw_after_promotion_flag",
+    "whipsaw_transition_date",
+    "whipsaw_transition_type",
+    "whipsaw_to_score",
+    "drift_status",
+    "rollback_recommendation",
+    "monitoring_status",
+    "explanation",
+]
+
+
+def fetch_promotion_post_execution_monitoring(
+    conn: psycopg.Connection,
+    *,
+    promotion_id: str,
+    limit: int = 100,
+) -> dict[str, Any]:
+    sql = """
+        SELECT
+            execution_id,
+            acceptance_id,
+            decision_record_id,
+            candidate_id,
+            baseline_parameter_set,
+            executed_by,
+            executed_at,
+            rollback_status,
+            market_signal_id,
+            market_signal_live,
+            ticker,
+            action,
+            confidence_score,
+            candidate_bar_date,
+            rollback_marker,
+            candidate_score,
+            candidate_monthly_triangle,
+            candidate_weekly_triangle,
+            candidate_daily_triangle,
+            entry_close,
+            outcome_1d_bar_date,
+            outcome_1d_close,
+            outcome_1d_directional_return,
+            outcome_5d_bar_date,
+            outcome_5d_close,
+            outcome_5d_directional_return,
+            outcome_20d_bar_date,
+            outcome_20d_close,
+            outcome_20d_directional_return,
+            latest_candidate_bar_date,
+            latest_candidate_score,
+            latest_monthly_triangle,
+            latest_weekly_triangle,
+            latest_daily_triangle,
+            score_delta,
+            signal_decay_flag,
+            signal_decay_date,
+            signal_decay_score,
+            signal_decay_daily_triangle,
+            whipsaw_after_promotion_flag,
+            whipsaw_transition_date,
+            whipsaw_transition_type,
+            whipsaw_to_score,
+            drift_status,
+            rollback_recommendation,
+            monitoring_status,
+            explanation
+        FROM hedge_fund.v_signal_promotion_post_execution_monitoring
+        WHERE candidate_id = %(promotion_id)s
+           OR acceptance_id::TEXT = %(promotion_id)s
+           OR execution_id::TEXT = %(promotion_id)s
+        ORDER BY
+            CASE monitoring_status
+                WHEN 'WARNING' THEN 0
+                WHEN 'PENDING' THEN 1
+                WHEN 'HEALTHY' THEN 2
+                ELSE 3
+            END,
+            ABS(COALESCE(outcome_20d_directional_return, outcome_5d_directional_return, 0)) DESC,
+            ticker
+        LIMIT %(limit)s
+    """
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(sql, {"promotion_id": promotion_id, "limit": limit})
+        rows = [
+            {key: row[key] for key in PROMOTION_POST_EXECUTION_MONITORING_FIELDS}
+            for row in cur.fetchall()
+        ]
+    warning_rows = [
+        row for row in rows if row["monitoring_status"] == "WARNING"
+    ]
+    rollback_warning_rows = [
+        row for row in rows if row["rollback_recommendation"] == "REVIEW_ROLLBACK_WARNING"
+    ]
+    return {
+        "generated_at": dt.datetime.now(dt.UTC),
+        "promotion_id": promotion_id,
+        "summary": {
+            "rows_checked": len(rows),
+            "live_rows": sum(1 for row in rows if row["market_signal_live"]),
+            "pending_rows": sum(1 for row in rows if row["monitoring_status"] == "PENDING"),
+            "healthy_rows": sum(1 for row in rows if row["monitoring_status"] == "HEALTHY"),
+            "warning_rows": len(warning_rows),
+            "rollback_warning_rows": len(rollback_warning_rows),
+            "whipsaw_after_promotion_rows": sum(
+                1 for row in rows if row["whipsaw_after_promotion_flag"]
+            ),
+            "signal_decay_rows": sum(1 for row in rows if row["signal_decay_flag"]),
+            "adverse_5d_rows": sum(
+                1
+                for row in rows
+                if row["outcome_5d_directional_return"] is not None
+                and row["outcome_5d_directional_return"] < 0
+            ),
+            "adverse_20d_rows": sum(
+                1
+                for row in rows
+                if row["outcome_20d_directional_return"] is not None
+                and row["outcome_20d_directional_return"] < 0
+            ),
+        },
+        "rows": rows,
+    }
+
+
 def execute_guarded_promotion(
     conn: psycopg.Connection,
     *,
@@ -2600,6 +2771,20 @@ class PostgresSignalDataStore:
         with connect() as conn:
             conn.execute("SET default_transaction_read_only = on")
             return fetch_promotion_reconciliation(
+                conn,
+                promotion_id=promotion_id,
+                limit=limit,
+            )
+
+    def promotion_post_execution_monitoring(
+        self,
+        *,
+        promotion_id: str,
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        with connect() as conn:
+            conn.execute("SET default_transaction_read_only = on")
+            return fetch_promotion_post_execution_monitoring(
                 conn,
                 promotion_id=promotion_id,
                 limit=limit,

--- a/crog-ai-backend/deploy/sql/marketclub_post_execution_monitoring.sql
+++ b/crog-ai-backend/deploy/sql/marketclub_post_execution_monitoring.sql
@@ -1,0 +1,289 @@
+CREATE OR REPLACE VIEW hedge_fund.v_signal_promotion_post_execution_monitoring
+WITH (security_invoker = true) AS
+WITH audited_promotions AS (
+    SELECT
+        e.id AS execution_id,
+        e.acceptance_id,
+        e.decision_record_id,
+        e.candidate_parameter_set AS candidate_id,
+        e.baseline_parameter_set,
+        e.executed_by,
+        e.created_at AS executed_at,
+        e.rollback_status,
+        r.market_signal_id,
+        r.ticker,
+        r.action,
+        r.confidence_score,
+        r.candidate_bar_date,
+        r.rollback_marker,
+        r.row_payload,
+        (r.row_payload ->> 'composite_score')::INTEGER AS candidate_score,
+        (r.row_payload #>> '{lineage,explanation_payload,states,monthly}')::INTEGER
+            AS candidate_monthly_triangle,
+        (r.row_payload #>> '{lineage,explanation_payload,states,weekly}')::INTEGER
+            AS candidate_weekly_triangle,
+        (r.row_payload #>> '{lineage,explanation_payload,states,daily}')::INTEGER
+            AS candidate_daily_triangle,
+        ms.id IS NOT NULL AS market_signal_live
+    FROM hedge_fund.signal_promotion_executions e
+    JOIN hedge_fund.signal_promotion_execution_rows r
+      ON r.execution_id = e.id
+    LEFT JOIN hedge_fund.market_signals ms
+      ON ms.id = r.market_signal_id
+),
+future_bars AS (
+    SELECT
+        a.execution_id,
+        a.market_signal_id,
+        b.bar_date,
+        b.close,
+        row_number() OVER (
+            PARTITION BY a.execution_id, a.market_signal_id
+            ORDER BY b.bar_date
+        ) AS sessions_after_promotion
+    FROM audited_promotions a
+    JOIN hedge_fund.eod_bars b
+      ON b.ticker = a.ticker
+     AND b.bar_date > a.candidate_bar_date
+),
+bar_rollup AS (
+    SELECT
+        a.execution_id,
+        a.market_signal_id,
+        entry.close AS entry_close,
+        MAX(f.bar_date) FILTER (WHERE f.sessions_after_promotion = 1) AS outcome_1d_bar_date,
+        MAX(f.close) FILTER (WHERE f.sessions_after_promotion = 1) AS outcome_1d_close,
+        MAX(f.bar_date) FILTER (WHERE f.sessions_after_promotion = 5) AS outcome_5d_bar_date,
+        MAX(f.close) FILTER (WHERE f.sessions_after_promotion = 5) AS outcome_5d_close,
+        MAX(f.bar_date) FILTER (WHERE f.sessions_after_promotion = 20) AS outcome_20d_bar_date,
+        MAX(f.close) FILTER (WHERE f.sessions_after_promotion = 20) AS outcome_20d_close
+    FROM audited_promotions a
+    LEFT JOIN hedge_fund.eod_bars entry
+      ON entry.ticker = a.ticker
+     AND entry.bar_date = a.candidate_bar_date
+    LEFT JOIN future_bars f
+      ON f.execution_id = a.execution_id
+     AND f.market_signal_id = a.market_signal_id
+    GROUP BY a.execution_id, a.market_signal_id, entry.close
+),
+latest_candidate_state AS (
+    SELECT DISTINCT ON (a.execution_id, a.market_signal_id)
+        a.execution_id,
+        a.market_signal_id,
+        v.bar_date AS latest_candidate_bar_date,
+        v.composite_score AS latest_candidate_score,
+        v.monthly_state AS latest_monthly_triangle,
+        v.weekly_state AS latest_weekly_triangle,
+        v.daily_state AS latest_daily_triangle
+    FROM audited_promotions a
+    JOIN hedge_fund.v_signal_scores_composite v
+      ON v.ticker = a.ticker
+     AND v.parameter_set_name = a.candidate_id
+     AND v.bar_date >= a.candidate_bar_date
+    ORDER BY a.execution_id, a.market_signal_id, v.bar_date DESC, v.computed_at DESC
+),
+first_decay AS (
+    SELECT DISTINCT ON (a.execution_id, a.market_signal_id)
+        a.execution_id,
+        a.market_signal_id,
+        v.bar_date AS signal_decay_date,
+        v.composite_score AS signal_decay_score,
+        v.daily_state AS signal_decay_daily_triangle
+    FROM audited_promotions a
+    JOIN hedge_fund.v_signal_scores_composite v
+      ON v.ticker = a.ticker
+     AND v.parameter_set_name = a.candidate_id
+     AND v.bar_date > a.candidate_bar_date
+    WHERE (
+        a.action = 'BUY'
+        AND (v.composite_score < 50 OR v.daily_state <> 1)
+    ) OR (
+        a.action = 'SELL'
+        AND (v.composite_score > -50 OR v.daily_state <> -1)
+    )
+    ORDER BY a.execution_id, a.market_signal_id, v.bar_date ASC, v.computed_at ASC
+),
+first_whipsaw AS (
+    SELECT DISTINCT ON (a.execution_id, a.market_signal_id)
+        a.execution_id,
+        a.market_signal_id,
+        t.to_bar_date AS whipsaw_transition_date,
+        t.transition_type AS whipsaw_transition_type,
+        t.to_score AS whipsaw_to_score
+    FROM audited_promotions a
+    JOIN hedge_fund.scoring_parameters p
+      ON p.name = a.candidate_id
+    JOIN hedge_fund.signal_transitions t
+      ON t.ticker = a.ticker
+     AND t.parameter_set_id = p.id
+     AND t.to_bar_date > a.candidate_bar_date
+    LEFT JOIN bar_rollup b
+      ON b.execution_id = a.execution_id
+     AND b.market_signal_id = a.market_signal_id
+    WHERE t.to_bar_date <= COALESCE(b.outcome_5d_bar_date, a.candidate_bar_date + 10)
+      AND (
+        (a.action = 'BUY' AND (t.to_score < 0 OR (t.to_states ->> 'daily')::INTEGER = -1))
+        OR
+        (a.action = 'SELL' AND (t.to_score > 0 OR (t.to_states ->> 'daily')::INTEGER = 1))
+      )
+    ORDER BY a.execution_id, a.market_signal_id, t.to_bar_date ASC, t.detected_at ASC
+),
+monitored AS (
+    SELECT
+        a.*,
+        b.entry_close,
+        b.outcome_1d_bar_date,
+        b.outcome_1d_close,
+        CASE
+            WHEN b.entry_close IS NULL OR b.entry_close = 0 OR b.outcome_1d_close IS NULL THEN NULL
+            WHEN a.action = 'BUY' THEN (b.outcome_1d_close - b.entry_close) / b.entry_close
+            ELSE (b.entry_close - b.outcome_1d_close) / b.entry_close
+        END AS outcome_1d_directional_return,
+        b.outcome_5d_bar_date,
+        b.outcome_5d_close,
+        CASE
+            WHEN b.entry_close IS NULL OR b.entry_close = 0 OR b.outcome_5d_close IS NULL THEN NULL
+            WHEN a.action = 'BUY' THEN (b.outcome_5d_close - b.entry_close) / b.entry_close
+            ELSE (b.entry_close - b.outcome_5d_close) / b.entry_close
+        END AS outcome_5d_directional_return,
+        b.outcome_20d_bar_date,
+        b.outcome_20d_close,
+        CASE
+            WHEN b.entry_close IS NULL OR b.entry_close = 0 OR b.outcome_20d_close IS NULL THEN NULL
+            WHEN a.action = 'BUY' THEN (b.outcome_20d_close - b.entry_close) / b.entry_close
+            ELSE (b.entry_close - b.outcome_20d_close) / b.entry_close
+        END AS outcome_20d_directional_return,
+        s.latest_candidate_bar_date,
+        s.latest_candidate_score,
+        s.latest_monthly_triangle,
+        s.latest_weekly_triangle,
+        s.latest_daily_triangle,
+        s.latest_candidate_score - a.candidate_score AS score_delta,
+        d.signal_decay_date,
+        d.signal_decay_score,
+        d.signal_decay_daily_triangle,
+        d.signal_decay_date IS NOT NULL AS signal_decay_flag,
+        w.whipsaw_transition_date,
+        w.whipsaw_transition_type,
+        w.whipsaw_to_score,
+        w.whipsaw_transition_date IS NOT NULL AS whipsaw_after_promotion_flag
+    FROM audited_promotions a
+    LEFT JOIN bar_rollup b
+      ON b.execution_id = a.execution_id
+     AND b.market_signal_id = a.market_signal_id
+    LEFT JOIN latest_candidate_state s
+      ON s.execution_id = a.execution_id
+     AND s.market_signal_id = a.market_signal_id
+    LEFT JOIN first_decay d
+      ON d.execution_id = a.execution_id
+     AND d.market_signal_id = a.market_signal_id
+    LEFT JOIN first_whipsaw w
+      ON w.execution_id = a.execution_id
+     AND w.market_signal_id = a.market_signal_id
+)
+SELECT
+    execution_id,
+    acceptance_id,
+    decision_record_id,
+    candidate_id,
+    baseline_parameter_set,
+    executed_by,
+    executed_at,
+    rollback_status,
+    market_signal_id,
+    market_signal_live,
+    ticker,
+    action,
+    confidence_score,
+    candidate_bar_date,
+    rollback_marker,
+    candidate_score,
+    candidate_monthly_triangle,
+    candidate_weekly_triangle,
+    candidate_daily_triangle,
+    entry_close,
+    outcome_1d_bar_date,
+    outcome_1d_close,
+    outcome_1d_directional_return,
+    outcome_5d_bar_date,
+    outcome_5d_close,
+    outcome_5d_directional_return,
+    outcome_20d_bar_date,
+    outcome_20d_close,
+    outcome_20d_directional_return,
+    latest_candidate_bar_date,
+    latest_candidate_score,
+    latest_monthly_triangle,
+    latest_weekly_triangle,
+    latest_daily_triangle,
+    score_delta,
+    signal_decay_flag,
+    signal_decay_date,
+    signal_decay_score,
+    signal_decay_daily_triangle,
+    whipsaw_after_promotion_flag,
+    whipsaw_transition_date,
+    whipsaw_transition_type,
+    whipsaw_to_score,
+    CASE
+        WHEN outcome_5d_directional_return IS NULL
+         AND outcome_20d_directional_return IS NULL THEN 'PENDING'
+        WHEN signal_decay_flag
+         AND (
+            outcome_20d_directional_return < -0.03
+            OR (outcome_20d_directional_return IS NULL AND outcome_5d_directional_return < -0.02)
+         ) THEN 'PRICE_AND_SCORE_DRIFT'
+        WHEN signal_decay_flag THEN 'SCORE_DRIFT'
+        WHEN outcome_20d_directional_return < -0.03
+          OR (outcome_20d_directional_return IS NULL AND outcome_5d_directional_return < -0.02)
+            THEN 'PRICE_DRIFT'
+        ELSE 'IN_LINE'
+    END AS drift_status,
+    CASE
+        WHEN rollback_status = 'rolled_back' THEN 'NO_ACTION_ROLLED_BACK'
+        WHEN whipsaw_after_promotion_flag
+         AND signal_decay_flag
+         AND (
+            outcome_20d_directional_return < -0.03
+            OR outcome_5d_directional_return < -0.02
+         ) THEN 'REVIEW_ROLLBACK_WARNING'
+        WHEN whipsaw_after_promotion_flag
+          OR signal_decay_flag
+          OR outcome_20d_directional_return < -0.03
+          OR (outcome_20d_directional_return IS NULL AND outcome_5d_directional_return < -0.02)
+            THEN 'WATCH_WARNING'
+        ELSE 'NO_WARNING'
+    END AS rollback_recommendation,
+    CASE
+        WHEN rollback_status = 'rolled_back' THEN 'ROLLED_BACK'
+        WHEN outcome_1d_directional_return IS NULL
+         AND outcome_5d_directional_return IS NULL
+         AND outcome_20d_directional_return IS NULL THEN 'PENDING'
+        WHEN whipsaw_after_promotion_flag
+          OR signal_decay_flag
+          OR outcome_20d_directional_return < -0.03
+          OR (outcome_20d_directional_return IS NULL AND outcome_5d_directional_return < -0.02)
+            THEN 'WARNING'
+        ELSE 'HEALTHY'
+    END AS monitoring_status,
+    CASE
+        WHEN rollback_status = 'rolled_back'
+            THEN 'Promotion has already been rolled back; monitoring remains read-only.'
+        WHEN whipsaw_after_promotion_flag AND signal_decay_flag
+            THEN 'Candidate state whipsawed after promotion and score support decayed; rollback review warning only.'
+        WHEN whipsaw_after_promotion_flag
+            THEN 'Opposite candidate transition appeared after promotion; rollback review warning only.'
+        WHEN signal_decay_flag
+            THEN 'Candidate score or daily triangle no longer supports the promoted state; rollback review warning only.'
+        WHEN outcome_20d_directional_return < -0.03
+          OR (outcome_20d_directional_return IS NULL AND outcome_5d_directional_return < -0.02)
+            THEN 'Observed return is drifting against candidate expectation; rollback review warning only.'
+        WHEN outcome_1d_directional_return IS NULL
+         AND outcome_5d_directional_return IS NULL
+         AND outcome_20d_directional_return IS NULL
+            THEN 'Outcome windows are still pending.'
+        ELSE 'Promoted signal remains in line with monitored candidate expectations.'
+    END AS explanation
+FROM monitored;
+
+GRANT SELECT ON TABLE hedge_fund.v_signal_promotion_post_execution_monitoring TO crog_ai_app;

--- a/crog-ai-backend/docs/OPERATOR-AUDIT-PLAYBOOK.md
+++ b/crog-ai-backend/docs/OPERATOR-AUDIT-PLAYBOOK.md
@@ -36,6 +36,20 @@ snapshot still returns `ERROR`.
 
 Any failed invariant returns `ERROR`. Clean invariants with cross-model, high-churn, or whipsaw warnings return `WARNING`. Fully clean rows return `HEALTHY`.
 
+## Post-Execution Monitoring
+
+Use `GET /api/financial/signals/promotion/{id}/monitoring` with a candidate parameter set, dry-run acceptance id, or execution id. The monitoring view is `hedge_fund.v_signal_promotion_post_execution_monitoring`.
+
+The monitor is read-only and evaluates only audited execution rows:
+
+- 1-session, 5-session, and 20-session directional returns from `hedge_fund.eod_bars`
+- whipsaw-after-promotion transitions from the candidate parameter set
+- signal decay when candidate score or daily triangle no longer supports the promoted action
+- drift between observed outcomes and the candidate expectation
+- rollback recommendation warnings
+
+Rollback recommendations are warnings only. The monitoring endpoint does not call rollback functions, delete `market_signals`, create rollback audit rows, or auto-heal promotion records.
+
 ## Snapshots
 
 Acceptance records persist:

--- a/crog-ai-backend/tests/test_api_signals.py
+++ b/crog-ai-backend/tests/test_api_signals.py
@@ -805,6 +805,139 @@ class FakeSignalStore:
             }
         ][:limit]
 
+    def promotion_post_execution_monitoring(
+        self,
+        *,
+        promotion_id: str,
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        rows = [
+            {
+                "execution_id": EXECUTION_ID,
+                "acceptance_id": ACCEPTANCE_ID,
+                "decision_record_id": DECISION_ID,
+                "candidate_id": "dochia_v0_2_range_daily",
+                "baseline_parameter_set": "dochia_v0_estimated",
+                "executed_by": "MarketClub Operator",
+                "executed_at": dt.datetime(2026, 5, 3, 21, 0, tzinfo=dt.UTC),
+                "rollback_status": "active",
+                "market_signal_id": 1201,
+                "market_signal_live": True,
+                "ticker": "AA",
+                "action": "BUY",
+                "confidence_score": 80,
+                "candidate_bar_date": dt.date(2026, 4, 24),
+                "rollback_marker": "dochia-dry-run:dochia_v0_2_range_daily:AA:2026-04-24",
+                "candidate_score": 80,
+                "candidate_monthly_triangle": 1,
+                "candidate_weekly_triangle": 1,
+                "candidate_daily_triangle": 1,
+                "entry_close": Decimal("69.00"),
+                "outcome_1d_bar_date": dt.date(2026, 4, 27),
+                "outcome_1d_close": Decimal("70.00"),
+                "outcome_1d_directional_return": Decimal("0.014493"),
+                "outcome_5d_bar_date": dt.date(2026, 5, 1),
+                "outcome_5d_close": Decimal("66.00"),
+                "outcome_5d_directional_return": Decimal("-0.043478"),
+                "outcome_20d_bar_date": None,
+                "outcome_20d_close": None,
+                "outcome_20d_directional_return": None,
+                "latest_candidate_bar_date": dt.date(2026, 5, 1),
+                "latest_candidate_score": 20,
+                "latest_monthly_triangle": 1,
+                "latest_weekly_triangle": 1,
+                "latest_daily_triangle": -1,
+                "score_delta": -60,
+                "signal_decay_flag": True,
+                "signal_decay_date": dt.date(2026, 4, 30),
+                "signal_decay_score": 20,
+                "signal_decay_daily_triangle": -1,
+                "whipsaw_after_promotion_flag": True,
+                "whipsaw_transition_date": dt.date(2026, 4, 30),
+                "whipsaw_transition_type": "breakout_bearish",
+                "whipsaw_to_score": -50,
+                "drift_status": "PRICE_AND_SCORE_DRIFT",
+                "rollback_recommendation": "REVIEW_ROLLBACK_WARNING",
+                "monitoring_status": "WARNING",
+                "explanation": "Candidate state whipsawed after promotion; warning only.",
+            },
+            {
+                "execution_id": EXECUTION_ID,
+                "acceptance_id": ACCEPTANCE_ID,
+                "decision_record_id": DECISION_ID,
+                "candidate_id": "dochia_v0_2_range_daily",
+                "baseline_parameter_set": "dochia_v0_estimated",
+                "executed_by": "MarketClub Operator",
+                "executed_at": dt.datetime(2026, 5, 3, 21, 0, tzinfo=dt.UTC),
+                "rollback_status": "active",
+                "market_signal_id": 1202,
+                "market_signal_live": True,
+                "ticker": "AGIO",
+                "action": "BUY",
+                "confidence_score": 80,
+                "candidate_bar_date": dt.date(2026, 4, 24),
+                "rollback_marker": "dochia-dry-run:dochia_v0_2_range_daily:AGIO:2026-04-24",
+                "candidate_score": 80,
+                "candidate_monthly_triangle": 1,
+                "candidate_weekly_triangle": 1,
+                "candidate_daily_triangle": 1,
+                "entry_close": Decimal("32.00"),
+                "outcome_1d_bar_date": dt.date(2026, 4, 27),
+                "outcome_1d_close": Decimal("32.50"),
+                "outcome_1d_directional_return": Decimal("0.015625"),
+                "outcome_5d_bar_date": None,
+                "outcome_5d_close": None,
+                "outcome_5d_directional_return": None,
+                "outcome_20d_bar_date": None,
+                "outcome_20d_close": None,
+                "outcome_20d_directional_return": None,
+                "latest_candidate_bar_date": dt.date(2026, 4, 27),
+                "latest_candidate_score": 80,
+                "latest_monthly_triangle": 1,
+                "latest_weekly_triangle": 1,
+                "latest_daily_triangle": 1,
+                "score_delta": 0,
+                "signal_decay_flag": False,
+                "signal_decay_date": None,
+                "signal_decay_score": None,
+                "signal_decay_daily_triangle": None,
+                "whipsaw_after_promotion_flag": False,
+                "whipsaw_transition_date": None,
+                "whipsaw_transition_type": None,
+                "whipsaw_to_score": None,
+                "drift_status": "PENDING",
+                "rollback_recommendation": "NO_WARNING",
+                "monitoring_status": "PENDING",
+                "explanation": "Outcome windows are still pending.",
+            },
+        ][:limit]
+        return {
+            "generated_at": dt.datetime(2026, 5, 4, 13, 0, tzinfo=dt.UTC),
+            "promotion_id": promotion_id,
+            "summary": {
+                "rows_checked": len(rows),
+                "live_rows": sum(1 for row in rows if row["market_signal_live"]),
+                "pending_rows": sum(1 for row in rows if row["monitoring_status"] == "PENDING"),
+                "healthy_rows": sum(1 for row in rows if row["monitoring_status"] == "HEALTHY"),
+                "warning_rows": sum(1 for row in rows if row["monitoring_status"] == "WARNING"),
+                "rollback_warning_rows": sum(
+                    1 for row in rows if row["rollback_recommendation"] == "REVIEW_ROLLBACK_WARNING"
+                ),
+                "whipsaw_after_promotion_rows": sum(
+                    1 for row in rows if row["whipsaw_after_promotion_flag"]
+                ),
+                "signal_decay_rows": sum(1 for row in rows if row["signal_decay_flag"]),
+                "adverse_5d_rows": sum(
+                    1
+                    for row in rows
+                    if row["outcome_5d_directional_return"] is not None
+                    and row["outcome_5d_directional_return"] < 0
+                ),
+                "adverse_20d_rows": 0,
+            },
+            "rows": rows,
+        }
+
     def execute_guarded_promotion(
         self,
         *,
@@ -1396,6 +1529,35 @@ def test_promotion_reconciliation_endpoint_returns_invariant_checks() -> None:
     assert payload[0]["checks"]["verification_gate"] == "PASS"
     assert payload[0]["checks"]["idempotency"] == "PASS"
     assert payload[0]["drilldown"]["audited_market_signal_ids"] == [1201, 1202]
+
+
+def test_promotion_post_execution_monitoring_endpoint_returns_warning_only_tracking() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    response = client.get(
+        f"/api/financial/signals/promotion/{EXECUTION_ID}/monitoring?limit=10"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["promotion_id"] == str(EXECUTION_ID)
+    assert payload["summary"]["rows_checked"] == 2
+    assert payload["summary"]["warning_rows"] == 1
+    assert payload["summary"]["rollback_warning_rows"] == 1
+    assert payload["summary"]["whipsaw_after_promotion_rows"] == 1
+    assert payload["summary"]["signal_decay_rows"] == 1
+    warning = payload["rows"][0]
+    assert warning["ticker"] == "AA"
+    assert warning["outcome_1d_directional_return"] == "0.014493"
+    assert warning["outcome_5d_directional_return"] == "-0.043478"
+    assert warning["outcome_20d_directional_return"] is None
+    assert warning["whipsaw_after_promotion_flag"] is True
+    assert warning["signal_decay_flag"] is True
+    assert warning["drift_status"] == "PRICE_AND_SCORE_DRIFT"
+    assert warning["rollback_recommendation"] == "REVIEW_ROLLBACK_WARNING"
+    assert "warning" in warning["explanation"].lower()
 
 
 def test_execute_guarded_promotion_endpoint_returns_execution_record() -> None:

--- a/crog-ai-backend/tests/test_post_execution_monitoring.py
+++ b/crog-ai-backend/tests/test_post_execution_monitoring.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+
+
+def _monitoring_sql() -> str:
+    return (
+        Path(__file__).resolve().parents[1]
+        / "deploy"
+        / "sql"
+        / "marketclub_post_execution_monitoring.sql"
+    ).read_text(encoding="utf-8")
+
+
+def test_post_execution_monitoring_view_is_read_only_and_audited() -> None:
+    sql = _monitoring_sql()
+
+    assert "CREATE OR REPLACE VIEW hedge_fund.v_signal_promotion_post_execution_monitoring" in sql
+    assert "WITH (security_invoker = true) AS" in sql
+    assert "FROM hedge_fund.signal_promotion_executions e" in sql
+    assert "JOIN hedge_fund.signal_promotion_execution_rows r" in sql
+    assert "r.market_signal_id" in sql
+    assert "candidate_bar_date" in sql
+    assert "GRANT SELECT ON TABLE hedge_fund.v_signal_promotion_post_execution_monitoring" in sql
+    assert "INSERT INTO hedge_fund.market_signals" not in sql
+    assert "DELETE FROM hedge_fund.market_signals" not in sql
+    assert "UPDATE hedge_fund.signal_promotion_executions" not in sql
+
+
+def test_post_execution_monitoring_tracks_required_outcome_windows() -> None:
+    sql = _monitoring_sql()
+
+    assert "sessions_after_promotion = 1" in sql
+    assert "sessions_after_promotion = 5" in sql
+    assert "sessions_after_promotion = 20" in sql
+    assert "outcome_1d_directional_return" in sql
+    assert "outcome_5d_directional_return" in sql
+    assert "outcome_20d_directional_return" in sql
+    assert "WHEN a.action = 'BUY' THEN (b.outcome_5d_close - b.entry_close)" in sql
+    assert "ELSE (b.entry_close - b.outcome_5d_close)" in sql
+
+
+def test_post_execution_monitoring_flags_whipsaw_after_promotion() -> None:
+    sql = _monitoring_sql()
+
+    assert "first_whipsaw AS" in sql
+    assert "t.to_bar_date > a.candidate_bar_date" in sql
+    assert "t.to_bar_date <= COALESCE(b.outcome_5d_bar_date" in sql
+    assert "a.action = 'BUY' AND (t.to_score < 0" in sql
+    assert "a.action = 'SELL' AND (t.to_score > 0" in sql
+    assert "whipsaw_after_promotion_flag" in sql
+
+
+def test_post_execution_monitoring_flags_signal_decay_and_drift() -> None:
+    sql = _monitoring_sql()
+
+    assert "first_decay AS" in sql
+    assert "a.action = 'BUY'" in sql
+    assert "v.composite_score < 50 OR v.daily_state <> 1" in sql
+    assert "a.action = 'SELL'" in sql
+    assert "v.composite_score > -50 OR v.daily_state <> -1" in sql
+    assert "signal_decay_flag" in sql
+    assert "PRICE_AND_SCORE_DRIFT" in sql
+    assert "SCORE_DRIFT" in sql
+    assert "PRICE_DRIFT" in sql
+
+
+def test_post_execution_monitoring_recommends_warning_only() -> None:
+    sql = _monitoring_sql()
+
+    assert "REVIEW_ROLLBACK_WARNING" in sql
+    assert "WATCH_WARNING" in sql
+    assert "NO_WARNING" in sql
+    assert "rollback review warning only" in sql
+    assert "rollback_guarded_signal_promotion" not in sql

--- a/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
+++ b/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
@@ -745,6 +745,123 @@ const promotionReconciliation = [
   },
 ];
 
+const promotionPostExecutionMonitoring = {
+  generated_at: "2026-05-04T13:00:00Z",
+  promotion_id: "55555555-5555-5555-5555-555555555555",
+  summary: {
+    rows_checked: 2,
+    live_rows: 2,
+    pending_rows: 1,
+    healthy_rows: 0,
+    warning_rows: 1,
+    rollback_warning_rows: 1,
+    whipsaw_after_promotion_rows: 1,
+    signal_decay_rows: 1,
+    adverse_5d_rows: 1,
+    adverse_20d_rows: 0,
+  },
+  rows: [
+    {
+      execution_id: "55555555-5555-5555-5555-555555555555",
+      acceptance_id: "44444444-4444-4444-4444-444444444444",
+      decision_record_id: "33333333-3333-3333-3333-333333333333",
+      candidate_id: "dochia_v0_2_range_daily",
+      baseline_parameter_set: "dochia_v0_estimated",
+      executed_by: "MarketClub Operator",
+      executed_at: "2026-05-03T21:00:00Z",
+      rollback_status: "active",
+      market_signal_id: 1201,
+      market_signal_live: true,
+      ticker: "AA",
+      action: "BUY",
+      confidence_score: 80,
+      candidate_bar_date: "2026-04-24",
+      rollback_marker: "dochia-dry-run:dochia_v0_2_range_daily:AA:2026-04-24",
+      candidate_score: 80,
+      candidate_monthly_triangle: 1,
+      candidate_weekly_triangle: 1,
+      candidate_daily_triangle: 1,
+      entry_close: "69.00",
+      outcome_1d_bar_date: "2026-04-27",
+      outcome_1d_close: "70.00",
+      outcome_1d_directional_return: "0.014493",
+      outcome_5d_bar_date: "2026-05-01",
+      outcome_5d_close: "66.00",
+      outcome_5d_directional_return: "-0.043478",
+      outcome_20d_bar_date: null,
+      outcome_20d_close: null,
+      outcome_20d_directional_return: null,
+      latest_candidate_bar_date: "2026-05-01",
+      latest_candidate_score: 20,
+      latest_monthly_triangle: 1,
+      latest_weekly_triangle: 1,
+      latest_daily_triangle: -1,
+      score_delta: -60,
+      signal_decay_flag: true,
+      signal_decay_date: "2026-04-30",
+      signal_decay_score: 20,
+      signal_decay_daily_triangle: -1,
+      whipsaw_after_promotion_flag: true,
+      whipsaw_transition_date: "2026-04-30",
+      whipsaw_transition_type: "breakout_bearish",
+      whipsaw_to_score: -50,
+      drift_status: "PRICE_AND_SCORE_DRIFT",
+      rollback_recommendation: "REVIEW_ROLLBACK_WARNING",
+      monitoring_status: "WARNING",
+      explanation: "Candidate state whipsawed after promotion; rollback review warning only.",
+    },
+    {
+      execution_id: "55555555-5555-5555-5555-555555555555",
+      acceptance_id: "44444444-4444-4444-4444-444444444444",
+      decision_record_id: "33333333-3333-3333-3333-333333333333",
+      candidate_id: "dochia_v0_2_range_daily",
+      baseline_parameter_set: "dochia_v0_estimated",
+      executed_by: "MarketClub Operator",
+      executed_at: "2026-05-03T21:00:00Z",
+      rollback_status: "active",
+      market_signal_id: 1202,
+      market_signal_live: true,
+      ticker: "AGIO",
+      action: "BUY",
+      confidence_score: 80,
+      candidate_bar_date: "2026-04-24",
+      rollback_marker: "dochia-dry-run:dochia_v0_2_range_daily:AGIO:2026-04-24",
+      candidate_score: 80,
+      candidate_monthly_triangle: 1,
+      candidate_weekly_triangle: 1,
+      candidate_daily_triangle: 1,
+      entry_close: "32.00",
+      outcome_1d_bar_date: "2026-04-27",
+      outcome_1d_close: "32.50",
+      outcome_1d_directional_return: "0.015625",
+      outcome_5d_bar_date: null,
+      outcome_5d_close: null,
+      outcome_5d_directional_return: null,
+      outcome_20d_bar_date: null,
+      outcome_20d_close: null,
+      outcome_20d_directional_return: null,
+      latest_candidate_bar_date: "2026-04-27",
+      latest_candidate_score: 80,
+      latest_monthly_triangle: 1,
+      latest_weekly_triangle: 1,
+      latest_daily_triangle: 1,
+      score_delta: 0,
+      signal_decay_flag: false,
+      signal_decay_date: null,
+      signal_decay_score: null,
+      signal_decay_daily_triangle: null,
+      whipsaw_after_promotion_flag: false,
+      whipsaw_transition_date: null,
+      whipsaw_transition_type: null,
+      whipsaw_to_score: null,
+      drift_status: "PENDING",
+      rollback_recommendation: "NO_WARNING",
+      monitoring_status: "PENDING",
+      explanation: "Outcome windows are still pending.",
+    },
+  ],
+};
+
 let promotionDryRunAcceptancesMock = promotionDryRunAcceptances;
 let promotionExecutionsMock = promotionExecutions;
 let promotionDryRunVerificationMock = promotionDryRunVerification;
@@ -872,6 +989,13 @@ vi.mock("@/lib/hooks", () => ({
     isLoading: false,
     refetch: vi.fn(),
   }),
+  useFinancialPromotionPostExecutionMonitoring: () => ({
+    data: promotionPostExecutionMonitoring,
+    isError: false,
+    isFetching: false,
+    isLoading: false,
+    refetch: vi.fn(),
+  }),
   useCreateFinancialShadowDecisionRecord: () => ({
     isPending: false,
     mutateAsync: vi.fn(),
@@ -934,6 +1058,14 @@ describe("HedgeFundSignalsShell", () => {
     expect(screen.getByText("decision link")).toBeInTheDocument();
     expect(screen.getByText("Cross-model diagnostic")).toBeInTheDocument();
     expect(screen.getByText("Execution Drilldown")).toBeInTheDocument();
+    expect(screen.getByText("Post-Execution Monitoring")).toBeInTheDocument();
+    expect(screen.getByText("1 warnings")).toBeInTheDocument();
+    expect(screen.getByText("Rollback review")).toBeInTheDocument();
+    expect(screen.getByText("Price And Score Drift")).toBeInTheDocument();
+    expect(screen.getByText("Review Rollback Warning")).toBeInTheDocument();
+    expect(screen.getByText("-4.3%")).toBeInTheDocument();
+    expect(screen.getAllByText("Whipsaw").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Decay").length).toBeGreaterThan(0);
     expect(screen.getByText("Dry-Run Verification Gate")).toBeInTheDocument();
     expect(screen.getByText("Eligible for operator dry-run acceptance review")).toBeInTheDocument();
     expect(screen.getByText("CROSS_MODEL_DIAGNOSTIC_ONLY")).toBeInTheDocument();

--- a/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
+++ b/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
@@ -52,6 +52,7 @@ import {
   useFinancialPromotionDryRunVerification,
   useFinancialPromotionExecutions,
   useFinancialPromotionLifecycleTimeline,
+  useFinancialPromotionPostExecutionMonitoring,
   useFinancialPromotionReconciliation,
   useFinancialPromotionRollbackDrills,
   useRollbackFinancialPromotionExecution,
@@ -77,6 +78,8 @@ import type {
   FinancialPromotionExecutionCreate,
   FinancialPromotionExecutionRollbackCreate,
   FinancialPromotionLifecycleEvent,
+  FinancialPromotionPostExecutionMonitoringResponse,
+  FinancialPromotionPostExecutionMonitoringRow,
   FinancialPromotionReconciliation,
   FinancialPromotionRollbackDrill,
   FinancialPromotionRollbackEligibility,
@@ -360,6 +363,27 @@ function promotionLifecycleEventLabel(type: FinancialPromotionLifecycleEvent["ty
     .split("_")
     .map((part) => part[0]?.toUpperCase() + part.slice(1))
     .join(" ");
+}
+
+function promotionMonitoringStatusClasses(status: string): string {
+  if (status === "HEALTHY") return "border-emerald-500/40 bg-emerald-500/10 text-emerald-600";
+  if (status === "WARNING") return "border-amber-500/40 bg-amber-500/10 text-amber-600";
+  if (status === "ROLLED_BACK") return "border-sky-500/40 bg-sky-500/10 text-sky-600";
+  return "border-border bg-muted/30 text-muted-foreground";
+}
+
+function promotionMonitoringLabel(value: string): string {
+  return value
+    .toLowerCase()
+    .split("_")
+    .map((part) => part[0]?.toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function numericPercent(value: string | number | null | undefined): number | null {
+  if (value === null || value === undefined) return null;
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
 }
 
 function formatIdList(values: number[]): string {
@@ -1759,6 +1783,196 @@ function ReconciliationPanel({
   );
 }
 
+function MonitoringReturnCell({
+  row,
+  windowKey,
+}: {
+  row: FinancialPromotionPostExecutionMonitoringRow;
+  windowKey: "1d" | "5d" | "20d";
+}) {
+  const value =
+    windowKey === "1d"
+      ? numericPercent(row.outcome_1d_directional_return)
+      : windowKey === "5d"
+        ? numericPercent(row.outcome_5d_directional_return)
+        : numericPercent(row.outcome_20d_directional_return);
+  const barDate =
+    windowKey === "1d"
+      ? row.outcome_1d_bar_date
+      : windowKey === "5d"
+        ? row.outcome_5d_bar_date
+        : row.outcome_20d_bar_date;
+  return (
+    <div>
+      <span className={cn("font-mono", value !== null && value < 0 ? "text-red-500" : "text-emerald-500")}>
+        {formatSignedPercent(value)}
+      </span>
+      <p className="mt-0.5 text-[11px] text-muted-foreground">{formatDate(barDate)}</p>
+    </div>
+  );
+}
+
+function PostExecutionMonitoringPanel({
+  monitoring,
+  loading,
+  error,
+}: {
+  monitoring: FinancialPromotionPostExecutionMonitoringResponse | null;
+  loading: boolean;
+  error: boolean;
+}) {
+  const summary = monitoring?.summary ?? null;
+  const rows = monitoring?.rows.slice(0, 8) ?? [];
+
+  return (
+    <div className="border border-border p-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Activity className="h-4 w-4 text-primary" />
+          <h2 className="text-sm font-semibold">Post-Execution Monitoring</h2>
+        </div>
+        <Badge
+          variant="outline"
+          className={cn(
+            "font-medium",
+            summary && summary.warning_rows > 0
+              ? "border-amber-500/40 bg-amber-500/10 text-amber-600"
+              : summary
+                ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-600"
+                : "border-border bg-muted/30 text-muted-foreground",
+          )}
+        >
+          {loading && !monitoring ? "Checking" : summary ? `${summary.warning_rows} warnings` : "No audit"}
+        </Badge>
+      </div>
+
+      {error ? (
+        <p className="mt-3 text-xs text-destructive">Post-execution monitoring unavailable.</p>
+      ) : loading && !monitoring ? (
+        <p className="mt-3 text-xs text-muted-foreground">Loading post-execution monitoring…</p>
+      ) : summary ? (
+        <div className="mt-3 space-y-3">
+          <div className="grid gap-2 sm:grid-cols-5">
+            <div className="bg-muted/40 p-2 text-xs">
+              <span className="text-muted-foreground">Tracked</span>
+              <p className="mt-1 font-mono text-lg font-semibold">{summary.rows_checked}</p>
+            </div>
+            <div className="bg-muted/40 p-2 text-xs">
+              <span className="text-muted-foreground">Pending</span>
+              <p className="mt-1 font-mono text-lg font-semibold">{summary.pending_rows}</p>
+            </div>
+            <div className="bg-muted/40 p-2 text-xs">
+              <span className="text-muted-foreground">Whipsaw</span>
+              <p className="mt-1 font-mono text-lg font-semibold">{summary.whipsaw_after_promotion_rows}</p>
+            </div>
+            <div className="bg-muted/40 p-2 text-xs">
+              <span className="text-muted-foreground">Decay</span>
+              <p className="mt-1 font-mono text-lg font-semibold">{summary.signal_decay_rows}</p>
+            </div>
+            <div className="bg-muted/40 p-2 text-xs">
+              <span className="text-muted-foreground">Rollback review</span>
+              <p className="mt-1 font-mono text-lg font-semibold">{summary.rollback_warning_rows}</p>
+            </div>
+          </div>
+
+          {rows.length ? (
+            <div className="overflow-x-auto border border-border/70">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Ticker</TableHead>
+                    <TableHead>1d</TableHead>
+                    <TableHead>5d</TableHead>
+                    <TableHead>20d</TableHead>
+                    <TableHead>Candidate Drift</TableHead>
+                    <TableHead>Warnings</TableHead>
+                    <TableHead>Rollback</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {rows.map((row) => (
+                    <TableRow key={`${row.execution_id}-${row.market_signal_id}`}>
+                      <TableCell>
+                        <div>
+                          <span className="font-mono font-semibold">{row.ticker}</span>
+                          <p className="mt-0.5 text-[11px] text-muted-foreground">
+                            {row.action} {formatSignedNumber(row.candidate_score)}
+                          </p>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <MonitoringReturnCell row={row} windowKey="1d" />
+                      </TableCell>
+                      <TableCell>
+                        <MonitoringReturnCell row={row} windowKey="5d" />
+                      </TableCell>
+                      <TableCell>
+                        <MonitoringReturnCell row={row} windowKey="20d" />
+                      </TableCell>
+                      <TableCell>
+                        <div className="space-y-1 text-xs">
+                          <Badge
+                            variant="outline"
+                            className={cn("text-[10px]", promotionMonitoringStatusClasses(row.monitoring_status))}
+                          >
+                            {promotionMonitoringLabel(row.drift_status)}
+                          </Badge>
+                          <p className="font-mono text-[11px] text-muted-foreground">
+                            {formatSignedNumber(row.score_delta)} score
+                          </p>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex flex-wrap gap-1">
+                          {row.whipsaw_after_promotion_flag ? (
+                            <Badge variant="outline" className="border-amber-500/40 bg-amber-500/10 text-amber-600">
+                              Whipsaw
+                            </Badge>
+                          ) : null}
+                          {row.signal_decay_flag ? (
+                            <Badge variant="outline" className="border-amber-500/40 bg-amber-500/10 text-amber-600">
+                              Decay
+                            </Badge>
+                          ) : null}
+                          {!row.whipsaw_after_promotion_flag && !row.signal_decay_flag ? (
+                            <span className="text-xs text-muted-foreground">—</span>
+                          ) : null}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="space-y-1">
+                          <Badge
+                            variant="outline"
+                            className={cn(
+                              "text-[10px]",
+                              row.rollback_recommendation === "REVIEW_ROLLBACK_WARNING"
+                                ? "border-amber-500/40 bg-amber-500/10 text-amber-600"
+                                : promotionMonitoringStatusClasses(row.monitoring_status),
+                            )}
+                          >
+                            {promotionMonitoringLabel(row.rollback_recommendation)}
+                          </Badge>
+                          <p className="line-clamp-2 max-w-64 text-[11px] text-muted-foreground">
+                            {row.explanation}
+                          </p>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          ) : (
+            <p className="text-xs text-muted-foreground">No promoted signal rows to monitor yet.</p>
+          )}
+        </div>
+      ) : (
+        <p className="mt-3 text-xs text-muted-foreground">No post-execution monitoring rows yet.</p>
+      )}
+    </div>
+  );
+}
+
 function PromotionDryRunPanel({
   dryRun,
   loading,
@@ -1778,6 +1992,9 @@ function PromotionDryRunPanel({
   reconciliations,
   reconciliationLoading,
   reconciliationError,
+  postExecutionMonitoring,
+  postExecutionMonitoringLoading,
+  postExecutionMonitoringError,
   onSubmitAcceptance,
   submittingAcceptance,
   onSubmitExecution,
@@ -1803,6 +2020,9 @@ function PromotionDryRunPanel({
   reconciliations: FinancialPromotionReconciliation[];
   reconciliationLoading: boolean;
   reconciliationError: boolean;
+  postExecutionMonitoring: FinancialPromotionPostExecutionMonitoringResponse | null;
+  postExecutionMonitoringLoading: boolean;
+  postExecutionMonitoringError: boolean;
   onSubmitAcceptance: (payload: FinancialPromotionDryRunAcceptanceCreate) => Promise<void>;
   submittingAcceptance: boolean;
   onSubmitExecution: (payload: FinancialPromotionExecutionCreate) => Promise<void>;
@@ -1980,6 +2200,12 @@ function PromotionDryRunPanel({
           error={reconciliationError}
         />
       </div>
+
+      <PostExecutionMonitoringPanel
+        monitoring={postExecutionMonitoring}
+        loading={postExecutionMonitoringLoading}
+        error={postExecutionMonitoringError}
+      />
 
       <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
         <div className="overflow-hidden border border-border">
@@ -2566,6 +2792,9 @@ export function HedgeFundSignalsShell() {
   const promotionReconciliation = useFinancialPromotionReconciliation(promotionAuditId, {
     limit: 5,
   });
+  const promotionPostExecutionMonitoring = useFinancialPromotionPostExecutionMonitoring(promotionAuditId, {
+    limit: 100,
+  });
   const createShadowDecisionRecord = useCreateFinancialShadowDecisionRecord();
   const createPromotionDryRunAcceptance = useCreateFinancialPromotionDryRunAcceptance();
   const executePromotionDryRunAcceptance = useExecuteFinancialPromotionDryRunAcceptance();
@@ -2621,7 +2850,8 @@ export function HedgeFundSignalsShell() {
     promotionExecutions.isFetching ||
     promotionRollbackDrills.isFetching ||
     promotionLifecycleTimeline.isFetching ||
-    promotionReconciliation.isFetching;
+    promotionReconciliation.isFetching ||
+    promotionPostExecutionMonitoring.isFetching;
 
   async function handleShadowDecisionSubmit(payload: FinancialShadowReviewDecisionRecordCreate) {
     await createShadowDecisionRecord.mutateAsync(payload);
@@ -2635,6 +2865,7 @@ export function HedgeFundSignalsShell() {
     void promotionDryRunAcceptances.refetch();
     void promotionLifecycleTimeline.refetch();
     void promotionReconciliation.refetch();
+    void promotionPostExecutionMonitoring.refetch();
   }
 
   async function handlePromotionExecutionSubmit(payload: FinancialPromotionExecutionCreate) {
@@ -2643,6 +2874,7 @@ export function HedgeFundSignalsShell() {
     void promotionRollbackDrills.refetch();
     void promotionLifecycleTimeline.refetch();
     void promotionReconciliation.refetch();
+    void promotionPostExecutionMonitoring.refetch();
   }
 
   async function handlePromotionRollbackSubmit(payload: FinancialPromotionExecutionRollbackCreate) {
@@ -2651,6 +2883,7 @@ export function HedgeFundSignalsShell() {
     void promotionRollbackDrills.refetch();
     void promotionLifecycleTimeline.refetch();
     void promotionReconciliation.refetch();
+    void promotionPostExecutionMonitoring.refetch();
   }
 
   return (
@@ -2710,6 +2943,7 @@ export function HedgeFundSignalsShell() {
               void promotionRollbackDrills.refetch();
               void promotionLifecycleTimeline.refetch();
               void promotionReconciliation.refetch();
+              void promotionPostExecutionMonitoring.refetch();
             }}
             disabled={isRefreshing}
             aria-label="Refresh hedge fund signals"
@@ -2860,6 +3094,9 @@ export function HedgeFundSignalsShell() {
             reconciliations={promotionReconciliation.data ?? []}
             reconciliationLoading={promotionReconciliation.isLoading}
             reconciliationError={promotionReconciliation.isError}
+            postExecutionMonitoring={promotionPostExecutionMonitoring.data ?? null}
+            postExecutionMonitoringLoading={promotionPostExecutionMonitoring.isLoading}
+            postExecutionMonitoringError={promotionPostExecutionMonitoring.isError}
             onSubmitAcceptance={handlePromotionDryRunAcceptanceSubmit}
             submittingAcceptance={createPromotionDryRunAcceptance.isPending}
             onSubmitExecution={handlePromotionExecutionSubmit}

--- a/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
@@ -21,6 +21,7 @@ import type {
   FinancialPromotionExecutionCreate,
   FinancialPromotionExecutionRollbackCreate,
   FinancialPromotionLifecycleEvent,
+  FinancialPromotionPostExecutionMonitoringResponse,
   FinancialPromotionReconciliation,
   FinancialPromotionRollbackDrill,
   FinancialPromotionDryRunVerificationResponse,
@@ -353,6 +354,23 @@ export function useFinancialPromotionReconciliation(
         params,
       ),
     enabled: Boolean(promotionId),
+    staleTime: 60_000,
+  });
+}
+
+export function useFinancialPromotionPostExecutionMonitoring(
+  promotionId: string | null,
+  params?: { limit?: number },
+) {
+  return useQuery<FinancialPromotionPostExecutionMonitoringResponse>({
+    queryKey: ["financial", "signals", "promotion", promotionId, "post-execution-monitoring", params],
+    queryFn: () =>
+      api.get(
+        `/api/financial/signals/promotion/${encodeURIComponent(promotionId ?? "")}/monitoring`,
+        params,
+      ),
+    enabled: Boolean(promotionId),
+    refetchInterval: 60_000,
     staleTime: 60_000,
   });
 }

--- a/fortress-guest-platform/apps/command-center/src/lib/types.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/types.ts
@@ -687,6 +687,89 @@ export interface FinancialPromotionReconciliation {
   explanation: string;
 }
 
+export type FinancialPromotionMonitoringStatus = "PENDING" | "HEALTHY" | "WARNING" | "ROLLED_BACK";
+export type FinancialPromotionMonitoringDriftStatus =
+  | "PENDING"
+  | "IN_LINE"
+  | "PRICE_DRIFT"
+  | "SCORE_DRIFT"
+  | "PRICE_AND_SCORE_DRIFT";
+export type FinancialPromotionRollbackRecommendation =
+  | "NO_WARNING"
+  | "WATCH_WARNING"
+  | "REVIEW_ROLLBACK_WARNING"
+  | "NO_ACTION_ROLLED_BACK";
+
+export interface FinancialPromotionPostExecutionMonitoringSummary {
+  rows_checked: number;
+  live_rows: number;
+  pending_rows: number;
+  healthy_rows: number;
+  warning_rows: number;
+  rollback_warning_rows: number;
+  whipsaw_after_promotion_rows: number;
+  signal_decay_rows: number;
+  adverse_5d_rows: number;
+  adverse_20d_rows: number;
+}
+
+export interface FinancialPromotionPostExecutionMonitoringRow {
+  execution_id: string;
+  acceptance_id: string;
+  decision_record_id: string;
+  candidate_id: string;
+  baseline_parameter_set: string;
+  executed_by: string;
+  executed_at: string;
+  rollback_status: FinancialPromotionExecutionRollbackStatus;
+  market_signal_id: number;
+  market_signal_live: boolean;
+  ticker: string;
+  action: "BUY" | "SELL";
+  confidence_score: number;
+  candidate_bar_date: string;
+  rollback_marker: string;
+  candidate_score: number;
+  candidate_monthly_triangle: number | null;
+  candidate_weekly_triangle: number | null;
+  candidate_daily_triangle: number | null;
+  entry_close: string | number | null;
+  outcome_1d_bar_date: string | null;
+  outcome_1d_close: string | number | null;
+  outcome_1d_directional_return: string | number | null;
+  outcome_5d_bar_date: string | null;
+  outcome_5d_close: string | number | null;
+  outcome_5d_directional_return: string | number | null;
+  outcome_20d_bar_date: string | null;
+  outcome_20d_close: string | number | null;
+  outcome_20d_directional_return: string | number | null;
+  latest_candidate_bar_date: string | null;
+  latest_candidate_score: number | null;
+  latest_monthly_triangle: number | null;
+  latest_weekly_triangle: number | null;
+  latest_daily_triangle: number | null;
+  score_delta: number | null;
+  signal_decay_flag: boolean;
+  signal_decay_date: string | null;
+  signal_decay_score: number | null;
+  signal_decay_daily_triangle: number | null;
+  whipsaw_after_promotion_flag: boolean;
+  whipsaw_transition_date: string | null;
+  whipsaw_transition_type: FinancialTransitionType | null;
+  whipsaw_to_score: number | null;
+  drift_status: FinancialPromotionMonitoringDriftStatus;
+  rollback_recommendation: FinancialPromotionRollbackRecommendation;
+  monitoring_status: FinancialPromotionMonitoringStatus;
+  explanation: string;
+}
+
+export interface FinancialPromotionPostExecutionMonitoringResponse {
+  generated_at: string;
+  promotion_id: string;
+  summary: FinancialPromotionPostExecutionMonitoringSummary;
+  rows: FinancialPromotionPostExecutionMonitoringRow[];
+}
+
 export interface FinancialWatchlistCandidate {
   ticker: string;
   bar_date: string;


### PR DESCRIPTION
## Summary
- Add read-only post-execution monitoring for audited Hedge Fund signal promotions.
- Track promoted signal outcomes across 1-session, 5-session, and 20-session windows.
- Surface whipsaw-after-promotion, signal decay, candidate drift, and rollback review warnings.
- Add cockpit Post-Execution Monitoring panel before the existing dry-run/execution controls.
- Update Operator Audit Playbook.

## Safety
- Monitoring is read-only and keyed from `signal_promotion_execution_rows` audited IDs.
- No automatic rollback is added.
- No execute or rollback control is added by this slice.
- Rollback recommendations are warning-only labels: `WATCH_WARNING` or `REVIEW_ROLLBACK_WARNING`.
- The SQL view uses `security_invoker`.

## Tests
- `PYTHONPATH=. .venv-test/bin/python -m pytest`
- `PYTHONPATH=. .venv-test/bin/python -m pytest tests/test_post_execution_monitoring.py tests/test_api_signals.py`
- `PYTHONPATH=. .venv-test/bin/python -m ruff check app/api/signals.py app/signals/repository.py tests/test_api_signals.py tests/test_post_execution_monitoring.py`
- `npx tsc --noEmit`
- `npx eslint src/lib/hooks.ts src/lib/types.ts "src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx" src/__tests__/components/financial-hedge-fund-shell.test.tsx`
- `npm test`
- `npm test -- financial-hedge-fund-shell.test.tsx`
- `npm run build`
