### PR TITLE
feat(financial): add post-execution alerts

### DIFF
--- a/crog-ai-backend/alembic/versions/0012_post_execution_alerts.py
+++ b/crog-ai-backend/alembic/versions/0012_post_execution_alerts.py
@@ -1,0 +1,29 @@
+"""Add post-execution promotion alerts.
+
+Revision ID: 0012_post_execution_alerts
+Revises: 0011_post_execution_monitoring
+Create Date: 2026-05-04 13:35:00.000000
+"""
+
+from pathlib import Path
+
+from alembic import op
+
+revision = "0012_post_execution_alerts"
+down_revision = "0011_post_execution_monitoring"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    sql_path = (
+        Path(__file__).resolve().parents[2]
+        / "deploy"
+        / "sql"
+        / "marketclub_post_execution_alerts.sql"
+    )
+    op.execute(sql_path.read_text(encoding="utf-8"))
+
+
+def downgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS hedge_fund.v_signal_promotion_post_execution_alerts")

--- a/crog-ai-backend/app/api/signals.py
+++ b/crog-ai-backend/app/api/signals.py
@@ -650,6 +650,65 @@ class PromotionPostExecutionMonitoringResponse(BaseModel):
     rows: list[PromotionPostExecutionMonitoringRow]
 
 
+class PromotionPostExecutionAlertSummary(BaseModel):
+    total_alerts: int
+    high_alerts: int
+    medium_alerts: int
+    low_alerts: int
+    signal_decay_alerts: int
+    whipsaw_after_promotion_alerts: int
+    drift_alerts: int
+    stale_execution_monitoring_alerts: int
+    rollback_recommendation_alerts: int
+
+
+class PromotionPostExecutionAlert(BaseModel):
+    alert_id: str
+    execution_id: UUID
+    acceptance_id: UUID
+    decision_record_id: UUID
+    candidate_id: str
+    market_signal_id: int
+    ticker: str
+    action: Literal["BUY", "SELL"]
+    candidate_bar_date: dt.date
+    alert_type: Literal[
+        "SIGNAL_DECAY",
+        "WHIPSAW_AFTER_PROMOTION",
+        "DRIFT",
+        "STALE_EXECUTION_MONITORING",
+        "ROLLBACK_RECOMMENDATION",
+    ]
+    severity: Literal["LOW", "MEDIUM", "HIGH"]
+    alert_status: Literal["ACTIVE"]
+    alert_date: dt.date | None
+    metric_value: Decimal | None
+    rollback_recommendation: Literal[
+        "NO_WARNING",
+        "WATCH_WARNING",
+        "REVIEW_ROLLBACK_WARNING",
+        "NO_ACTION_ROLLED_BACK",
+    ]
+    monitoring_status: Literal["PENDING", "HEALTHY", "WARNING", "ROLLED_BACK"]
+    drift_status: Literal[
+        "PENDING",
+        "IN_LINE",
+        "PRICE_DRIFT",
+        "SCORE_DRIFT",
+        "PRICE_AND_SCORE_DRIFT",
+    ]
+    evidence: dict[str, object]
+    explanation: str
+    operator_guidance: str
+
+
+class PromotionPostExecutionAlertsResponse(BaseModel):
+    generated_at: dt.datetime
+    promotion_id: str
+    summary: PromotionPostExecutionAlertSummary
+    alerts: list[PromotionPostExecutionAlert]
+
+
 class SymbolChartBar(BaseModel):
     ticker: str
     bar_date: dt.date
@@ -1074,6 +1133,21 @@ def promotion_post_execution_monitoring(
     limit: Annotated[int, Query(ge=1, le=500)] = 100,
 ) -> dict[str, object]:
     return store.promotion_post_execution_monitoring(
+        promotion_id=promotion_id,
+        limit=limit,
+    )
+
+
+@router.get(
+    "/promotion/{promotion_id}/alerts",
+    response_model=PromotionPostExecutionAlertsResponse,
+)
+def promotion_post_execution_alerts(
+    promotion_id: Annotated[str, Path(min_length=1, max_length=120)],
+    store: Annotated[SignalDataStore, Depends(get_signal_store)],
+    limit: Annotated[int, Query(ge=1, le=500)] = 100,
+) -> dict[str, object]:
+    return store.promotion_post_execution_alerts(
         promotion_id=promotion_id,
         limit=limit,
     )

--- a/crog-ai-backend/app/signals/repository.py
+++ b/crog-ai-backend/app/signals/repository.py
@@ -178,6 +178,13 @@ class SignalDataStore(Protocol):
         limit: int = 100,
     ) -> dict[str, Any]: ...
 
+    def promotion_post_execution_alerts(
+        self,
+        *,
+        promotion_id: str,
+        limit: int = 100,
+    ) -> dict[str, Any]: ...
+
     def execute_guarded_promotion(
         self,
         *,
@@ -2283,6 +2290,101 @@ def fetch_promotion_post_execution_monitoring(
     }
 
 
+PROMOTION_POST_EXECUTION_ALERT_FIELDS = [
+    "alert_id",
+    "execution_id",
+    "acceptance_id",
+    "decision_record_id",
+    "candidate_id",
+    "market_signal_id",
+    "ticker",
+    "action",
+    "candidate_bar_date",
+    "alert_type",
+    "severity",
+    "alert_status",
+    "alert_date",
+    "metric_value",
+    "rollback_recommendation",
+    "monitoring_status",
+    "drift_status",
+    "evidence",
+    "explanation",
+    "operator_guidance",
+]
+
+
+def fetch_promotion_post_execution_alerts(
+    conn: psycopg.Connection,
+    *,
+    promotion_id: str,
+    limit: int = 100,
+) -> dict[str, Any]:
+    sql = """
+        SELECT
+            alert_id,
+            execution_id,
+            acceptance_id,
+            decision_record_id,
+            candidate_id,
+            market_signal_id,
+            ticker,
+            action,
+            candidate_bar_date,
+            alert_type,
+            severity,
+            alert_status,
+            alert_date,
+            metric_value,
+            rollback_recommendation,
+            monitoring_status,
+            drift_status,
+            evidence,
+            explanation,
+            operator_guidance
+        FROM hedge_fund.v_signal_promotion_post_execution_alerts
+        WHERE candidate_id = %(promotion_id)s
+           OR acceptance_id::TEXT = %(promotion_id)s
+           OR execution_id::TEXT = %(promotion_id)s
+        ORDER BY
+            CASE severity
+                WHEN 'HIGH' THEN 0
+                WHEN 'MEDIUM' THEN 1
+                ELSE 2
+            END,
+            alert_date DESC NULLS LAST,
+            ticker,
+            alert_type
+        LIMIT %(limit)s
+    """
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(sql, {"promotion_id": promotion_id, "limit": limit})
+        rows = [
+            {key: row[key] for key in PROMOTION_POST_EXECUTION_ALERT_FIELDS}
+            for row in cur.fetchall()
+        ]
+    alert_counts = Counter(row["alert_type"] for row in rows)
+    severity_counts = Counter(row["severity"] for row in rows)
+    return {
+        "generated_at": dt.datetime.now(dt.UTC),
+        "promotion_id": promotion_id,
+        "summary": {
+            "total_alerts": len(rows),
+            "high_alerts": severity_counts["HIGH"],
+            "medium_alerts": severity_counts["MEDIUM"],
+            "low_alerts": severity_counts["LOW"],
+            "signal_decay_alerts": alert_counts["SIGNAL_DECAY"],
+            "whipsaw_after_promotion_alerts": alert_counts["WHIPSAW_AFTER_PROMOTION"],
+            "drift_alerts": alert_counts["DRIFT"],
+            "stale_execution_monitoring_alerts": alert_counts[
+                "STALE_EXECUTION_MONITORING"
+            ],
+            "rollback_recommendation_alerts": alert_counts["ROLLBACK_RECOMMENDATION"],
+        },
+        "alerts": rows,
+    }
+
+
 def execute_guarded_promotion(
     conn: psycopg.Connection,
     *,
@@ -2785,6 +2887,20 @@ class PostgresSignalDataStore:
         with connect() as conn:
             conn.execute("SET default_transaction_read_only = on")
             return fetch_promotion_post_execution_monitoring(
+                conn,
+                promotion_id=promotion_id,
+                limit=limit,
+            )
+
+    def promotion_post_execution_alerts(
+        self,
+        *,
+        promotion_id: str,
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        with connect() as conn:
+            conn.execute("SET default_transaction_read_only = on")
+            return fetch_promotion_post_execution_alerts(
                 conn,
                 promotion_id=promotion_id,
                 limit=limit,

--- a/crog-ai-backend/deploy/sql/marketclub_post_execution_alerts.sql
+++ b/crog-ai-backend/deploy/sql/marketclub_post_execution_alerts.sql
@@ -1,0 +1,221 @@
+CREATE OR REPLACE VIEW hedge_fund.v_signal_promotion_post_execution_alerts
+WITH (security_invoker = true) AS
+WITH monitoring AS (
+    SELECT *
+    FROM hedge_fund.v_signal_promotion_post_execution_monitoring
+),
+signal_decay_alerts AS (
+    SELECT
+        md5(execution_id::TEXT || ':' || market_signal_id::TEXT || ':SIGNAL_DECAY') AS alert_id,
+        execution_id,
+        acceptance_id,
+        decision_record_id,
+        candidate_id,
+        market_signal_id,
+        ticker,
+        action,
+        candidate_bar_date,
+        'SIGNAL_DECAY'::TEXT AS alert_type,
+        CASE
+            WHEN rollback_recommendation = 'REVIEW_ROLLBACK_WARNING' THEN 'HIGH'
+            ELSE 'MEDIUM'
+        END AS severity,
+        'ACTIVE'::TEXT AS alert_status,
+        signal_decay_date AS alert_date,
+        signal_decay_score::NUMERIC AS metric_value,
+        rollback_recommendation,
+        monitoring_status,
+        drift_status,
+        jsonb_build_object(
+            'rollback_marker', rollback_marker,
+            'signal_decay_score', signal_decay_score,
+            'signal_decay_daily_triangle', signal_decay_daily_triangle,
+            'latest_candidate_score', latest_candidate_score,
+            'latest_daily_triangle', latest_daily_triangle,
+            'score_delta', score_delta
+        ) AS evidence,
+        'Candidate score or daily triangle decayed after promotion.'::TEXT AS explanation,
+        'Warning only: review the audited execution; no automated rollback is performed.'::TEXT
+            AS operator_guidance
+    FROM monitoring
+    WHERE signal_decay_flag
+      AND rollback_status = 'active'
+),
+whipsaw_alerts AS (
+    SELECT
+        md5(execution_id::TEXT || ':' || market_signal_id::TEXT || ':WHIPSAW_AFTER_PROMOTION')
+            AS alert_id,
+        execution_id,
+        acceptance_id,
+        decision_record_id,
+        candidate_id,
+        market_signal_id,
+        ticker,
+        action,
+        candidate_bar_date,
+        'WHIPSAW_AFTER_PROMOTION'::TEXT AS alert_type,
+        CASE
+            WHEN rollback_recommendation = 'REVIEW_ROLLBACK_WARNING' THEN 'HIGH'
+            ELSE 'MEDIUM'
+        END AS severity,
+        'ACTIVE'::TEXT AS alert_status,
+        whipsaw_transition_date AS alert_date,
+        whipsaw_to_score::NUMERIC AS metric_value,
+        rollback_recommendation,
+        monitoring_status,
+        drift_status,
+        jsonb_build_object(
+            'rollback_marker', rollback_marker,
+            'whipsaw_transition_date', whipsaw_transition_date,
+            'whipsaw_transition_type', whipsaw_transition_type,
+            'whipsaw_to_score', whipsaw_to_score
+        ) AS evidence,
+        'Candidate produced an opposite transition after promotion.'::TEXT AS explanation,
+        'Warning only: review whipsaw context; no automatic trade or signal change is made.'::TEXT
+            AS operator_guidance
+    FROM monitoring
+    WHERE whipsaw_after_promotion_flag
+      AND rollback_status = 'active'
+),
+drift_alerts AS (
+    SELECT
+        md5(execution_id::TEXT || ':' || market_signal_id::TEXT || ':DRIFT') AS alert_id,
+        execution_id,
+        acceptance_id,
+        decision_record_id,
+        candidate_id,
+        market_signal_id,
+        ticker,
+        action,
+        candidate_bar_date,
+        'DRIFT'::TEXT AS alert_type,
+        CASE
+            WHEN drift_status = 'PRICE_AND_SCORE_DRIFT' THEN 'HIGH'
+            ELSE 'MEDIUM'
+        END AS severity,
+        'ACTIVE'::TEXT AS alert_status,
+        COALESCE(outcome_20d_bar_date, outcome_5d_bar_date, latest_candidate_bar_date)
+            AS alert_date,
+        COALESCE(
+            outcome_20d_directional_return,
+            outcome_5d_directional_return,
+            score_delta::NUMERIC
+        ) AS metric_value,
+        rollback_recommendation,
+        monitoring_status,
+        drift_status,
+        jsonb_build_object(
+            'rollback_marker', rollback_marker,
+            'outcome_1d_directional_return', outcome_1d_directional_return,
+            'outcome_5d_directional_return', outcome_5d_directional_return,
+            'outcome_20d_directional_return', outcome_20d_directional_return,
+            'score_delta', score_delta,
+            'latest_candidate_score', latest_candidate_score
+        ) AS evidence,
+        'Promoted signal drifted away from candidate expectation.'::TEXT AS explanation,
+        'Warning only: review candidate drift; no automatic trade or signal change is made.'::TEXT
+            AS operator_guidance
+    FROM monitoring
+    WHERE drift_status IN ('PRICE_DRIFT', 'SCORE_DRIFT', 'PRICE_AND_SCORE_DRIFT')
+      AND rollback_status = 'active'
+),
+stale_alerts AS (
+    SELECT
+        md5(execution_id::TEXT || ':' || market_signal_id::TEXT || ':STALE_EXECUTION_MONITORING')
+            AS alert_id,
+        execution_id,
+        acceptance_id,
+        decision_record_id,
+        candidate_id,
+        market_signal_id,
+        ticker,
+        action,
+        candidate_bar_date,
+        'STALE_EXECUTION_MONITORING'::TEXT AS alert_type,
+        CASE
+            WHEN executed_at < now() - INTERVAL '5 days' THEN 'MEDIUM'
+            ELSE 'LOW'
+        END AS severity,
+        'ACTIVE'::TEXT AS alert_status,
+        executed_at::DATE AS alert_date,
+        EXTRACT(EPOCH FROM (now() - executed_at)) / 86400.0 AS metric_value,
+        rollback_recommendation,
+        monitoring_status,
+        drift_status,
+        jsonb_build_object(
+            'rollback_marker', rollback_marker,
+            'executed_at', executed_at,
+            'latest_candidate_bar_date', latest_candidate_bar_date,
+            'outcome_1d_bar_date', outcome_1d_bar_date,
+            'market_signal_live', market_signal_live
+        ) AS evidence,
+        'Execution monitoring is stale: no post-promotion outcome or candidate update has arrived.'::TEXT
+            AS explanation,
+        'Warning only: verify data freshness; no automatic trade, signal, or rollback action is made.'::TEXT
+            AS operator_guidance
+    FROM monitoring
+    WHERE rollback_status = 'active'
+      AND market_signal_live
+      AND monitoring_status = 'PENDING'
+      AND executed_at < now() - INTERVAL '2 days'
+      AND outcome_1d_bar_date IS NULL
+      AND (
+        latest_candidate_bar_date IS NULL
+        OR latest_candidate_bar_date <= candidate_bar_date
+      )
+),
+rollback_recommendation_alerts AS (
+    SELECT
+        md5(execution_id::TEXT || ':' || market_signal_id::TEXT || ':ROLLBACK_RECOMMENDATION')
+            AS alert_id,
+        execution_id,
+        acceptance_id,
+        decision_record_id,
+        candidate_id,
+        market_signal_id,
+        ticker,
+        action,
+        candidate_bar_date,
+        'ROLLBACK_RECOMMENDATION'::TEXT AS alert_type,
+        CASE
+            WHEN rollback_recommendation = 'REVIEW_ROLLBACK_WARNING' THEN 'HIGH'
+            ELSE 'MEDIUM'
+        END AS severity,
+        'ACTIVE'::TEXT AS alert_status,
+        COALESCE(
+            whipsaw_transition_date,
+            signal_decay_date,
+            outcome_20d_bar_date,
+            outcome_5d_bar_date,
+            latest_candidate_bar_date
+        ) AS alert_date,
+        COALESCE(outcome_20d_directional_return, outcome_5d_directional_return)
+            AS metric_value,
+        rollback_recommendation,
+        monitoring_status,
+        drift_status,
+        jsonb_build_object(
+            'rollback_marker', rollback_marker,
+            'rollback_recommendation', rollback_recommendation,
+            'whipsaw_after_promotion_flag', whipsaw_after_promotion_flag,
+            'signal_decay_flag', signal_decay_flag,
+            'drift_status', drift_status
+        ) AS evidence,
+        'Monitoring recommends operator rollback review.'::TEXT AS explanation,
+        'Warning only: this alert never calls rollback_guarded_signal_promotion and never changes trades or signals automatically.'::TEXT
+            AS operator_guidance
+    FROM monitoring
+    WHERE rollback_recommendation IN ('WATCH_WARNING', 'REVIEW_ROLLBACK_WARNING')
+      AND rollback_status = 'active'
+)
+SELECT * FROM signal_decay_alerts
+UNION ALL
+SELECT * FROM whipsaw_alerts
+UNION ALL
+SELECT * FROM drift_alerts
+UNION ALL
+SELECT * FROM stale_alerts
+UNION ALL
+SELECT * FROM rollback_recommendation_alerts;
+
+GRANT SELECT ON TABLE hedge_fund.v_signal_promotion_post_execution_alerts TO crog_ai_app;

--- a/crog-ai-backend/docs/OPERATOR-AUDIT-PLAYBOOK.md
+++ b/crog-ai-backend/docs/OPERATOR-AUDIT-PLAYBOOK.md
@@ -50,6 +50,20 @@ The monitor is read-only and evaluates only audited execution rows:
 
 Rollback recommendations are warnings only. The monitoring endpoint does not call rollback functions, delete `market_signals`, create rollback audit rows, or auto-heal promotion records.
 
+## Post-Execution Alerts
+
+Use `GET /api/financial/signals/promotion/{id}/alerts` with a candidate parameter set, dry-run acceptance id, or execution id. The alert view is `hedge_fund.v_signal_promotion_post_execution_alerts`.
+
+The alert layer is read-only and derives from post-execution monitoring rows:
+
+- `SIGNAL_DECAY`
+- `WHIPSAW_AFTER_PROMOTION`
+- `DRIFT`
+- `STALE_EXECUTION_MONITORING`
+- `ROLLBACK_RECOMMENDATION`
+
+Alerts are operator warnings only. They do not call rollback functions, write or delete `market_signals`, create acceptance records, create execution records, change trades, or change signal state. Rollback recommendation alerts mean “review this audited execution,” not “rollback automatically.”
+
 ## Snapshots
 
 Acceptance records persist:

--- a/crog-ai-backend/tests/test_api_signals.py
+++ b/crog-ai-backend/tests/test_api_signals.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import hashlib
+from collections import Counter
 from decimal import Decimal
 from typing import Any
 from uuid import UUID
@@ -938,6 +939,156 @@ class FakeSignalStore:
             "rows": rows,
         }
 
+    def promotion_post_execution_alerts(
+        self,
+        *,
+        promotion_id: str,
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        alerts = [
+            {
+                "alert_id": "signal-decay-aa",
+                "execution_id": EXECUTION_ID,
+                "acceptance_id": ACCEPTANCE_ID,
+                "decision_record_id": DECISION_ID,
+                "candidate_id": "dochia_v0_2_range_daily",
+                "market_signal_id": 1201,
+                "ticker": "AA",
+                "action": "BUY",
+                "candidate_bar_date": dt.date(2026, 4, 24),
+                "alert_type": "SIGNAL_DECAY",
+                "severity": "HIGH",
+                "alert_status": "ACTIVE",
+                "alert_date": dt.date(2026, 4, 30),
+                "metric_value": Decimal("20"),
+                "rollback_recommendation": "REVIEW_ROLLBACK_WARNING",
+                "monitoring_status": "WARNING",
+                "drift_status": "PRICE_AND_SCORE_DRIFT",
+                "evidence": {"signal_decay_score": 20, "score_delta": -60},
+                "explanation": "Candidate score or daily triangle decayed after promotion.",
+                "operator_guidance": (
+                    "Warning only: review the audited execution; no automated rollback is performed."
+                ),
+            },
+            {
+                "alert_id": "whipsaw-aa",
+                "execution_id": EXECUTION_ID,
+                "acceptance_id": ACCEPTANCE_ID,
+                "decision_record_id": DECISION_ID,
+                "candidate_id": "dochia_v0_2_range_daily",
+                "market_signal_id": 1201,
+                "ticker": "AA",
+                "action": "BUY",
+                "candidate_bar_date": dt.date(2026, 4, 24),
+                "alert_type": "WHIPSAW_AFTER_PROMOTION",
+                "severity": "HIGH",
+                "alert_status": "ACTIVE",
+                "alert_date": dt.date(2026, 4, 30),
+                "metric_value": Decimal("-50"),
+                "rollback_recommendation": "REVIEW_ROLLBACK_WARNING",
+                "monitoring_status": "WARNING",
+                "drift_status": "PRICE_AND_SCORE_DRIFT",
+                "evidence": {"whipsaw_transition_type": "breakout_bearish"},
+                "explanation": "Candidate produced an opposite transition after promotion.",
+                "operator_guidance": (
+                    "Warning only: review whipsaw context; no automatic trade or signal change is made."
+                ),
+            },
+            {
+                "alert_id": "drift-aa",
+                "execution_id": EXECUTION_ID,
+                "acceptance_id": ACCEPTANCE_ID,
+                "decision_record_id": DECISION_ID,
+                "candidate_id": "dochia_v0_2_range_daily",
+                "market_signal_id": 1201,
+                "ticker": "AA",
+                "action": "BUY",
+                "candidate_bar_date": dt.date(2026, 4, 24),
+                "alert_type": "DRIFT",
+                "severity": "HIGH",
+                "alert_status": "ACTIVE",
+                "alert_date": dt.date(2026, 5, 1),
+                "metric_value": Decimal("-0.043478"),
+                "rollback_recommendation": "REVIEW_ROLLBACK_WARNING",
+                "monitoring_status": "WARNING",
+                "drift_status": "PRICE_AND_SCORE_DRIFT",
+                "evidence": {"outcome_5d_directional_return": "-0.043478"},
+                "explanation": "Promoted signal drifted away from candidate expectation.",
+                "operator_guidance": (
+                    "Warning only: review candidate drift; no automatic trade or signal change is made."
+                ),
+            },
+            {
+                "alert_id": "stale-agio",
+                "execution_id": EXECUTION_ID,
+                "acceptance_id": ACCEPTANCE_ID,
+                "decision_record_id": DECISION_ID,
+                "candidate_id": "dochia_v0_2_range_daily",
+                "market_signal_id": 1202,
+                "ticker": "AGIO",
+                "action": "BUY",
+                "candidate_bar_date": dt.date(2026, 4, 24),
+                "alert_type": "STALE_EXECUTION_MONITORING",
+                "severity": "MEDIUM",
+                "alert_status": "ACTIVE",
+                "alert_date": dt.date(2026, 5, 3),
+                "metric_value": Decimal("2.5"),
+                "rollback_recommendation": "NO_WARNING",
+                "monitoring_status": "PENDING",
+                "drift_status": "PENDING",
+                "evidence": {"outcome_1d_bar_date": None},
+                "explanation": "Execution monitoring is stale.",
+                "operator_guidance": (
+                    "Warning only: verify data freshness; no automatic trade, signal, "
+                    "or rollback action is made."
+                ),
+            },
+            {
+                "alert_id": "rollback-review-aa",
+                "execution_id": EXECUTION_ID,
+                "acceptance_id": ACCEPTANCE_ID,
+                "decision_record_id": DECISION_ID,
+                "candidate_id": "dochia_v0_2_range_daily",
+                "market_signal_id": 1201,
+                "ticker": "AA",
+                "action": "BUY",
+                "candidate_bar_date": dt.date(2026, 4, 24),
+                "alert_type": "ROLLBACK_RECOMMENDATION",
+                "severity": "HIGH",
+                "alert_status": "ACTIVE",
+                "alert_date": dt.date(2026, 4, 30),
+                "metric_value": Decimal("-0.043478"),
+                "rollback_recommendation": "REVIEW_ROLLBACK_WARNING",
+                "monitoring_status": "WARNING",
+                "drift_status": "PRICE_AND_SCORE_DRIFT",
+                "evidence": {"rollback_recommendation": "REVIEW_ROLLBACK_WARNING"},
+                "explanation": "Monitoring recommends operator rollback review.",
+                "operator_guidance": (
+                    "Warning only: this alert never calls rollback_guarded_signal_promotion."
+                ),
+            },
+        ][:limit]
+        alert_counts = Counter(alert["alert_type"] for alert in alerts)
+        severity_counts = Counter(alert["severity"] for alert in alerts)
+        return {
+            "generated_at": dt.datetime(2026, 5, 4, 13, 30, tzinfo=dt.UTC),
+            "promotion_id": promotion_id,
+            "summary": {
+                "total_alerts": len(alerts),
+                "high_alerts": severity_counts["HIGH"],
+                "medium_alerts": severity_counts["MEDIUM"],
+                "low_alerts": severity_counts["LOW"],
+                "signal_decay_alerts": alert_counts["SIGNAL_DECAY"],
+                "whipsaw_after_promotion_alerts": alert_counts["WHIPSAW_AFTER_PROMOTION"],
+                "drift_alerts": alert_counts["DRIFT"],
+                "stale_execution_monitoring_alerts": alert_counts[
+                    "STALE_EXECUTION_MONITORING"
+                ],
+                "rollback_recommendation_alerts": alert_counts["ROLLBACK_RECOMMENDATION"],
+            },
+            "alerts": alerts,
+        }
+
     def execute_guarded_promotion(
         self,
         *,
@@ -1558,6 +1709,42 @@ def test_promotion_post_execution_monitoring_endpoint_returns_warning_only_track
     assert warning["drift_status"] == "PRICE_AND_SCORE_DRIFT"
     assert warning["rollback_recommendation"] == "REVIEW_ROLLBACK_WARNING"
     assert "warning" in warning["explanation"].lower()
+
+
+def test_promotion_post_execution_alerts_endpoint_returns_warning_only_alerts() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    response = client.get(
+        f"/api/financial/signals/promotion/{EXECUTION_ID}/alerts?limit=10"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["promotion_id"] == str(EXECUTION_ID)
+    assert payload["summary"]["total_alerts"] == 5
+    assert payload["summary"]["high_alerts"] == 4
+    assert payload["summary"]["medium_alerts"] == 1
+    assert payload["summary"]["signal_decay_alerts"] == 1
+    assert payload["summary"]["whipsaw_after_promotion_alerts"] == 1
+    assert payload["summary"]["drift_alerts"] == 1
+    assert payload["summary"]["stale_execution_monitoring_alerts"] == 1
+    assert payload["summary"]["rollback_recommendation_alerts"] == 1
+    alert_types = {alert["alert_type"] for alert in payload["alerts"]}
+    assert alert_types == {
+        "SIGNAL_DECAY",
+        "WHIPSAW_AFTER_PROMOTION",
+        "DRIFT",
+        "STALE_EXECUTION_MONITORING",
+        "ROLLBACK_RECOMMENDATION",
+    }
+    assert all(alert["alert_status"] == "ACTIVE" for alert in payload["alerts"])
+    assert all("Warning only" in alert["operator_guidance"] for alert in payload["alerts"])
+    guidance = " ".join(alert["operator_guidance"] for alert in payload["alerts"])
+    assert "no automated rollback is performed" in guidance
+    assert "no automatic trade or signal change is made" in guidance
+    assert "no automatic trade, signal, or rollback action is made" in guidance
 
 
 def test_execute_guarded_promotion_endpoint_returns_execution_record() -> None:

--- a/crog-ai-backend/tests/test_post_execution_alerts.py
+++ b/crog-ai-backend/tests/test_post_execution_alerts.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+
+def _alerts_sql() -> str:
+    return (
+        Path(__file__).resolve().parents[1]
+        / "deploy"
+        / "sql"
+        / "marketclub_post_execution_alerts.sql"
+    ).read_text(encoding="utf-8")
+
+
+def test_post_execution_alerts_view_is_read_only_and_audited() -> None:
+    sql = _alerts_sql()
+
+    assert "CREATE OR REPLACE VIEW hedge_fund.v_signal_promotion_post_execution_alerts" in sql
+    assert "WITH (security_invoker = true) AS" in sql
+    assert "FROM hedge_fund.v_signal_promotion_post_execution_monitoring" in sql
+    assert "market_signal_id" in sql
+    assert "rollback_marker" in sql
+    assert "GRANT SELECT ON TABLE hedge_fund.v_signal_promotion_post_execution_alerts" in sql
+    assert "INSERT INTO hedge_fund.market_signals" not in sql
+    assert "DELETE FROM hedge_fund.market_signals" not in sql
+    assert "UPDATE hedge_fund" not in sql
+    assert "FROM hedge_fund.rollback_guarded_signal_promotion(" not in sql
+    assert "SELECT * FROM hedge_fund.rollback_guarded_signal_promotion" not in sql
+
+
+def test_post_execution_alerts_emit_required_alert_types() -> None:
+    sql = _alerts_sql()
+
+    assert "'SIGNAL_DECAY'::TEXT AS alert_type" in sql
+    assert "'WHIPSAW_AFTER_PROMOTION'::TEXT AS alert_type" in sql
+    assert "'DRIFT'::TEXT AS alert_type" in sql
+    assert "'STALE_EXECUTION_MONITORING'::TEXT AS alert_type" in sql
+    assert "'ROLLBACK_RECOMMENDATION'::TEXT AS alert_type" in sql
+    assert "UNION ALL" in sql
+
+
+def test_post_execution_alerts_are_warning_only() -> None:
+    sql = _alerts_sql()
+
+    assert "Warning only" in sql
+    assert "no automated rollback is performed" in sql
+    assert "no automatic trade or signal change is made" in sql
+    assert "no automatic trade, signal, or rollback action is made" in sql
+    assert "rollback_guarded_signal_promotion" in sql
+
+
+def test_post_execution_alerts_track_requested_conditions() -> None:
+    sql = _alerts_sql()
+
+    assert "WHERE signal_decay_flag" in sql
+    assert "WHERE whipsaw_after_promotion_flag" in sql
+    assert "drift_status IN ('PRICE_DRIFT', 'SCORE_DRIFT', 'PRICE_AND_SCORE_DRIFT')" in sql
+    assert "monitoring_status = 'PENDING'" in sql
+    assert "executed_at < now() - INTERVAL '2 days'" in sql
+    assert "rollback_recommendation IN ('WATCH_WARNING', 'REVIEW_ROLLBACK_WARNING')" in sql
+    assert "rollback_status = 'active'" in sql

--- a/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
+++ b/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
@@ -862,6 +862,134 @@ const promotionPostExecutionMonitoring = {
   ],
 };
 
+const promotionPostExecutionAlerts = {
+  generated_at: "2026-05-04T13:30:00Z",
+  promotion_id: "55555555-5555-5555-5555-555555555555",
+  summary: {
+    total_alerts: 5,
+    high_alerts: 4,
+    medium_alerts: 1,
+    low_alerts: 0,
+    signal_decay_alerts: 1,
+    whipsaw_after_promotion_alerts: 1,
+    drift_alerts: 1,
+    stale_execution_monitoring_alerts: 1,
+    rollback_recommendation_alerts: 1,
+  },
+  alerts: [
+    {
+      alert_id: "signal-decay-aa",
+      execution_id: "55555555-5555-5555-5555-555555555555",
+      acceptance_id: "44444444-4444-4444-4444-444444444444",
+      decision_record_id: "33333333-3333-3333-3333-333333333333",
+      candidate_id: "dochia_v0_2_range_daily",
+      market_signal_id: 1201,
+      ticker: "AA",
+      action: "BUY",
+      candidate_bar_date: "2026-04-24",
+      alert_type: "SIGNAL_DECAY",
+      severity: "HIGH",
+      alert_status: "ACTIVE",
+      alert_date: "2026-04-30",
+      metric_value: "20",
+      rollback_recommendation: "REVIEW_ROLLBACK_WARNING",
+      monitoring_status: "WARNING",
+      drift_status: "PRICE_AND_SCORE_DRIFT",
+      evidence: { signal_decay_score: 20, score_delta: -60 },
+      explanation: "Candidate score or daily triangle decayed after promotion.",
+      operator_guidance: "Warning only: review the audited execution; no automated rollback is performed.",
+    },
+    {
+      alert_id: "whipsaw-aa",
+      execution_id: "55555555-5555-5555-5555-555555555555",
+      acceptance_id: "44444444-4444-4444-4444-444444444444",
+      decision_record_id: "33333333-3333-3333-3333-333333333333",
+      candidate_id: "dochia_v0_2_range_daily",
+      market_signal_id: 1201,
+      ticker: "AA",
+      action: "BUY",
+      candidate_bar_date: "2026-04-24",
+      alert_type: "WHIPSAW_AFTER_PROMOTION",
+      severity: "HIGH",
+      alert_status: "ACTIVE",
+      alert_date: "2026-04-30",
+      metric_value: "-50",
+      rollback_recommendation: "REVIEW_ROLLBACK_WARNING",
+      monitoring_status: "WARNING",
+      drift_status: "PRICE_AND_SCORE_DRIFT",
+      evidence: { whipsaw_transition_type: "breakout_bearish" },
+      explanation: "Candidate produced an opposite transition after promotion.",
+      operator_guidance: "Warning only: review whipsaw context; no automatic trade or signal change is made.",
+    },
+    {
+      alert_id: "drift-aa",
+      execution_id: "55555555-5555-5555-5555-555555555555",
+      acceptance_id: "44444444-4444-4444-4444-444444444444",
+      decision_record_id: "33333333-3333-3333-3333-333333333333",
+      candidate_id: "dochia_v0_2_range_daily",
+      market_signal_id: 1201,
+      ticker: "AA",
+      action: "BUY",
+      candidate_bar_date: "2026-04-24",
+      alert_type: "DRIFT",
+      severity: "HIGH",
+      alert_status: "ACTIVE",
+      alert_date: "2026-05-01",
+      metric_value: "-0.043478",
+      rollback_recommendation: "REVIEW_ROLLBACK_WARNING",
+      monitoring_status: "WARNING",
+      drift_status: "PRICE_AND_SCORE_DRIFT",
+      evidence: { outcome_5d_directional_return: "-0.043478" },
+      explanation: "Promoted signal drifted away from candidate expectation.",
+      operator_guidance: "Warning only: review candidate drift; no automatic trade or signal change is made.",
+    },
+    {
+      alert_id: "stale-agio",
+      execution_id: "55555555-5555-5555-5555-555555555555",
+      acceptance_id: "44444444-4444-4444-4444-444444444444",
+      decision_record_id: "33333333-3333-3333-3333-333333333333",
+      candidate_id: "dochia_v0_2_range_daily",
+      market_signal_id: 1202,
+      ticker: "AGIO",
+      action: "BUY",
+      candidate_bar_date: "2026-04-24",
+      alert_type: "STALE_EXECUTION_MONITORING",
+      severity: "MEDIUM",
+      alert_status: "ACTIVE",
+      alert_date: "2026-05-03",
+      metric_value: "2.5",
+      rollback_recommendation: "NO_WARNING",
+      monitoring_status: "PENDING",
+      drift_status: "PENDING",
+      evidence: { outcome_1d_bar_date: null },
+      explanation: "Execution monitoring is stale.",
+      operator_guidance: "Warning only: verify data freshness; no automatic trade, signal, or rollback action is made.",
+    },
+    {
+      alert_id: "rollback-review-aa",
+      execution_id: "55555555-5555-5555-5555-555555555555",
+      acceptance_id: "44444444-4444-4444-4444-444444444444",
+      decision_record_id: "33333333-3333-3333-3333-333333333333",
+      candidate_id: "dochia_v0_2_range_daily",
+      market_signal_id: 1201,
+      ticker: "AA",
+      action: "BUY",
+      candidate_bar_date: "2026-04-24",
+      alert_type: "ROLLBACK_RECOMMENDATION",
+      severity: "HIGH",
+      alert_status: "ACTIVE",
+      alert_date: "2026-04-30",
+      metric_value: "-0.043478",
+      rollback_recommendation: "REVIEW_ROLLBACK_WARNING",
+      monitoring_status: "WARNING",
+      drift_status: "PRICE_AND_SCORE_DRIFT",
+      evidence: { rollback_recommendation: "REVIEW_ROLLBACK_WARNING" },
+      explanation: "Monitoring recommends operator rollback review.",
+      operator_guidance: "Warning only: this alert never calls rollback_guarded_signal_promotion.",
+    },
+  ],
+};
+
 let promotionDryRunAcceptancesMock = promotionDryRunAcceptances;
 let promotionExecutionsMock = promotionExecutions;
 let promotionDryRunVerificationMock = promotionDryRunVerification;
@@ -996,6 +1124,13 @@ vi.mock("@/lib/hooks", () => ({
     isLoading: false,
     refetch: vi.fn(),
   }),
+  useFinancialPromotionPostExecutionAlerts: () => ({
+    data: promotionPostExecutionAlerts,
+    isError: false,
+    isFetching: false,
+    isLoading: false,
+    refetch: vi.fn(),
+  }),
   useCreateFinancialShadowDecisionRecord: () => ({
     isPending: false,
     mutateAsync: vi.fn(),
@@ -1061,11 +1196,21 @@ describe("HedgeFundSignalsShell", () => {
     expect(screen.getByText("Post-Execution Monitoring")).toBeInTheDocument();
     expect(screen.getByText("1 warnings")).toBeInTheDocument();
     expect(screen.getByText("Rollback review")).toBeInTheDocument();
-    expect(screen.getByText("Price And Score Drift")).toBeInTheDocument();
-    expect(screen.getByText("Review Rollback Warning")).toBeInTheDocument();
+    expect(screen.getAllByText("Price And Score Drift").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Review Rollback Warning").length).toBeGreaterThan(0);
     expect(screen.getByText("-4.3%")).toBeInTheDocument();
     expect(screen.getAllByText("Whipsaw").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Decay").length).toBeGreaterThan(0);
+    expect(screen.getByText("Post-Execution Alerts")).toBeInTheDocument();
+    expect(screen.getByText("No automated rollback")).toBeInTheDocument();
+    expect(screen.getByText("5 alerts")).toBeInTheDocument();
+    expect(screen.getByText("Signal Decay")).toBeInTheDocument();
+    expect(screen.getByText("Whipsaw After Promotion")).toBeInTheDocument();
+    expect(screen.getAllByText("Drift").length).toBeGreaterThan(0);
+    expect(screen.getByText("Stale Execution Monitoring")).toBeInTheDocument();
+    expect(screen.getByText("Rollback Recommendation")).toBeInTheDocument();
+    expect(screen.getAllByText(/no automatic trade or signal change is made/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/no automatic trade, signal, or rollback action is made/i)).toBeInTheDocument();
     expect(screen.getByText("Dry-Run Verification Gate")).toBeInTheDocument();
     expect(screen.getByText("Eligible for operator dry-run acceptance review")).toBeInTheDocument();
     expect(screen.getByText("CROSS_MODEL_DIAGNOSTIC_ONLY")).toBeInTheDocument();

--- a/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
+++ b/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
@@ -52,6 +52,7 @@ import {
   useFinancialPromotionDryRunVerification,
   useFinancialPromotionExecutions,
   useFinancialPromotionLifecycleTimeline,
+  useFinancialPromotionPostExecutionAlerts,
   useFinancialPromotionPostExecutionMonitoring,
   useFinancialPromotionReconciliation,
   useFinancialPromotionRollbackDrills,
@@ -78,6 +79,8 @@ import type {
   FinancialPromotionExecutionCreate,
   FinancialPromotionExecutionRollbackCreate,
   FinancialPromotionLifecycleEvent,
+  FinancialPromotionPostExecutionAlert,
+  FinancialPromotionPostExecutionAlertsResponse,
   FinancialPromotionPostExecutionMonitoringResponse,
   FinancialPromotionPostExecutionMonitoringRow,
   FinancialPromotionReconciliation,
@@ -374,6 +377,20 @@ function promotionMonitoringStatusClasses(status: string): string {
 
 function promotionMonitoringLabel(value: string): string {
   return value
+    .toLowerCase()
+    .split("_")
+    .map((part) => part[0]?.toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function promotionAlertSeverityClasses(severity: FinancialPromotionPostExecutionAlert["severity"]): string {
+  if (severity === "HIGH") return "border-red-500/40 bg-red-500/10 text-red-600";
+  if (severity === "MEDIUM") return "border-amber-500/40 bg-amber-500/10 text-amber-600";
+  return "border-border bg-muted/30 text-muted-foreground";
+}
+
+function promotionAlertTypeLabel(type: FinancialPromotionPostExecutionAlert["alert_type"]): string {
+  return type
     .toLowerCase()
     .split("_")
     .map((part) => part[0]?.toUpperCase() + part.slice(1))
@@ -1973,6 +1990,161 @@ function PostExecutionMonitoringPanel({
   );
 }
 
+function PostExecutionAlertsPanel({
+  alerts,
+  loading,
+  error,
+}: {
+  alerts: FinancialPromotionPostExecutionAlertsResponse | null;
+  loading: boolean;
+  error: boolean;
+}) {
+  const summary = alerts?.summary ?? null;
+  const rows = alerts?.alerts.slice(0, 10) ?? [];
+
+  return (
+    <div className="border border-border p-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <ShieldAlert className="h-4 w-4 text-primary" />
+          <h2 className="text-sm font-semibold">Post-Execution Alerts</h2>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Badge variant="outline" className="border-sky-500/40 bg-sky-500/10 text-sky-600">
+            No automated rollback
+          </Badge>
+          <Badge
+            variant="outline"
+            className={cn(
+              "font-medium",
+              summary && summary.high_alerts > 0
+                ? "border-red-500/40 bg-red-500/10 text-red-600"
+                : summary && summary.total_alerts > 0
+                  ? "border-amber-500/40 bg-amber-500/10 text-amber-600"
+                  : summary
+                    ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-600"
+                    : "border-border bg-muted/30 text-muted-foreground",
+            )}
+          >
+            {loading && !alerts ? "Checking" : summary ? `${summary.total_alerts} alerts` : "No alerts"}
+          </Badge>
+        </div>
+      </div>
+
+      {error ? (
+        <p className="mt-3 text-xs text-destructive">Post-execution alerts unavailable.</p>
+      ) : loading && !alerts ? (
+        <p className="mt-3 text-xs text-muted-foreground">Loading post-execution alerts…</p>
+      ) : summary ? (
+        <div className="mt-3 space-y-3">
+          <div className="grid gap-2 sm:grid-cols-5">
+            <div className="bg-muted/40 p-2 text-xs">
+              <span className="text-muted-foreground">High</span>
+              <p className="mt-1 font-mono text-lg font-semibold">{summary.high_alerts}</p>
+            </div>
+            <div className="bg-muted/40 p-2 text-xs">
+              <span className="text-muted-foreground">Decay</span>
+              <p className="mt-1 font-mono text-lg font-semibold">{summary.signal_decay_alerts}</p>
+            </div>
+            <div className="bg-muted/40 p-2 text-xs">
+              <span className="text-muted-foreground">Whipsaw</span>
+              <p className="mt-1 font-mono text-lg font-semibold">{summary.whipsaw_after_promotion_alerts}</p>
+            </div>
+            <div className="bg-muted/40 p-2 text-xs">
+              <span className="text-muted-foreground">Drift</span>
+              <p className="mt-1 font-mono text-lg font-semibold">{summary.drift_alerts}</p>
+            </div>
+            <div className="bg-muted/40 p-2 text-xs">
+              <span className="text-muted-foreground">Stale</span>
+              <p className="mt-1 font-mono text-lg font-semibold">{summary.stale_execution_monitoring_alerts}</p>
+            </div>
+          </div>
+
+          {rows.length ? (
+            <div className="overflow-x-auto border border-border/70">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Alert</TableHead>
+                    <TableHead>Ticker</TableHead>
+                    <TableHead>Signal ID</TableHead>
+                    <TableHead>Metric</TableHead>
+                    <TableHead>Rollback Review</TableHead>
+                    <TableHead>Operator Note</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {rows.map((alert) => (
+                    <TableRow key={alert.alert_id}>
+                      <TableCell>
+                        <div className="space-y-1">
+                          <Badge
+                            variant="outline"
+                            className={cn("text-[10px]", promotionAlertSeverityClasses(alert.severity))}
+                          >
+                            {alert.severity}
+                          </Badge>
+                          <p className="font-medium">{promotionAlertTypeLabel(alert.alert_type)}</p>
+                          <p className="text-[11px] text-muted-foreground">{formatDate(alert.alert_date)}</p>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div>
+                          <span className="font-mono font-semibold">{alert.ticker}</span>
+                          <p className="mt-0.5 text-[11px] text-muted-foreground">
+                            {alert.action} {formatDate(alert.candidate_bar_date)}
+                          </p>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <span className="font-mono text-xs">{alert.market_signal_id}</span>
+                      </TableCell>
+                      <TableCell>
+                        <div className="space-y-1 text-xs">
+                          <p className="font-mono">{alert.metric_value ?? "—"}</p>
+                          <Badge
+                            variant="outline"
+                            className={cn("text-[10px]", promotionMonitoringStatusClasses(alert.monitoring_status))}
+                          >
+                            {promotionMonitoringLabel(alert.drift_status)}
+                          </Badge>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <Badge
+                          variant="outline"
+                          className={cn(
+                            "text-[10px]",
+                            alert.rollback_recommendation === "REVIEW_ROLLBACK_WARNING"
+                              ? "border-amber-500/40 bg-amber-500/10 text-amber-600"
+                              : "border-border bg-muted/30 text-muted-foreground",
+                          )}
+                        >
+                          {promotionMonitoringLabel(alert.rollback_recommendation)}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <div className="max-w-72 space-y-1 text-xs">
+                          <p className="line-clamp-2">{alert.explanation}</p>
+                          <p className="line-clamp-2 text-muted-foreground">{alert.operator_guidance}</p>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          ) : (
+            <p className="text-xs text-muted-foreground">No active post-execution alerts.</p>
+          )}
+        </div>
+      ) : (
+        <p className="mt-3 text-xs text-muted-foreground">No post-execution alert rows yet.</p>
+      )}
+    </div>
+  );
+}
+
 function PromotionDryRunPanel({
   dryRun,
   loading,
@@ -1995,6 +2167,9 @@ function PromotionDryRunPanel({
   postExecutionMonitoring,
   postExecutionMonitoringLoading,
   postExecutionMonitoringError,
+  postExecutionAlerts,
+  postExecutionAlertsLoading,
+  postExecutionAlertsError,
   onSubmitAcceptance,
   submittingAcceptance,
   onSubmitExecution,
@@ -2023,6 +2198,9 @@ function PromotionDryRunPanel({
   postExecutionMonitoring: FinancialPromotionPostExecutionMonitoringResponse | null;
   postExecutionMonitoringLoading: boolean;
   postExecutionMonitoringError: boolean;
+  postExecutionAlerts: FinancialPromotionPostExecutionAlertsResponse | null;
+  postExecutionAlertsLoading: boolean;
+  postExecutionAlertsError: boolean;
   onSubmitAcceptance: (payload: FinancialPromotionDryRunAcceptanceCreate) => Promise<void>;
   submittingAcceptance: boolean;
   onSubmitExecution: (payload: FinancialPromotionExecutionCreate) => Promise<void>;
@@ -2205,6 +2383,12 @@ function PromotionDryRunPanel({
         monitoring={postExecutionMonitoring}
         loading={postExecutionMonitoringLoading}
         error={postExecutionMonitoringError}
+      />
+
+      <PostExecutionAlertsPanel
+        alerts={postExecutionAlerts}
+        loading={postExecutionAlertsLoading}
+        error={postExecutionAlertsError}
       />
 
       <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
@@ -2795,6 +2979,9 @@ export function HedgeFundSignalsShell() {
   const promotionPostExecutionMonitoring = useFinancialPromotionPostExecutionMonitoring(promotionAuditId, {
     limit: 100,
   });
+  const promotionPostExecutionAlerts = useFinancialPromotionPostExecutionAlerts(promotionAuditId, {
+    limit: 100,
+  });
   const createShadowDecisionRecord = useCreateFinancialShadowDecisionRecord();
   const createPromotionDryRunAcceptance = useCreateFinancialPromotionDryRunAcceptance();
   const executePromotionDryRunAcceptance = useExecuteFinancialPromotionDryRunAcceptance();
@@ -2851,7 +3038,8 @@ export function HedgeFundSignalsShell() {
     promotionRollbackDrills.isFetching ||
     promotionLifecycleTimeline.isFetching ||
     promotionReconciliation.isFetching ||
-    promotionPostExecutionMonitoring.isFetching;
+    promotionPostExecutionMonitoring.isFetching ||
+    promotionPostExecutionAlerts.isFetching;
 
   async function handleShadowDecisionSubmit(payload: FinancialShadowReviewDecisionRecordCreate) {
     await createShadowDecisionRecord.mutateAsync(payload);
@@ -2866,6 +3054,7 @@ export function HedgeFundSignalsShell() {
     void promotionLifecycleTimeline.refetch();
     void promotionReconciliation.refetch();
     void promotionPostExecutionMonitoring.refetch();
+    void promotionPostExecutionAlerts.refetch();
   }
 
   async function handlePromotionExecutionSubmit(payload: FinancialPromotionExecutionCreate) {
@@ -2875,6 +3064,7 @@ export function HedgeFundSignalsShell() {
     void promotionLifecycleTimeline.refetch();
     void promotionReconciliation.refetch();
     void promotionPostExecutionMonitoring.refetch();
+    void promotionPostExecutionAlerts.refetch();
   }
 
   async function handlePromotionRollbackSubmit(payload: FinancialPromotionExecutionRollbackCreate) {
@@ -2884,6 +3074,7 @@ export function HedgeFundSignalsShell() {
     void promotionLifecycleTimeline.refetch();
     void promotionReconciliation.refetch();
     void promotionPostExecutionMonitoring.refetch();
+    void promotionPostExecutionAlerts.refetch();
   }
 
   return (
@@ -2944,6 +3135,7 @@ export function HedgeFundSignalsShell() {
               void promotionLifecycleTimeline.refetch();
               void promotionReconciliation.refetch();
               void promotionPostExecutionMonitoring.refetch();
+              void promotionPostExecutionAlerts.refetch();
             }}
             disabled={isRefreshing}
             aria-label="Refresh hedge fund signals"
@@ -3097,6 +3289,9 @@ export function HedgeFundSignalsShell() {
             postExecutionMonitoring={promotionPostExecutionMonitoring.data ?? null}
             postExecutionMonitoringLoading={promotionPostExecutionMonitoring.isLoading}
             postExecutionMonitoringError={promotionPostExecutionMonitoring.isError}
+            postExecutionAlerts={promotionPostExecutionAlerts.data ?? null}
+            postExecutionAlertsLoading={promotionPostExecutionAlerts.isLoading}
+            postExecutionAlertsError={promotionPostExecutionAlerts.isError}
             onSubmitAcceptance={handlePromotionDryRunAcceptanceSubmit}
             submittingAcceptance={createPromotionDryRunAcceptance.isPending}
             onSubmitExecution={handlePromotionExecutionSubmit}

--- a/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
@@ -20,6 +20,7 @@ import type {
   FinancialPromotionExecution,
   FinancialPromotionExecutionCreate,
   FinancialPromotionExecutionRollbackCreate,
+  FinancialPromotionPostExecutionAlertsResponse,
   FinancialPromotionLifecycleEvent,
   FinancialPromotionPostExecutionMonitoringResponse,
   FinancialPromotionReconciliation,
@@ -367,6 +368,23 @@ export function useFinancialPromotionPostExecutionMonitoring(
     queryFn: () =>
       api.get(
         `/api/financial/signals/promotion/${encodeURIComponent(promotionId ?? "")}/monitoring`,
+        params,
+      ),
+    enabled: Boolean(promotionId),
+    refetchInterval: 60_000,
+    staleTime: 60_000,
+  });
+}
+
+export function useFinancialPromotionPostExecutionAlerts(
+  promotionId: string | null,
+  params?: { limit?: number },
+) {
+  return useQuery<FinancialPromotionPostExecutionAlertsResponse>({
+    queryKey: ["financial", "signals", "promotion", promotionId, "post-execution-alerts", params],
+    queryFn: () =>
+      api.get(
+        `/api/financial/signals/promotion/${encodeURIComponent(promotionId ?? "")}/alerts`,
         params,
       ),
     enabled: Boolean(promotionId),

--- a/fortress-guest-platform/apps/command-center/src/lib/types.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/types.ts
@@ -770,6 +770,57 @@ export interface FinancialPromotionPostExecutionMonitoringResponse {
   rows: FinancialPromotionPostExecutionMonitoringRow[];
 }
 
+export type FinancialPromotionPostExecutionAlertType =
+  | "SIGNAL_DECAY"
+  | "WHIPSAW_AFTER_PROMOTION"
+  | "DRIFT"
+  | "STALE_EXECUTION_MONITORING"
+  | "ROLLBACK_RECOMMENDATION";
+
+export type FinancialPromotionPostExecutionAlertSeverity = "LOW" | "MEDIUM" | "HIGH";
+
+export interface FinancialPromotionPostExecutionAlertSummary {
+  total_alerts: number;
+  high_alerts: number;
+  medium_alerts: number;
+  low_alerts: number;
+  signal_decay_alerts: number;
+  whipsaw_after_promotion_alerts: number;
+  drift_alerts: number;
+  stale_execution_monitoring_alerts: number;
+  rollback_recommendation_alerts: number;
+}
+
+export interface FinancialPromotionPostExecutionAlert {
+  alert_id: string;
+  execution_id: string;
+  acceptance_id: string;
+  decision_record_id: string;
+  candidate_id: string;
+  market_signal_id: number;
+  ticker: string;
+  action: "BUY" | "SELL";
+  candidate_bar_date: string;
+  alert_type: FinancialPromotionPostExecutionAlertType;
+  severity: FinancialPromotionPostExecutionAlertSeverity;
+  alert_status: "ACTIVE";
+  alert_date: string | null;
+  metric_value: string | number | null;
+  rollback_recommendation: FinancialPromotionRollbackRecommendation;
+  monitoring_status: FinancialPromotionMonitoringStatus;
+  drift_status: FinancialPromotionMonitoringDriftStatus;
+  evidence: Record<string, unknown>;
+  explanation: string;
+  operator_guidance: string;
+}
+
+export interface FinancialPromotionPostExecutionAlertsResponse {
+  generated_at: string;
+  promotion_id: string;
+  summary: FinancialPromotionPostExecutionAlertSummary;
+  alerts: FinancialPromotionPostExecutionAlert[];
+}
+
 export interface FinancialWatchlistCandidate {
   ticker: string;
   bar_date: string;


### PR DESCRIPTION
## Summary

- Adds a read-only `hedge_fund.v_signal_promotion_post_execution_alerts` view for signal decay, whipsaw-after-promotion, drift, stale monitoring, and rollback recommendation alerts.
- Adds `/api/financial/signals/promotion/{id}/alerts` and cockpit `Post-Execution Alerts` observability.
- Documents that alerts are warning-only and cannot trigger rollback or trade/signal changes.

## Safety

- No execute button changes.
- No automatic rollback.
- No writes to `hedge_fund.market_signals`.
- No acceptance or execution records are created by alert verification.
- Alert rows are derived from audited post-execution monitoring rows.

## Tests

- `PYTHONPATH=. .venv-test/bin/python -m pytest tests/test_post_execution_alerts.py tests/test_api_signals.py`
- `PYTHONPATH=. .venv-test/bin/python -m pytest`
- `PYTHONPATH=. .venv-test/bin/python -m ruff check app/api/signals.py app/signals/repository.py tests/test_api_signals.py tests/test_post_execution_alerts.py`
- `npm --prefix fortress-guest-platform/apps/command-center test -- financial-hedge-fund-shell.test.tsx`
- `npm --prefix fortress-guest-platform/apps/command-center test`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint src/lib/hooks.ts src/lib/types.ts "src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx" src/__tests__/components/financial-hedge-fund-shell.test.tsx`
- `npm --prefix fortress-guest-platform/apps/command-center run build`
- `git diff --check`
