### PR TITLE
feat(financial): add post-execution alert acknowledgements

### DIFF
--- a/crog-ai-backend/alembic/versions/0013_post_execution_alert_acknowledgements.py
+++ b/crog-ai-backend/alembic/versions/0013_post_execution_alert_acknowledgements.py
@@ -1,0 +1,45 @@
+"""Add post-execution alert acknowledgements.
+
+Revision ID: 0013_post_execution_alert_acknowledgements
+Revises: 0012_post_execution_alerts
+Create Date: 2026-05-04 15:15:00.000000
+"""
+
+from pathlib import Path
+
+from alembic import op
+
+revision = "0013_post_execution_alert_acknowledgements"
+down_revision = "0012_post_execution_alerts"
+branch_labels = None
+depends_on = None
+
+
+def _sql_path(name: str) -> Path:
+    return Path(__file__).resolve().parents[2] / "deploy" / "sql" / name
+
+
+def upgrade() -> None:
+    op.execute(
+        _sql_path("marketclub_post_execution_alert_acknowledgements.sql").read_text(
+            encoding="utf-8"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS hedge_fund.v_signal_promotion_post_execution_alerts")
+    op.execute(
+        """
+        DROP FUNCTION IF EXISTS hedge_fund.acknowledge_signal_promotion_alert(
+            TEXT,
+            TEXT,
+            TEXT,
+            TEXT
+        )
+        """
+    )
+    op.execute("DROP TABLE IF EXISTS hedge_fund.signal_promotion_alert_acknowledgements")
+    op.execute(
+        _sql_path("marketclub_post_execution_alerts.sql").read_text(encoding="utf-8")
+    )

--- a/crog-ai-backend/app/api/signals.py
+++ b/crog-ai-backend/app/api/signals.py
@@ -489,6 +489,17 @@ class PromotionExecutionRollbackCreate(BaseModel):
     rollback_reason: str = Field(min_length=12, max_length=2000)
 
 
+class PromotionPostExecutionAlertAcknowledgementCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    acknowledgement_note: str = Field(min_length=8, max_length=2000)
+    acknowledgement_status: Literal[
+        "ACKNOWLEDGED",
+        "WATCHING",
+        "NO_ACTION_NEEDED",
+    ] = "ACKNOWLEDGED"
+
+
 class PromotionExecution(BaseModel):
     id: UUID
     acceptance_id: UUID
@@ -700,6 +711,17 @@ class PromotionPostExecutionAlert(BaseModel):
     evidence: dict[str, object]
     explanation: str
     operator_guidance: str
+    acknowledgement_count: int
+    acknowledged: bool
+    latest_acknowledgement_status: Literal[
+        "ACKNOWLEDGED",
+        "WATCHING",
+        "NO_ACTION_NEEDED",
+    ] | None
+    latest_acknowledged_by: str | None
+    latest_acknowledged_at: dt.datetime | None
+    latest_acknowledgement_note: str | None
+    acknowledgement_required: bool
 
 
 class PromotionPostExecutionAlertsResponse(BaseModel):
@@ -707,6 +729,36 @@ class PromotionPostExecutionAlertsResponse(BaseModel):
     promotion_id: str
     summary: PromotionPostExecutionAlertSummary
     alerts: list[PromotionPostExecutionAlert]
+
+
+class PromotionPostExecutionAlertAcknowledgement(BaseModel):
+    id: UUID
+    alert_id: str
+    execution_id: UUID
+    acceptance_id: UUID
+    decision_record_id: UUID
+    market_signal_id: int
+    ticker: str
+    action: Literal["BUY", "SELL"]
+    candidate_bar_date: dt.date
+    alert_type: Literal[
+        "SIGNAL_DECAY",
+        "WHIPSAW_AFTER_PROMOTION",
+        "DRIFT",
+        "STALE_EXECUTION_MONITORING",
+        "ROLLBACK_RECOMMENDATION",
+    ]
+    severity: Literal["LOW", "MEDIUM", "HIGH"]
+    operator_membership_id: UUID
+    acknowledged_by: str
+    acknowledgement_status: Literal[
+        "ACKNOWLEDGED",
+        "WATCHING",
+        "NO_ACTION_NEEDED",
+    ]
+    acknowledgement_note: str
+    alert_evidence_snapshot: dict[str, object]
+    created_at: dt.datetime
 
 
 class SymbolChartBar(BaseModel):
@@ -1151,6 +1203,28 @@ def promotion_post_execution_alerts(
         promotion_id=promotion_id,
         limit=limit,
     )
+
+
+@router.post(
+    "/promotion-alerts/{alert_id}/acknowledgements",
+    response_model=PromotionPostExecutionAlertAcknowledgement,
+    status_code=201,
+)
+def acknowledge_promotion_post_execution_alert(
+    alert_id: Annotated[str, Path(min_length=1, max_length=120)],
+    payload: PromotionPostExecutionAlertAcknowledgementCreate,
+    store: Annotated[SignalDataStore, Depends(get_signal_store)],
+    operator_token: OperatorToken,
+) -> dict[str, object]:
+    try:
+        return store.acknowledge_promotion_post_execution_alert(
+            alert_id=alert_id,
+            operator_token_sha256=_operator_token_sha256(operator_token),
+            acknowledgement_note=payload.acknowledgement_note.strip(),
+            acknowledgement_status=payload.acknowledgement_status,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.post(

--- a/crog-ai-backend/app/signals/repository.py
+++ b/crog-ai-backend/app/signals/repository.py
@@ -185,6 +185,15 @@ class SignalDataStore(Protocol):
         limit: int = 100,
     ) -> dict[str, Any]: ...
 
+    def acknowledge_promotion_post_execution_alert(
+        self,
+        *,
+        alert_id: str,
+        operator_token_sha256: str,
+        acknowledgement_note: str,
+        acknowledgement_status: str = "ACKNOWLEDGED",
+    ) -> dict[str, Any]: ...
+
     def execute_guarded_promotion(
         self,
         *,
@@ -2311,6 +2320,13 @@ PROMOTION_POST_EXECUTION_ALERT_FIELDS = [
     "evidence",
     "explanation",
     "operator_guidance",
+    "acknowledgement_count",
+    "acknowledged",
+    "latest_acknowledgement_status",
+    "latest_acknowledged_by",
+    "latest_acknowledged_at",
+    "latest_acknowledgement_note",
+    "acknowledgement_required",
 ]
 
 
@@ -2341,7 +2357,14 @@ def fetch_promotion_post_execution_alerts(
             drift_status,
             evidence,
             explanation,
-            operator_guidance
+            operator_guidance,
+            acknowledgement_count,
+            acknowledged,
+            latest_acknowledgement_status,
+            latest_acknowledged_by,
+            latest_acknowledged_at,
+            latest_acknowledgement_note,
+            acknowledgement_required
         FROM hedge_fund.v_signal_promotion_post_execution_alerts
         WHERE candidate_id = %(promotion_id)s
            OR acceptance_id::TEXT = %(promotion_id)s
@@ -2383,6 +2406,62 @@ def fetch_promotion_post_execution_alerts(
         },
         "alerts": rows,
     }
+
+
+PROMOTION_POST_EXECUTION_ALERT_ACK_FIELDS = [
+    "id",
+    "alert_id",
+    "execution_id",
+    "acceptance_id",
+    "decision_record_id",
+    "market_signal_id",
+    "ticker",
+    "action",
+    "candidate_bar_date",
+    "alert_type",
+    "severity",
+    "operator_membership_id",
+    "acknowledged_by",
+    "acknowledgement_status",
+    "acknowledgement_note",
+    "alert_evidence_snapshot",
+    "created_at",
+]
+
+
+def acknowledge_promotion_post_execution_alert(
+    conn: psycopg.Connection,
+    *,
+    alert_id: str,
+    operator_token_sha256: str,
+    acknowledgement_note: str,
+    acknowledgement_status: str = "ACKNOWLEDGED",
+) -> dict[str, Any]:
+    try:
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                """
+                SELECT *
+                FROM hedge_fund.acknowledge_signal_promotion_alert(
+                    %(alert_id)s,
+                    %(operator_token_sha256)s,
+                    %(acknowledgement_note)s,
+                    %(acknowledgement_status)s
+                )
+                """,
+                {
+                    "alert_id": alert_id,
+                    "operator_token_sha256": operator_token_sha256,
+                    "acknowledgement_note": acknowledgement_note,
+                    "acknowledgement_status": acknowledgement_status,
+                },
+            )
+            row = cur.fetchone()
+    except psycopg.Error as exc:
+        raise ValueError(str(exc).splitlines()[0]) from exc
+    if row is None:
+        raise RuntimeError("alert acknowledgement returned no row")
+    return {key: row[key] for key in PROMOTION_POST_EXECUTION_ALERT_ACK_FIELDS}
 
 
 def execute_guarded_promotion(
@@ -2904,6 +2983,23 @@ class PostgresSignalDataStore:
                 conn,
                 promotion_id=promotion_id,
                 limit=limit,
+            )
+
+    def acknowledge_promotion_post_execution_alert(
+        self,
+        *,
+        alert_id: str,
+        operator_token_sha256: str,
+        acknowledgement_note: str,
+        acknowledgement_status: str = "ACKNOWLEDGED",
+    ) -> dict[str, Any]:
+        with connect() as conn:
+            return acknowledge_promotion_post_execution_alert(
+                conn,
+                alert_id=alert_id,
+                operator_token_sha256=operator_token_sha256,
+                acknowledgement_note=acknowledgement_note,
+                acknowledgement_status=acknowledgement_status,
             )
 
     def execute_guarded_promotion(

--- a/crog-ai-backend/deploy/sql/marketclub_post_execution_alert_acknowledgements.sql
+++ b/crog-ai-backend/deploy/sql/marketclub_post_execution_alert_acknowledgements.sql
@@ -1,0 +1,409 @@
+CREATE TABLE IF NOT EXISTS hedge_fund.signal_promotion_alert_acknowledgements (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    alert_id TEXT NOT NULL,
+    execution_id UUID NOT NULL
+        REFERENCES hedge_fund.signal_promotion_executions(id)
+        ON DELETE RESTRICT,
+    acceptance_id UUID NOT NULL
+        REFERENCES hedge_fund.signal_promotion_dry_run_acceptances(id)
+        ON DELETE RESTRICT,
+    decision_record_id UUID NOT NULL
+        REFERENCES hedge_fund.signal_shadow_review_decisions(id)
+        ON DELETE RESTRICT,
+    market_signal_id INTEGER NOT NULL,
+    ticker TEXT NOT NULL,
+    action TEXT NOT NULL,
+    candidate_bar_date DATE NOT NULL,
+    alert_type TEXT NOT NULL,
+    severity TEXT NOT NULL,
+    operator_membership_id UUID NOT NULL
+        REFERENCES hedge_fund.signal_operator_memberships(id)
+        ON DELETE RESTRICT,
+    acknowledged_by VARCHAR(120) NOT NULL,
+    acknowledgement_status TEXT NOT NULL,
+    acknowledgement_note TEXT NOT NULL,
+    alert_evidence_snapshot JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT ck_signal_promotion_alert_ack_action
+        CHECK (action IN ('BUY', 'SELL')),
+    CONSTRAINT ck_signal_promotion_alert_ack_type
+        CHECK (
+            alert_type IN (
+                'SIGNAL_DECAY',
+                'WHIPSAW_AFTER_PROMOTION',
+                'DRIFT',
+                'STALE_EXECUTION_MONITORING',
+                'ROLLBACK_RECOMMENDATION'
+            )
+        ),
+    CONSTRAINT ck_signal_promotion_alert_ack_severity
+        CHECK (severity IN ('LOW', 'MEDIUM', 'HIGH')),
+    CONSTRAINT ck_signal_promotion_alert_ack_status
+        CHECK (acknowledgement_status IN ('ACKNOWLEDGED', 'WATCHING', 'NO_ACTION_NEEDED')),
+    CONSTRAINT ck_signal_promotion_alert_ack_note
+        CHECK (length(trim(acknowledgement_note)) >= 8)
+);
+
+CREATE INDEX IF NOT EXISTS ix_signal_promotion_alert_ack_alert_created
+ON hedge_fund.signal_promotion_alert_acknowledgements (
+    alert_id,
+    created_at DESC
+);
+
+CREATE INDEX IF NOT EXISTS ix_signal_promotion_alert_ack_execution_created
+ON hedge_fund.signal_promotion_alert_acknowledgements (
+    execution_id,
+    created_at DESC
+);
+
+CREATE OR REPLACE FUNCTION hedge_fund.acknowledge_signal_promotion_alert(
+    p_alert_id TEXT,
+    p_operator_token_sha256 TEXT,
+    p_acknowledgement_note TEXT,
+    p_acknowledgement_status TEXT DEFAULT 'ACKNOWLEDGED'
+)
+RETURNS hedge_fund.signal_promotion_alert_acknowledgements
+LANGUAGE plpgsql
+-- SECURITY DEFINER is intentionally narrow: crog_ai_app gets EXECUTE on this
+-- audit-only function, not direct INSERT on acknowledgement tables. The function
+-- checks active operator membership and requires an existing alert_id from the
+-- audited post-execution alert view before writing an acknowledgement audit row.
+SECURITY DEFINER
+SET search_path = pg_catalog, hedge_fund
+AS $$
+DECLARE
+    v_operator RECORD;
+    v_alert RECORD;
+    v_ack hedge_fund.signal_promotion_alert_acknowledgements%ROWTYPE;
+    v_status TEXT;
+BEGIN
+    v_status := upper(trim(COALESCE(p_acknowledgement_status, 'ACKNOWLEDGED')));
+
+    IF v_status NOT IN ('ACKNOWLEDGED', 'WATCHING', 'NO_ACTION_NEEDED') THEN
+        RAISE EXCEPTION 'Unsupported alert acknowledgement status: %', v_status;
+    END IF;
+
+    IF length(trim(COALESCE(p_acknowledgement_note, ''))) < 8 THEN
+        RAISE EXCEPTION 'acknowledgement_note is required for alert acknowledgement';
+    END IF;
+
+    SELECT id, operator_label, role
+    INTO v_operator
+    FROM hedge_fund.signal_operator_memberships
+    WHERE token_sha256 = lower(trim(COALESCE(p_operator_token_sha256, '')))
+      AND is_active = TRUE
+      AND role IN ('signal_operator', 'signal_admin')
+    LIMIT 1;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Active signal operator membership is required for alert acknowledgement';
+    END IF;
+
+    SELECT *
+    INTO v_alert
+    FROM hedge_fund.v_signal_promotion_post_execution_alerts
+    WHERE alert_id = trim(COALESCE(p_alert_id, ''))
+    LIMIT 1;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'No active post-execution alert found for alert_id';
+    END IF;
+
+    INSERT INTO hedge_fund.signal_promotion_alert_acknowledgements (
+        alert_id,
+        execution_id,
+        acceptance_id,
+        decision_record_id,
+        market_signal_id,
+        ticker,
+        action,
+        candidate_bar_date,
+        alert_type,
+        severity,
+        operator_membership_id,
+        acknowledged_by,
+        acknowledgement_status,
+        acknowledgement_note,
+        alert_evidence_snapshot
+    ) VALUES (
+        v_alert.alert_id,
+        v_alert.execution_id,
+        v_alert.acceptance_id,
+        v_alert.decision_record_id,
+        v_alert.market_signal_id,
+        v_alert.ticker,
+        v_alert.action,
+        v_alert.candidate_bar_date,
+        v_alert.alert_type,
+        v_alert.severity,
+        v_operator.id,
+        v_operator.operator_label,
+        v_status,
+        trim(p_acknowledgement_note),
+        to_jsonb(v_alert)
+    )
+    RETURNING * INTO v_ack;
+
+    RETURN v_ack;
+END;
+$$;
+
+CREATE OR REPLACE VIEW hedge_fund.v_signal_promotion_post_execution_alerts
+WITH (security_invoker = true) AS
+WITH monitoring AS (
+    SELECT *
+    FROM hedge_fund.v_signal_promotion_post_execution_monitoring
+),
+signal_decay_alerts AS (
+    SELECT
+        md5(execution_id::TEXT || ':' || market_signal_id::TEXT || ':SIGNAL_DECAY') AS alert_id,
+        execution_id,
+        acceptance_id,
+        decision_record_id,
+        candidate_id,
+        market_signal_id,
+        ticker,
+        action,
+        candidate_bar_date,
+        'SIGNAL_DECAY'::TEXT AS alert_type,
+        CASE
+            WHEN rollback_recommendation = 'REVIEW_ROLLBACK_WARNING' THEN 'HIGH'
+            ELSE 'MEDIUM'
+        END AS severity,
+        'ACTIVE'::TEXT AS alert_status,
+        signal_decay_date AS alert_date,
+        signal_decay_score::NUMERIC AS metric_value,
+        rollback_recommendation,
+        monitoring_status,
+        drift_status,
+        jsonb_build_object(
+            'rollback_marker', rollback_marker,
+            'signal_decay_score', signal_decay_score,
+            'signal_decay_daily_triangle', signal_decay_daily_triangle,
+            'latest_candidate_score', latest_candidate_score,
+            'latest_daily_triangle', latest_daily_triangle,
+            'score_delta', score_delta
+        ) AS evidence,
+        'Candidate score or daily triangle decayed after promotion.'::TEXT AS explanation,
+        'Warning only: review the audited execution; no automated rollback is performed.'::TEXT
+            AS operator_guidance
+    FROM monitoring
+    WHERE signal_decay_flag
+      AND rollback_status = 'active'
+),
+whipsaw_alerts AS (
+    SELECT
+        md5(execution_id::TEXT || ':' || market_signal_id::TEXT || ':WHIPSAW_AFTER_PROMOTION')
+            AS alert_id,
+        execution_id,
+        acceptance_id,
+        decision_record_id,
+        candidate_id,
+        market_signal_id,
+        ticker,
+        action,
+        candidate_bar_date,
+        'WHIPSAW_AFTER_PROMOTION'::TEXT AS alert_type,
+        CASE
+            WHEN rollback_recommendation = 'REVIEW_ROLLBACK_WARNING' THEN 'HIGH'
+            ELSE 'MEDIUM'
+        END AS severity,
+        'ACTIVE'::TEXT AS alert_status,
+        whipsaw_transition_date AS alert_date,
+        whipsaw_to_score::NUMERIC AS metric_value,
+        rollback_recommendation,
+        monitoring_status,
+        drift_status,
+        jsonb_build_object(
+            'rollback_marker', rollback_marker,
+            'whipsaw_transition_date', whipsaw_transition_date,
+            'whipsaw_transition_type', whipsaw_transition_type,
+            'whipsaw_to_score', whipsaw_to_score
+        ) AS evidence,
+        'Candidate produced an opposite transition after promotion.'::TEXT AS explanation,
+        'Warning only: review whipsaw context; no automatic trade or signal change is made.'::TEXT
+            AS operator_guidance
+    FROM monitoring
+    WHERE whipsaw_after_promotion_flag
+      AND rollback_status = 'active'
+),
+drift_alerts AS (
+    SELECT
+        md5(execution_id::TEXT || ':' || market_signal_id::TEXT || ':DRIFT') AS alert_id,
+        execution_id,
+        acceptance_id,
+        decision_record_id,
+        candidate_id,
+        market_signal_id,
+        ticker,
+        action,
+        candidate_bar_date,
+        'DRIFT'::TEXT AS alert_type,
+        CASE
+            WHEN drift_status = 'PRICE_AND_SCORE_DRIFT' THEN 'HIGH'
+            ELSE 'MEDIUM'
+        END AS severity,
+        'ACTIVE'::TEXT AS alert_status,
+        COALESCE(outcome_20d_bar_date, outcome_5d_bar_date, latest_candidate_bar_date)
+            AS alert_date,
+        COALESCE(
+            outcome_20d_directional_return,
+            outcome_5d_directional_return,
+            score_delta::NUMERIC
+        ) AS metric_value,
+        rollback_recommendation,
+        monitoring_status,
+        drift_status,
+        jsonb_build_object(
+            'rollback_marker', rollback_marker,
+            'outcome_1d_directional_return', outcome_1d_directional_return,
+            'outcome_5d_directional_return', outcome_5d_directional_return,
+            'outcome_20d_directional_return', outcome_20d_directional_return,
+            'score_delta', score_delta,
+            'latest_candidate_score', latest_candidate_score
+        ) AS evidence,
+        'Promoted signal drifted away from candidate expectation.'::TEXT AS explanation,
+        'Warning only: review candidate drift; no automatic trade or signal change is made.'::TEXT
+            AS operator_guidance
+    FROM monitoring
+    WHERE drift_status IN ('PRICE_DRIFT', 'SCORE_DRIFT', 'PRICE_AND_SCORE_DRIFT')
+      AND rollback_status = 'active'
+),
+stale_alerts AS (
+    SELECT
+        md5(execution_id::TEXT || ':' || market_signal_id::TEXT || ':STALE_EXECUTION_MONITORING')
+            AS alert_id,
+        execution_id,
+        acceptance_id,
+        decision_record_id,
+        candidate_id,
+        market_signal_id,
+        ticker,
+        action,
+        candidate_bar_date,
+        'STALE_EXECUTION_MONITORING'::TEXT AS alert_type,
+        CASE
+            WHEN executed_at < now() - INTERVAL '5 days' THEN 'MEDIUM'
+            ELSE 'LOW'
+        END AS severity,
+        'ACTIVE'::TEXT AS alert_status,
+        executed_at::DATE AS alert_date,
+        EXTRACT(EPOCH FROM (now() - executed_at)) / 86400.0 AS metric_value,
+        rollback_recommendation,
+        monitoring_status,
+        drift_status,
+        jsonb_build_object(
+            'rollback_marker', rollback_marker,
+            'executed_at', executed_at,
+            'latest_candidate_bar_date', latest_candidate_bar_date,
+            'outcome_1d_bar_date', outcome_1d_bar_date,
+            'market_signal_live', market_signal_live
+        ) AS evidence,
+        'Execution monitoring is stale: no post-promotion outcome or candidate update has arrived.'::TEXT
+            AS explanation,
+        'Warning only: verify data freshness; no automatic trade, signal, or rollback action is made.'::TEXT
+            AS operator_guidance
+    FROM monitoring
+    WHERE rollback_status = 'active'
+      AND market_signal_live
+      AND monitoring_status = 'PENDING'
+      AND executed_at < now() - INTERVAL '2 days'
+      AND outcome_1d_bar_date IS NULL
+      AND (
+        latest_candidate_bar_date IS NULL
+        OR latest_candidate_bar_date <= candidate_bar_date
+      )
+),
+rollback_recommendation_alerts AS (
+    SELECT
+        md5(execution_id::TEXT || ':' || market_signal_id::TEXT || ':ROLLBACK_RECOMMENDATION')
+            AS alert_id,
+        execution_id,
+        acceptance_id,
+        decision_record_id,
+        candidate_id,
+        market_signal_id,
+        ticker,
+        action,
+        candidate_bar_date,
+        'ROLLBACK_RECOMMENDATION'::TEXT AS alert_type,
+        CASE
+            WHEN rollback_recommendation = 'REVIEW_ROLLBACK_WARNING' THEN 'HIGH'
+            ELSE 'MEDIUM'
+        END AS severity,
+        'ACTIVE'::TEXT AS alert_status,
+        COALESCE(
+            whipsaw_transition_date,
+            signal_decay_date,
+            outcome_20d_bar_date,
+            outcome_5d_bar_date,
+            latest_candidate_bar_date
+        ) AS alert_date,
+        COALESCE(outcome_20d_directional_return, outcome_5d_directional_return)
+            AS metric_value,
+        rollback_recommendation,
+        monitoring_status,
+        drift_status,
+        jsonb_build_object(
+            'rollback_marker', rollback_marker,
+            'rollback_recommendation', rollback_recommendation,
+            'whipsaw_after_promotion_flag', whipsaw_after_promotion_flag,
+            'signal_decay_flag', signal_decay_flag,
+            'drift_status', drift_status
+        ) AS evidence,
+        'Monitoring recommends operator rollback review.'::TEXT AS explanation,
+        'Warning only: this alert never calls rollback_guarded_signal_promotion and never changes trades or signals automatically.'::TEXT
+            AS operator_guidance
+    FROM monitoring
+    WHERE rollback_recommendation IN ('WATCH_WARNING', 'REVIEW_ROLLBACK_WARNING')
+      AND rollback_status = 'active'
+),
+alert_rows AS (
+    SELECT * FROM signal_decay_alerts
+    UNION ALL
+    SELECT * FROM whipsaw_alerts
+    UNION ALL
+    SELECT * FROM drift_alerts
+    UNION ALL
+    SELECT * FROM stale_alerts
+    UNION ALL
+    SELECT * FROM rollback_recommendation_alerts
+),
+acknowledgement_rollup AS (
+    SELECT DISTINCT ON (a.alert_id)
+        a.alert_id,
+        count(*) OVER (PARTITION BY a.alert_id)::INTEGER AS acknowledgement_count,
+        a.acknowledgement_status AS latest_acknowledgement_status,
+        a.acknowledged_by AS latest_acknowledged_by,
+        a.acknowledgement_note AS latest_acknowledgement_note,
+        a.created_at AS latest_acknowledged_at
+    FROM hedge_fund.signal_promotion_alert_acknowledgements a
+    ORDER BY a.alert_id, a.created_at DESC
+)
+SELECT
+    r.*,
+    COALESCE(a.acknowledgement_count, 0)::INTEGER AS acknowledgement_count,
+    COALESCE(a.acknowledgement_count, 0) > 0 AS acknowledged,
+    a.latest_acknowledgement_status,
+    a.latest_acknowledged_by,
+    a.latest_acknowledged_at,
+    a.latest_acknowledgement_note,
+    COALESCE(a.acknowledgement_count, 0) = 0
+        AND r.severity IN ('HIGH', 'MEDIUM') AS acknowledgement_required
+FROM alert_rows r
+LEFT JOIN acknowledgement_rollup a
+  ON a.alert_id = r.alert_id;
+
+REVOKE ALL ON FUNCTION hedge_fund.acknowledge_signal_promotion_alert(TEXT, TEXT, TEXT, TEXT)
+FROM PUBLIC;
+REVOKE ALL ON TABLE hedge_fund.signal_promotion_alert_acknowledgements FROM PUBLIC;
+REVOKE ALL ON TABLE hedge_fund.v_signal_promotion_post_execution_alerts FROM PUBLIC;
+
+GRANT SELECT ON TABLE
+    hedge_fund.signal_promotion_alert_acknowledgements,
+    hedge_fund.v_signal_promotion_post_execution_alerts
+TO crog_ai_app;
+
+GRANT EXECUTE ON FUNCTION
+    hedge_fund.acknowledge_signal_promotion_alert(TEXT, TEXT, TEXT, TEXT)
+TO crog_ai_app;

--- a/crog-ai-backend/docs/OPERATOR-AUDIT-PLAYBOOK.md
+++ b/crog-ai-backend/docs/OPERATOR-AUDIT-PLAYBOOK.md
@@ -64,6 +64,18 @@ The alert layer is read-only and derives from post-execution monitoring rows:
 
 Alerts are operator warnings only. They do not call rollback functions, write or delete `market_signals`, create acceptance records, create execution records, change trades, or change signal state. Rollback recommendation alerts mean “review this audited execution,” not “rollback automatically.”
 
+## Alert Acknowledgements
+
+Use `POST /api/financial/signals/promotion-alerts/{alert_id}/acknowledgements` to record operator review notes for an active post-execution alert. The acknowledgement write is audit-only:
+
+- it only accepts an `alert_id`, never ticker/date
+- it requires an active `signal_operator` or `signal_admin` token
+- it snapshots the alert evidence at acknowledgement time
+- it writes only to `hedge_fund.signal_promotion_alert_acknowledgements`
+- it does not call rollback, update trades, or change signal rows
+
+Acknowledgement status values are `ACKNOWLEDGED`, `WATCHING`, and `NO_ACTION_NEEDED`. The alerts endpoint surfaces latest acknowledgement status and whether review is still open.
+
 ## Snapshots
 
 Acceptance records persist:

--- a/crog-ai-backend/tests/test_api_signals.py
+++ b/crog-ai-backend/tests/test_api_signals.py
@@ -1068,6 +1068,30 @@ class FakeSignalStore:
                 ),
             },
         ][:limit]
+        for alert in alerts:
+            alert.update(
+                {
+                    "acknowledgement_count": 0,
+                    "acknowledged": False,
+                    "latest_acknowledgement_status": None,
+                    "latest_acknowledged_by": None,
+                    "latest_acknowledged_at": None,
+                    "latest_acknowledgement_note": None,
+                    "acknowledgement_required": alert["severity"] in {"HIGH", "MEDIUM"},
+                }
+            )
+        if alerts:
+            alerts[0].update(
+                {
+                    "acknowledgement_count": 1,
+                    "acknowledged": True,
+                    "latest_acknowledgement_status": "WATCHING",
+                    "latest_acknowledged_by": "MarketClub Operator",
+                    "latest_acknowledged_at": dt.datetime(2026, 5, 4, 13, 45, tzinfo=dt.UTC),
+                    "latest_acknowledgement_note": "Operator reviewed decay context.",
+                    "acknowledgement_required": False,
+                }
+            )
         alert_counts = Counter(alert["alert_type"] for alert in alerts)
         severity_counts = Counter(alert["severity"] for alert in alerts)
         return {
@@ -1087,6 +1111,43 @@ class FakeSignalStore:
                 "rollback_recommendation_alerts": alert_counts["ROLLBACK_RECOMMENDATION"],
             },
             "alerts": alerts,
+        }
+
+    def acknowledge_promotion_post_execution_alert(
+        self,
+        *,
+        alert_id: str,
+        operator_token_sha256: str,
+        acknowledgement_note: str,
+        acknowledgement_status: str = "ACKNOWLEDGED",
+    ) -> dict[str, Any]:
+        if operator_token_sha256 != OPERATOR_TOKEN_SHA256:
+            raise ValueError("Active signal operator membership is required for alert acknowledgement")
+        alerts = self.promotion_post_execution_alerts(
+            promotion_id=str(EXECUTION_ID),
+            limit=10,
+        )["alerts"]
+        alert = next((item for item in alerts if item["alert_id"] == alert_id), None)
+        if alert is None:
+            raise ValueError("No active post-execution alert found for alert_id")
+        return {
+            "id": UUID("88888888-8888-8888-8888-888888888888"),
+            "alert_id": alert["alert_id"],
+            "execution_id": alert["execution_id"],
+            "acceptance_id": alert["acceptance_id"],
+            "decision_record_id": alert["decision_record_id"],
+            "market_signal_id": alert["market_signal_id"],
+            "ticker": alert["ticker"],
+            "action": alert["action"],
+            "candidate_bar_date": alert["candidate_bar_date"],
+            "alert_type": alert["alert_type"],
+            "severity": alert["severity"],
+            "operator_membership_id": OPERATOR_MEMBERSHIP_ID,
+            "acknowledged_by": "MarketClub Operator",
+            "acknowledgement_status": acknowledgement_status,
+            "acknowledgement_note": acknowledgement_note,
+            "alert_evidence_snapshot": alert,
+            "created_at": dt.datetime(2026, 5, 4, 13, 46, tzinfo=dt.UTC),
         }
 
     def execute_guarded_promotion(
@@ -1741,10 +1802,74 @@ def test_promotion_post_execution_alerts_endpoint_returns_warning_only_alerts() 
     }
     assert all(alert["alert_status"] == "ACTIVE" for alert in payload["alerts"])
     assert all("Warning only" in alert["operator_guidance"] for alert in payload["alerts"])
+    assert payload["alerts"][0]["acknowledged"] is True
+    assert payload["alerts"][0]["latest_acknowledgement_status"] == "WATCHING"
+    assert payload["alerts"][1]["acknowledgement_required"] is True
     guidance = " ".join(alert["operator_guidance"] for alert in payload["alerts"])
     assert "no automated rollback is performed" in guidance
     assert "no automatic trade or signal change is made" in guidance
     assert "no automatic trade, signal, or rollback action is made" in guidance
+
+
+def test_promotion_post_execution_alert_acknowledgement_endpoint_creates_audit_row() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/financial/signals/promotion-alerts/whipsaw-aa/acknowledgements",
+        headers={"X-MarketClub-Operator-Token": OPERATOR_TOKEN},
+        json={
+            "acknowledgement_status": "WATCHING",
+            "acknowledgement_note": "Operator reviewed whipsaw context.",
+        },
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["alert_id"] == "whipsaw-aa"
+    assert payload["execution_id"] == str(EXECUTION_ID)
+    assert payload["operator_membership_id"] == str(OPERATOR_MEMBERSHIP_ID)
+    assert payload["acknowledged_by"] == "MarketClub Operator"
+    assert payload["acknowledgement_status"] == "WATCHING"
+    assert payload["acknowledgement_note"] == "Operator reviewed whipsaw context."
+    assert payload["alert_evidence_snapshot"]["market_signal_id"] == 1201
+
+
+def test_promotion_post_execution_alert_acknowledgement_rejects_unauthorized_operator() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/financial/signals/promotion-alerts/whipsaw-aa/acknowledgements",
+        headers={"X-MarketClub-Operator-Token": "bad-marketclub-token"},
+        json={
+            "acknowledgement_status": "ACKNOWLEDGED",
+            "acknowledgement_note": "Operator reviewed whipsaw context.",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "Active signal operator membership is required" in response.json()["detail"]
+
+
+def test_promotion_post_execution_alert_acknowledgement_rejects_nonexistent_alert() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/financial/signals/promotion-alerts/not-real/acknowledgements",
+        headers={"X-MarketClub-Operator-Token": OPERATOR_TOKEN},
+        json={
+            "acknowledgement_status": "ACKNOWLEDGED",
+            "acknowledgement_note": "Operator reviewed whipsaw context.",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "No active post-execution alert found for alert_id" in response.json()["detail"]
 
 
 def test_execute_guarded_promotion_endpoint_returns_execution_record() -> None:

--- a/crog-ai-backend/tests/test_post_execution_alert_acknowledgements.py
+++ b/crog-ai-backend/tests/test_post_execution_alert_acknowledgements.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+
+def _ack_sql() -> str:
+    return (
+        Path(__file__).resolve().parents[1]
+        / "deploy"
+        / "sql"
+        / "marketclub_post_execution_alert_acknowledgements.sql"
+    ).read_text(encoding="utf-8")
+
+
+def test_alert_acknowledgement_sql_is_audit_only() -> None:
+    sql = _ack_sql()
+
+    assert "CREATE TABLE IF NOT EXISTS hedge_fund.signal_promotion_alert_acknowledgements" in sql
+    assert "CREATE OR REPLACE FUNCTION hedge_fund.acknowledge_signal_promotion_alert" in sql
+    assert "CREATE OR REPLACE VIEW hedge_fund.v_signal_promotion_post_execution_alerts" in sql
+    assert "INSERT INTO hedge_fund.signal_promotion_alert_acknowledgements" in sql
+    assert "INSERT INTO hedge_fund.market_signals" not in sql
+    assert "DELETE FROM hedge_fund.market_signals" not in sql
+    assert "UPDATE hedge_fund.market_signals" not in sql
+    assert "rollback_guarded_signal_promotion(" not in sql
+
+
+def test_alert_acknowledgement_requires_operator_and_alert_id_only() -> None:
+    sql = _ack_sql()
+
+    assert "p_alert_id TEXT" in sql
+    assert "p_operator_token_sha256 TEXT" in sql
+    assert "role IN ('signal_operator', 'signal_admin')" in sql
+    assert "WHERE alert_id = trim(COALESCE(p_alert_id, ''))" in sql
+    assert "No active post-execution alert found for alert_id" in sql
+    assert "p_ticker" not in sql
+    assert "p_bar_date" not in sql
+
+
+def test_alert_acknowledgement_snapshots_evidence_and_surfaces_state() -> None:
+    sql = _ack_sql()
+
+    assert "alert_evidence_snapshot JSONB NOT NULL" in sql
+    assert "to_jsonb(v_alert)" in sql
+    assert "acknowledgement_rollup AS" in sql
+    assert "acknowledgement_count" in sql
+    assert "acknowledged" in sql
+    assert "latest_acknowledgement_status" in sql
+    assert "acknowledgement_required" in sql
+
+
+def test_alert_acknowledgement_grants_are_narrow() -> None:
+    sql = _ack_sql()
+
+    assert "REVOKE ALL ON FUNCTION hedge_fund.acknowledge_signal_promotion_alert" in sql
+    assert "REVOKE ALL ON TABLE hedge_fund.signal_promotion_alert_acknowledgements" in sql
+    assert "GRANT SELECT ON TABLE" in sql
+    assert "GRANT EXECUTE ON FUNCTION" in sql

--- a/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
+++ b/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
@@ -990,6 +990,17 @@ const promotionPostExecutionAlerts = {
   ],
 };
 
+promotionPostExecutionAlerts.alerts = promotionPostExecutionAlerts.alerts.map((alert, index) => ({
+  ...alert,
+  acknowledgement_count: index === 0 ? 1 : 0,
+  acknowledged: index === 0,
+  latest_acknowledgement_status: index === 0 ? "WATCHING" : null,
+  latest_acknowledged_by: index === 0 ? "MarketClub Operator" : null,
+  latest_acknowledged_at: index === 0 ? "2026-05-04T13:45:00Z" : null,
+  latest_acknowledgement_note: index === 0 ? "Operator reviewed decay context." : null,
+  acknowledgement_required: index !== 0,
+}));
+
 let promotionDryRunAcceptancesMock = promotionDryRunAcceptances;
 let promotionExecutionsMock = promotionExecutions;
 let promotionDryRunVerificationMock = promotionDryRunVerification;
@@ -1131,6 +1142,10 @@ vi.mock("@/lib/hooks", () => ({
     isLoading: false,
     refetch: vi.fn(),
   }),
+  useAcknowledgeFinancialPromotionPostExecutionAlert: () => ({
+    isPending: false,
+    mutateAsync: vi.fn(),
+  }),
   useCreateFinancialShadowDecisionRecord: () => ({
     isPending: false,
     mutateAsync: vi.fn(),
@@ -1203,12 +1218,18 @@ describe("HedgeFundSignalsShell", () => {
     expect(screen.getAllByText("Decay").length).toBeGreaterThan(0);
     expect(screen.getByText("Post-Execution Alerts")).toBeInTheDocument();
     expect(screen.getByText("No automated rollback")).toBeInTheDocument();
+    expect(screen.getByText("No signal changes")).toBeInTheDocument();
     expect(screen.getByText("5 alerts")).toBeInTheDocument();
+    expect(screen.getByLabelText("Alert Operator Token")).toBeInTheDocument();
+    expect(screen.getByLabelText("Acknowledgement Note")).toBeInTheDocument();
     expect(screen.getByText("Signal Decay")).toBeInTheDocument();
     expect(screen.getByText("Whipsaw After Promotion")).toBeInTheDocument();
     expect(screen.getAllByText("Drift").length).toBeGreaterThan(0);
     expect(screen.getByText("Stale Execution Monitoring")).toBeInTheDocument();
     expect(screen.getByText("Rollback Recommendation")).toBeInTheDocument();
+    expect(screen.getByText("Operator reviewed decay context.")).toBeInTheDocument();
+    expect(screen.getAllByText("Review open").length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("button", { name: "Acknowledge" }).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/no automatic trade or signal change is made/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/no automatic trade, signal, or rollback action is made/i)).toBeInTheDocument();
     expect(screen.getByText("Dry-Run Verification Gate")).toBeInTheDocument();

--- a/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
+++ b/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
@@ -41,6 +41,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import {
+  useAcknowledgeFinancialPromotionPostExecutionAlert,
   useCreateFinancialShadowDecisionRecord,
   useCreateFinancialPromotionDryRunAcceptance,
   useExecuteFinancialPromotionDryRunAcceptance,
@@ -80,6 +81,8 @@ import type {
   FinancialPromotionExecutionRollbackCreate,
   FinancialPromotionLifecycleEvent,
   FinancialPromotionPostExecutionAlert,
+  FinancialPromotionPostExecutionAlertAcknowledgementCreate,
+  FinancialPromotionPostExecutionAlertAcknowledgementStatus,
   FinancialPromotionPostExecutionAlertsResponse,
   FinancialPromotionPostExecutionMonitoringResponse,
   FinancialPromotionPostExecutionMonitoringRow,
@@ -1994,13 +1997,40 @@ function PostExecutionAlertsPanel({
   alerts,
   loading,
   error,
+  onAcknowledge,
+  submittingAcknowledgement,
 }: {
   alerts: FinancialPromotionPostExecutionAlertsResponse | null;
   loading: boolean;
   error: boolean;
+  onAcknowledge: (payload: FinancialPromotionPostExecutionAlertAcknowledgementCreate) => Promise<void>;
+  submittingAcknowledgement: boolean;
 }) {
+  const [acknowledgementOperatorToken, setAcknowledgementOperatorToken] = useState("");
+  const [acknowledgementNote, setAcknowledgementNote] = useState("");
+  const [acknowledgementStatus, setAcknowledgementStatus] =
+    useState<FinancialPromotionPostExecutionAlertAcknowledgementStatus>("ACKNOWLEDGED");
   const summary = alerts?.summary ?? null;
   const rows = alerts?.alerts.slice(0, 10) ?? [];
+  const canAcknowledge =
+    acknowledgementOperatorToken.trim().length >= 16 &&
+    acknowledgementNote.trim().length >= 8 &&
+    !submittingAcknowledgement;
+
+  async function handleAcknowledge(alertId: string) {
+    if (!canAcknowledge) return;
+    try {
+      await onAcknowledge({
+        alert_id: alertId,
+        operator_token: acknowledgementOperatorToken.trim(),
+        acknowledgement_status: acknowledgementStatus,
+        acknowledgement_note: acknowledgementNote.trim(),
+      });
+      setAcknowledgementNote("");
+    } catch {
+      // The mutation hook owns the operator-facing error toast.
+    }
+  }
 
   return (
     <div className="border border-border p-3">
@@ -2012,6 +2042,9 @@ function PostExecutionAlertsPanel({
         <div className="flex flex-wrap gap-2">
           <Badge variant="outline" className="border-sky-500/40 bg-sky-500/10 text-sky-600">
             No automated rollback
+          </Badge>
+          <Badge variant="outline" className="border-sky-500/40 bg-sky-500/10 text-sky-600">
+            No signal changes
           </Badge>
           <Badge
             variant="outline"
@@ -2037,6 +2070,44 @@ function PostExecutionAlertsPanel({
         <p className="mt-3 text-xs text-muted-foreground">Loading post-execution alerts…</p>
       ) : summary ? (
         <div className="mt-3 space-y-3">
+          {rows.length ? (
+            <div className="grid gap-2 border border-border/70 bg-muted/20 p-3 text-xs md:grid-cols-[minmax(180px,0.7fr)_minmax(220px,1fr)_170px]">
+              <label className="space-y-1">
+                <span className="font-medium">Alert Operator Token</span>
+                <Input
+                  type="password"
+                  value={acknowledgementOperatorToken}
+                  onChange={(event) => setAcknowledgementOperatorToken(event.target.value)}
+                  placeholder="Operator token"
+                />
+              </label>
+              <label className="space-y-1">
+                <span className="font-medium">Acknowledgement Note</span>
+                <Input
+                  value={acknowledgementNote}
+                  onChange={(event) => setAcknowledgementNote(event.target.value)}
+                  placeholder="Reviewed context and next watch point"
+                />
+              </label>
+              <label className="space-y-1">
+                <span className="font-medium">Status</span>
+                <select
+                  className="h-10 w-full border border-input bg-background px-3 text-sm"
+                  value={acknowledgementStatus}
+                  onChange={(event) =>
+                    setAcknowledgementStatus(
+                      event.target.value as FinancialPromotionPostExecutionAlertAcknowledgementStatus,
+                    )
+                  }
+                >
+                  <option value="ACKNOWLEDGED">Acknowledged</option>
+                  <option value="WATCHING">Watching</option>
+                  <option value="NO_ACTION_NEEDED">No action needed</option>
+                </select>
+              </label>
+            </div>
+          ) : null}
+
           <div className="grid gap-2 sm:grid-cols-5">
             <div className="bg-muted/40 p-2 text-xs">
               <span className="text-muted-foreground">High</span>
@@ -2071,6 +2142,7 @@ function PostExecutionAlertsPanel({
                     <TableHead>Metric</TableHead>
                     <TableHead>Rollback Review</TableHead>
                     <TableHead>Operator Note</TableHead>
+                    <TableHead>Acknowledgement</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -2129,6 +2201,46 @@ function PostExecutionAlertsPanel({
                           <p className="line-clamp-2 text-muted-foreground">{alert.operator_guidance}</p>
                         </div>
                       </TableCell>
+                      <TableCell>
+                        <div className="space-y-2 text-xs">
+                          {alert.acknowledged ? (
+                            <div className="space-y-1">
+                              <Badge
+                                variant="outline"
+                                className="border-emerald-500/40 bg-emerald-500/10 text-emerald-600"
+                              >
+                                {promotionMonitoringLabel(alert.latest_acknowledgement_status ?? "ACKNOWLEDGED")}
+                              </Badge>
+                              <p className="text-muted-foreground">
+                                {alert.latest_acknowledged_by ?? "Operator"} · {formatDate(alert.latest_acknowledged_at)}
+                              </p>
+                              <p className="line-clamp-2 max-w-52">{alert.latest_acknowledgement_note}</p>
+                            </div>
+                          ) : (
+                            <Badge
+                              variant="outline"
+                              className={cn(
+                                alert.acknowledgement_required
+                                  ? "border-amber-500/40 bg-amber-500/10 text-amber-600"
+                                  : "border-border bg-muted/30 text-muted-foreground",
+                              )}
+                            >
+                              Review open
+                            </Badge>
+                          )}
+                          {!alert.acknowledged ? (
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant="outline"
+                              disabled={!canAcknowledge}
+                              onClick={() => void handleAcknowledge(alert.alert_id)}
+                            >
+                              {submittingAcknowledgement ? "Recording…" : "Acknowledge"}
+                            </Button>
+                          ) : null}
+                        </div>
+                      </TableCell>
                     </TableRow>
                   ))}
                 </TableBody>
@@ -2170,6 +2282,8 @@ function PromotionDryRunPanel({
   postExecutionAlerts,
   postExecutionAlertsLoading,
   postExecutionAlertsError,
+  onSubmitAlertAcknowledgement,
+  submittingAlertAcknowledgement,
   onSubmitAcceptance,
   submittingAcceptance,
   onSubmitExecution,
@@ -2201,6 +2315,10 @@ function PromotionDryRunPanel({
   postExecutionAlerts: FinancialPromotionPostExecutionAlertsResponse | null;
   postExecutionAlertsLoading: boolean;
   postExecutionAlertsError: boolean;
+  onSubmitAlertAcknowledgement: (
+    payload: FinancialPromotionPostExecutionAlertAcknowledgementCreate,
+  ) => Promise<void>;
+  submittingAlertAcknowledgement: boolean;
   onSubmitAcceptance: (payload: FinancialPromotionDryRunAcceptanceCreate) => Promise<void>;
   submittingAcceptance: boolean;
   onSubmitExecution: (payload: FinancialPromotionExecutionCreate) => Promise<void>;
@@ -2389,6 +2507,8 @@ function PromotionDryRunPanel({
         alerts={postExecutionAlerts}
         loading={postExecutionAlertsLoading}
         error={postExecutionAlertsError}
+        onAcknowledge={onSubmitAlertAcknowledgement}
+        submittingAcknowledgement={submittingAlertAcknowledgement}
       />
 
       <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
@@ -2984,6 +3104,7 @@ export function HedgeFundSignalsShell() {
   });
   const createShadowDecisionRecord = useCreateFinancialShadowDecisionRecord();
   const createPromotionDryRunAcceptance = useCreateFinancialPromotionDryRunAcceptance();
+  const acknowledgePromotionPostExecutionAlert = useAcknowledgeFinancialPromotionPostExecutionAlert();
   const executePromotionDryRunAcceptance = useExecuteFinancialPromotionDryRunAcceptance();
   const rollbackPromotionExecution = useRollbackFinancialPromotionExecution();
   const signals = latest.data ?? EMPTY_SIGNALS;
@@ -3074,6 +3195,13 @@ export function HedgeFundSignalsShell() {
     void promotionLifecycleTimeline.refetch();
     void promotionReconciliation.refetch();
     void promotionPostExecutionMonitoring.refetch();
+    void promotionPostExecutionAlerts.refetch();
+  }
+
+  async function handlePromotionAlertAcknowledgementSubmit(
+    payload: FinancialPromotionPostExecutionAlertAcknowledgementCreate,
+  ) {
+    await acknowledgePromotionPostExecutionAlert.mutateAsync(payload);
     void promotionPostExecutionAlerts.refetch();
   }
 
@@ -3292,6 +3420,8 @@ export function HedgeFundSignalsShell() {
             postExecutionAlerts={promotionPostExecutionAlerts.data ?? null}
             postExecutionAlertsLoading={promotionPostExecutionAlerts.isLoading}
             postExecutionAlertsError={promotionPostExecutionAlerts.isError}
+            onSubmitAlertAcknowledgement={handlePromotionAlertAcknowledgementSubmit}
+            submittingAlertAcknowledgement={acknowledgePromotionPostExecutionAlert.isPending}
             onSubmitAcceptance={handlePromotionDryRunAcceptanceSubmit}
             submittingAcceptance={createPromotionDryRunAcceptance.isPending}
             onSubmitExecution={handlePromotionExecutionSubmit}

--- a/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
@@ -20,6 +20,8 @@ import type {
   FinancialPromotionExecution,
   FinancialPromotionExecutionCreate,
   FinancialPromotionExecutionRollbackCreate,
+  FinancialPromotionPostExecutionAlertAcknowledgement,
+  FinancialPromotionPostExecutionAlertAcknowledgementCreate,
   FinancialPromotionPostExecutionAlertsResponse,
   FinancialPromotionLifecycleEvent,
   FinancialPromotionPostExecutionMonitoringResponse,
@@ -390,6 +392,37 @@ export function useFinancialPromotionPostExecutionAlerts(
     enabled: Boolean(promotionId),
     refetchInterval: 60_000,
     staleTime: 60_000,
+  });
+}
+
+export function useAcknowledgeFinancialPromotionPostExecutionAlert() {
+  const qc = useQueryClient();
+  return useMutation<
+    FinancialPromotionPostExecutionAlertAcknowledgement,
+    ApiError,
+    FinancialPromotionPostExecutionAlertAcknowledgementCreate
+  >({
+    mutationFn: ({
+      alert_id,
+      operator_token,
+      acknowledgement_status,
+      acknowledgement_note,
+    }) =>
+      api.post(
+        `/api/financial/signals/promotion-alerts/${encodeURIComponent(alert_id)}/acknowledgements`,
+        {
+          acknowledgement_status,
+          acknowledgement_note,
+        },
+        { headers: { "X-MarketClub-Operator-Token": operator_token } },
+      ),
+    onSuccess: () => {
+      qc.invalidateQueries({
+        queryKey: ["financial", "signals", "promotion"],
+      });
+      toast.success("Alert acknowledgement recorded");
+    },
+    onError: (error) => toast.error(error.message || "Failed to acknowledge alert"),
   });
 }
 

--- a/fortress-guest-platform/apps/command-center/src/lib/types.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/types.ts
@@ -778,6 +778,10 @@ export type FinancialPromotionPostExecutionAlertType =
   | "ROLLBACK_RECOMMENDATION";
 
 export type FinancialPromotionPostExecutionAlertSeverity = "LOW" | "MEDIUM" | "HIGH";
+export type FinancialPromotionPostExecutionAlertAcknowledgementStatus =
+  | "ACKNOWLEDGED"
+  | "WATCHING"
+  | "NO_ACTION_NEEDED";
 
 export interface FinancialPromotionPostExecutionAlertSummary {
   total_alerts: number;
@@ -812,6 +816,13 @@ export interface FinancialPromotionPostExecutionAlert {
   evidence: Record<string, unknown>;
   explanation: string;
   operator_guidance: string;
+  acknowledgement_count: number;
+  acknowledged: boolean;
+  latest_acknowledgement_status: FinancialPromotionPostExecutionAlertAcknowledgementStatus | null;
+  latest_acknowledged_by: string | null;
+  latest_acknowledged_at: string | null;
+  latest_acknowledgement_note: string | null;
+  acknowledgement_required: boolean;
 }
 
 export interface FinancialPromotionPostExecutionAlertsResponse {
@@ -819,6 +830,33 @@ export interface FinancialPromotionPostExecutionAlertsResponse {
   promotion_id: string;
   summary: FinancialPromotionPostExecutionAlertSummary;
   alerts: FinancialPromotionPostExecutionAlert[];
+}
+
+export interface FinancialPromotionPostExecutionAlertAcknowledgementCreate {
+  alert_id: string;
+  operator_token: string;
+  acknowledgement_status: FinancialPromotionPostExecutionAlertAcknowledgementStatus;
+  acknowledgement_note: string;
+}
+
+export interface FinancialPromotionPostExecutionAlertAcknowledgement {
+  id: string;
+  alert_id: string;
+  execution_id: string;
+  acceptance_id: string;
+  decision_record_id: string;
+  market_signal_id: number;
+  ticker: string;
+  action: "BUY" | "SELL";
+  candidate_bar_date: string;
+  alert_type: FinancialPromotionPostExecutionAlertType;
+  severity: FinancialPromotionPostExecutionAlertSeverity;
+  operator_membership_id: string;
+  acknowledged_by: string;
+  acknowledgement_status: FinancialPromotionPostExecutionAlertAcknowledgementStatus;
+  acknowledgement_note: string;
+  alert_evidence_snapshot: Record<string, unknown>;
+  created_at: string;
 }
 
 export interface FinancialWatchlistCandidate {


### PR DESCRIPTION
## Summary

- Adds audit-only post-execution alert acknowledgements scoped by `alert_id`.
- Adds a guarded SQL function plus backend endpoint for operator review notes.
- Surfaces latest acknowledgement state in the Hedge Fund Signals cockpit alert panel.
- Updates the Operator Audit Playbook with acknowledgement rules.

## Safety

- Acknowledgement only accepts `alert_id`; no ticker/date write path.
- Requires active `signal_operator` or `signal_admin` token.
- Writes only to `hedge_fund.signal_promotion_alert_acknowledgements`.
- Does not write, update, or delete `hedge_fund.market_signals`.
- Does not call rollback, execute promotion, create acceptance, or change signal/trade state.

## Tests

- `PYTHONPATH=. .venv-test/bin/python -m pytest tests/test_post_execution_alert_acknowledgements.py tests/test_post_execution_alerts.py tests/test_api_signals.py`
- `PYTHONPATH=. .venv-test/bin/python -m pytest`
- `PYTHONPATH=. .venv-test/bin/python -m ruff check app/api/signals.py app/signals/repository.py tests/test_api_signals.py tests/test_post_execution_alert_acknowledgements.py`
- `npm --prefix fortress-guest-platform/apps/command-center test -- financial-hedge-fund-shell.test.tsx`
- `npm --prefix fortress-guest-platform/apps/command-center test`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint src/lib/hooks.ts src/lib/types.ts "src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx" src/__tests__/components/financial-hedge-fund-shell.test.tsx`
- `npm --prefix fortress-guest-platform/apps/command-center run build`
- `git diff --check`
