### PR TITLE
feat(financial): add signal health dashboard

### DIFF
--- a/crog-ai-backend/alembic/versions/0014_signal_health_dashboard.py
+++ b/crog-ai-backend/alembic/versions/0014_signal_health_dashboard.py
@@ -1,0 +1,40 @@
+"""Add read-only signal health dashboard.
+
+Revision ID: 0014_signal_health_dashboard
+Revises: 0013_post_execution_alert_acknowledgements
+Create Date: 2026-05-04 16:30:00.000000
+"""
+
+from pathlib import Path
+
+from alembic import op
+
+revision = "0014_signal_health_dashboard"
+down_revision = "0013_post_execution_alert_acknowledgements"
+branch_labels = None
+depends_on = None
+
+
+def _sql_path(name: str) -> Path:
+    return Path(__file__).resolve().parents[2] / "deploy" / "sql" / name
+
+
+def upgrade() -> None:
+    op.execute(
+        _sql_path("marketclub_signal_health_dashboard.sql").read_text(encoding="utf-8")
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DROP FUNCTION IF EXISTS hedge_fund.signal_health_model_divergence(
+            TEXT,
+            TEXT,
+            INTEGER
+        )
+        """
+    )
+    op.execute("DROP VIEW IF EXISTS hedge_fund.v_signal_health_execution_outcomes")
+    op.execute("DROP VIEW IF EXISTS hedge_fund.v_signal_health_at_risk_signals")
+    op.execute("DROP VIEW IF EXISTS hedge_fund.v_signal_health_active_promotions")

--- a/crog-ai-backend/app/api/signals.py
+++ b/crog-ai-backend/app/api/signals.py
@@ -731,6 +731,146 @@ class PromotionPostExecutionAlertsResponse(BaseModel):
     alerts: list[PromotionPostExecutionAlert]
 
 
+class SignalHealthDashboardSummary(BaseModel):
+    active_execution_count: int
+    degraded_execution_count: int
+    warning_execution_count: int
+    at_risk_signal_count: int
+    divergence_count: int
+    latest_divergence_bar_date: dt.date | None
+    rollback_review_count: int
+
+
+class SignalHealthActivePromotion(BaseModel):
+    execution_id: UUID
+    acceptance_id: UUID
+    candidate_id: str
+    baseline_parameter_set: str
+    executed_by: str
+    executed_at: dt.datetime
+    rollback_status: Literal["active", "rolled_back"]
+    inserted_count: int
+    live_signal_count: int
+    warning_signal_count: int
+    drift_signal_count: int
+    whipsaw_signal_count: int
+    decay_signal_count: int
+    rollback_review_count: int
+    avg_1d_return: Decimal | None
+    avg_5d_return: Decimal | None
+    avg_20d_return: Decimal | None
+    positive_1d_pct: Decimal | None
+    positive_5d_pct: Decimal | None
+    positive_20d_pct: Decimal | None
+    whipsaw_pct: Decimal | None
+    health_status: Literal["HEALTHY", "WARNING", "DEGRADED"]
+    key_flags: dict[str, bool]
+    explanation: str
+
+
+class SignalHealthAtRiskSignal(BaseModel):
+    execution_id: UUID
+    acceptance_id: UUID
+    decision_record_id: UUID
+    candidate_id: str
+    market_signal_id: int
+    ticker: str
+    action: Literal["BUY", "SELL"]
+    candidate_bar_date: dt.date
+    candidate_score: int
+    rollback_marker: str
+    outcome_5d_directional_return: Decimal | None
+    outcome_20d_directional_return: Decimal | None
+    drift_status: Literal[
+        "PENDING",
+        "IN_LINE",
+        "PRICE_DRIFT",
+        "SCORE_DRIFT",
+        "PRICE_AND_SCORE_DRIFT",
+    ]
+    whipsaw_after_promotion_flag: bool
+    signal_decay_flag: bool
+    rollback_recommendation: Literal[
+        "NO_WARNING",
+        "WATCH_WARNING",
+        "REVIEW_ROLLBACK_WARNING",
+        "NO_ACTION_ROLLED_BACK",
+    ]
+    monitoring_status: Literal["PENDING", "HEALTHY", "WARNING", "ROLLED_BACK"]
+    risk_score: int
+    risk_reason: Literal[
+        "whipsaw-after-promotion",
+        "5d return below threshold",
+        "drift vs expected range",
+    ]
+    explanation: str
+
+
+class SignalHealthModelDivergenceTrend(BaseModel):
+    bar_date: dt.date
+    candidate_80_count: int
+    production_matching_80_count: int
+    divergence_count: int
+    divergence_rate: Decimal | None
+    divergent_tickers: list[str]
+
+
+class SignalHealthModelDivergence(BaseModel):
+    latest_bar_date: dt.date | None
+    current_candidate_80_count: int
+    current_divergence_count: int
+    current_divergence_rate: Decimal | None
+    trend: list[SignalHealthModelDivergenceTrend]
+
+
+class SignalHealthExecutionOutcome(BaseModel):
+    execution_id: UUID
+    acceptance_id: UUID
+    candidate_id: str
+    baseline_parameter_set: str
+    executed_by: str
+    executed_at: dt.datetime
+    rollback_status: Literal["active", "rolled_back"]
+    inserted_count: int
+    avg_1d_return: Decimal | None
+    avg_5d_return: Decimal | None
+    avg_20d_return: Decimal | None
+    positive_1d_pct: Decimal | None
+    positive_5d_pct: Decimal | None
+    positive_20d_pct: Decimal | None
+    whipsaw_pct: Decimal | None
+    health_status: Literal["HEALTHY", "WARNING", "DEGRADED"]
+    key_flags: dict[str, bool]
+
+
+class SignalHealthAwarenessAlert(BaseModel):
+    severity: Literal["INFO", "WARNING"]
+    alert_type: Literal[
+        "CLEAR",
+        "DRIFT",
+        "WHIPSAW_AFTER_PROMOTION",
+        "SIGNAL_DECAY",
+        "PERFORMANCE_BAND",
+        "ROLLBACK_RECOMMENDATION",
+        "MODEL_PRODUCTION_DIVERGENCE",
+    ]
+    execution_id: UUID | None
+    message: str
+    non_blocking: bool
+
+
+class SignalHealthDashboardResponse(BaseModel):
+    generated_at: dt.datetime
+    candidate_parameter_set: str
+    production_parameter_set: str
+    summary: SignalHealthDashboardSummary
+    active_promotions: list[SignalHealthActivePromotion]
+    at_risk_signals: list[SignalHealthAtRiskSignal]
+    model_divergence: SignalHealthModelDivergence
+    execution_outcomes: list[SignalHealthExecutionOutcome]
+    awareness_alerts: list[SignalHealthAwarenessAlert]
+
+
 class PromotionPostExecutionAlertAcknowledgement(BaseModel):
     id: UUID
     alert_id: str
@@ -1202,6 +1342,30 @@ def promotion_post_execution_alerts(
     return store.promotion_post_execution_alerts(
         promotion_id=promotion_id,
         limit=limit,
+    )
+
+
+@router.get("/health-dashboard", response_model=SignalHealthDashboardResponse)
+def signal_health_dashboard(
+    store: Annotated[SignalDataStore, Depends(get_signal_store)],
+    candidate_parameter_set: Annotated[
+        str,
+        Query(min_length=1, max_length=80),
+    ] = "dochia_v0_2_range_daily",
+    production_parameter_set: Annotated[
+        str,
+        Query(min_length=1, max_length=80),
+    ] = "dochia_v0_estimated",
+    execution_limit: Annotated[int, Query(ge=1, le=25)] = 10,
+    risk_limit: Annotated[int, Query(ge=1, le=100)] = 25,
+    divergence_lookback_bars: Annotated[int, Query(ge=1, le=120)] = 30,
+) -> dict[str, object]:
+    return store.signal_health_dashboard(
+        candidate_parameter_set=candidate_parameter_set,
+        production_parameter_set=production_parameter_set,
+        execution_limit=execution_limit,
+        risk_limit=risk_limit,
+        divergence_lookback_bars=divergence_lookback_bars,
     )
 
 

--- a/crog-ai-backend/app/signals/repository.py
+++ b/crog-ai-backend/app/signals/repository.py
@@ -185,6 +185,16 @@ class SignalDataStore(Protocol):
         limit: int = 100,
     ) -> dict[str, Any]: ...
 
+    def signal_health_dashboard(
+        self,
+        *,
+        candidate_parameter_set: str,
+        production_parameter_set: str = PRODUCTION_PARAMETER_SET,
+        execution_limit: int = 10,
+        risk_limit: int = 25,
+        divergence_lookback_bars: int = 30,
+    ) -> dict[str, Any]: ...
+
     def acknowledge_promotion_post_execution_alert(
         self,
         *,
@@ -2408,6 +2418,392 @@ def fetch_promotion_post_execution_alerts(
     }
 
 
+SIGNAL_HEALTH_ACTIVE_PROMOTION_FIELDS = [
+    "execution_id",
+    "acceptance_id",
+    "candidate_id",
+    "baseline_parameter_set",
+    "executed_by",
+    "executed_at",
+    "rollback_status",
+    "inserted_count",
+    "live_signal_count",
+    "warning_signal_count",
+    "drift_signal_count",
+    "whipsaw_signal_count",
+    "decay_signal_count",
+    "rollback_review_count",
+    "avg_1d_return",
+    "avg_5d_return",
+    "avg_20d_return",
+    "positive_1d_pct",
+    "positive_5d_pct",
+    "positive_20d_pct",
+    "whipsaw_pct",
+    "health_status",
+    "key_flags",
+    "explanation",
+]
+
+
+SIGNAL_HEALTH_AT_RISK_FIELDS = [
+    "execution_id",
+    "acceptance_id",
+    "decision_record_id",
+    "candidate_id",
+    "market_signal_id",
+    "ticker",
+    "action",
+    "candidate_bar_date",
+    "candidate_score",
+    "rollback_marker",
+    "outcome_5d_directional_return",
+    "outcome_20d_directional_return",
+    "drift_status",
+    "whipsaw_after_promotion_flag",
+    "signal_decay_flag",
+    "rollback_recommendation",
+    "monitoring_status",
+    "risk_score",
+    "risk_reason",
+    "explanation",
+]
+
+
+SIGNAL_HEALTH_EXECUTION_OUTCOME_FIELDS = [
+    "execution_id",
+    "acceptance_id",
+    "candidate_id",
+    "baseline_parameter_set",
+    "executed_by",
+    "executed_at",
+    "rollback_status",
+    "inserted_count",
+    "avg_1d_return",
+    "avg_5d_return",
+    "avg_20d_return",
+    "positive_1d_pct",
+    "positive_5d_pct",
+    "positive_20d_pct",
+    "whipsaw_pct",
+    "health_status",
+    "key_flags",
+]
+
+
+SIGNAL_HEALTH_DIVERGENCE_FIELDS = [
+    "bar_date",
+    "candidate_80_count",
+    "production_matching_80_count",
+    "divergence_count",
+    "divergence_rate",
+    "divergent_tickers",
+]
+
+
+def _signal_health_row(row: dict[str, Any], fields: list[str]) -> dict[str, Any]:
+    response = {key: row[key] for key in fields}
+    if "key_flags" in response:
+        response["key_flags"] = dict(response["key_flags"] or {})
+    if "divergent_tickers" in response:
+        response["divergent_tickers"] = list(response["divergent_tickers"] or [])
+    return response
+
+
+def _short_execution_id(execution_id: Any) -> str:
+    return str(execution_id)[:8]
+
+
+def _signal_health_awareness_alerts(
+    *,
+    active_promotions: list[dict[str, Any]],
+    at_risk_signals: list[dict[str, Any]],
+    latest_divergence: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    alerts: list[dict[str, Any]] = []
+    for row in active_promotions:
+        execution_id = row["execution_id"]
+        short_id = _short_execution_id(execution_id)
+        if row["drift_signal_count"] > 0:
+            alerts.append(
+                {
+                    "severity": "WARNING",
+                    "alert_type": "DRIFT",
+                    "execution_id": execution_id,
+                    "message": f"Drift detected in execution {short_id}",
+                    "non_blocking": True,
+                }
+            )
+        if row["whipsaw_signal_count"] > 0:
+            alerts.append(
+                {
+                    "severity": "WARNING",
+                    "alert_type": "WHIPSAW_AFTER_PROMOTION",
+                    "execution_id": execution_id,
+                    "message": (
+                        f"{row['whipsaw_signal_count']} signals entered whipsaw "
+                        f"after execution {short_id}"
+                    ),
+                    "non_blocking": True,
+                }
+            )
+        if row["decay_signal_count"] > 0:
+            alerts.append(
+                {
+                    "severity": "WARNING",
+                    "alert_type": "SIGNAL_DECAY",
+                    "execution_id": execution_id,
+                    "message": f"Signal decay detected in execution {short_id}",
+                    "non_blocking": True,
+                }
+            )
+        if row["avg_5d_return"] is not None and row["avg_5d_return"] < Decimal("-0.02"):
+            alerts.append(
+                {
+                    "severity": "WARNING",
+                    "alert_type": "PERFORMANCE_BAND",
+                    "execution_id": execution_id,
+                    "message": f"5d performance below expected band in execution {short_id}",
+                    "non_blocking": True,
+                }
+            )
+        if row["rollback_review_count"] > 0:
+            alerts.append(
+                {
+                    "severity": "WARNING",
+                    "alert_type": "ROLLBACK_RECOMMENDATION",
+                    "execution_id": execution_id,
+                    "message": f"Rollback review warning present in execution {short_id}",
+                    "non_blocking": True,
+                }
+            )
+
+    if latest_divergence and latest_divergence["divergence_count"] > 0:
+        alerts.append(
+            {
+                "severity": "INFO",
+                "alert_type": "MODEL_PRODUCTION_DIVERGENCE",
+                "execution_id": None,
+                "message": (
+                    f"{latest_divergence['divergence_count']} candidate +80 tickers "
+                    "diverge from production baseline"
+                ),
+                "non_blocking": True,
+            }
+        )
+
+    if not alerts and not at_risk_signals:
+        return [
+            {
+                "severity": "INFO",
+                "alert_type": "CLEAR",
+                "execution_id": None,
+                "message": "No active post-execution risk signals require attention.",
+                "non_blocking": True,
+            }
+        ]
+    return alerts[:10]
+
+
+def fetch_signal_health_dashboard(
+    conn: psycopg.Connection,
+    *,
+    candidate_parameter_set: str,
+    production_parameter_set: str = PRODUCTION_PARAMETER_SET,
+    execution_limit: int = 10,
+    risk_limit: int = 25,
+    divergence_lookback_bars: int = 30,
+) -> dict[str, Any]:
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            """
+            SELECT
+                execution_id,
+                acceptance_id,
+                candidate_id,
+                baseline_parameter_set,
+                executed_by,
+                executed_at,
+                rollback_status,
+                inserted_count,
+                live_signal_count,
+                warning_signal_count,
+                drift_signal_count,
+                whipsaw_signal_count,
+                decay_signal_count,
+                rollback_review_count,
+                avg_1d_return,
+                avg_5d_return,
+                avg_20d_return,
+                positive_1d_pct,
+                positive_5d_pct,
+                positive_20d_pct,
+                whipsaw_pct,
+                health_status,
+                key_flags,
+                explanation
+            FROM hedge_fund.v_signal_health_active_promotions
+            WHERE candidate_id = %(candidate_parameter_set)s
+            ORDER BY executed_at DESC
+            LIMIT %(limit)s
+            """,
+            {
+                "candidate_parameter_set": candidate_parameter_set,
+                "limit": execution_limit,
+            },
+        )
+        active_promotions = [
+            _signal_health_row(dict(row), SIGNAL_HEALTH_ACTIVE_PROMOTION_FIELDS)
+            for row in cur.fetchall()
+        ]
+
+        cur.execute(
+            """
+            SELECT
+                execution_id,
+                acceptance_id,
+                decision_record_id,
+                candidate_id,
+                market_signal_id,
+                ticker,
+                action,
+                candidate_bar_date,
+                candidate_score,
+                rollback_marker,
+                outcome_5d_directional_return,
+                outcome_20d_directional_return,
+                drift_status,
+                whipsaw_after_promotion_flag,
+                signal_decay_flag,
+                rollback_recommendation,
+                monitoring_status,
+                risk_score,
+                risk_reason,
+                explanation
+            FROM hedge_fund.v_signal_health_at_risk_signals
+            WHERE candidate_id = %(candidate_parameter_set)s
+            ORDER BY risk_score DESC, candidate_bar_date DESC, ticker
+            LIMIT %(limit)s
+            """,
+            {
+                "candidate_parameter_set": candidate_parameter_set,
+                "limit": risk_limit,
+            },
+        )
+        at_risk_signals = [
+            _signal_health_row(dict(row), SIGNAL_HEALTH_AT_RISK_FIELDS)
+            for row in cur.fetchall()
+        ]
+
+        cur.execute(
+            """
+            SELECT
+                execution_id,
+                acceptance_id,
+                candidate_id,
+                baseline_parameter_set,
+                executed_by,
+                executed_at,
+                rollback_status,
+                inserted_count,
+                avg_1d_return,
+                avg_5d_return,
+                avg_20d_return,
+                positive_1d_pct,
+                positive_5d_pct,
+                positive_20d_pct,
+                whipsaw_pct,
+                health_status,
+                key_flags
+            FROM hedge_fund.v_signal_health_execution_outcomes
+            WHERE candidate_id = %(candidate_parameter_set)s
+            ORDER BY executed_at DESC
+            LIMIT %(limit)s
+            """,
+            {
+                "candidate_parameter_set": candidate_parameter_set,
+                "limit": execution_limit,
+            },
+        )
+        execution_outcomes = [
+            _signal_health_row(dict(row), SIGNAL_HEALTH_EXECUTION_OUTCOME_FIELDS)
+            for row in cur.fetchall()
+        ]
+
+        cur.execute(
+            """
+            SELECT
+                bar_date,
+                candidate_80_count,
+                production_matching_80_count,
+                divergence_count,
+                divergence_rate,
+                divergent_tickers
+            FROM hedge_fund.signal_health_model_divergence(
+                %(candidate_parameter_set)s,
+                %(production_parameter_set)s,
+                %(lookback_bars)s
+            )
+            """,
+            {
+                "candidate_parameter_set": candidate_parameter_set,
+                "production_parameter_set": production_parameter_set,
+                "lookback_bars": divergence_lookback_bars,
+            },
+        )
+        divergence_trend = [
+            _signal_health_row(dict(row), SIGNAL_HEALTH_DIVERGENCE_FIELDS)
+            for row in cur.fetchall()
+        ]
+
+    latest_divergence = divergence_trend[0] if divergence_trend else None
+    return {
+        "generated_at": dt.datetime.now(dt.UTC),
+        "candidate_parameter_set": candidate_parameter_set,
+        "production_parameter_set": production_parameter_set,
+        "summary": {
+            "active_execution_count": len(active_promotions),
+            "degraded_execution_count": sum(
+                1 for row in active_promotions if row["health_status"] == "DEGRADED"
+            ),
+            "warning_execution_count": sum(
+                1 for row in active_promotions if row["health_status"] == "WARNING"
+            ),
+            "at_risk_signal_count": len(at_risk_signals),
+            "divergence_count": latest_divergence["divergence_count"]
+            if latest_divergence
+            else 0,
+            "latest_divergence_bar_date": latest_divergence["bar_date"]
+            if latest_divergence
+            else None,
+            "rollback_review_count": sum(
+                row["rollback_review_count"] for row in active_promotions
+            ),
+        },
+        "active_promotions": active_promotions,
+        "at_risk_signals": at_risk_signals,
+        "model_divergence": {
+            "latest_bar_date": latest_divergence["bar_date"] if latest_divergence else None,
+            "current_candidate_80_count": latest_divergence["candidate_80_count"]
+            if latest_divergence
+            else 0,
+            "current_divergence_count": latest_divergence["divergence_count"]
+            if latest_divergence
+            else 0,
+            "current_divergence_rate": latest_divergence["divergence_rate"]
+            if latest_divergence
+            else None,
+            "trend": divergence_trend,
+        },
+        "execution_outcomes": execution_outcomes,
+        "awareness_alerts": _signal_health_awareness_alerts(
+            active_promotions=active_promotions,
+            at_risk_signals=at_risk_signals,
+            latest_divergence=latest_divergence,
+        ),
+    }
+
+
 PROMOTION_POST_EXECUTION_ALERT_ACK_FIELDS = [
     "id",
     "alert_id",
@@ -2983,6 +3379,26 @@ class PostgresSignalDataStore:
                 conn,
                 promotion_id=promotion_id,
                 limit=limit,
+            )
+
+    def signal_health_dashboard(
+        self,
+        *,
+        candidate_parameter_set: str,
+        production_parameter_set: str = PRODUCTION_PARAMETER_SET,
+        execution_limit: int = 10,
+        risk_limit: int = 25,
+        divergence_lookback_bars: int = 30,
+    ) -> dict[str, Any]:
+        with connect() as conn:
+            conn.execute("SET default_transaction_read_only = on")
+            return fetch_signal_health_dashboard(
+                conn,
+                candidate_parameter_set=candidate_parameter_set,
+                production_parameter_set=production_parameter_set,
+                execution_limit=execution_limit,
+                risk_limit=risk_limit,
+                divergence_lookback_bars=divergence_lookback_bars,
             )
 
     def acknowledge_promotion_post_execution_alert(

--- a/crog-ai-backend/deploy/sql/marketclub_signal_health_dashboard.sql
+++ b/crog-ai-backend/deploy/sql/marketclub_signal_health_dashboard.sql
@@ -1,0 +1,235 @@
+CREATE OR REPLACE VIEW hedge_fund.v_signal_health_active_promotions
+WITH (security_invoker = true) AS
+WITH execution_rollup AS (
+    SELECT
+        execution_id,
+        acceptance_id,
+        candidate_id,
+        baseline_parameter_set,
+        executed_by,
+        executed_at,
+        rollback_status,
+        count(*)::INTEGER AS inserted_count,
+        count(*) FILTER (WHERE market_signal_live)::INTEGER AS live_signal_count,
+        count(*) FILTER (WHERE monitoring_status = 'WARNING')::INTEGER AS warning_signal_count,
+        count(*) FILTER (
+            WHERE drift_status IN ('PRICE_DRIFT', 'SCORE_DRIFT', 'PRICE_AND_SCORE_DRIFT')
+        )::INTEGER AS drift_signal_count,
+        count(*) FILTER (WHERE whipsaw_after_promotion_flag)::INTEGER AS whipsaw_signal_count,
+        count(*) FILTER (WHERE signal_decay_flag)::INTEGER AS decay_signal_count,
+        count(*) FILTER (
+            WHERE rollback_recommendation = 'REVIEW_ROLLBACK_WARNING'
+        )::INTEGER AS rollback_review_count,
+        avg(outcome_1d_directional_return) AS avg_1d_return,
+        avg(outcome_5d_directional_return) AS avg_5d_return,
+        avg(outcome_20d_directional_return) AS avg_20d_return,
+        (
+            count(*) FILTER (WHERE outcome_1d_directional_return > 0)::NUMERIC
+            / NULLIF(count(*) FILTER (WHERE outcome_1d_directional_return IS NOT NULL), 0)
+        ) AS positive_1d_pct,
+        (
+            count(*) FILTER (WHERE outcome_5d_directional_return > 0)::NUMERIC
+            / NULLIF(count(*) FILTER (WHERE outcome_5d_directional_return IS NOT NULL), 0)
+        ) AS positive_5d_pct,
+        (
+            count(*) FILTER (WHERE outcome_20d_directional_return > 0)::NUMERIC
+            / NULLIF(count(*) FILTER (WHERE outcome_20d_directional_return IS NOT NULL), 0)
+        ) AS positive_20d_pct,
+        (
+            count(*) FILTER (WHERE whipsaw_after_promotion_flag)::NUMERIC
+            / NULLIF(count(*), 0)
+        ) AS whipsaw_pct
+    FROM hedge_fund.v_signal_promotion_post_execution_monitoring
+    GROUP BY
+        execution_id,
+        acceptance_id,
+        candidate_id,
+        baseline_parameter_set,
+        executed_by,
+        executed_at,
+        rollback_status
+)
+SELECT
+    *,
+    CASE
+        WHEN rollback_review_count > 0 THEN 'DEGRADED'
+        WHEN rollback_status = 'active'
+         AND (
+            (whipsaw_signal_count > 0 AND decay_signal_count > 0)
+            OR avg_5d_return < -0.02
+            OR avg_20d_return < -0.03
+         ) THEN 'DEGRADED'
+        WHEN warning_signal_count > 0
+          OR drift_signal_count > 0
+          OR whipsaw_signal_count > 0
+          OR decay_signal_count > 0 THEN 'WARNING'
+        ELSE 'HEALTHY'
+    END AS health_status,
+    jsonb_build_object(
+        'drift', drift_signal_count > 0,
+        'whipsaw', whipsaw_signal_count > 0,
+        'decay', decay_signal_count > 0
+    ) AS key_flags,
+    CASE
+        WHEN rollback_review_count > 0
+            THEN 'Rollback review warning is present; operator review only.'
+        WHEN whipsaw_signal_count > 0 AND decay_signal_count > 0
+            THEN 'Promotion has both whipsaw and signal decay flags; watch closely.'
+        WHEN avg_5d_return < -0.02 OR avg_20d_return < -0.03
+            THEN 'Outcome returns are below the monitored expected band.'
+        WHEN warning_signal_count > 0
+            THEN 'Promotion has warning rows in post-execution monitoring.'
+        ELSE 'Latest audited promotion outcome is in line with monitored expectations.'
+    END AS explanation
+FROM execution_rollup;
+
+CREATE OR REPLACE VIEW hedge_fund.v_signal_health_at_risk_signals
+WITH (security_invoker = true) AS
+SELECT
+    execution_id,
+    acceptance_id,
+    decision_record_id,
+    candidate_id,
+    market_signal_id,
+    ticker,
+    action,
+    candidate_bar_date,
+    candidate_score,
+    rollback_marker,
+    outcome_5d_directional_return,
+    outcome_20d_directional_return,
+    drift_status,
+    whipsaw_after_promotion_flag,
+    signal_decay_flag,
+    rollback_recommendation,
+    monitoring_status,
+    (
+        CASE WHEN whipsaw_after_promotion_flag THEN 50 ELSE 0 END
+        + CASE WHEN outcome_5d_directional_return < -0.02 THEN 30 ELSE 0 END
+        + CASE
+            WHEN drift_status = 'PRICE_AND_SCORE_DRIFT' THEN 25
+            WHEN drift_status IN ('PRICE_DRIFT', 'SCORE_DRIFT') THEN 15
+            ELSE 0
+          END
+    )::INTEGER AS risk_score,
+    CASE
+        WHEN whipsaw_after_promotion_flag
+            THEN 'whipsaw-after-promotion'
+        WHEN outcome_5d_directional_return < -0.02
+            THEN '5d return below threshold'
+        ELSE 'drift vs expected range'
+    END AS risk_reason,
+    explanation
+FROM hedge_fund.v_signal_promotion_post_execution_monitoring
+WHERE rollback_status = 'active'
+  AND market_signal_live
+  AND (
+    whipsaw_after_promotion_flag
+    OR outcome_5d_directional_return < -0.02
+    OR drift_status IN ('PRICE_DRIFT', 'SCORE_DRIFT', 'PRICE_AND_SCORE_DRIFT')
+  );
+
+CREATE OR REPLACE VIEW hedge_fund.v_signal_health_execution_outcomes
+WITH (security_invoker = true) AS
+SELECT
+    execution_id,
+    acceptance_id,
+    candidate_id,
+    baseline_parameter_set,
+    executed_by,
+    executed_at,
+    rollback_status,
+    inserted_count,
+    avg_1d_return,
+    avg_5d_return,
+    avg_20d_return,
+    positive_1d_pct,
+    positive_5d_pct,
+    positive_20d_pct,
+    whipsaw_pct,
+    health_status,
+    key_flags
+FROM hedge_fund.v_signal_health_active_promotions;
+
+CREATE OR REPLACE FUNCTION hedge_fund.signal_health_model_divergence(
+    candidate_parameter_set TEXT DEFAULT 'dochia_v0_2_range_daily',
+    production_parameter_set TEXT DEFAULT 'dochia_v0_estimated',
+    lookback_bars INTEGER DEFAULT 30
+)
+RETURNS TABLE (
+    bar_date DATE,
+    candidate_80_count INTEGER,
+    production_matching_80_count INTEGER,
+    divergence_count INTEGER,
+    divergence_rate NUMERIC,
+    divergent_tickers TEXT[]
+)
+LANGUAGE sql
+STABLE
+SET search_path = pg_catalog, hedge_fund
+AS $$
+WITH candidate_bar_dates AS (
+    SELECT DISTINCT v.bar_date
+    FROM hedge_fund.v_signal_scores_composite v
+    WHERE v.parameter_set_name = candidate_parameter_set
+    ORDER BY v.bar_date DESC
+    LIMIT GREATEST(1, COALESCE(lookback_bars, 30))
+),
+candidate AS (
+    SELECT
+        v.ticker,
+        v.bar_date,
+        v.composite_score
+    FROM hedge_fund.v_signal_scores_composite v
+    JOIN candidate_bar_dates b
+      ON b.bar_date = v.bar_date
+    WHERE v.parameter_set_name = candidate_parameter_set
+      AND v.composite_score = 80
+),
+joined AS (
+    SELECT
+        c.ticker,
+        c.bar_date,
+        p.composite_score AS production_score
+    FROM candidate c
+    LEFT JOIN hedge_fund.v_signal_scores_composite p
+      ON p.ticker = c.ticker
+     AND p.bar_date = c.bar_date
+     AND p.parameter_set_name = production_parameter_set
+)
+SELECT
+    j.bar_date,
+    count(*)::INTEGER AS candidate_80_count,
+    count(*) FILTER (WHERE j.production_score = 80)::INTEGER
+        AS production_matching_80_count,
+    count(*) FILTER (WHERE j.production_score IS DISTINCT FROM 80)::INTEGER
+        AS divergence_count,
+    (
+        count(*) FILTER (WHERE j.production_score IS DISTINCT FROM 80)::NUMERIC
+        / NULLIF(count(*), 0)
+    ) AS divergence_rate,
+    COALESCE(
+        array_agg(j.ticker ORDER BY j.ticker)
+            FILTER (WHERE j.production_score IS DISTINCT FROM 80),
+        ARRAY[]::TEXT[]
+    ) AS divergent_tickers
+FROM joined j
+GROUP BY j.bar_date
+ORDER BY j.bar_date DESC;
+$$;
+
+REVOKE ALL ON TABLE hedge_fund.v_signal_health_active_promotions FROM PUBLIC;
+REVOKE ALL ON TABLE hedge_fund.v_signal_health_at_risk_signals FROM PUBLIC;
+REVOKE ALL ON TABLE hedge_fund.v_signal_health_execution_outcomes FROM PUBLIC;
+REVOKE ALL ON FUNCTION hedge_fund.signal_health_model_divergence(TEXT, TEXT, INTEGER)
+FROM PUBLIC;
+
+GRANT SELECT ON TABLE
+    hedge_fund.v_signal_health_active_promotions,
+    hedge_fund.v_signal_health_at_risk_signals,
+    hedge_fund.v_signal_health_execution_outcomes
+TO crog_ai_app;
+
+GRANT EXECUTE ON FUNCTION
+    hedge_fund.signal_health_model_divergence(TEXT, TEXT, INTEGER)
+TO crog_ai_app;

--- a/crog-ai-backend/docs/OPERATOR-AUDIT-PLAYBOOK.md
+++ b/crog-ai-backend/docs/OPERATOR-AUDIT-PLAYBOOK.md
@@ -76,6 +76,27 @@ Use `POST /api/financial/signals/promotion-alerts/{alert_id}/acknowledgements` t
 
 Acknowledgement status values are `ACKNOWLEDGED`, `WATCHING`, and `NO_ACTION_NEEDED`. The alerts endpoint surfaces latest acknowledgement status and whether review is still open.
 
+## Signal Health Dashboard
+
+Use `GET /api/financial/signals/health-dashboard` for the read-only operator awareness layer. It answers: what changed, what is degrading, and what should be watched right now.
+
+The dashboard uses these read-only objects:
+
+- `hedge_fund.v_signal_health_active_promotions`
+- `hedge_fund.v_signal_health_at_risk_signals`
+- `hedge_fund.v_signal_health_execution_outcomes`
+- `hedge_fund.signal_health_model_divergence(...)`
+
+The dashboard surfaces:
+
+- last 10 promotion executions with `HEALTHY`, `WARNING`, or `DEGRADED` status
+- drift, whipsaw, and decay flags
+- at-risk signals only when whipsaw, adverse 5-day return, or drift conditions exist
+- candidate +80 vs production non-+80 divergence trend
+- execution outcome summaries for 1-session, 5-session, and 20-session windows
+
+Awareness alerts are non-blocking and warning-only. They do not write `market_signals`, create acceptances, create executions, call rollback, or attach any automated action.
+
 ## Snapshots
 
 Acceptance records persist:

--- a/crog-ai-backend/tests/test_api_signals.py
+++ b/crog-ai-backend/tests/test_api_signals.py
@@ -1113,6 +1113,150 @@ class FakeSignalStore:
             "alerts": alerts,
         }
 
+    def signal_health_dashboard(
+        self,
+        *,
+        candidate_parameter_set: str,
+        production_parameter_set: str = "dochia_v0_estimated",
+        execution_limit: int = 10,
+        risk_limit: int = 25,
+        divergence_lookback_bars: int = 30,
+    ) -> dict[str, Any]:
+        return {
+            "generated_at": dt.datetime(2026, 5, 4, 14, 15, tzinfo=dt.UTC),
+            "candidate_parameter_set": candidate_parameter_set,
+            "production_parameter_set": production_parameter_set,
+            "summary": {
+                "active_execution_count": 1,
+                "degraded_execution_count": 1,
+                "warning_execution_count": 0,
+                "at_risk_signal_count": 1,
+                "divergence_count": 3,
+                "latest_divergence_bar_date": dt.date(2026, 5, 1),
+                "rollback_review_count": 1,
+            },
+            "active_promotions": [
+                {
+                    "execution_id": EXECUTION_ID,
+                    "acceptance_id": ACCEPTANCE_ID,
+                    "candidate_id": candidate_parameter_set,
+                    "baseline_parameter_set": production_parameter_set,
+                    "executed_by": "MarketClub Operator",
+                    "executed_at": dt.datetime(2026, 5, 3, 21, 0, tzinfo=dt.UTC),
+                    "rollback_status": "active",
+                    "inserted_count": 4,
+                    "live_signal_count": 4,
+                    "warning_signal_count": 2,
+                    "drift_signal_count": 1,
+                    "whipsaw_signal_count": 1,
+                    "decay_signal_count": 1,
+                    "rollback_review_count": 1,
+                    "avg_1d_return": Decimal("0.0075"),
+                    "avg_5d_return": Decimal("-0.0310"),
+                    "avg_20d_return": None,
+                    "positive_1d_pct": Decimal("0.7500"),
+                    "positive_5d_pct": Decimal("0.2500"),
+                    "positive_20d_pct": None,
+                    "whipsaw_pct": Decimal("0.2500"),
+                    "health_status": "DEGRADED",
+                    "key_flags": {"drift": True, "whipsaw": True, "decay": True},
+                    "explanation": "Rollback review warning is present; operator review only.",
+                }
+            ][:execution_limit],
+            "at_risk_signals": [
+                {
+                    "execution_id": EXECUTION_ID,
+                    "acceptance_id": ACCEPTANCE_ID,
+                    "decision_record_id": DECISION_ID,
+                    "candidate_id": candidate_parameter_set,
+                    "market_signal_id": 1201,
+                    "ticker": "AA",
+                    "action": "BUY",
+                    "candidate_bar_date": dt.date(2026, 4, 24),
+                    "candidate_score": 80,
+                    "rollback_marker": "dochia-dry-run:dochia_v0_2_range_daily:AA:2026-04-24",
+                    "outcome_5d_directional_return": Decimal("-0.043478"),
+                    "outcome_20d_directional_return": None,
+                    "drift_status": "PRICE_AND_SCORE_DRIFT",
+                    "whipsaw_after_promotion_flag": True,
+                    "signal_decay_flag": True,
+                    "rollback_recommendation": "REVIEW_ROLLBACK_WARNING",
+                    "monitoring_status": "WARNING",
+                    "risk_score": 105,
+                    "risk_reason": "whipsaw-after-promotion",
+                    "explanation": "Candidate state whipsawed after promotion; warning only.",
+                }
+            ][:risk_limit],
+            "model_divergence": {
+                "latest_bar_date": dt.date(2026, 5, 1),
+                "current_candidate_80_count": 12,
+                "current_divergence_count": 3,
+                "current_divergence_rate": Decimal("0.2500"),
+                "trend": [
+                    {
+                        "bar_date": dt.date(2026, 5, 1),
+                        "candidate_80_count": 12,
+                        "production_matching_80_count": 9,
+                        "divergence_count": 3,
+                        "divergence_rate": Decimal("0.2500"),
+                        "divergent_tickers": ["AA", "ACLX", "AEP"],
+                    },
+                    {
+                        "bar_date": dt.date(2026, 4, 30),
+                        "candidate_80_count": 10,
+                        "production_matching_80_count": 8,
+                        "divergence_count": 2,
+                        "divergence_rate": Decimal("0.2000"),
+                        "divergent_tickers": ["ACLX", "AEP"],
+                    },
+                ][:divergence_lookback_bars],
+            },
+            "execution_outcomes": [
+                {
+                    "execution_id": EXECUTION_ID,
+                    "acceptance_id": ACCEPTANCE_ID,
+                    "candidate_id": candidate_parameter_set,
+                    "baseline_parameter_set": production_parameter_set,
+                    "executed_by": "MarketClub Operator",
+                    "executed_at": dt.datetime(2026, 5, 3, 21, 0, tzinfo=dt.UTC),
+                    "rollback_status": "active",
+                    "inserted_count": 4,
+                    "avg_1d_return": Decimal("0.0075"),
+                    "avg_5d_return": Decimal("-0.0310"),
+                    "avg_20d_return": None,
+                    "positive_1d_pct": Decimal("0.7500"),
+                    "positive_5d_pct": Decimal("0.2500"),
+                    "positive_20d_pct": None,
+                    "whipsaw_pct": Decimal("0.2500"),
+                    "health_status": "DEGRADED",
+                    "key_flags": {"drift": True, "whipsaw": True, "decay": True},
+                }
+            ][:execution_limit],
+            "awareness_alerts": [
+                {
+                    "severity": "WARNING",
+                    "alert_type": "DRIFT",
+                    "execution_id": EXECUTION_ID,
+                    "message": "Drift detected in execution 55555555",
+                    "non_blocking": True,
+                },
+                {
+                    "severity": "WARNING",
+                    "alert_type": "WHIPSAW_AFTER_PROMOTION",
+                    "execution_id": EXECUTION_ID,
+                    "message": "1 signals entered whipsaw after execution 55555555",
+                    "non_blocking": True,
+                },
+                {
+                    "severity": "WARNING",
+                    "alert_type": "PERFORMANCE_BAND",
+                    "execution_id": EXECUTION_ID,
+                    "message": "5d performance below expected band in execution 55555555",
+                    "non_blocking": True,
+                },
+            ],
+        }
+
     def acknowledge_promotion_post_execution_alert(
         self,
         *,
@@ -1809,6 +1953,50 @@ def test_promotion_post_execution_alerts_endpoint_returns_warning_only_alerts() 
     assert "no automated rollback is performed" in guidance
     assert "no automatic trade or signal change is made" in guidance
     assert "no automatic trade, signal, or rollback action is made" in guidance
+
+
+def test_signal_health_dashboard_endpoint_returns_operator_awareness_layer() -> None:
+    app = create_app()
+    app.dependency_overrides[get_signal_store] = FakeSignalStore
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/financial/signals/health-dashboard"
+        "?candidate_parameter_set=dochia_v0_2_range_daily"
+        "&production_parameter_set=dochia_v0_estimated"
+        "&execution_limit=10"
+        "&risk_limit=25"
+        "&divergence_lookback_bars=2"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["candidate_parameter_set"] == "dochia_v0_2_range_daily"
+    assert payload["production_parameter_set"] == "dochia_v0_estimated"
+    assert payload["summary"]["active_execution_count"] == 1
+    assert payload["summary"]["degraded_execution_count"] == 1
+    assert payload["summary"]["at_risk_signal_count"] == 1
+    assert payload["active_promotions"][0]["health_status"] == "DEGRADED"
+    assert payload["active_promotions"][0]["key_flags"] == {
+        "drift": True,
+        "whipsaw": True,
+        "decay": True,
+    }
+    assert payload["at_risk_signals"][0]["risk_reason"] == "whipsaw-after-promotion"
+    assert payload["model_divergence"]["current_divergence_count"] == 3
+    assert payload["model_divergence"]["trend"][0]["divergent_tickers"] == [
+        "AA",
+        "ACLX",
+        "AEP",
+    ]
+    assert payload["execution_outcomes"][0]["inserted_count"] == 4
+    assert payload["execution_outcomes"][0]["avg_5d_return"] == "-0.0310"
+    assert all(alert["non_blocking"] is True for alert in payload["awareness_alerts"])
+    assert [alert["message"] for alert in payload["awareness_alerts"]] == [
+        "Drift detected in execution 55555555",
+        "1 signals entered whipsaw after execution 55555555",
+        "5d performance below expected band in execution 55555555",
+    ]
 
 
 def test_promotion_post_execution_alert_acknowledgement_endpoint_creates_audit_row() -> None:

--- a/crog-ai-backend/tests/test_signal_health_dashboard.py
+++ b/crog-ai-backend/tests/test_signal_health_dashboard.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+
+
+def _health_sql() -> str:
+    return (
+        Path(__file__).resolve().parents[1]
+        / "deploy"
+        / "sql"
+        / "marketclub_signal_health_dashboard.sql"
+    ).read_text(encoding="utf-8")
+
+
+def test_signal_health_dashboard_is_read_only() -> None:
+    sql = _health_sql()
+
+    assert "CREATE OR REPLACE VIEW hedge_fund.v_signal_health_active_promotions" in sql
+    assert "CREATE OR REPLACE VIEW hedge_fund.v_signal_health_at_risk_signals" in sql
+    assert "CREATE OR REPLACE VIEW hedge_fund.v_signal_health_execution_outcomes" in sql
+    assert "CREATE OR REPLACE FUNCTION hedge_fund.signal_health_model_divergence" in sql
+    assert "WITH (security_invoker = true) AS" in sql
+    assert "FROM hedge_fund.v_signal_promotion_post_execution_monitoring" in sql
+    assert "FROM hedge_fund.v_signal_scores_composite" in sql
+    assert "INSERT INTO hedge_fund.market_signals" not in sql
+    assert "DELETE FROM hedge_fund.market_signals" not in sql
+    assert "UPDATE hedge_fund.market_signals" not in sql
+    assert "rollback_guarded_signal_promotion" not in sql
+
+
+def test_signal_health_dashboard_tracks_requested_health_flags() -> None:
+    sql = _health_sql()
+
+    assert "'drift', drift_signal_count > 0" in sql
+    assert "'whipsaw', whipsaw_signal_count > 0" in sql
+    assert "'decay', decay_signal_count > 0" in sql
+    assert "'HEALTHY'" in sql
+    assert "'WARNING'" in sql
+    assert "'DEGRADED'" in sql
+    assert "outcome_1d_directional_return" in sql
+    assert "outcome_5d_directional_return" in sql
+    assert "outcome_20d_directional_return" in sql
+    assert "positive_5d_pct" in sql
+    assert "whipsaw_pct" in sql
+
+
+def test_signal_health_dashboard_surfaces_only_actionable_at_risk_conditions() -> None:
+    sql = _health_sql()
+
+    assert "WHERE rollback_status = 'active'" in sql
+    assert "AND market_signal_live" in sql
+    assert "whipsaw_after_promotion_flag" in sql
+    assert "outcome_5d_directional_return < -0.02" in sql
+    assert "drift_status IN ('PRICE_DRIFT', 'SCORE_DRIFT', 'PRICE_AND_SCORE_DRIFT')" in sql
+    assert "'whipsaw-after-promotion'" in sql
+    assert "'5d return below threshold'" in sql
+    assert "'drift vs expected range'" in sql
+
+
+def test_signal_health_model_divergence_compares_candidate_80_to_production() -> None:
+    sql = _health_sql()
+
+    assert "candidate_parameter_set TEXT DEFAULT 'dochia_v0_2_range_daily'" in sql
+    assert "production_parameter_set TEXT DEFAULT 'dochia_v0_estimated'" in sql
+    assert "v.composite_score = 80" in sql
+    assert "p.parameter_set_name = production_parameter_set" in sql
+    assert "j.production_score IS DISTINCT FROM 80" in sql
+    assert "divergence_rate" in sql
+    assert "divergent_tickers" in sql
+
+
+def test_signal_health_dashboard_grants_are_read_only() -> None:
+    sql = _health_sql()
+
+    assert "REVOKE ALL ON TABLE hedge_fund.v_signal_health_active_promotions" in sql
+    assert "REVOKE ALL ON TABLE hedge_fund.v_signal_health_at_risk_signals" in sql
+    assert "REVOKE ALL ON TABLE hedge_fund.v_signal_health_execution_outcomes" in sql
+    assert "REVOKE ALL ON FUNCTION hedge_fund.signal_health_model_divergence" in sql
+    assert "GRANT SELECT ON TABLE" in sql
+    assert "GRANT EXECUTE ON FUNCTION" in sql
+    assert "GRANT INSERT" not in sql
+    assert "GRANT UPDATE" not in sql
+    assert "GRANT DELETE" not in sql

--- a/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
+++ b/fortress-guest-platform/apps/command-center/src/__tests__/components/financial-hedge-fund-shell.test.tsx
@@ -1001,6 +1001,141 @@ promotionPostExecutionAlerts.alerts = promotionPostExecutionAlerts.alerts.map((a
   acknowledgement_required: index !== 0,
 }));
 
+const signalHealthDashboard = {
+  generated_at: "2026-05-04T14:15:00Z",
+  candidate_parameter_set: "dochia_v0_2_range_daily",
+  production_parameter_set: "dochia_v0_estimated",
+  summary: {
+    active_execution_count: 1,
+    degraded_execution_count: 1,
+    warning_execution_count: 0,
+    at_risk_signal_count: 1,
+    divergence_count: 3,
+    latest_divergence_bar_date: "2026-05-01",
+    rollback_review_count: 1,
+  },
+  active_promotions: [
+    {
+      execution_id: "55555555-5555-5555-5555-555555555555",
+      acceptance_id: "44444444-4444-4444-4444-444444444444",
+      candidate_id: "dochia_v0_2_range_daily",
+      baseline_parameter_set: "dochia_v0_estimated",
+      executed_by: "MarketClub Operator",
+      executed_at: "2026-05-03T21:00:00Z",
+      rollback_status: "active",
+      inserted_count: 4,
+      live_signal_count: 4,
+      warning_signal_count: 2,
+      drift_signal_count: 1,
+      whipsaw_signal_count: 1,
+      decay_signal_count: 1,
+      rollback_review_count: 1,
+      avg_1d_return: "0.0075",
+      avg_5d_return: "-0.0310",
+      avg_20d_return: null,
+      positive_1d_pct: "0.7500",
+      positive_5d_pct: "0.2500",
+      positive_20d_pct: null,
+      whipsaw_pct: "0.2500",
+      health_status: "DEGRADED",
+      key_flags: { drift: true, whipsaw: true, decay: true },
+      explanation: "Rollback review warning is present; operator review only.",
+    },
+  ],
+  at_risk_signals: [
+    {
+      execution_id: "55555555-5555-5555-5555-555555555555",
+      acceptance_id: "44444444-4444-4444-4444-444444444444",
+      decision_record_id: "33333333-3333-3333-3333-333333333333",
+      candidate_id: "dochia_v0_2_range_daily",
+      market_signal_id: 1201,
+      ticker: "AA",
+      action: "BUY",
+      candidate_bar_date: "2026-04-24",
+      candidate_score: 80,
+      rollback_marker: "dochia-dry-run:dochia_v0_2_range_daily:AA:2026-04-24",
+      outcome_5d_directional_return: "-0.043478",
+      outcome_20d_directional_return: null,
+      drift_status: "PRICE_AND_SCORE_DRIFT",
+      whipsaw_after_promotion_flag: true,
+      signal_decay_flag: true,
+      rollback_recommendation: "REVIEW_ROLLBACK_WARNING",
+      monitoring_status: "WARNING",
+      risk_score: 105,
+      risk_reason: "whipsaw-after-promotion",
+      explanation: "Candidate state whipsawed after promotion; warning only.",
+    },
+  ],
+  model_divergence: {
+    latest_bar_date: "2026-05-01",
+    current_candidate_80_count: 12,
+    current_divergence_count: 3,
+    current_divergence_rate: "0.2500",
+    trend: [
+      {
+        bar_date: "2026-05-01",
+        candidate_80_count: 12,
+        production_matching_80_count: 9,
+        divergence_count: 3,
+        divergence_rate: "0.2500",
+        divergent_tickers: ["AA", "ACLX", "AEP"],
+      },
+      {
+        bar_date: "2026-04-30",
+        candidate_80_count: 10,
+        production_matching_80_count: 8,
+        divergence_count: 2,
+        divergence_rate: "0.2000",
+        divergent_tickers: ["ACLX", "AEP"],
+      },
+    ],
+  },
+  execution_outcomes: [
+    {
+      execution_id: "55555555-5555-5555-5555-555555555555",
+      acceptance_id: "44444444-4444-4444-4444-444444444444",
+      candidate_id: "dochia_v0_2_range_daily",
+      baseline_parameter_set: "dochia_v0_estimated",
+      executed_by: "MarketClub Operator",
+      executed_at: "2026-05-03T21:00:00Z",
+      rollback_status: "active",
+      inserted_count: 4,
+      avg_1d_return: "0.0075",
+      avg_5d_return: "-0.0310",
+      avg_20d_return: null,
+      positive_1d_pct: "0.7500",
+      positive_5d_pct: "0.2500",
+      positive_20d_pct: null,
+      whipsaw_pct: "0.2500",
+      health_status: "DEGRADED",
+      key_flags: { drift: true, whipsaw: true, decay: true },
+    },
+  ],
+  awareness_alerts: [
+    {
+      severity: "WARNING",
+      alert_type: "DRIFT",
+      execution_id: "55555555-5555-5555-5555-555555555555",
+      message: "Drift detected in execution 55555555",
+      non_blocking: true,
+    },
+    {
+      severity: "WARNING",
+      alert_type: "WHIPSAW_AFTER_PROMOTION",
+      execution_id: "55555555-5555-5555-5555-555555555555",
+      message: "1 signals entered whipsaw after execution 55555555",
+      non_blocking: true,
+    },
+    {
+      severity: "WARNING",
+      alert_type: "PERFORMANCE_BAND",
+      execution_id: "55555555-5555-5555-5555-555555555555",
+      message: "5d performance below expected band in execution 55555555",
+      non_blocking: true,
+    },
+  ],
+};
+
 let promotionDryRunAcceptancesMock = promotionDryRunAcceptances;
 let promotionExecutionsMock = promotionExecutions;
 let promotionDryRunVerificationMock = promotionDryRunVerification;
@@ -1142,6 +1277,13 @@ vi.mock("@/lib/hooks", () => ({
     isLoading: false,
     refetch: vi.fn(),
   }),
+  useFinancialSignalHealthDashboard: () => ({
+    data: signalHealthDashboard,
+    isError: false,
+    isFetching: false,
+    isLoading: false,
+    refetch: vi.fn(),
+  }),
   useAcknowledgeFinancialPromotionPostExecutionAlert: () => ({
     isPending: false,
     mutateAsync: vi.fn(),
@@ -1194,6 +1336,18 @@ describe("HedgeFundSignalsShell", () => {
     expect(screen.getByText("Decision Record")).toBeInTheDocument();
     expect(screen.getByText("Decision Records")).toBeInTheDocument();
     expect(screen.getAllByText("Continue shadow").length).toBeGreaterThan(0);
+    expect(screen.getByText("Signal Health Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Awareness Alerts")).toBeInTheDocument();
+    expect(screen.getByText("Active Promotions Health")).toBeInTheDocument();
+    expect(screen.getAllByText("At-Risk Signals").length).toBeGreaterThan(0);
+    expect(screen.getByText("Model vs Production Divergence")).toBeInTheDocument();
+    expect(screen.getByText("Execution Outcome Summary")).toBeInTheDocument();
+    expect(screen.getAllByText("DEGRADED").length).toBeGreaterThan(0);
+    expect(screen.getByText("Drift detected in execution 55555555")).toBeInTheDocument();
+    expect(screen.getByText("1 signals entered whipsaw after execution 55555555")).toBeInTheDocument();
+    expect(screen.getByText("5d performance below expected band in execution 55555555")).toBeInTheDocument();
+    expect(screen.getByText("whipsaw-after-promotion")).toBeInTheDocument();
+    expect(screen.getByText("Candidate +80 while production is not +80.")).toBeInTheDocument();
     expect(screen.getByText("Promotion Dry-Run")).toBeInTheDocument();
     expect(screen.getByText("market_signals Preview")).toBeInTheDocument();
     expect(screen.getByText("Ready for dry-run")).toBeInTheDocument();
@@ -1213,7 +1367,7 @@ describe("HedgeFundSignalsShell", () => {
     expect(screen.getByText("Rollback review")).toBeInTheDocument();
     expect(screen.getAllByText("Price And Score Drift").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Review Rollback Warning").length).toBeGreaterThan(0);
-    expect(screen.getByText("-4.3%")).toBeInTheDocument();
+    expect(screen.getAllByText("-4.3%").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Whipsaw").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Decay").length).toBeGreaterThan(0);
     expect(screen.getByText("Post-Execution Alerts")).toBeInTheDocument();

--- a/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
+++ b/fortress-guest-platform/apps/command-center/src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx
@@ -57,6 +57,7 @@ import {
   useFinancialPromotionPostExecutionMonitoring,
   useFinancialPromotionReconciliation,
   useFinancialPromotionRollbackDrills,
+  useFinancialSignalHealthDashboard,
   useRollbackFinancialPromotionExecution,
   useFinancialShadowDecisionRecords,
   useFinancialShadowReview,
@@ -89,6 +90,8 @@ import type {
   FinancialPromotionReconciliation,
   FinancialPromotionRollbackDrill,
   FinancialPromotionRollbackEligibility,
+  FinancialSignalHealthDashboardResponse,
+  FinancialSignalHealthStatus,
   FinancialPromotionGateGuardrailStatus,
   FinancialPromotionGateRecommendationStatus,
   FinancialPromotionGateResponse,
@@ -390,6 +393,12 @@ function promotionAlertSeverityClasses(severity: FinancialPromotionPostExecution
   if (severity === "HIGH") return "border-red-500/40 bg-red-500/10 text-red-600";
   if (severity === "MEDIUM") return "border-amber-500/40 bg-amber-500/10 text-amber-600";
   return "border-border bg-muted/30 text-muted-foreground";
+}
+
+function signalHealthStatusClasses(status: FinancialSignalHealthStatus): string {
+  if (status === "HEALTHY") return "border-emerald-500/40 bg-emerald-500/10 text-emerald-600";
+  if (status === "WARNING") return "border-amber-500/40 bg-amber-500/10 text-amber-600";
+  return "border-red-500/40 bg-red-500/10 text-red-600";
 }
 
 function promotionAlertTypeLabel(type: FinancialPromotionPostExecutionAlert["alert_type"]): string {
@@ -2257,6 +2266,317 @@ function PostExecutionAlertsPanel({
   );
 }
 
+function SignalHealthDashboardPanel({
+  dashboard,
+  loading,
+  error,
+}: {
+  dashboard: FinancialSignalHealthDashboardResponse | null;
+  loading: boolean;
+  error: boolean;
+}) {
+  if (error) {
+    return (
+      <div className="flex items-center gap-2 border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+        <AlertTriangle className="h-4 w-4" />
+        Signal health dashboard unavailable.
+      </div>
+    );
+  }
+
+  if (loading && !dashboard) {
+    return <div className="py-8 text-sm text-muted-foreground">Loading signal health...</div>;
+  }
+
+  if (!dashboard) {
+    return (
+      <div className="border border-dashed border-border p-5 text-sm text-muted-foreground">
+        No signal health rows yet.
+      </div>
+    );
+  }
+
+  const activeRows = dashboard.active_promotions.slice(0, 10);
+  const riskRows = dashboard.at_risk_signals.slice(0, 8);
+  const outcomeRows = dashboard.execution_outcomes.slice(0, 10);
+  const divergenceTrend = dashboard.model_divergence.trend.slice(0, 6);
+
+  return (
+    <div className="space-y-5">
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+        <div className="border border-border p-3">
+          <p className="text-xs text-muted-foreground">Active Executions</p>
+          <p className="mt-1 font-mono text-2xl font-bold">
+            {dashboard.summary.active_execution_count}
+          </p>
+        </div>
+        <div className="border border-border p-3">
+          <p className="text-xs text-muted-foreground">Degraded</p>
+          <p className="mt-1 font-mono text-2xl font-bold text-red-500">
+            {dashboard.summary.degraded_execution_count}
+          </p>
+        </div>
+        <div className="border border-border p-3">
+          <p className="text-xs text-muted-foreground">At-Risk Signals</p>
+          <p className="mt-1 font-mono text-2xl font-bold text-amber-500">
+            {dashboard.summary.at_risk_signal_count}
+          </p>
+        </div>
+        <div className="border border-border p-3">
+          <p className="text-xs text-muted-foreground">Candidate Divergence</p>
+          <p className="mt-1 font-mono text-2xl font-bold">
+            {dashboard.summary.divergence_count}
+          </p>
+        </div>
+        <div className="border border-border p-3">
+          <p className="text-xs text-muted-foreground">Rollback Review</p>
+          <p className="mt-1 font-mono text-2xl font-bold">
+            {dashboard.summary.rollback_review_count}
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="text-sm font-semibold">Awareness Alerts</h2>
+          <Badge variant="outline">Warning only</Badge>
+        </div>
+        <div className="grid gap-2 md:grid-cols-2">
+          {dashboard.awareness_alerts.map((alert) => (
+            <div
+              key={`${alert.alert_type}-${alert.execution_id ?? "global"}-${alert.message}`}
+              className={cn(
+                "flex items-start gap-2 border p-3 text-sm",
+                alert.severity === "WARNING"
+                  ? "border-amber-500/40 bg-amber-500/10 text-amber-700"
+                  : "border-border bg-muted/20 text-muted-foreground",
+              )}
+            >
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <div className="min-w-0">
+                <p>{alert.message}</p>
+                <p className="text-xs text-muted-foreground">Non-blocking, no automated action.</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
+        <div className="space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-sm font-semibold">Active Promotions Health</h2>
+            <Badge variant="outline">Last 10 executions</Badge>
+          </div>
+          <div className="overflow-hidden border border-border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Execution</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Rows</TableHead>
+                  <TableHead>Flags</TableHead>
+                  <TableHead>5d Avg</TableHead>
+                  <TableHead>Rollback</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {activeRows.length ? (
+                  activeRows.map((row) => (
+                    <TableRow key={row.execution_id}>
+                      <TableCell>
+                        <div className="space-y-1">
+                          <p className="font-mono text-xs">{row.execution_id.slice(0, 8)}</p>
+                          <p className="text-xs text-muted-foreground">{formatDateTime(row.executed_at)}</p>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="outline" className={signalHealthStatusClasses(row.health_status)}>
+                          {row.health_status}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="font-mono text-sm">{row.inserted_count}</TableCell>
+                      <TableCell>
+                        <div className="flex flex-wrap gap-1">
+                          {row.key_flags.drift ? <Badge variant="outline">drift</Badge> : null}
+                          {row.key_flags.whipsaw ? <Badge variant="outline">whipsaw</Badge> : null}
+                          {row.key_flags.decay ? <Badge variant="outline">decay</Badge> : null}
+                          {!row.key_flags.drift && !row.key_flags.whipsaw && !row.key_flags.decay ? (
+                            <span className="text-xs text-muted-foreground">Clear</span>
+                          ) : null}
+                        </div>
+                      </TableCell>
+                      <TableCell className="font-mono text-sm">
+                        {formatSignedPercent(numericPercent(row.avg_5d_return))}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="outline" className={promotionExecutionRollbackClasses(row.rollback_status)}>
+                          {row.rollback_status === "rolled_back" ? "Rolled back" : "Active"}
+                        </Badge>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell colSpan={6} className="py-6 text-sm text-muted-foreground">
+                      No executed promotions yet.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </div>
+
+        <div className="space-y-3 border border-border p-3">
+          <div>
+            <h2 className="text-sm font-semibold">Model vs Production Divergence</h2>
+            <p className="text-xs text-muted-foreground">
+              Candidate +80 while production is not +80.
+            </p>
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            <div className="border border-border p-3">
+              <p className="text-xs text-muted-foreground">Current</p>
+              <p className="mt-1 font-mono text-2xl font-bold">
+                {dashboard.model_divergence.current_divergence_count}
+              </p>
+            </div>
+            <div className="border border-border p-3">
+              <p className="text-xs text-muted-foreground">Rate</p>
+              <p className="mt-1 font-mono text-2xl font-bold">
+                {formatPercent(numericPercent(dashboard.model_divergence.current_divergence_rate))}
+              </p>
+            </div>
+          </div>
+          <div className="space-y-2">
+            {divergenceTrend.length ? (
+              divergenceTrend.map((row) => (
+                <div key={row.bar_date} className="flex items-center justify-between gap-3 text-xs">
+                  <span>{formatDate(row.bar_date)}</span>
+                  <span className="font-mono">
+                    {row.divergence_count}/{row.candidate_80_count}
+                  </span>
+                  <span className="text-muted-foreground">
+                    {formatPercent(numericPercent(row.divergence_rate))}
+                  </span>
+                </div>
+              ))
+            ) : (
+              <p className="text-xs text-muted-foreground">No divergence trend rows yet.</p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        <div className="space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-sm font-semibold">At-Risk Signals</h2>
+            <Badge variant="outline">Actionable risk only</Badge>
+          </div>
+          <div className="overflow-hidden border border-border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Ticker</TableHead>
+                  <TableHead>Reason</TableHead>
+                  <TableHead>5d</TableHead>
+                  <TableHead>Drift</TableHead>
+                  <TableHead>Risk</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {riskRows.length ? (
+                  riskRows.map((row) => (
+                    <TableRow key={`${row.execution_id}-${row.market_signal_id}`}>
+                      <TableCell>
+                        <div className="space-y-1">
+                          <p className="font-mono font-semibold">{row.ticker}</p>
+                          <p className="text-xs text-muted-foreground">{row.action} {row.candidate_score}</p>
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-xs">{row.risk_reason}</TableCell>
+                      <TableCell className="font-mono text-sm">
+                        {formatSignedPercent(numericPercent(row.outcome_5d_directional_return))}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="outline" className={promotionMonitoringStatusClasses(row.drift_status)}>
+                          {promotionMonitoringLabel(row.drift_status)}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="font-mono text-sm">{row.risk_score}</TableCell>
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell colSpan={5} className="py-6 text-sm text-muted-foreground">
+                      No actionable at-risk signals.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-sm font-semibold">Execution Outcome Summary</h2>
+            <Badge variant="outline">Read-only</Badge>
+          </div>
+          <div className="overflow-hidden border border-border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Execution</TableHead>
+                  <TableHead>Rows</TableHead>
+                  <TableHead>1d</TableHead>
+                  <TableHead>5d</TableHead>
+                  <TableHead>20d</TableHead>
+                  <TableHead>+%</TableHead>
+                  <TableHead>Whipsaw</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {outcomeRows.length ? (
+                  outcomeRows.map((row) => (
+                    <TableRow key={row.execution_id}>
+                      <TableCell className="font-mono text-xs">{row.execution_id.slice(0, 8)}</TableCell>
+                      <TableCell className="font-mono text-sm">{row.inserted_count}</TableCell>
+                      <TableCell className="font-mono text-sm">
+                        {formatSignedPercent(numericPercent(row.avg_1d_return))}
+                      </TableCell>
+                      <TableCell className="font-mono text-sm">
+                        {formatSignedPercent(numericPercent(row.avg_5d_return))}
+                      </TableCell>
+                      <TableCell className="font-mono text-sm">
+                        {formatSignedPercent(numericPercent(row.avg_20d_return))}
+                      </TableCell>
+                      <TableCell className="font-mono text-sm">
+                        {formatPercent(numericPercent(row.positive_5d_pct))}
+                      </TableCell>
+                      <TableCell className="font-mono text-sm">
+                        {formatPercent(numericPercent(row.whipsaw_pct))}
+                      </TableCell>
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell colSpan={7} className="py-6 text-sm text-muted-foreground">
+                      No execution outcomes yet.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function PromotionDryRunPanel({
   dryRun,
   loading,
@@ -3102,6 +3422,13 @@ export function HedgeFundSignalsShell() {
   const promotionPostExecutionAlerts = useFinancialPromotionPostExecutionAlerts(promotionAuditId, {
     limit: 100,
   });
+  const signalHealthDashboard = useFinancialSignalHealthDashboard({
+    candidate_parameter_set: "dochia_v0_2_range_daily",
+    production_parameter_set: "dochia_v0_estimated",
+    execution_limit: 10,
+    risk_limit: 25,
+    divergence_lookback_bars: 30,
+  });
   const createShadowDecisionRecord = useCreateFinancialShadowDecisionRecord();
   const createPromotionDryRunAcceptance = useCreateFinancialPromotionDryRunAcceptance();
   const acknowledgePromotionPostExecutionAlert = useAcknowledgeFinancialPromotionPostExecutionAlert();
@@ -3160,7 +3487,8 @@ export function HedgeFundSignalsShell() {
     promotionLifecycleTimeline.isFetching ||
     promotionReconciliation.isFetching ||
     promotionPostExecutionMonitoring.isFetching ||
-    promotionPostExecutionAlerts.isFetching;
+    promotionPostExecutionAlerts.isFetching ||
+    signalHealthDashboard.isFetching;
 
   async function handleShadowDecisionSubmit(payload: FinancialShadowReviewDecisionRecordCreate) {
     await createShadowDecisionRecord.mutateAsync(payload);
@@ -3176,6 +3504,7 @@ export function HedgeFundSignalsShell() {
     void promotionReconciliation.refetch();
     void promotionPostExecutionMonitoring.refetch();
     void promotionPostExecutionAlerts.refetch();
+    void signalHealthDashboard.refetch();
   }
 
   async function handlePromotionExecutionSubmit(payload: FinancialPromotionExecutionCreate) {
@@ -3186,6 +3515,7 @@ export function HedgeFundSignalsShell() {
     void promotionReconciliation.refetch();
     void promotionPostExecutionMonitoring.refetch();
     void promotionPostExecutionAlerts.refetch();
+    void signalHealthDashboard.refetch();
   }
 
   async function handlePromotionRollbackSubmit(payload: FinancialPromotionExecutionRollbackCreate) {
@@ -3196,6 +3526,7 @@ export function HedgeFundSignalsShell() {
     void promotionReconciliation.refetch();
     void promotionPostExecutionMonitoring.refetch();
     void promotionPostExecutionAlerts.refetch();
+    void signalHealthDashboard.refetch();
   }
 
   async function handlePromotionAlertAcknowledgementSubmit(
@@ -3203,6 +3534,7 @@ export function HedgeFundSignalsShell() {
   ) {
     await acknowledgePromotionPostExecutionAlert.mutateAsync(payload);
     void promotionPostExecutionAlerts.refetch();
+    void signalHealthDashboard.refetch();
   }
 
   return (
@@ -3264,6 +3596,7 @@ export function HedgeFundSignalsShell() {
               void promotionReconciliation.refetch();
               void promotionPostExecutionMonitoring.refetch();
               void promotionPostExecutionAlerts.refetch();
+              void signalHealthDashboard.refetch();
             }}
             disabled={isRefreshing}
             aria-label="Refresh hedge fund signals"
@@ -3380,6 +3713,25 @@ export function HedgeFundSignalsShell() {
             decisionRecordsLoading={shadowDecisionRecords.isLoading}
             onSubmitDecision={handleShadowDecisionSubmit}
             submittingDecision={createShadowDecisionRecord.isPending}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <Activity className="h-5 w-5 text-primary" />
+            <CardTitle>Signal Health Dashboard</CardTitle>
+          </div>
+          <Badge variant="outline">
+            {signalHealthDashboard.data ? formatDate(signalHealthDashboard.data.generated_at) : "—"}
+          </Badge>
+        </CardHeader>
+        <CardContent>
+          <SignalHealthDashboardPanel
+            dashboard={signalHealthDashboard.data ?? null}
+            loading={signalHealthDashboard.isLoading}
+            error={signalHealthDashboard.isError}
           />
         </CardContent>
       </Card>

--- a/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/hooks.ts
@@ -27,6 +27,7 @@ import type {
   FinancialPromotionPostExecutionMonitoringResponse,
   FinancialPromotionReconciliation,
   FinancialPromotionRollbackDrill,
+  FinancialSignalHealthDashboardResponse,
   FinancialPromotionDryRunVerificationResponse,
   FinancialPromotionDryRunResponse,
   FinancialPromotionGateResponse,
@@ -390,6 +391,21 @@ export function useFinancialPromotionPostExecutionAlerts(
         params,
       ),
     enabled: Boolean(promotionId),
+    refetchInterval: 60_000,
+    staleTime: 60_000,
+  });
+}
+
+export function useFinancialSignalHealthDashboard(params?: {
+  candidate_parameter_set?: string;
+  production_parameter_set?: string;
+  execution_limit?: number;
+  risk_limit?: number;
+  divergence_lookback_bars?: number;
+}) {
+  return useQuery<FinancialSignalHealthDashboardResponse>({
+    queryKey: ["financial", "signals", "health-dashboard", params],
+    queryFn: () => api.get("/api/financial/signals/health-dashboard", params),
     refetchInterval: 60_000,
     staleTime: 60_000,
   });

--- a/fortress-guest-platform/apps/command-center/src/lib/types.ts
+++ b/fortress-guest-platform/apps/command-center/src/lib/types.ts
@@ -859,6 +859,146 @@ export interface FinancialPromotionPostExecutionAlertAcknowledgement {
   created_at: string;
 }
 
+export type FinancialSignalHealthStatus = "HEALTHY" | "WARNING" | "DEGRADED";
+export type FinancialSignalHealthAwarenessAlertType =
+  | "CLEAR"
+  | "DRIFT"
+  | "WHIPSAW_AFTER_PROMOTION"
+  | "SIGNAL_DECAY"
+  | "PERFORMANCE_BAND"
+  | "ROLLBACK_RECOMMENDATION"
+  | "MODEL_PRODUCTION_DIVERGENCE";
+
+export interface FinancialSignalHealthSummary {
+  active_execution_count: number;
+  degraded_execution_count: number;
+  warning_execution_count: number;
+  at_risk_signal_count: number;
+  divergence_count: number;
+  latest_divergence_bar_date: string | null;
+  rollback_review_count: number;
+}
+
+export interface FinancialSignalHealthActivePromotion {
+  execution_id: string;
+  acceptance_id: string;
+  candidate_id: string;
+  baseline_parameter_set: string;
+  executed_by: string;
+  executed_at: string;
+  rollback_status: FinancialPromotionExecutionRollbackStatus;
+  inserted_count: number;
+  live_signal_count: number;
+  warning_signal_count: number;
+  drift_signal_count: number;
+  whipsaw_signal_count: number;
+  decay_signal_count: number;
+  rollback_review_count: number;
+  avg_1d_return: string | number | null;
+  avg_5d_return: string | number | null;
+  avg_20d_return: string | number | null;
+  positive_1d_pct: string | number | null;
+  positive_5d_pct: string | number | null;
+  positive_20d_pct: string | number | null;
+  whipsaw_pct: string | number | null;
+  health_status: FinancialSignalHealthStatus;
+  key_flags: {
+    drift?: boolean;
+    whipsaw?: boolean;
+    decay?: boolean;
+    [key: string]: boolean | undefined;
+  };
+  explanation: string;
+}
+
+export interface FinancialSignalHealthAtRiskSignal {
+  execution_id: string;
+  acceptance_id: string;
+  decision_record_id: string;
+  candidate_id: string;
+  market_signal_id: number;
+  ticker: string;
+  action: "BUY" | "SELL";
+  candidate_bar_date: string;
+  candidate_score: number;
+  rollback_marker: string;
+  outcome_5d_directional_return: string | number | null;
+  outcome_20d_directional_return: string | number | null;
+  drift_status: FinancialPromotionMonitoringDriftStatus;
+  whipsaw_after_promotion_flag: boolean;
+  signal_decay_flag: boolean;
+  rollback_recommendation: FinancialPromotionRollbackRecommendation;
+  monitoring_status: FinancialPromotionMonitoringStatus;
+  risk_score: number;
+  risk_reason:
+    | "whipsaw-after-promotion"
+    | "5d return below threshold"
+    | "drift vs expected range";
+  explanation: string;
+}
+
+export interface FinancialSignalHealthModelDivergenceTrend {
+  bar_date: string;
+  candidate_80_count: number;
+  production_matching_80_count: number;
+  divergence_count: number;
+  divergence_rate: string | number | null;
+  divergent_tickers: string[];
+}
+
+export interface FinancialSignalHealthModelDivergence {
+  latest_bar_date: string | null;
+  current_candidate_80_count: number;
+  current_divergence_count: number;
+  current_divergence_rate: string | number | null;
+  trend: FinancialSignalHealthModelDivergenceTrend[];
+}
+
+export interface FinancialSignalHealthExecutionOutcome {
+  execution_id: string;
+  acceptance_id: string;
+  candidate_id: string;
+  baseline_parameter_set: string;
+  executed_by: string;
+  executed_at: string;
+  rollback_status: FinancialPromotionExecutionRollbackStatus;
+  inserted_count: number;
+  avg_1d_return: string | number | null;
+  avg_5d_return: string | number | null;
+  avg_20d_return: string | number | null;
+  positive_1d_pct: string | number | null;
+  positive_5d_pct: string | number | null;
+  positive_20d_pct: string | number | null;
+  whipsaw_pct: string | number | null;
+  health_status: FinancialSignalHealthStatus;
+  key_flags: {
+    drift?: boolean;
+    whipsaw?: boolean;
+    decay?: boolean;
+    [key: string]: boolean | undefined;
+  };
+}
+
+export interface FinancialSignalHealthAwarenessAlert {
+  severity: "INFO" | "WARNING";
+  alert_type: FinancialSignalHealthAwarenessAlertType;
+  execution_id: string | null;
+  message: string;
+  non_blocking: boolean;
+}
+
+export interface FinancialSignalHealthDashboardResponse {
+  generated_at: string;
+  candidate_parameter_set: string;
+  production_parameter_set: string;
+  summary: FinancialSignalHealthSummary;
+  active_promotions: FinancialSignalHealthActivePromotion[];
+  at_risk_signals: FinancialSignalHealthAtRiskSignal[];
+  model_divergence: FinancialSignalHealthModelDivergence;
+  execution_outcomes: FinancialSignalHealthExecutionOutcome[];
+  awareness_alerts: FinancialSignalHealthAwarenessAlert[];
+}
+
 export interface FinancialWatchlistCandidate {
   ticker: string;
   bar_date: string;


### PR DESCRIPTION
## Summary
- add read-only SQL views/function for Signal Health Dashboard: active promotion health, at-risk signals, execution outcomes, and candidate-vs-production divergence
- add /api/financial/signals/health-dashboard plus repository read model and typed cockpit hook/types
- add cockpit Signal Health Dashboard panels for awareness alerts, health, risk rows, divergence, and outcome summary
- document the operator awareness layer in the Operator Audit Playbook

## Safety
- read-only dashboard layer only
- no execute/rollback/acceptance controls added
- no writes to hedge_fund.market_signals
- no automatic rollback, signal change, trade change, or automation path

## Tests
- PYTHONPATH=. .venv-test/bin/python -m pytest tests/test_signal_health_dashboard.py tests/test_api_signals.py
- PYTHONPATH=. .venv-test/bin/python -m pytest
- PYTHONPATH=. .venv-test/bin/python -m ruff check app/api/signals.py app/signals/repository.py tests/test_api_signals.py tests/test_signal_health_dashboard.py
- npm test -- financial-hedge-fund-shell.test.tsx
- npm exec -- tsc --noEmit
- npm run lint -- src/lib/hooks.ts src/lib/types.ts src/app/(dashboard)/financial/hedge-fund/_components/hedge-fund-signals-shell.tsx src/__tests__/components/financial-hedge-fund-shell.test.tsx
- npm test
- npm run build