### PR TITLE
docs(financial): add signal release hardening runbooks

### DIFF
--- a/crog-ai-backend/deploy/sql/marketclub_release_hardening_verification.sql
+++ b/crog-ai-backend/deploy/sql/marketclub_release_hardening_verification.sql
@@ -1,0 +1,160 @@
+-- MarketClub Hedge Fund Signals release hardening verification.
+--
+-- This file is intentionally read-only. Run with:
+-- psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f deploy/sql/marketclub_release_hardening_verification.sql
+
+SELECT
+    current_database() AS database_name,
+    current_user AS connected_as,
+    now() AS checked_at;
+
+SELECT version_num
+FROM hedge_fund.alembic_version_crog_ai
+ORDER BY version_num;
+
+SELECT
+    object_name,
+    object_kind,
+    object_exists
+FROM (
+    VALUES
+        ('hedge_fund.verify_promotion_dry_run(TEXT,TEXT)', 'function',
+            to_regprocedure('hedge_fund.verify_promotion_dry_run(TEXT,TEXT)') IS NOT NULL),
+        ('hedge_fund.execute_guarded_signal_promotion(UUID,TEXT,TEXT,TEXT)', 'function',
+            to_regprocedure('hedge_fund.execute_guarded_signal_promotion(UUID,TEXT,TEXT,TEXT)') IS NOT NULL),
+        ('hedge_fund.rollback_guarded_signal_promotion(UUID,TEXT,TEXT)', 'function',
+            to_regprocedure('hedge_fund.rollback_guarded_signal_promotion(UUID,TEXT,TEXT)') IS NOT NULL),
+        ('hedge_fund.acknowledge_signal_promotion_alert(TEXT,TEXT,TEXT,TEXT)', 'function',
+            to_regprocedure('hedge_fund.acknowledge_signal_promotion_alert(TEXT,TEXT,TEXT,TEXT)') IS NOT NULL),
+        ('hedge_fund.signal_health_model_divergence(TEXT,TEXT,INTEGER)', 'function',
+            to_regprocedure('hedge_fund.signal_health_model_divergence(TEXT,TEXT,INTEGER)') IS NOT NULL),
+        ('hedge_fund.signal_promotion_dry_run_acceptances', 'table',
+            to_regclass('hedge_fund.signal_promotion_dry_run_acceptances') IS NOT NULL),
+        ('hedge_fund.signal_promotion_executions', 'table',
+            to_regclass('hedge_fund.signal_promotion_executions') IS NOT NULL),
+        ('hedge_fund.signal_promotion_execution_rows', 'table',
+            to_regclass('hedge_fund.signal_promotion_execution_rows') IS NOT NULL),
+        ('hedge_fund.signal_promotion_alert_acknowledgements', 'table',
+            to_regclass('hedge_fund.signal_promotion_alert_acknowledgements') IS NOT NULL),
+        ('hedge_fund.v_signal_promotion_lifecycle_timeline', 'view',
+            to_regclass('hedge_fund.v_signal_promotion_lifecycle_timeline') IS NOT NULL),
+        ('hedge_fund.v_signal_promotion_reconciliation', 'view',
+            to_regclass('hedge_fund.v_signal_promotion_reconciliation') IS NOT NULL),
+        ('hedge_fund.v_signal_promotion_post_execution_monitoring', 'view',
+            to_regclass('hedge_fund.v_signal_promotion_post_execution_monitoring') IS NOT NULL),
+        ('hedge_fund.v_signal_promotion_post_execution_alerts', 'view',
+            to_regclass('hedge_fund.v_signal_promotion_post_execution_alerts') IS NOT NULL),
+        ('hedge_fund.v_signal_health_active_promotions', 'view',
+            to_regclass('hedge_fund.v_signal_health_active_promotions') IS NOT NULL),
+        ('hedge_fund.v_signal_health_at_risk_signals', 'view',
+            to_regclass('hedge_fund.v_signal_health_at_risk_signals') IS NOT NULL),
+        ('hedge_fund.v_signal_health_execution_outcomes', 'view',
+            to_regclass('hedge_fund.v_signal_health_execution_outcomes') IS NOT NULL)
+) AS objects(object_name, object_kind, object_exists)
+ORDER BY object_kind, object_name;
+
+SELECT
+    n.nspname AS schema_name,
+    c.relname AS table_name,
+    c.relrowsecurity AS rls_enabled,
+    c.relforcerowsecurity AS rls_forced
+FROM pg_class c
+JOIN pg_namespace n
+  ON n.oid = c.relnamespace
+WHERE n.nspname = 'hedge_fund'
+  AND c.relname IN (
+    'market_signals',
+    'signal_shadow_review_decisions',
+    'signal_promotion_dry_run_acceptances',
+    'signal_promotion_executions',
+    'signal_promotion_execution_rows',
+    'signal_promotion_alert_acknowledgements',
+    'signal_operator_memberships'
+  )
+ORDER BY c.relname;
+
+SELECT
+    table_schema,
+    table_name,
+    grantee,
+    privilege_type
+FROM information_schema.table_privileges
+WHERE table_schema = 'hedge_fund'
+  AND table_name IN (
+    'market_signals',
+    'signal_shadow_review_decisions',
+    'signal_promotion_dry_run_acceptances',
+    'signal_promotion_executions',
+    'signal_promotion_execution_rows',
+    'signal_promotion_alert_acknowledgements',
+    'v_signal_promotion_lifecycle_timeline',
+    'v_signal_promotion_reconciliation',
+    'v_signal_promotion_post_execution_monitoring',
+    'v_signal_promotion_post_execution_alerts',
+    'v_signal_health_active_promotions',
+    'v_signal_health_at_risk_signals',
+    'v_signal_health_execution_outcomes'
+  )
+  AND grantee IN ('PUBLIC', 'crog_ai_app')
+ORDER BY table_name, grantee, privilege_type;
+
+SELECT
+    n.nspname AS schema_name,
+    p.proname AS function_name,
+    pg_get_function_arguments(p.oid) AS arguments,
+    p.prosecdef AS security_definer,
+    has_function_privilege('crog_ai_app', p.oid, 'EXECUTE') AS crog_ai_app_can_execute
+FROM pg_proc p
+JOIN pg_namespace n
+  ON n.oid = p.pronamespace
+WHERE n.nspname = 'hedge_fund'
+  AND p.proname IN (
+    'verify_promotion_dry_run',
+    'execute_guarded_signal_promotion',
+    'rollback_guarded_signal_promotion',
+    'acknowledge_signal_promotion_alert',
+    'signal_health_model_divergence'
+  )
+ORDER BY p.proname, arguments;
+
+SELECT
+    acceptance_id,
+    idempotency_key,
+    count(*) AS execution_count
+FROM hedge_fund.signal_promotion_executions
+GROUP BY acceptance_id, idempotency_key
+HAVING count(*) > 1
+ORDER BY execution_count DESC;
+
+SELECT
+    e.id AS execution_id,
+    e.acceptance_id,
+    cardinality(e.inserted_market_signal_ids) AS execution_inserted_id_count,
+    count(r.market_signal_id)::INTEGER AS audited_row_count,
+    e.rollback_status,
+    e.rolled_back_at
+FROM hedge_fund.signal_promotion_executions e
+LEFT JOIN hedge_fund.signal_promotion_execution_rows r
+  ON r.execution_id = e.id
+GROUP BY
+    e.id,
+    e.acceptance_id,
+    e.inserted_market_signal_ids,
+    e.rollback_status,
+    e.rolled_back_at
+ORDER BY e.created_at DESC
+LIMIT 20;
+
+SELECT
+    status,
+    count(*) AS reconciliation_count
+FROM hedge_fund.v_signal_promotion_reconciliation
+GROUP BY status
+ORDER BY status;
+
+SELECT
+    health_status,
+    count(*) AS active_promotion_count
+FROM hedge_fund.v_signal_health_active_promotions
+GROUP BY health_status
+ORDER BY health_status;

--- a/crog-ai-backend/docs/MARKETCLUB-SIGNALS-INCIDENT-RESPONSE-CHECKLIST.md
+++ b/crog-ai-backend/docs/MARKETCLUB-SIGNALS-INCIDENT-RESPONSE-CHECKLIST.md
@@ -1,0 +1,150 @@
+# MarketClub Hedge Fund Signals Incident Response Checklist
+
+**Status:** operator checklist; no automated remediation
+**Scope:** Hedge Fund Signals promotion, execution, rollback, audit, monitoring, alerts, and Signal Health Dashboard
+
+## First 15 Minutes
+
+1. Freeze new operator mutations.
+   - Do not accept a dry-run.
+   - Do not execute an accepted dry-run.
+   - Do not roll back unless the incident commander explicitly authorizes a scoped `execution_id` rollback.
+2. Capture the incident header.
+   - timestamp
+   - reporter
+   - environment
+   - candidate parameter set
+   - affected `decision_id`, `acceptance_id`, `execution_id`, or `alert_id`
+3. Confirm system reachability.
+   - `GET /healthz`
+   - Command Center `/financial/hedge-fund`
+   - database connectivity as read-only observer
+4. Pull read-only evidence.
+   - Lifecycle Timeline
+   - Reconciliation
+   - Post-Execution Monitoring
+   - Post-Execution Alerts
+   - Signal Health Dashboard
+5. Assign severity and owner.
+
+## Severity Guide
+
+`SEV1`:
+
+- production `market_signals` rows were written without an execution audit
+- rollback removed unaudited rows
+- RLS/policy exposure permits unauthorized write
+- execution path bypassed human decision, acceptance, or verification PASS
+
+`SEV2`:
+
+- cockpit cannot trace decision -> execution -> outcome -> rollback
+- reconciliation reports `ERROR`
+- post-execution monitoring is stale for an active execution after expected data availability
+- operator mutation endpoint is unavailable after a valid operator request
+
+`SEV3`:
+
+- Signal Health Dashboard or alert panel fails read-only rendering
+- cross-model divergence spikes but candidate lineage is still clean
+- acknowledgement write fails but core audit trail remains intact
+
+## Evidence Queries
+
+Use exact IDs. Do not investigate by ticker/date alone.
+
+```sql
+SELECT *
+FROM hedge_fund.v_signal_promotion_lifecycle_timeline
+WHERE candidate_id = :candidate_id
+   OR acceptance_id::TEXT = :acceptance_id
+   OR execution_id::TEXT = :execution_id
+ORDER BY ts;
+
+SELECT *
+FROM hedge_fund.v_signal_promotion_reconciliation
+WHERE candidate_id = :candidate_id
+   OR acceptance_id::TEXT = :acceptance_id
+   OR execution_id::TEXT = :execution_id;
+
+SELECT *
+FROM hedge_fund.v_signal_promotion_post_execution_monitoring
+WHERE execution_id::TEXT = :execution_id
+ORDER BY ticker;
+
+SELECT *
+FROM hedge_fund.v_signal_promotion_post_execution_alerts
+WHERE execution_id::TEXT = :execution_id
+ORDER BY severity, alert_type, ticker;
+```
+
+## Decision Tree
+
+Verification or lineage incident:
+
+- Check `verify_promotion_dry_run` output and acceptance verification snapshot.
+- If source lineage cannot be traced, block acceptance and continue shadow.
+- If acceptance already exists without PASS snapshot, classify as `SEV2` or higher.
+
+Execution incident:
+
+- Check `signal_promotion_executions`.
+- Check `signal_promotion_execution_rows`.
+- Confirm inserted IDs match audited rows.
+- If unaudited production rows exist, classify as `SEV1`.
+
+Rollback incident:
+
+- Check rollback audit by `execution_id`.
+- Confirm removed IDs are exactly audited IDs.
+- If rollback was requested by ticker/date, classify as invalid operator procedure.
+- If unaudited rows were removed, classify as `SEV1`.
+
+Monitoring or alert incident:
+
+- Check whether `eod_bars` has expected outcome windows.
+- Check Signal Health Dashboard awareness alerts.
+- Treat rollback recommendations as warnings only until a human authorizes a scoped rollback.
+
+RLS/policy incident:
+
+- Run the RLS section of `deploy/sql/marketclub_release_hardening_verification.sql`.
+- Compare grants to the last release sign-off.
+- If `PUBLIC` or `crog_ai_app` gained unintended write privileges, freeze operator mutations.
+
+## Communication Template
+
+```text
+Incident:
+Severity:
+Environment:
+Candidate parameter set:
+Decision/acceptance/execution/alert id:
+What changed:
+Current operator impact:
+Production write impact:
+Rollback impact:
+Evidence links:
+Next human action:
+Automation status: none
+```
+
+## Recovery Rules
+
+- Prefer read-only diagnosis first.
+- Do not auto-heal.
+- Do not backfill from the cockpit.
+- Do not create fake decisions, acceptances, or executions.
+- Do not roll back by ticker/date.
+- Rollback is permitted only by `execution_id`, only against audited `market_signal_id` rows, and only after the rollback drill checklist passes.
+
+## Closeout
+
+Close the incident only when:
+
+- root cause is documented
+- audit/reconciliation status is understood
+- RLS/policy state is verified
+- any rollback action has a matching audit row
+- operator impact and data impact are written down
+- follow-up issue or PR is linked

--- a/crog-ai-backend/docs/MARKETCLUB-SIGNALS-PRODUCTION-RUNBOOK.md
+++ b/crog-ai-backend/docs/MARKETCLUB-SIGNALS-PRODUCTION-RUNBOOK.md
@@ -1,0 +1,183 @@
+# MarketClub Hedge Fund Signals Production Runbook
+
+**Status:** release hardening only; no new product mechanics
+**Scope:** Hedge Fund Signals cockpit, dry-run gate, guarded execution, rollback, audit, monitoring, alerts, and Signal Health Dashboard
+**Primary audience:** supervised operator and release owner
+
+## Release Rule
+
+Do not expand product behavior until this runbook, the audit playbook, incident response checklist, rollback drill checklist, hosted database migration verification, RLS/policy verification, and staging smoke test are complete.
+
+This phase is not allowed to add:
+
+- automatic rollback
+- automatic trade or signal changes
+- acceptance/execution shortcuts
+- ticker/date rollback paths
+- new production write mechanics
+- RLS bypasses or broad grants
+
+## Production Surfaces
+
+Backend:
+
+- service: `crog-ai-backend.service`
+- port: `127.0.0.1:8026`
+- required env: `DATABASE_URL`
+- optional env: `CROG_AI_CORS_ORIGINS`
+- app health: `GET /healthz`
+
+Database:
+
+- schema: `hedge_fund`
+- Alembic version table: `hedge_fund.alembic_version_crog_ai`
+- app role: `crog_ai_app`
+- production baseline parameter set: `dochia_v0_estimated`
+- candidate parameter set: `dochia_v0_2_range_daily`
+
+Cockpit:
+
+- Command Center path: `/financial/hedge-fund`
+- read-only awareness layer: `GET /api/financial/signals/health-dashboard`
+- audit endpoints under `GET /api/financial/signals/promotion/{id}/...`
+
+## Pre-Release Lock
+
+The release owner must record:
+
+- branch, PR number, merge commit, and deploy target
+- staging backend URL and staging cockpit URL
+- database name and host
+- operator token owner for execution/rollback drills
+- last backup timestamp or hosted provider restore point
+- exact Alembic head before migration
+- exact Alembic head after migration
+
+Hard stop if the target database is not `fortress_db` or the staging/production database cannot be distinguished.
+
+## Environment And Config Verification
+
+Run on the target host before deploying:
+
+```bash
+systemctl status crog-ai-backend.service --no-pager
+systemctl cat crog-ai-backend.service
+journalctl -u crog-ai-backend.service -n 80 --no-pager
+```
+
+Verify:
+
+- service runs as `admin`
+- working directory is `/home/admin/Fortress-Prime/crog-ai-backend`
+- `NoNewPrivileges=true`
+- backend binds `127.0.0.1:8026`
+- no operator token, database password, or raw `DATABASE_URL` is printed in logs
+- `DATABASE_URL` points to `fortress_db`, not `fortress_prod`
+- frontend `NEXT_PUBLIC_API_URL` points to the intended backend for staging
+- Cloudflare/tunnel route points at the intended frontend/backend pair
+
+Backend checks:
+
+```bash
+cd /home/admin/Fortress-Prime/crog-ai-backend
+.venv/bin/python - <<'PY'
+from app.database import database_url
+url = database_url()
+print(url.split('@')[-1])
+assert 'fortress_db' in url
+assert 'fortress_prod' not in url
+PY
+curl -fsS http://127.0.0.1:8026/healthz
+```
+
+## Hosted DB Migration Verification
+
+Before running migrations:
+
+```bash
+cd /home/admin/Fortress-Prime/crog-ai-backend
+.venv/bin/alembic current
+.venv/bin/alembic history --verbose | head -80
+```
+
+Apply only after confirming the restore point:
+
+```bash
+.venv/bin/alembic upgrade head
+.venv/bin/alembic current
+```
+
+Then run the read-only verification SQL:
+
+```bash
+psql "$DATABASE_URL" \
+  -v ON_ERROR_STOP=1 \
+  -f deploy/sql/marketclub_release_hardening_verification.sql
+```
+
+Required outcomes:
+
+- `hedge_fund.alembic_version_crog_ai` is at the expected head
+- all audit, monitoring, alert, acknowledgement, and signal health objects exist
+- `crog_ai_app` has SELECT/EXECUTE only where expected
+- no unexpected `SECURITY DEFINER` functions are present
+- rollback and execution audit tables can be joined by audited IDs
+- no duplicate executions exist for the same acceptance/idempotency pair
+
+## RLS And Policy Verification
+
+Run the RLS section in `deploy/sql/marketclub_release_hardening_verification.sql`.
+
+Hard stop if:
+
+- any promoted write/audit table has RLS unexpectedly disabled
+- `crog_ai_app` has INSERT/UPDATE/DELETE on tables outside the intentional function path
+- `PUBLIC` has privileges on Hedge Fund signal tables, views, or functions
+- a new `SECURITY DEFINER` function appears without a narrow, documented operator check
+- rollback can be reasoned about by ticker/date instead of audited `market_signal_id`
+
+## Staging Smoke Test
+
+Use `MARKETCLUB-SIGNALS-STAGING-SMOKE-TEST.md`.
+
+Minimum pass:
+
+- backend health works
+- cockpit loads `/financial/hedge-fund`
+- Promotion Gate, Shadow Review, Dry-Run Verification Gate, Lifecycle Timeline, Reconciliation, Post-Execution Monitoring, Post-Execution Alerts, and Signal Health Dashboard render
+- acceptance button remains disabled unless verification is PASS
+- execution/rollback controls are not triggered during smoke
+- health dashboard alerts are non-blocking warnings only
+
+## Release Decision
+
+Release may proceed only when:
+
+- local and CI tests passed
+- hosted migration verification passed
+- RLS/policy verification passed
+- staging smoke test passed
+- incident response and rollback drill checklists are reviewed
+- operator audit playbook is current
+
+Record the sign-off in the release notes with:
+
+- release owner
+- timestamp
+- PR/commit
+- staging evidence links
+- migration version
+- smoke test result
+- known warnings
+
+## Post-Release Watch
+
+For the first trading session after deploy, watch:
+
+- `GET /api/financial/signals/health-dashboard`
+- `GET /api/financial/signals/promotion/{id}/reconciliation`
+- `GET /api/financial/signals/promotion/{id}/alerts`
+- backend logs for 5xx/errors
+- database lock or permission errors
+
+Escalate using `MARKETCLUB-SIGNALS-INCIDENT-RESPONSE-CHECKLIST.md` if any audit invariant changes from `HEALTHY/WARNING` to `ERROR`, any mutation endpoint fails after operator submission, or the cockpit cannot trace decision -> execution -> outcome -> rollback.

--- a/crog-ai-backend/docs/MARKETCLUB-SIGNALS-ROLLBACK-DRILL-CHECKLIST.md
+++ b/crog-ai-backend/docs/MARKETCLUB-SIGNALS-ROLLBACK-DRILL-CHECKLIST.md
@@ -1,0 +1,136 @@
+# MarketClub Hedge Fund Signals Rollback Drill Checklist
+
+**Status:** operator-controlled rollback drill; no automatic rollback
+**Allowed target:** `execution_id` only
+
+## Purpose
+
+Prove that a promoted Hedge Fund signal execution can be inspected and rolled back safely using only audited `market_signal_id` rows from that execution.
+
+This checklist must be rehearsed on staging before release and reviewed before any production rollback.
+
+## Hard Rules
+
+- Rollback may only target `execution_id`.
+- Never roll back by ticker, date, action, score, or parameter set.
+- Rollback preview must only include audited IDs from `hedge_fund.signal_promotion_execution_rows`.
+- Repeat rollback must be safe: either no-op or already-rolled-back state.
+- Rollback must write audit/status.
+- No unaudited `hedge_fund.market_signals` rows may be affected.
+
+## Pre-Drill Inputs
+
+Record:
+
+- environment
+- operator
+- execution id
+- dry-run acceptance id
+- candidate parameter set
+- inserted market signal IDs
+- rollback markers
+- pre-drill reconciliation status
+- pre-drill rollback eligibility
+
+## Read-Only Preview
+
+```sql
+SELECT
+  execution_id,
+  dry_run_acceptance_id,
+  inserted_market_signal_ids,
+  rollback_markers,
+  audited_market_signal_ids,
+  rollback_preview_market_signal_ids,
+  rollback_preview_count,
+  rollback_eligibility,
+  rollback_eligible,
+  already_rolled_back,
+  rollback_status,
+  rollback_attempted_at,
+  rolled_back_at
+FROM hedge_fund.v_signal_promotion_rollback_drill
+WHERE execution_id = :execution_id;
+```
+
+Pass criteria:
+
+- exactly one execution row
+- `rollback_eligible = true`
+- `rollback_preview_market_signal_ids` is a subset of `audited_market_signal_ids`
+- preview count equals the intended audited live row count
+- no ticker/date predicate is used
+
+Hard stop if:
+
+- no execution row exists
+- preview includes a row not audited to this execution
+- execution is already rolled back and operator expected active
+- reconciliation has `ERROR`
+
+## Authorized Rollback Action
+
+Use the cockpit rollback control or the guarded API only after preview passes.
+
+API path:
+
+```text
+POST /api/financial/signals/promotion-dry-run/executions/{execution_id}/rollback
+Header: X-MarketClub-Operator-Token: <operator token>
+Body: { "rollback_reason": "<human reason>" }
+```
+
+Do not include ticker/date fields. The backend must ignore or reject any attempt to target rollback outside the path `execution_id`.
+
+## Post-Rollback Verification
+
+```sql
+SELECT *
+FROM hedge_fund.v_signal_promotion_rollback_drill
+WHERE execution_id = :execution_id;
+
+SELECT *
+FROM hedge_fund.v_signal_promotion_reconciliation
+WHERE execution_id::TEXT = :execution_id;
+
+SELECT *
+FROM hedge_fund.v_signal_promotion_lifecycle_timeline
+WHERE execution_id::TEXT = :execution_id
+ORDER BY ts;
+```
+
+Pass criteria:
+
+- rollback status is `rolled_back`
+- `already_rolled_back = true`
+- rollback preview count is `0`
+- audited IDs are absent from live `market_signals`
+- unaudited `market_signals` rows remain untouched
+- lifecycle timeline includes `ROLLBACK_COMPLETED`
+- reconciliation is `HEALTHY` or expected `WARNING`, not `ERROR`
+
+## Repeat Rollback Test
+
+Repeat the same rollback request with the same `execution_id`.
+
+Expected:
+
+- no duplicate deletes
+- no unaudited deletes
+- state remains `rolled_back`
+- response is safe no-op or explicit already-rolled-back state
+
+## Drill Sign-Off
+
+Record:
+
+- execution id
+- operator
+- preview count
+- audited IDs
+- rollback response timestamp
+- repeated rollback result
+- reconciliation result
+- incident link if any check failed
+
+Release is blocked if the drill cannot prove audited-ID-only rollback.

--- a/crog-ai-backend/docs/MARKETCLUB-SIGNALS-STAGING-SMOKE-TEST.md
+++ b/crog-ai-backend/docs/MARKETCLUB-SIGNALS-STAGING-SMOKE-TEST.md
@@ -1,0 +1,122 @@
+# MarketClub Hedge Fund Signals Staging Smoke Test
+
+**Status:** final read-only staging smoke before release
+**Mutation rule:** do not create decisions, acceptances, executions, acknowledgements, or rollbacks during this smoke unless the release owner explicitly starts a separate rollback drill.
+
+## Smoke Inputs
+
+Record before starting:
+
+- staging backend URL:
+- staging cockpit URL:
+- database host/name:
+- release PR:
+- release commit:
+- Alembic head:
+- candidate parameter set: `dochia_v0_2_range_daily`
+- production parameter set: `dochia_v0_estimated`
+
+## Backend Health
+
+```bash
+curl -fsS "$STAGING_BACKEND_URL/healthz"
+```
+
+Pass:
+
+- response is HTTP 200
+- no stack trace
+- no secret values in response
+
+## Read-Only API Smoke
+
+```bash
+curl -fsS "$STAGING_BACKEND_URL/api/financial/signals/latest?limit=5"
+curl -fsS "$STAGING_BACKEND_URL/api/financial/signals/promotion-gate/daily?candidate_parameter_set=dochia_v0_2_range_daily&top_tickers=3"
+curl -fsS "$STAGING_BACKEND_URL/api/financial/signals/promotion-dry-run/verification?candidate_parameter_set=dochia_v0_2_range_daily&production_parameter_set=dochia_v0_estimated&limit=25"
+curl -fsS "$STAGING_BACKEND_URL/api/financial/signals/promotion-dry-run/executions?candidate_parameter_set=dochia_v0_2_range_daily&limit=3"
+curl -fsS "$STAGING_BACKEND_URL/api/financial/signals/promotion-dry-run/executions/rollback-drill?candidate_parameter_set=dochia_v0_2_range_daily&limit=3"
+curl -fsS "$STAGING_BACKEND_URL/api/financial/signals/health-dashboard?candidate_parameter_set=dochia_v0_2_range_daily&production_parameter_set=dochia_v0_estimated"
+```
+
+Pass:
+
+- all calls return HTTP 200
+- verification returns `PASS`, `FAIL`, or `INCONCLUSIVE` explicitly
+- health dashboard returns active promotions, at-risk signals, divergence, outcome summary, and awareness alerts fields
+- no POST requests are made
+- no `market_signals` row count changes during the smoke
+
+## Cockpit Smoke
+
+Open staging Command Center:
+
+```text
+/financial/hedge-fund
+```
+
+Verify panels render:
+
+- Portfolio Lens
+- Calibration Baseline
+- Promotion Gate
+- Shadow Review
+- Signal Health Dashboard
+- Promotion Dry-Run
+- Dry-Run Verification Gate
+- Lifecycle Timeline
+- Reconciliation
+- Post-Execution Monitoring
+- Post-Execution Alerts
+- Execution Records
+- Rollback Drill
+
+Required operator checks:
+
+- acceptance button is disabled unless verification is `PASS`
+- execution action only appears for accepted dry-runs that are not executed
+- rollback action only appears when `rollback_eligible = true`
+- Signal Health Dashboard alerts are non-blocking and have no automatic action
+- any rollback recommendation is phrased as operator review only
+
+## Hosted DB Verification
+
+Run:
+
+```bash
+psql "$DATABASE_URL" \
+  -v ON_ERROR_STOP=1 \
+  -f deploy/sql/marketclub_release_hardening_verification.sql
+```
+
+Pass:
+
+- required objects exist
+- RLS and grants match expectations
+- no duplicate execution idempotency rows
+- no unaudited rollback target is implied
+
+## Evidence Table
+
+| Check | Result | Evidence |
+|---|---|---|
+| backend health |  |  |
+| read-only API smoke |  |  |
+| cockpit panel smoke |  |  |
+| DB migration head |  |  |
+| RLS/policy verification |  |  |
+| rollback drill preview |  |  |
+| signal health dashboard |  |  |
+| no mutation during smoke |  |  |
+
+## Release Blockers
+
+Block release if:
+
+- any required panel fails to render
+- any read-only endpoint returns 5xx
+- verification status is missing or ambiguous
+- RLS/policy verification fails
+- migration head differs from expected release head
+- any smoke step writes production rows
+- operator cannot trace decision -> execution -> outcome -> rollback

--- a/crog-ai-backend/docs/OPERATOR-AUDIT-PLAYBOOK.md
+++ b/crog-ai-backend/docs/OPERATOR-AUDIT-PLAYBOOK.md
@@ -2,6 +2,18 @@
 
 This playbook describes the read-only audit surface for Hedge Fund Signals promotions.
 
+## Release Hardening Lock
+
+Before any new product mechanics are added, the release owner must complete:
+
+- `MARKETCLUB-SIGNALS-PRODUCTION-RUNBOOK.md`
+- `MARKETCLUB-SIGNALS-INCIDENT-RESPONSE-CHECKLIST.md`
+- `MARKETCLUB-SIGNALS-ROLLBACK-DRILL-CHECKLIST.md`
+- `MARKETCLUB-SIGNALS-STAGING-SMOKE-TEST.md`
+- `deploy/sql/marketclub_release_hardening_verification.sql`
+
+No release is ready until an operator can trace decision -> execution -> outcome -> rollback, explain why a signal was promoted, verify observed behavior, identify degradation quickly, and act manually without automation.
+
 ## Lifecycle Timeline
 
 Use `GET /api/financial/signals/promotion/{id}/timeline` with a candidate parameter set, decision id, dry-run acceptance id, or execution id. The timeline only emits events backed by audited rows:

--- a/crog-ai-backend/tests/test_marketclub_release_hardening_docs.py
+++ b/crog-ai-backend/tests/test_marketclub_release_hardening_docs.py
@@ -1,0 +1,111 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+SQL = ROOT / "deploy" / "sql" / "marketclub_release_hardening_verification.sql"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_production_runbook_locks_release_hardening_scope() -> None:
+    text = _read(DOCS / "MARKETCLUB-SIGNALS-PRODUCTION-RUNBOOK.md")
+
+    assert "release hardening only; no new product mechanics" in text
+    assert "Environment And Config Verification" in text
+    assert "Hosted DB Migration Verification" in text
+    assert "RLS And Policy Verification" in text
+    assert "Staging Smoke Test" in text
+    assert "Do not expand product behavior" in text
+    assert "automatic rollback" in text
+    assert "automatic trade or signal changes" in text
+    assert "DATABASE_URL" in text
+    assert "fortress_db" in text
+    assert "fortress_prod" in text
+    assert "marketclub_release_hardening_verification.sql" in text
+
+
+def test_incident_response_requires_audited_ids_and_no_auto_heal() -> None:
+    text = _read(DOCS / "MARKETCLUB-SIGNALS-INCIDENT-RESPONSE-CHECKLIST.md")
+
+    assert "Freeze new operator mutations" in text
+    assert "decision -> execution -> outcome -> rollback" in text
+    assert "Do not auto-heal" in text
+    assert "Do not backfill from the cockpit" in text
+    assert "Do not roll back by ticker/date" in text
+    assert "execution_id" in text
+    assert "market_signal_id" in text
+    assert "SEV1" in text
+    assert "SEV2" in text
+    assert "SEV3" in text
+
+
+def test_rollback_drill_is_scoped_to_execution_id_only() -> None:
+    text = _read(DOCS / "MARKETCLUB-SIGNALS-ROLLBACK-DRILL-CHECKLIST.md")
+
+    assert "Allowed target:** `execution_id` only" in text
+    assert "Never roll back by ticker, date, action, score, or parameter set" in text
+    assert "audited_market_signal_ids" in text
+    assert "rollback_preview_market_signal_ids" in text
+    assert "Repeat Rollback Test" in text
+    assert "No unaudited" in text
+
+
+def test_staging_smoke_is_read_only_and_covers_required_panels() -> None:
+    text = _read(DOCS / "MARKETCLUB-SIGNALS-STAGING-SMOKE-TEST.md")
+
+    assert "do not create decisions, acceptances, executions, acknowledgements, or rollbacks" in text
+    assert "/financial/hedge-fund" in text
+    assert "Signal Health Dashboard" in text
+    assert "Dry-Run Verification Gate" in text
+    assert "Lifecycle Timeline" in text
+    assert "Reconciliation" in text
+    assert "Post-Execution Monitoring" in text
+    assert "Post-Execution Alerts" in text
+    assert "Rollback Drill" in text
+    assert "no POST requests are made" in text
+    assert "no `market_signals` row count changes" in text
+
+
+def test_operator_audit_playbook_links_release_hardening_pack() -> None:
+    text = _read(DOCS / "OPERATOR-AUDIT-PLAYBOOK.md")
+
+    assert "Release Hardening Lock" in text
+    assert "MARKETCLUB-SIGNALS-PRODUCTION-RUNBOOK.md" in text
+    assert "MARKETCLUB-SIGNALS-INCIDENT-RESPONSE-CHECKLIST.md" in text
+    assert "MARKETCLUB-SIGNALS-ROLLBACK-DRILL-CHECKLIST.md" in text
+    assert "MARKETCLUB-SIGNALS-STAGING-SMOKE-TEST.md" in text
+    assert "marketclub_release_hardening_verification.sql" in text
+
+
+def test_release_hardening_sql_is_read_only_and_covers_release_checks() -> None:
+    sql = _read(SQL)
+
+    assert "SELECT version_num" in sql
+    assert "hedge_fund.alembic_version_crog_ai" in sql
+    assert "to_regprocedure('hedge_fund.verify_promotion_dry_run" in sql
+    assert "to_regprocedure('hedge_fund.execute_guarded_signal_promotion" in sql
+    assert "to_regprocedure('hedge_fund.rollback_guarded_signal_promotion" in sql
+    assert "to_regclass('hedge_fund.v_signal_health_active_promotions')" in sql
+    assert "relrowsecurity" in sql
+    assert "information_schema.table_privileges" in sql
+    assert "has_function_privilege('crog_ai_app'" in sql
+    assert "GROUP BY acceptance_id, idempotency_key" in sql
+    assert "v_signal_promotion_reconciliation" in sql
+    assert "v_signal_health_active_promotions" in sql
+    forbidden = [
+        "INSERT ",
+        "UPDATE ",
+        "DELETE ",
+        "TRUNCATE ",
+        "ALTER ",
+        "DROP ",
+        "CREATE ",
+        "GRANT ",
+        "REVOKE ",
+        "SECURITY DEFINER",
+    ]
+    upper_sql = sql.upper()
+    for token in forbidden:
+        assert token not in upper_sql


### PR DESCRIPTION
## Summary
- add production release runbook for Hedge Fund Signals hardening
- add incident response, rollback drill, and staging smoke-test checklists
- add read-only hosted DB/RLS/policy verification SQL
- update the operator audit playbook with the release hardening lock
- add static tests that enforce the hardening pack coverage and read-only SQL posture

## Safety
- docs/checklists/read-only verification only
- no product mechanics added
- no execute/rollback/acceptance behavior changed
- no market_signals write path changes

## Tests
- PYTHONPATH=. .venv-test/bin/python -m pytest tests/test_marketclub_release_hardening_docs.py
- PYTHONPATH=. .venv-test/bin/python -m pytest
- PYTHONPATH=. .venv-test/bin/python -m ruff check tests/test_marketclub_release_hardening_docs.py