### PR TITLE
Fix dry-run snapshot UUID serialization

### DIFF
--- a/crog-ai-backend/app/signals/repository.py
+++ b/crog-ai-backend/app/signals/repository.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime as dt
 import hashlib
 import json
+import uuid
 from collections import Counter
 from decimal import Decimal
 from typing import Any, Protocol
@@ -935,6 +936,8 @@ def _json_safe(value: Any) -> Any:
     if isinstance(value, (dt.datetime, dt.date)):
         return value.isoformat()
     if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, uuid.UUID):
         return str(value)
     if isinstance(value, dict):
         return {str(key): _json_safe(item) for key, item in value.items()}

--- a/crog-ai-backend/tests/test_api_signals.py
+++ b/crog-ai-backend/tests/test_api_signals.py
@@ -2415,3 +2415,14 @@ def test_symbol_signal_detail_404_when_no_latest_score() -> None:
     response = client.get("/api/financial/signals/missing")
 
     assert response.status_code == 404
+
+def test_json_safe_serializes_uuid_values() -> None:
+    import uuid
+
+    from app.signals.repository import _json_safe
+
+    value = uuid.UUID("53c4e3db-a111-4500-a34d-0bcecb398a77")
+    assert _json_safe({"decision_id": value}) == {
+        "decision_id": "53c4e3db-a111-4500-a34d-0bcecb398a77"
+    }
+


### PR DESCRIPTION
## Summary
- serialize UUID values in MarketClub dry-run snapshot payloads
- cover UUID serialization with a focused API signal test

## Tests
- /home/admin/Fortress-Prime/crog-ai-backend/.venv/bin/python -m pytest tests/test_api_signals.py -k json_safe_serializes_uuid_values
- /home/admin/Fortress-Prime/crog-ai-backend/.venv/bin/python -m ruff check app/signals/repository.py tests/test_api_signals.py