### PR TITLE
Fix rollback reconciliation after repeat rollback

### DIFF
--- a/crog-ai-backend/alembic/versions/0015_promotion_reconciliation_repeat_rollback.py
+++ b/crog-ai-backend/alembic/versions/0015_promotion_reconciliation_repeat_rollback.py
@@ -1,0 +1,29 @@
+"""Keep rollback reconciliation stable after repeat rollback no-op.
+
+Revision ID: 0015_promotion_reconciliation_repeat_rollback
+Revises: 0014_signal_health_dashboard
+Create Date: 2026-05-04 20:05:00.000000
+"""
+
+from pathlib import Path
+
+from alembic import op
+
+revision = "0015_promotion_reconciliation_repeat_rollback"
+down_revision = "0014_signal_health_dashboard"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    sql_path = (
+        Path(__file__).resolve().parents[2]
+        / "deploy"
+        / "sql"
+        / "marketclub_promotion_audit_observability.sql"
+    )
+    op.execute(sql_path.read_text(encoding="utf-8"))
+
+
+def downgrade() -> None:
+    pass

--- a/crog-ai-backend/deploy/sql/marketclub_promotion_audit_observability.sql
+++ b/crog-ai-backend/deploy/sql/marketclub_promotion_audit_observability.sql
@@ -56,7 +56,7 @@ SET (security_invoker = true);
 
 CREATE OR REPLACE VIEW hedge_fund.v_signal_promotion_lifecycle_timeline
 WITH (security_invoker = true) AS
-WITH latest_rollback_audit AS (
+WITH successful_rollback_audit AS (
     SELECT DISTINCT ON (a.execution_id)
         a.execution_id,
         a.rollback_status,
@@ -66,7 +66,8 @@ WITH latest_rollback_audit AS (
         a.attempted_at,
         a.completed_at
     FROM hedge_fund.signal_promotion_rollback_audits a
-    ORDER BY a.execution_id, a.attempted_at DESC
+    WHERE a.rollback_status = 'rolled_back'
+    ORDER BY a.execution_id, COALESCE(a.completed_at, a.attempted_at) DESC
 ),
 rollback_eligible AS (
     SELECT
@@ -207,9 +208,8 @@ SELECT
         'ids_hash', a.deleted_market_signal_ids_hash,
         'rollback_status', a.rollback_status
     ) AS meta
-FROM latest_rollback_audit a
-JOIN hedge_fund.signal_promotion_executions e ON e.id = a.execution_id
-WHERE a.rollback_status = 'rolled_back';
+FROM successful_rollback_audit a
+JOIN hedge_fund.signal_promotion_executions e ON e.id = a.execution_id;
 
 CREATE OR REPLACE VIEW hedge_fund.v_signal_promotion_reconciliation
 WITH (security_invoker = true) AS
@@ -224,7 +224,7 @@ WITH execution_base AS (
         COUNT(*) OVER (PARTITION BY e.acceptance_id, e.idempotency_key) AS executions_for_acceptance_key
     FROM hedge_fund.signal_promotion_executions e
 ),
-latest_rollback_audit AS (
+successful_rollback_audit AS (
     SELECT DISTINCT ON (a.execution_id)
         a.execution_id,
         a.rollback_status,
@@ -233,7 +233,8 @@ latest_rollback_audit AS (
         a.attempted_at,
         a.completed_at
     FROM hedge_fund.signal_promotion_rollback_audits a
-    ORDER BY a.execution_id, a.attempted_at DESC
+    WHERE a.rollback_status = 'rolled_back'
+    ORDER BY a.execution_id, COALESCE(a.completed_at, a.attempted_at) DESC
 ),
 row_rollup AS (
     SELECT
@@ -333,7 +334,7 @@ checks AS (
     LEFT JOIN execution_base e ON e.acceptance_id = a.id
     LEFT JOIN hedge_fund.signal_shadow_review_decisions d ON d.id = a.decision_record_id
     LEFT JOIN row_rollup r ON r.execution_id = e.id
-    LEFT JOIN latest_rollback_audit ra ON ra.execution_id = e.id
+    LEFT JOIN successful_rollback_audit ra ON ra.execution_id = e.id
     LEFT JOIN evidence_flags flags ON flags.decision_id = d.id
 ),
 classified AS (

--- a/crog-ai-backend/tests/test_promotion_audit_observability.py
+++ b/crog-ai-backend/tests/test_promotion_audit_observability.py
@@ -98,6 +98,20 @@ def test_reconciliation_partial_rollback_returns_error() -> None:
     assert "END AS rollback_integrity" in sql
 
 
+def test_reconciliation_uses_successful_rollback_audit_after_repeat_noop() -> None:
+    sql = _audit_sql()
+
+    assert "successful_rollback_audit AS" in sql
+    assert "latest_rollback_audit" not in sql
+    assert "WHERE a.rollback_status = 'rolled_back'" in sql
+    assert (
+        "ORDER BY a.execution_id, COALESCE(a.completed_at, a.attempted_at) DESC"
+        in sql
+    )
+    assert "FROM successful_rollback_audit a" in sql
+    assert "LEFT JOIN successful_rollback_audit ra ON ra.execution_id = e.id" in sql
+
+
 def test_reconciliation_double_execute_attempt_keeps_idempotency_explicit() -> None:
     sql = _audit_sql()
 


### PR DESCRIPTION
## Summary
- Make lifecycle timeline and reconciliation use the latest successful rollback audit, not the latest repeat no-op audit
- Add an Alembic migration so the view repair is applied through normal migration flow
- Add a regression test proving repeat rollback no-op audits cannot replace successful rollback evidence

## Verification
- python3 -m pytest tests/test_promotion_audit_observability.py
- ruff check tests/test_promotion_audit_observability.py alembic/versions/0015_promotion_reconciliation_repeat_rollback.py
- python3 -m py_compile alembic/versions/0015_promotion_reconciliation_repeat_rollback.py

## Staging Evidence
- Existing staged execution reconciles with all checks PASS after the view repair
- Reconciliation status is WARNING only because expected non-fatal diagnostics remain: cross-model diagnostic-only row and high-churn flag
- Timeline by decision now shows decision -> dry-run -> verification -> acceptance -> execution -> rollback completion